### PR TITLE
Add documentation maintenance rules

### DIFF
--- a/.claude/rules/doc-maintenance.md
+++ b/.claude/rules/doc-maintenance.md
@@ -1,0 +1,37 @@
+# Documentation Maintenance
+
+## Policy
+
+Project documentation (`CLAUDE.md`, `.claude/rules/`) is updated via **dedicated PRs**,
+not inside feature branches (as per the Shared Files Policy in `parallel-work.md`).
+
+Updates are **event-driven**, not periodic. After a PR merges to `main`, evaluate
+whether any of the triggers below apply and, if so, open a dedicated documentation PR
+promptly.
+
+## Update Triggers
+
+| Event | What to update |
+|---|---|
+| New crate added to workspace | `CLAUDE.md` Architecture table |
+| New rule or convention agreed upon | `.claude/rules/` — add new file |
+| Phase started or completed | `CLAUDE.md` Phase Roadmap |
+| Build commands or CI pipeline changed | `CLAUDE.md` Build Commands |
+| New workflow or process introduced | `.claude/rules/` — add new file |
+| Existing rule no longer applies | Remove or update the relevant `.claude/rules/` file |
+| Dependency policy changed | `CLAUDE.md` Dependency Policy section |
+
+## Phase Completion Review
+
+When a phase's tracking issue is closed, perform a full review of all documentation
+files to ensure they accurately reflect the current state of the project. This is the
+one scheduled (non-event-driven) documentation checkpoint.
+
+## Principles
+
+- Keep documentation minimal and accurate — remove stale content rather than
+  accumulating it.
+- Documentation should describe the current state and rules, not history. Use git
+  history for that.
+- If a trigger applies but the change is trivial (e.g., a typo fix), it may be batched
+  with the next documentation PR rather than requiring its own.


### PR DESCRIPTION
## What

Add `.claude/rules/doc-maintenance.md` defining when and how project documentation should be updated.

## Why

The project had rules for *how* to modify `CLAUDE.md` and `.claude/rules/` (via dedicated PRs), but no rules for *when* updates are needed. This led to a gap where documentation could silently drift from the actual project state.

## Changes

- New `.claude/rules/doc-maintenance.md` with:
  - Event-driven update triggers (new crate, phase change, build change, etc.)
  - Phase-completion review as a scheduled checkpoint
  - Principles for keeping docs minimal and accurate

## Test results

No code changes — documentation only. Verified file renders correctly on GitHub.

## Review summary

Straightforward addition of a process rule. Consistent with existing `parallel-work.md` Shared Files Policy.

Closes #44