### PR TITLE
Add automated CI → Claude review → fix workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,91 @@
+name: Claude Review
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  request-review:
+    # Only run when CI succeeds on a pull request (not push to main)
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Request Claude review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLAUDE_PAT }}
+          script: |
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs || prs.length === 0) {
+              console.log('No pull requests found (fork PRs are excluded for security)');
+              return;
+            }
+
+            const prNumber = prs[0].number;
+            const headSha = context.payload.workflow_run.head_sha;
+
+            // Skip Dependabot PRs (handled by claude-dependabot.yml)
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (pr.user.login === 'dependabot[bot]') {
+              console.log('Skipping Dependabot PR (handled separately)');
+              return;
+            }
+
+            // Fetch existing comments to prevent duplicates and limit iterations
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            // Skip if this commit was already reviewed
+            const marker = `<!-- claude-auto-review:${headSha} -->`;
+            if (comments.some(c => c.body.includes(marker))) {
+              console.log(`Review already requested for commit ${headSha}`);
+              return;
+            }
+
+            // Limit auto-review iterations to prevent infinite loops
+            const MAX_ITERATIONS = 3;
+            const autoReviewCount = comments.filter(c =>
+              c.body.startsWith('<!-- claude-auto-review:')
+            ).length;
+            if (autoReviewCount >= MAX_ITERATIONS) {
+              console.log(`Max auto-review iterations (${MAX_ITERATIONS}) reached for PR #${prNumber}`);
+              return;
+            }
+
+            // Post review request comment (triggers claude.yml via @claude mention)
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                marker,
+                '',
+                `@claude CI passed for commit \`${headSha.substring(0, 7)}\`. Please review this PR:`,
+                '',
+                '**Code Review:**',
+                '- Code quality and adherence to project conventions (see CLAUDE.md)',
+                '- Logic correctness and edge case handling',
+                '- Test coverage and quality',
+                '',
+                '**Security Review:**',
+                '- No unsafe code without justification',
+                '- Input validation at system boundaries',
+                '- Dependency safety (no unnecessary external deps, especially in chordpro-core)',
+                '',
+                'If you find fixable issues, push fix commits directly. For design issues requiring author input, leave review comments.',
+              ].join('\n'),
+            });
+
+            console.log(`Review requested for PR #${prNumber} at ${headSha.substring(0, 7)}`);

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,13 +12,19 @@ on:
 
 jobs:
   claude:
+    # Security: only allow unchidev to trigger @claude on this public repo.
+    # Automated review comments from claude-review.yml are posted via CLAUDE_PAT
+    # (owned by unchidev), so sender.login == 'unchidev' holds for those too.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.login == 'unchidev' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     concurrency:
       group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
@@ -36,6 +42,18 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use PAT so that Claude's pushes trigger CI workflows
+          # (GITHUB_TOKEN pushes do not trigger other workflows)
+          github_token: ${{ secrets.CLAUDE_PAT }}
           track_progress: true
-          claude_args: |
-            --allowedTools Edit,Write,Read,Bash
+          claude_args: "--allowedTools Edit,Write,Read,Bash"
+          prompt: |
+            When working on a GitHub issue (not a PR review), after implementing the
+            solution and pushing your changes to the branch, you MUST create a pull
+            request automatically using `gh pr create`. Do not just show a "Create PR"
+            link — actually create the PR.
+
+            PR requirements:
+            - Title: concise, imperative mood
+            - Body: include `Closes #N` referencing the issue number
+            - Follow all rules in CLAUDE.md and .claude/rules/


### PR DESCRIPTION
## What

Add an automated CI → Claude review → fix → CI re-check loop for pull requests.

### New: `claude-review.yml`
- Triggers via `workflow_run` when CI completes successfully on a PR
- Posts a review request comment (`@claude`) on the PR, which triggers `claude.yml`
- Review includes both code quality and security checks
- **Loop prevention**: commit SHA markers prevent duplicate reviews; max 3 iterations
- **Security**: fork PRs excluded (empty `pull_requests` array); Dependabot PRs excluded (handled by `claude-dependabot.yml`)

### Updated: `claude.yml`
- **User restriction**: only `unchidev` can trigger `@claude` (public repo security)
- **CLAUDE_PAT**: passed as `github_token` so Claude's pushes re-trigger CI workflows (GITHUB_TOKEN pushes don't trigger other workflows per GitHub's design)
- **PR auto-creation**: prompt instructs Claude to run `gh pr create` when working on issues, instead of just showing a "Create PR →" link
- **Timeout**: increased from 15 to 30 minutes

### Flow
```
PR opened → CI runs → CI passes
  → claude-review.yml posts @claude comment
    → claude.yml runs review
      → If issues found: push fix → CI re-runs → loop (max 3x)
      → If clean: done
```

## Why

Automate the review cycle so that every PR gets consistent code + security review after CI passes, with Claude able to fix simple issues directly.

## Test plan

- [ ] Merge this PR to `main` (required: `workflow_run` only activates from default branch)
- [ ] Open a test PR to verify the full flow: CI → auto-review comment → Claude review
- [ ] Verify `@claude` mentions from non-`unchidev` users are ignored
- [ ] Verify Dependabot PRs don't get double-reviewed

## Notes

- `workflow_run` triggers only work when the workflow file exists on the default branch — both `ci.yml` and `claude-review.yml` must be on `main`
- The review comment approach (vs. running claude-code-action directly in workflow_run) is necessary because the action needs PR event context to function correctly
- `CLAUDE_PAT` secret must be configured with Contents, Pull requests, and Issues read/write permissions

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)