### PR TITLE
Add auto-merge to Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -86,7 +86,7 @@ jobs:
                 '',
                 'If you find fixable issues, push fix commits directly. For design issues requiring author input, leave review comments.',
                 '',
-                'If both code review and security review pass with no issues, merge the PR with `gh pr merge --squash`.',
+                'If both code review and security review pass with no issues, enable auto-merge with `gh pr merge --squash --auto`.',
               ].join('\n'),
             });
 


### PR DESCRIPTION
## What

Add an instruction to the automated Claude review comment telling Claude to approve
and squash-merge the PR when both code and security review pass with no issues.

## Why

The current CI → Claude review → fix cycle stops after review approval. Claude says
"approve" but never actually merges. This leaves PRs in a reviewed-but-unmerged state
requiring manual intervention.

With this change, the full cycle is automated:
1. CI passes → Claude reviews
2. Issues found → Claude pushes fixes → CI runs again → loop (max 3 iterations)
3. No issues → Claude approves + squash-merges

## Test results

- `cargo fmt --check` — N/A (no Rust code changed)
- `cargo clippy` — N/A
- `cargo test` — N/A
- Workflow syntax validated by reviewing the YAML diff

## Review summary

Single-line addition to the review request comment body in `claude-review.yml`.
No changes to permissions, triggers, or iteration limits.

Closes #42