### PR TITLE
Allow Edit, Write, Read, and Bash tools in Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,3 +37,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
+          claude_args: |
+            --allowedTools Edit,Write,Read,Bash


### PR DESCRIPTION
## What
- Add `--allowedTools Edit,Write,Read,Bash` to `claude.yml` via `claude_args`

## Why
Claude Code Action blocks `gh` CLI commands (e.g., `gh label create`, `gh api graphql`) and file write operations by default. This prevented `@claude` from completing tasks like creating labels or editing `.claude/rules/` files (see #8).

Closes #8

## Test Results
No runtime code changes — CI workflow config only. After merge, `@claude` mentions on issues/PRs will have access to:
- `Bash` — enables `gh` CLI, `cargo`, and other shell commands
- `Edit` / `Write` — enables file modifications
- `Read` — enables file reading

## Review Summary
- `--allowedTools` is additive to the default tool set (GitHub comment/file operations)
- The action's built-in permission check (`checkWritePermissions()`) still gates access to repository collaborators with write permissions only
- No security regression: external users cannot trigger Claude execution