### PR TITLE
Implement standard directive parsing

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -15,6 +15,13 @@
 //! model: each [`LyricsSegment`] pairs an optional chord with the lyric text
 //! that follows it. This preserves the chord-text relationship without
 //! requiring offset arithmetic during rendering.
+//!
+//! # Directive Classification
+//!
+//! Directives carry a [`DirectiveKind`] that classifies them into metadata,
+//! formatting, environment (section), or unknown categories. The parser
+//! resolves short aliases (e.g., `t` → `title`) and performs case-insensitive
+//! matching per the ChordPro specification.
 
 // ---------------------------------------------------------------------------
 // Song (root node)
@@ -68,7 +75,7 @@ impl Default for Song {
 ///
 /// These fields correspond to standard ChordPro meta-directives such as
 /// `{title}`, `{subtitle}`, `{artist}`, `{composer}`, `{album}`, `{year}`,
-/// `{key}`, `{tempo}`, and `{capo}`.
+/// `{key}`, `{tempo}`, `{time}`, and `{capo}`.
 ///
 /// Fields that can logically appear multiple times (e.g., `subtitle`, `artist`,
 /// `composer`) are stored as `Vec<String>`. Fields that are expected to appear
@@ -96,6 +103,8 @@ pub struct Metadata {
     pub key: Option<String>,
     /// Tempo indication, from `{tempo}`.
     pub tempo: Option<String>,
+    /// Time signature, from `{time}`.
+    pub time: Option<String>,
     /// Capo position, from `{capo}`.
     pub capo: Option<String>,
     /// Custom metadata directives not covered by the standard fields.
@@ -129,11 +138,37 @@ pub enum Line {
     /// A directive such as `{title: My Song}` or `{start_of_chorus}`.
     Directive(Directive),
 
-    /// A comment line starting with `#` (file-level comment, not rendered).
-    Comment(String),
+    /// A comment line from a comment directive (`{comment}`, `{comment_italic}`,
+    /// `{comment_box}`) or a file-level `#` comment. The [`CommentStyle`]
+    /// distinguishes the rendering intent.
+    Comment(CommentStyle, String),
 
     /// An empty line, typically used to separate paragraphs or sections.
     Empty,
+}
+
+// ---------------------------------------------------------------------------
+// CommentStyle
+// ---------------------------------------------------------------------------
+
+/// The visual style of a comment, determined by the directive that produced it.
+///
+/// ChordPro supports three comment directives, each with a different rendering
+/// intent:
+///
+/// - `{comment}` / `{c}` — normal comment (typically highlighted or boxed)
+/// - `{comment_italic}` / `{ci}` — italic comment
+/// - `{comment_box}` / `{cb}` — boxed comment
+///
+/// File-level `#` comments use [`CommentStyle::Normal`] as a default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CommentStyle {
+    /// A normal comment, from `{comment}` / `{c}` or file-level `#`.
+    Normal,
+    /// An italic comment, from `{comment_italic}` / `{ci}`.
+    Italic,
+    /// A boxed comment, from `{comment_box}` / `{cb}`.
+    Boxed,
 }
 
 // ---------------------------------------------------------------------------
@@ -296,6 +331,207 @@ impl core::fmt::Display for Chord {
 }
 
 // ---------------------------------------------------------------------------
+// DirectiveKind
+// ---------------------------------------------------------------------------
+
+/// Classification of a ChordPro directive.
+///
+/// The parser examines each directive's name (case-insensitively, resolving
+/// short aliases) and assigns a `DirectiveKind` to indicate its semantic
+/// category. Renderers and downstream consumers can match on this enum
+/// rather than performing string comparisons.
+///
+/// # Categories
+///
+/// - **Metadata** — directives that set song metadata (`title`, `subtitle`,
+///   `artist`, `album`, `year`, `key`, `tempo`, `time`, `capo`, etc.).
+/// - **Formatting** — comment directives (`comment`, `comment_italic`,
+///   `comment_box`).
+/// - **Environment** — section start/end directives (`start_of_chorus`,
+///   `end_of_chorus`, `start_of_verse`, etc.).
+/// - **Unknown** — any directive not recognized as a standard directive.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DirectiveKind {
+    // -- Metadata directives ------------------------------------------------
+    /// `{title}` / `{t}` — the song title.
+    Title,
+    /// `{subtitle}` / `{st}` — a subtitle.
+    Subtitle,
+    /// `{artist}` — the artist name.
+    Artist,
+    /// `{composer}` — the composer name.
+    Composer,
+    /// `{lyricist}` — the lyricist name.
+    Lyricist,
+    /// `{album}` — the album name.
+    Album,
+    /// `{year}` — the year or date.
+    Year,
+    /// `{key}` — the musical key.
+    Key,
+    /// `{tempo}` — the tempo.
+    Tempo,
+    /// `{time}` — the time signature.
+    Time,
+    /// `{capo}` — the capo position.
+    Capo,
+
+    // -- Formatting directives (comment) ------------------------------------
+    /// `{comment}` / `{c}` — a normal comment.
+    Comment,
+    /// `{comment_italic}` / `{ci}` — an italic comment.
+    CommentItalic,
+    /// `{comment_box}` / `{cb}` — a boxed comment.
+    CommentBox,
+
+    // -- Environment (section) directives -----------------------------------
+    /// `{start_of_chorus}` / `{soc}` — begins a chorus section.
+    StartOfChorus,
+    /// `{end_of_chorus}` / `{eoc}` — ends a chorus section.
+    EndOfChorus,
+    /// `{start_of_verse}` / `{sov}` — begins a verse section.
+    StartOfVerse,
+    /// `{end_of_verse}` / `{eov}` — ends a verse section.
+    EndOfVerse,
+    /// `{start_of_bridge}` / `{sob}` — begins a bridge section.
+    StartOfBridge,
+    /// `{end_of_bridge}` / `{eob}` — ends a bridge section.
+    EndOfBridge,
+    /// `{start_of_tab}` / `{sot}` — begins a tab section.
+    StartOfTab,
+    /// `{end_of_tab}` / `{eot}` — ends a tab section.
+    EndOfTab,
+
+    // -- Unknown ------------------------------------------------------------
+    /// A directive not recognized as a standard ChordPro directive.
+    /// The original directive name (lowercased) is preserved.
+    Unknown(String),
+}
+
+impl DirectiveKind {
+    /// Resolves a directive name to its [`DirectiveKind`].
+    ///
+    /// The lookup is case-insensitive and recognizes standard short aliases
+    /// (e.g., `t` for `title`, `soc` for `start_of_chorus`).
+    #[must_use]
+    pub fn from_name(name: &str) -> Self {
+        match name.to_ascii_lowercase().as_str() {
+            // Metadata
+            "title" | "t" => Self::Title,
+            "subtitle" | "st" => Self::Subtitle,
+            "artist" => Self::Artist,
+            "composer" => Self::Composer,
+            "lyricist" => Self::Lyricist,
+            "album" => Self::Album,
+            "year" => Self::Year,
+            "key" => Self::Key,
+            "tempo" => Self::Tempo,
+            "time" => Self::Time,
+            "capo" => Self::Capo,
+
+            // Formatting (comments)
+            "comment" | "c" => Self::Comment,
+            "comment_italic" | "ci" => Self::CommentItalic,
+            "comment_box" | "cb" => Self::CommentBox,
+
+            // Environment (sections)
+            "start_of_chorus" | "soc" => Self::StartOfChorus,
+            "end_of_chorus" | "eoc" => Self::EndOfChorus,
+            "start_of_verse" | "sov" => Self::StartOfVerse,
+            "end_of_verse" | "eov" => Self::EndOfVerse,
+            "start_of_bridge" | "sob" => Self::StartOfBridge,
+            "end_of_bridge" | "eob" => Self::EndOfBridge,
+            "start_of_tab" | "sot" => Self::StartOfTab,
+            "end_of_tab" | "eot" => Self::EndOfTab,
+
+            // Unknown
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+
+    /// Returns the canonical (long-form) directive name for known directives.
+    ///
+    /// For [`DirectiveKind::Unknown`], returns the stored name.
+    #[must_use]
+    pub fn canonical_name(&self) -> &str {
+        match self {
+            Self::Title => "title",
+            Self::Subtitle => "subtitle",
+            Self::Artist => "artist",
+            Self::Composer => "composer",
+            Self::Lyricist => "lyricist",
+            Self::Album => "album",
+            Self::Year => "year",
+            Self::Key => "key",
+            Self::Tempo => "tempo",
+            Self::Time => "time",
+            Self::Capo => "capo",
+            Self::Comment => "comment",
+            Self::CommentItalic => "comment_italic",
+            Self::CommentBox => "comment_box",
+            Self::StartOfChorus => "start_of_chorus",
+            Self::EndOfChorus => "end_of_chorus",
+            Self::StartOfVerse => "start_of_verse",
+            Self::EndOfVerse => "end_of_verse",
+            Self::StartOfBridge => "start_of_bridge",
+            Self::EndOfBridge => "end_of_bridge",
+            Self::StartOfTab => "start_of_tab",
+            Self::EndOfTab => "end_of_tab",
+            Self::Unknown(name) => name.as_str(),
+        }
+    }
+
+    /// Returns `true` if this is a metadata directive.
+    #[must_use]
+    pub fn is_metadata(&self) -> bool {
+        matches!(
+            self,
+            Self::Title
+                | Self::Subtitle
+                | Self::Artist
+                | Self::Composer
+                | Self::Lyricist
+                | Self::Album
+                | Self::Year
+                | Self::Key
+                | Self::Tempo
+                | Self::Time
+                | Self::Capo
+        )
+    }
+
+    /// Returns `true` if this is a comment/formatting directive.
+    #[must_use]
+    pub fn is_comment(&self) -> bool {
+        matches!(self, Self::Comment | Self::CommentItalic | Self::CommentBox)
+    }
+
+    /// Returns `true` if this is a section start directive.
+    #[must_use]
+    pub fn is_section_start(&self) -> bool {
+        matches!(
+            self,
+            Self::StartOfChorus | Self::StartOfVerse | Self::StartOfBridge | Self::StartOfTab
+        )
+    }
+
+    /// Returns `true` if this is a section end directive.
+    #[must_use]
+    pub fn is_section_end(&self) -> bool {
+        matches!(
+            self,
+            Self::EndOfChorus | Self::EndOfVerse | Self::EndOfBridge | Self::EndOfTab
+        )
+    }
+
+    /// Returns `true` if this is an environment (section start or end) directive.
+    #[must_use]
+    pub fn is_environment(&self) -> bool {
+        self.is_section_start() || self.is_section_end()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Directive
 // ---------------------------------------------------------------------------
 
@@ -305,48 +541,67 @@ impl core::fmt::Display for Chord {
 /// optional value separated by a colon. Some directives have standard short
 /// aliases (e.g., `t` for `title`, `st` for `subtitle`).
 ///
-/// The AST stores the directive name as-is (not normalized). Normalization
-/// of aliases (e.g., `t` -> `title`) is the parser's responsibility.
+/// The `name` field stores the **canonical** (long-form, lowercase) name after
+/// alias resolution. The `kind` field provides a typed classification for
+/// pattern matching.
 ///
 /// # Examples
 ///
 /// ```
-/// use chordpro_core::ast::Directive;
+/// use chordpro_core::ast::{Directive, DirectiveKind};
 ///
 /// // {title: My Song}
 /// let d = Directive::with_value("title", "My Song");
 /// assert_eq!(d.name, "title");
 /// assert_eq!(d.value.as_deref(), Some("My Song"));
+/// assert_eq!(d.kind, DirectiveKind::Title);
 ///
 /// // {start_of_chorus}
 /// let d = Directive::name_only("start_of_chorus");
 /// assert_eq!(d.name, "start_of_chorus");
 /// assert!(d.value.is_none());
+/// assert_eq!(d.kind, DirectiveKind::StartOfChorus);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Directive {
-    /// The directive name (e.g., `"title"`, `"start_of_chorus"`, `"comment"`).
+    /// The canonical directive name (e.g., `"title"`, `"start_of_chorus"`).
     pub name: String,
     /// The optional value after the colon (e.g., `"My Song"` in `{title: My Song}`).
     pub value: Option<String>,
+    /// The classified kind of this directive.
+    pub kind: DirectiveKind,
 }
 
 impl Directive {
     /// Creates a directive with both a name and a value.
+    ///
+    /// The name is resolved to its canonical form and the [`DirectiveKind`]
+    /// is determined automatically.
     #[must_use]
     pub fn with_value(name: impl Into<String>, value: impl Into<String>) -> Self {
+        let name_str = name.into();
+        let kind = DirectiveKind::from_name(&name_str);
+        let canonical = kind.canonical_name().to_string();
         Self {
-            name: name.into(),
+            name: canonical,
             value: Some(value.into()),
+            kind,
         }
     }
 
     /// Creates a directive with only a name and no value.
+    ///
+    /// The name is resolved to its canonical form and the [`DirectiveKind`]
+    /// is determined automatically.
     #[must_use]
     pub fn name_only(name: impl Into<String>) -> Self {
+        let name_str = name.into();
+        let kind = DirectiveKind::from_name(&name_str);
+        let canonical = kind.canonical_name().to_string();
         Self {
-            name: name.into(),
+            name: canonical,
             value: None,
+            kind,
         }
     }
 
@@ -354,14 +609,14 @@ impl Directive {
     /// (e.g., `start_of_chorus`, `start_of_verse`, etc.).
     #[must_use]
     pub fn is_section_start(&self) -> bool {
-        self.name.starts_with("start_of_")
+        self.kind.is_section_start()
     }
 
     /// Returns `true` if this directive marks the end of a section
     /// (e.g., `end_of_chorus`, `end_of_verse`, etc.).
     #[must_use]
     pub fn is_section_end(&self) -> bool {
-        self.name.starts_with("end_of_")
+        self.kind.is_section_end()
     }
 
     /// If this is a section start or end directive, returns the section name
@@ -406,7 +661,8 @@ mod tests {
         let mut song = Song::new();
         song.metadata.title = Some("My Song".to_string());
         song.lines.push(Line::Empty);
-        song.lines.push(Line::Comment("A comment".to_string()));
+        song.lines
+            .push(Line::Comment(CommentStyle::Normal, "A comment".to_string()));
         assert_eq!(song.lines.len(), 2);
         assert_eq!(song.metadata.title.as_deref(), Some("My Song"));
     }
@@ -425,6 +681,7 @@ mod tests {
         assert_eq!(meta.year, None);
         assert_eq!(meta.key, None);
         assert_eq!(meta.tempo, None);
+        assert_eq!(meta.time, None);
         assert_eq!(meta.capo, None);
         assert!(meta.custom.is_empty());
     }
@@ -532,6 +789,159 @@ mod tests {
         assert_eq!(chord.name, "xyz");
     }
 
+    // -- DirectiveKind ------------------------------------------------------
+
+    #[test]
+    fn directive_kind_from_name_metadata() {
+        assert_eq!(DirectiveKind::from_name("title"), DirectiveKind::Title);
+        assert_eq!(DirectiveKind::from_name("t"), DirectiveKind::Title);
+        assert_eq!(DirectiveKind::from_name("TITLE"), DirectiveKind::Title);
+        assert_eq!(DirectiveKind::from_name("Title"), DirectiveKind::Title);
+        assert_eq!(
+            DirectiveKind::from_name("subtitle"),
+            DirectiveKind::Subtitle
+        );
+        assert_eq!(DirectiveKind::from_name("st"), DirectiveKind::Subtitle);
+        assert_eq!(DirectiveKind::from_name("artist"), DirectiveKind::Artist);
+        assert_eq!(
+            DirectiveKind::from_name("composer"),
+            DirectiveKind::Composer
+        );
+        assert_eq!(
+            DirectiveKind::from_name("lyricist"),
+            DirectiveKind::Lyricist
+        );
+        assert_eq!(DirectiveKind::from_name("album"), DirectiveKind::Album);
+        assert_eq!(DirectiveKind::from_name("year"), DirectiveKind::Year);
+        assert_eq!(DirectiveKind::from_name("key"), DirectiveKind::Key);
+        assert_eq!(DirectiveKind::from_name("tempo"), DirectiveKind::Tempo);
+        assert_eq!(DirectiveKind::from_name("time"), DirectiveKind::Time);
+        assert_eq!(DirectiveKind::from_name("capo"), DirectiveKind::Capo);
+    }
+
+    #[test]
+    fn directive_kind_from_name_comment() {
+        assert_eq!(DirectiveKind::from_name("comment"), DirectiveKind::Comment);
+        assert_eq!(DirectiveKind::from_name("c"), DirectiveKind::Comment);
+        assert_eq!(
+            DirectiveKind::from_name("comment_italic"),
+            DirectiveKind::CommentItalic
+        );
+        assert_eq!(DirectiveKind::from_name("ci"), DirectiveKind::CommentItalic);
+        assert_eq!(
+            DirectiveKind::from_name("comment_box"),
+            DirectiveKind::CommentBox
+        );
+        assert_eq!(DirectiveKind::from_name("cb"), DirectiveKind::CommentBox);
+    }
+
+    #[test]
+    fn directive_kind_from_name_environment() {
+        assert_eq!(
+            DirectiveKind::from_name("start_of_chorus"),
+            DirectiveKind::StartOfChorus
+        );
+        assert_eq!(
+            DirectiveKind::from_name("soc"),
+            DirectiveKind::StartOfChorus
+        );
+        assert_eq!(
+            DirectiveKind::from_name("end_of_chorus"),
+            DirectiveKind::EndOfChorus
+        );
+        assert_eq!(DirectiveKind::from_name("eoc"), DirectiveKind::EndOfChorus);
+        assert_eq!(
+            DirectiveKind::from_name("start_of_verse"),
+            DirectiveKind::StartOfVerse
+        );
+        assert_eq!(DirectiveKind::from_name("sov"), DirectiveKind::StartOfVerse);
+        assert_eq!(
+            DirectiveKind::from_name("end_of_verse"),
+            DirectiveKind::EndOfVerse
+        );
+        assert_eq!(DirectiveKind::from_name("eov"), DirectiveKind::EndOfVerse);
+        assert_eq!(
+            DirectiveKind::from_name("start_of_bridge"),
+            DirectiveKind::StartOfBridge
+        );
+        assert_eq!(
+            DirectiveKind::from_name("sob"),
+            DirectiveKind::StartOfBridge
+        );
+        assert_eq!(
+            DirectiveKind::from_name("end_of_bridge"),
+            DirectiveKind::EndOfBridge
+        );
+        assert_eq!(DirectiveKind::from_name("eob"), DirectiveKind::EndOfBridge);
+        assert_eq!(
+            DirectiveKind::from_name("start_of_tab"),
+            DirectiveKind::StartOfTab
+        );
+        assert_eq!(DirectiveKind::from_name("sot"), DirectiveKind::StartOfTab);
+        assert_eq!(
+            DirectiveKind::from_name("end_of_tab"),
+            DirectiveKind::EndOfTab
+        );
+        assert_eq!(DirectiveKind::from_name("eot"), DirectiveKind::EndOfTab);
+    }
+
+    #[test]
+    fn directive_kind_from_name_unknown() {
+        let kind = DirectiveKind::from_name("custom_thing");
+        assert_eq!(kind, DirectiveKind::Unknown("custom_thing".to_string()));
+    }
+
+    #[test]
+    fn directive_kind_case_insensitive() {
+        assert_eq!(DirectiveKind::from_name("TITLE"), DirectiveKind::Title);
+        assert_eq!(DirectiveKind::from_name("Title"), DirectiveKind::Title);
+        assert_eq!(
+            DirectiveKind::from_name("START_OF_CHORUS"),
+            DirectiveKind::StartOfChorus
+        );
+        assert_eq!(
+            DirectiveKind::from_name("Comment_Italic"),
+            DirectiveKind::CommentItalic
+        );
+    }
+
+    #[test]
+    fn directive_kind_canonical_name() {
+        assert_eq!(DirectiveKind::Title.canonical_name(), "title");
+        assert_eq!(
+            DirectiveKind::StartOfChorus.canonical_name(),
+            "start_of_chorus"
+        );
+        assert_eq!(DirectiveKind::Comment.canonical_name(), "comment");
+        assert_eq!(
+            DirectiveKind::Unknown("foo".to_string()).canonical_name(),
+            "foo"
+        );
+    }
+
+    #[test]
+    fn directive_kind_category_checks() {
+        assert!(DirectiveKind::Title.is_metadata());
+        assert!(!DirectiveKind::Title.is_comment());
+        assert!(!DirectiveKind::Title.is_environment());
+
+        assert!(DirectiveKind::Comment.is_comment());
+        assert!(!DirectiveKind::Comment.is_metadata());
+
+        assert!(DirectiveKind::StartOfChorus.is_section_start());
+        assert!(DirectiveKind::StartOfChorus.is_environment());
+        assert!(!DirectiveKind::StartOfChorus.is_section_end());
+
+        assert!(DirectiveKind::EndOfChorus.is_section_end());
+        assert!(DirectiveKind::EndOfChorus.is_environment());
+        assert!(!DirectiveKind::EndOfChorus.is_section_start());
+
+        let unknown = DirectiveKind::Unknown("x".to_string());
+        assert!(!unknown.is_metadata());
+        assert!(!unknown.is_comment());
+        assert!(!unknown.is_environment());
+    }
+
     // -- Directive ----------------------------------------------------------
 
     #[test]
@@ -539,6 +949,7 @@ mod tests {
         let d = Directive::with_value("title", "My Song");
         assert_eq!(d.name, "title");
         assert_eq!(d.value.as_deref(), Some("My Song"));
+        assert_eq!(d.kind, DirectiveKind::Title);
     }
 
     #[test]
@@ -546,6 +957,40 @@ mod tests {
         let d = Directive::name_only("start_of_chorus");
         assert_eq!(d.name, "start_of_chorus");
         assert!(d.value.is_none());
+        assert_eq!(d.kind, DirectiveKind::StartOfChorus);
+    }
+
+    #[test]
+    fn directive_short_alias_resolution() {
+        let d = Directive::with_value("t", "My Song");
+        assert_eq!(d.name, "title");
+        assert_eq!(d.kind, DirectiveKind::Title);
+
+        let d = Directive::name_only("soc");
+        assert_eq!(d.name, "start_of_chorus");
+        assert_eq!(d.kind, DirectiveKind::StartOfChorus);
+
+        let d = Directive::with_value("st", "Alternate Title");
+        assert_eq!(d.name, "subtitle");
+        assert_eq!(d.kind, DirectiveKind::Subtitle);
+    }
+
+    #[test]
+    fn directive_case_insensitive_resolution() {
+        let d = Directive::with_value("TITLE", "My Song");
+        assert_eq!(d.name, "title");
+        assert_eq!(d.kind, DirectiveKind::Title);
+
+        let d = Directive::name_only("SOC");
+        assert_eq!(d.name, "start_of_chorus");
+        assert_eq!(d.kind, DirectiveKind::StartOfChorus);
+    }
+
+    #[test]
+    fn directive_unknown_preserves_name() {
+        let d = Directive::with_value("my_custom", "value");
+        assert_eq!(d.name, "my_custom");
+        assert_eq!(d.kind, DirectiveKind::Unknown("my_custom".to_string()));
     }
 
     #[test]
@@ -575,19 +1020,43 @@ mod tests {
         assert_eq!(eob.section_name(), Some("bridge"));
     }
 
+    #[test]
+    fn directive_section_detection_via_short_alias() {
+        let soc = Directive::name_only("soc");
+        assert!(soc.is_section_start());
+        assert_eq!(soc.section_name(), Some("chorus"));
+
+        let eot = Directive::name_only("eot");
+        assert!(eot.is_section_end());
+        assert_eq!(eot.section_name(), Some("tab"));
+    }
+
+    // -- CommentStyle -------------------------------------------------------
+
+    #[test]
+    fn comment_style_variants() {
+        let normal = Line::Comment(CommentStyle::Normal, "text".to_string());
+        let italic = Line::Comment(CommentStyle::Italic, "text".to_string());
+        let boxed = Line::Comment(CommentStyle::Boxed, "text".to_string());
+
+        assert!(matches!(normal, Line::Comment(CommentStyle::Normal, _)));
+        assert!(matches!(italic, Line::Comment(CommentStyle::Italic, _)));
+        assert!(matches!(boxed, Line::Comment(CommentStyle::Boxed, _)));
+    }
+
     // -- Line enum ----------------------------------------------------------
 
     #[test]
     fn line_enum_variants() {
         let lyrics = Line::Lyrics(LyricsLine::new());
         let directive = Line::Directive(Directive::name_only("soc"));
-        let comment = Line::Comment("test".to_string());
+        let comment = Line::Comment(CommentStyle::Normal, "test".to_string());
         let empty = Line::Empty;
 
         // Ensure they are all distinct variants via pattern matching
         assert!(matches!(lyrics, Line::Lyrics(_)));
         assert!(matches!(directive, Line::Directive(_)));
-        assert!(matches!(comment, Line::Comment(_)));
+        assert!(matches!(comment, Line::Comment(..)));
         assert!(matches!(empty, Line::Empty));
     }
 

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -3,7 +3,15 @@
 //! The parser accepts the flat token sequence produced by [`crate::Lexer`] and
 //! builds a [`Song`] AST. Each source line is classified as a directive, a
 //! lyrics line (with optional inline chord annotations), an empty line, or a
-//! comment (the `{comment: ...}` directive).
+//! comment (from `{comment}`, `{comment_italic}`, or `{comment_box}`
+//! directives).
+//!
+//! # Directive Classification
+//!
+//! Directives are classified into typed variants via [`DirectiveKind`]. The
+//! parser resolves short aliases (e.g., `t` → `title`, `soc` →
+//! `start_of_chorus`) and normalizes names to their canonical lowercase form.
+//! Metadata directives automatically populate the [`Song::metadata`] fields.
 //!
 //! # Convenience Function
 //!
@@ -13,6 +21,7 @@
 //! use chordpro_core::parser::parse;
 //!
 //! let song = parse("{title: Hello}\n[Am]World").unwrap();
+//! assert_eq!(song.metadata.title.as_deref(), Some("Hello"));
 //! assert_eq!(song.lines.len(), 2);
 //! ```
 //!
@@ -22,7 +31,9 @@
 //! problems such as unclosed directives, unclosed chords, or empty directives.
 
 use crate::Lexer;
-use crate::ast::{Chord, Directive, Line, LyricsLine, LyricsSegment, Song};
+use crate::ast::{
+    Chord, CommentStyle, Directive, DirectiveKind, Line, LyricsLine, LyricsSegment, Song,
+};
 use crate::token::{Span, Token, TokenKind};
 
 // ---------------------------------------------------------------------------
@@ -86,6 +97,10 @@ impl Parser {
 
     /// Parses the token stream and returns a [`Song`] AST.
     ///
+    /// Metadata directives (`{title}`, `{artist}`, etc.) automatically
+    /// populate [`Song::metadata`]. Comment directives are converted to
+    /// [`Line::Comment`] with the appropriate [`CommentStyle`].
+    ///
     /// Returns a [`ParseError`] if the token stream contains structural
     /// problems (e.g., unclosed directives or chords).
     pub fn parse(mut self) -> Result<Song, ParseError> {
@@ -93,10 +108,64 @@ impl Parser {
 
         while !self.is_at_end() {
             let line = self.parse_line()?;
+
+            // If this is a metadata directive, populate the Song's metadata.
+            if let Line::Directive(ref directive) = line {
+                Self::populate_metadata(&mut song.metadata, directive);
+            }
+
             song.lines.push(line);
         }
 
         Ok(song)
+    }
+
+    // -- Metadata population ------------------------------------------------
+
+    /// Populates metadata fields from a directive, if it is a known metadata
+    /// directive with a value.
+    fn populate_metadata(metadata: &mut crate::ast::Metadata, directive: &Directive) {
+        let value = match directive.value.as_deref() {
+            Some(v) => v.to_string(),
+            None => return, // Metadata directives without values are no-ops.
+        };
+
+        match directive.kind {
+            DirectiveKind::Title => {
+                metadata.title = Some(value);
+            }
+            DirectiveKind::Subtitle => {
+                metadata.subtitles.push(value);
+            }
+            DirectiveKind::Artist => {
+                metadata.artists.push(value);
+            }
+            DirectiveKind::Composer => {
+                metadata.composers.push(value);
+            }
+            DirectiveKind::Lyricist => {
+                metadata.lyricists.push(value);
+            }
+            DirectiveKind::Album => {
+                metadata.album = Some(value);
+            }
+            DirectiveKind::Year => {
+                metadata.year = Some(value);
+            }
+            DirectiveKind::Key => {
+                metadata.key = Some(value);
+            }
+            DirectiveKind::Tempo => {
+                metadata.tempo = Some(value);
+            }
+            DirectiveKind::Time => {
+                metadata.time = Some(value);
+            }
+            DirectiveKind::Capo => {
+                metadata.capo = Some(value);
+            }
+            _ => {}
+        }
     }
 
     // -- Token navigation ---------------------------------------------------
@@ -150,7 +219,8 @@ impl Parser {
     /// Parses a directive line: `{name}` or `{name: value}`.
     ///
     /// After parsing the directive itself, consumes the trailing Newline (or
-    /// verifies Eof).
+    /// verifies Eof). Comment directives (`comment`, `comment_italic`,
+    /// `comment_box`) are converted to [`Line::Comment`].
     fn parse_directive_line(&mut self) -> Result<Line, ParseError> {
         let open_span = self.peek().span;
         self.advance(); // consume DirectiveOpen
@@ -182,15 +252,27 @@ impl Parser {
         let name = name.trim().to_string();
         let value = value.map(|v| v.trim().to_string());
 
-        // Check for the special `comment` / `c` directive -> Line::Comment.
-        if name == "comment" || name == "c" {
+        // Classify the directive.
+        let kind = DirectiveKind::from_name(&name);
+
+        // Comment directives → Line::Comment with appropriate style.
+        if kind.is_comment() {
+            let style = match kind {
+                DirectiveKind::Comment => CommentStyle::Normal,
+                DirectiveKind::CommentItalic => CommentStyle::Italic,
+                DirectiveKind::CommentBox => CommentStyle::Boxed,
+                _ => unreachable!(),
+            };
             let text = value.unwrap_or_default();
-            return Ok(Line::Comment(text));
+            return Ok(Line::Comment(style, text));
         }
 
-        let directive = match value {
-            Some(v) => Directive::with_value(name, v),
-            None => Directive::name_only(name),
+        // Build the directive with canonical name and kind.
+        let canonical = kind.canonical_name().to_string();
+        let directive = Directive {
+            name: canonical,
+            value,
+            kind,
         };
 
         Ok(Line::Directive(directive))
@@ -394,6 +476,7 @@ impl Parser {
 /// Parses a ChordPro source string into a [`Song`] AST.
 ///
 /// This is a convenience function that runs the lexer and parser in sequence.
+/// Metadata directives populate [`Song::metadata`] automatically.
 ///
 /// # Errors
 ///
@@ -405,6 +488,7 @@ impl Parser {
 /// use chordpro_core::parser::parse;
 ///
 /// let song = parse("{title: Hello World}\n[Am]La la la").unwrap();
+/// assert_eq!(song.metadata.title.as_deref(), Some("Hello World"));
 /// assert_eq!(song.lines.len(), 2);
 /// ```
 pub fn parse(input: &str) -> Result<Song, ParseError> {
@@ -419,7 +503,9 @@ pub fn parse(input: &str) -> Result<Song, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{Chord, Directive, Line, LyricsLine, LyricsSegment};
+    use crate::ast::{
+        Chord, CommentStyle, Directive, DirectiveKind, Line, LyricsLine, LyricsSegment,
+    };
 
     // -- Helper -------------------------------------------------------------
 
@@ -617,7 +703,13 @@ mod tests {
         // The lexer emits multiple Colon tokens; the parser joins extra colons.
         let result = lines("{comment: time 10:30}");
         // This is the `comment` directive, so it becomes Line::Comment.
-        assert_eq!(result, vec![Line::Comment("time 10:30".to_string())]);
+        assert_eq!(
+            result,
+            vec![Line::Comment(
+                CommentStyle::Normal,
+                "time 10:30".to_string()
+            )]
+        );
     }
 
     #[test]
@@ -639,19 +731,329 @@ mod tests {
     #[test]
     fn comment_directive_full_name() {
         let result = lines("{comment: This is a comment}");
-        assert_eq!(result, vec![Line::Comment("This is a comment".to_string())],);
+        assert_eq!(
+            result,
+            vec![Line::Comment(
+                CommentStyle::Normal,
+                "This is a comment".to_string()
+            )],
+        );
     }
 
     #[test]
     fn comment_directive_short_name() {
         let result = lines("{c: Short comment}");
-        assert_eq!(result, vec![Line::Comment("Short comment".to_string())],);
+        assert_eq!(
+            result,
+            vec![Line::Comment(
+                CommentStyle::Normal,
+                "Short comment".to_string()
+            )],
+        );
     }
 
     #[test]
     fn comment_directive_no_value() {
         let result = lines("{comment}");
-        assert_eq!(result, vec![Line::Comment(String::new())]);
+        assert_eq!(
+            result,
+            vec![Line::Comment(CommentStyle::Normal, String::new())]
+        );
+    }
+
+    #[test]
+    fn comment_italic_directive() {
+        let result = lines("{comment_italic: Softly}");
+        assert_eq!(
+            result,
+            vec![Line::Comment(CommentStyle::Italic, "Softly".to_string())],
+        );
+    }
+
+    #[test]
+    fn comment_italic_short_name() {
+        let result = lines("{ci: Softly}");
+        assert_eq!(
+            result,
+            vec![Line::Comment(CommentStyle::Italic, "Softly".to_string())],
+        );
+    }
+
+    #[test]
+    fn comment_box_directive() {
+        let result = lines("{comment_box: Important}");
+        assert_eq!(
+            result,
+            vec![Line::Comment(CommentStyle::Boxed, "Important".to_string())],
+        );
+    }
+
+    #[test]
+    fn comment_box_short_name() {
+        let result = lines("{cb: Important}");
+        assert_eq!(
+            result,
+            vec![Line::Comment(CommentStyle::Boxed, "Important".to_string())],
+        );
+    }
+
+    // -- Directive classification -------------------------------------------
+
+    #[test]
+    fn directive_short_alias_title() {
+        let result = lines("{t: My Song}");
+        let expected = Directive::with_value("title", "My Song");
+        assert_eq!(result, vec![Line::Directive(expected)]);
+    }
+
+    #[test]
+    fn directive_short_alias_subtitle() {
+        let result = lines("{st: Alternate}");
+        let expected = Directive::with_value("subtitle", "Alternate");
+        assert_eq!(result, vec![Line::Directive(expected)]);
+    }
+
+    #[test]
+    fn directive_short_alias_soc() {
+        let result = lines("{soc}");
+        let expected = Directive::name_only("start_of_chorus");
+        assert_eq!(result, vec![Line::Directive(expected)]);
+    }
+
+    #[test]
+    fn directive_short_alias_eoc() {
+        let result = lines("{eoc}");
+        let expected = Directive::name_only("end_of_chorus");
+        assert_eq!(result, vec![Line::Directive(expected)]);
+    }
+
+    #[test]
+    fn directive_case_insensitive() {
+        let result = lines("{TITLE: Upper}");
+        let expected = Directive::with_value("title", "Upper");
+        assert_eq!(result, vec![Line::Directive(expected)]);
+    }
+
+    #[test]
+    fn directive_mixed_case() {
+        let result = lines("{Start_Of_Chorus}");
+        let expected = Directive::name_only("start_of_chorus");
+        assert_eq!(result, vec![Line::Directive(expected)]);
+    }
+
+    #[test]
+    fn directive_unknown_preserved() {
+        let result = lines("{my_custom: value}");
+        assert_eq!(
+            result,
+            vec![Line::Directive(Directive {
+                name: "my_custom".to_string(),
+                value: Some("value".to_string()),
+                kind: DirectiveKind::Unknown("my_custom".to_string()),
+            })],
+        );
+    }
+
+    #[test]
+    fn directive_kind_on_parsed_directive() {
+        let song = parse("{title: Test}").unwrap();
+        if let Line::Directive(ref d) = song.lines[0] {
+            assert_eq!(d.kind, DirectiveKind::Title);
+            assert_eq!(d.name, "title");
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    // -- Environment directives (all variants) ------------------------------
+
+    #[test]
+    fn environment_directives_long_form() {
+        let cases = vec![
+            (
+                "{start_of_chorus}",
+                "start_of_chorus",
+                DirectiveKind::StartOfChorus,
+            ),
+            (
+                "{end_of_chorus}",
+                "end_of_chorus",
+                DirectiveKind::EndOfChorus,
+            ),
+            (
+                "{start_of_verse}",
+                "start_of_verse",
+                DirectiveKind::StartOfVerse,
+            ),
+            ("{end_of_verse}", "end_of_verse", DirectiveKind::EndOfVerse),
+            (
+                "{start_of_bridge}",
+                "start_of_bridge",
+                DirectiveKind::StartOfBridge,
+            ),
+            (
+                "{end_of_bridge}",
+                "end_of_bridge",
+                DirectiveKind::EndOfBridge,
+            ),
+            ("{start_of_tab}", "start_of_tab", DirectiveKind::StartOfTab),
+            ("{end_of_tab}", "end_of_tab", DirectiveKind::EndOfTab),
+        ];
+
+        for (input, expected_name, expected_kind) in cases {
+            let result = lines(input);
+            if let Line::Directive(ref d) = result[0] {
+                assert_eq!(d.name, expected_name, "failed for input: {input}");
+                assert_eq!(d.kind, expected_kind, "failed for input: {input}");
+            } else {
+                panic!("expected directive for input: {input}");
+            }
+        }
+    }
+
+    #[test]
+    fn environment_directives_short_form() {
+        let cases = vec![
+            ("{soc}", "start_of_chorus", DirectiveKind::StartOfChorus),
+            ("{eoc}", "end_of_chorus", DirectiveKind::EndOfChorus),
+            ("{sov}", "start_of_verse", DirectiveKind::StartOfVerse),
+            ("{eov}", "end_of_verse", DirectiveKind::EndOfVerse),
+            ("{sob}", "start_of_bridge", DirectiveKind::StartOfBridge),
+            ("{eob}", "end_of_bridge", DirectiveKind::EndOfBridge),
+            ("{sot}", "start_of_tab", DirectiveKind::StartOfTab),
+            ("{eot}", "end_of_tab", DirectiveKind::EndOfTab),
+        ];
+
+        for (input, expected_name, expected_kind) in cases {
+            let result = lines(input);
+            if let Line::Directive(ref d) = result[0] {
+                assert_eq!(d.name, expected_name, "failed for input: {input}");
+                assert_eq!(d.kind, expected_kind, "failed for input: {input}");
+            } else {
+                panic!("expected directive for input: {input}");
+            }
+        }
+    }
+
+    // -- Metadata population ------------------------------------------------
+
+    #[test]
+    fn metadata_title_populated() {
+        let song = parse("{title: Amazing Grace}").unwrap();
+        assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
+    }
+
+    #[test]
+    fn metadata_title_via_short_alias() {
+        let song = parse("{t: Amazing Grace}").unwrap();
+        assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
+    }
+
+    #[test]
+    fn metadata_subtitle_populated() {
+        let song = parse("{subtitle: How sweet}\n{st: The sound}").unwrap();
+        assert_eq!(song.metadata.subtitles, vec!["How sweet", "The sound"]);
+    }
+
+    #[test]
+    fn metadata_artist_populated() {
+        let song = parse("{artist: John Newton}").unwrap();
+        assert_eq!(song.metadata.artists, vec!["John Newton"]);
+    }
+
+    #[test]
+    fn metadata_multiple_artists() {
+        let song = parse("{artist: John}\n{artist: Jane}").unwrap();
+        assert_eq!(song.metadata.artists, vec!["John", "Jane"]);
+    }
+
+    #[test]
+    fn metadata_composer_populated() {
+        let song = parse("{composer: Bach}").unwrap();
+        assert_eq!(song.metadata.composers, vec!["Bach"]);
+    }
+
+    #[test]
+    fn metadata_lyricist_populated() {
+        let song = parse("{lyricist: Someone}").unwrap();
+        assert_eq!(song.metadata.lyricists, vec!["Someone"]);
+    }
+
+    #[test]
+    fn metadata_album_populated() {
+        let song = parse("{album: Greatest Hits}").unwrap();
+        assert_eq!(song.metadata.album.as_deref(), Some("Greatest Hits"));
+    }
+
+    #[test]
+    fn metadata_year_populated() {
+        let song = parse("{year: 1779}").unwrap();
+        assert_eq!(song.metadata.year.as_deref(), Some("1779"));
+    }
+
+    #[test]
+    fn metadata_key_populated() {
+        let song = parse("{key: G}").unwrap();
+        assert_eq!(song.metadata.key.as_deref(), Some("G"));
+    }
+
+    #[test]
+    fn metadata_tempo_populated() {
+        let song = parse("{tempo: 120}").unwrap();
+        assert_eq!(song.metadata.tempo.as_deref(), Some("120"));
+    }
+
+    #[test]
+    fn metadata_time_populated() {
+        let song = parse("{time: 3/4}").unwrap();
+        assert_eq!(song.metadata.time.as_deref(), Some("3/4"));
+    }
+
+    #[test]
+    fn metadata_capo_populated() {
+        let song = parse("{capo: 2}").unwrap();
+        assert_eq!(song.metadata.capo.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn metadata_case_insensitive() {
+        let song = parse("{TITLE: Upper Case}").unwrap();
+        assert_eq!(song.metadata.title.as_deref(), Some("Upper Case"));
+    }
+
+    #[test]
+    fn metadata_not_populated_without_value() {
+        let song = parse("{title}").unwrap();
+        assert_eq!(song.metadata.title, None);
+    }
+
+    #[test]
+    fn metadata_all_fields_populated() {
+        let input = "\
+{title: My Song}
+{subtitle: A Sub}
+{artist: An Artist}
+{composer: A Composer}
+{lyricist: A Lyricist}
+{album: An Album}
+{year: 2024}
+{key: Am}
+{tempo: 100}
+{time: 4/4}
+{capo: 3}";
+
+        let song = parse(input).unwrap();
+        assert_eq!(song.metadata.title.as_deref(), Some("My Song"));
+        assert_eq!(song.metadata.subtitles, vec!["A Sub"]);
+        assert_eq!(song.metadata.artists, vec!["An Artist"]);
+        assert_eq!(song.metadata.composers, vec!["A Composer"]);
+        assert_eq!(song.metadata.lyricists, vec!["A Lyricist"]);
+        assert_eq!(song.metadata.album.as_deref(), Some("An Album"));
+        assert_eq!(song.metadata.year.as_deref(), Some("2024"));
+        assert_eq!(song.metadata.key.as_deref(), Some("Am"));
+        assert_eq!(song.metadata.tempo.as_deref(), Some("100"));
+        assert_eq!(song.metadata.time.as_deref(), Some("4/4"));
+        assert_eq!(song.metadata.capo.as_deref(), Some("3"));
     }
 
     // -- Error cases --------------------------------------------------------
@@ -728,6 +1130,10 @@ mod tests {
         let song = parse(input).unwrap();
         assert_eq!(song.lines.len(), 5);
 
+        // Metadata populated
+        assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
+        assert_eq!(song.metadata.artists, vec!["John Newton"]);
+
         // First line: title directive
         assert_eq!(
             song.lines[0],
@@ -798,7 +1204,10 @@ mod tests {
             song.lines[0],
             Line::Directive(Directive::with_value("title", "Test"))
         );
-        assert_eq!(song.lines[1], Line::Comment("Intro".to_string()));
+        assert_eq!(
+            song.lines[1],
+            Line::Comment(CommentStyle::Normal, "Intro".to_string())
+        );
         assert_eq!(song.lines[2], Line::Empty);
         assert!(matches!(song.lines[3], Line::Lyrics(_)));
     }
@@ -854,22 +1263,16 @@ mod tests {
     }
 
     #[test]
-    fn metadata_not_populated_by_parser() {
-        // The parser does not populate metadata — that is a separate concern.
-        let song = parse("{title: Test}").unwrap();
-        assert_eq!(song.metadata.title, None);
-    }
-
-    #[test]
     fn multiple_colons_in_directive_value() {
         // Extra colons after the first are treated as part of the value.
         let result = lines("{meta: key:value:extra}");
         assert_eq!(
             result,
-            vec![Line::Directive(Directive::with_value(
-                "meta",
-                "key:value:extra"
-            ))],
+            vec![Line::Directive(Directive {
+                name: "meta".to_string(),
+                value: Some("key:value:extra".to_string()),
+                kind: DirectiveKind::Unknown("meta".to_string()),
+            })],
         );
     }
 
@@ -887,7 +1290,13 @@ mod tests {
     fn directive_with_brackets_in_value() {
         // Brackets inside a directive value are included literally.
         let result = lines("{comment: play [Am] here}");
-        assert_eq!(result, vec![Line::Comment("play [Am] here".to_string())],);
+        assert_eq!(
+            result,
+            vec![Line::Comment(
+                CommentStyle::Normal,
+                "play [Am] here".to_string()
+            )],
+        );
     }
 
     #[test]
@@ -922,5 +1331,73 @@ mod tests {
         let tokens = Lexer::new("[C]Hello").tokenize();
         let song = Parser::new(tokens).parse().unwrap();
         assert_eq!(song.lines.len(), 1);
+    }
+
+    // -- Full song with all directive types ---------------------------------
+
+    #[test]
+    fn full_song_with_all_directive_types() {
+        let input = "\
+{t: Amazing Grace}
+{st: A Hymn}
+{artist: John Newton}
+{key: G}
+{tempo: 80}
+{time: 3/4}
+{capo: 2}
+{comment: Verse 1}
+{ci: Play softly}
+{cb: Key change ahead}
+{soc}
+[G]Amazing [G7]grace
+{eoc}";
+
+        let song = parse(input).unwrap();
+
+        // Metadata checks
+        assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
+        assert_eq!(song.metadata.subtitles, vec!["A Hymn"]);
+        assert_eq!(song.metadata.artists, vec!["John Newton"]);
+        assert_eq!(song.metadata.key.as_deref(), Some("G"));
+        assert_eq!(song.metadata.tempo.as_deref(), Some("80"));
+        assert_eq!(song.metadata.time.as_deref(), Some("3/4"));
+        assert_eq!(song.metadata.capo.as_deref(), Some("2"));
+
+        // Line type checks
+        assert_eq!(song.lines.len(), 13);
+        assert!(matches!(song.lines[0], Line::Directive(_))); // title
+        assert!(matches!(song.lines[1], Line::Directive(_))); // subtitle
+        assert!(matches!(song.lines[2], Line::Directive(_))); // artist
+        assert!(matches!(song.lines[3], Line::Directive(_))); // key
+        assert!(matches!(song.lines[4], Line::Directive(_))); // tempo
+        assert!(matches!(song.lines[5], Line::Directive(_))); // time
+        assert!(matches!(song.lines[6], Line::Directive(_))); // capo
+        assert_eq!(
+            song.lines[7],
+            Line::Comment(CommentStyle::Normal, "Verse 1".to_string())
+        );
+        assert_eq!(
+            song.lines[8],
+            Line::Comment(CommentStyle::Italic, "Play softly".to_string())
+        );
+        assert_eq!(
+            song.lines[9],
+            Line::Comment(CommentStyle::Boxed, "Key change ahead".to_string())
+        );
+        // soc
+        if let Line::Directive(ref d) = song.lines[10] {
+            assert_eq!(d.kind, DirectiveKind::StartOfChorus);
+            assert_eq!(d.name, "start_of_chorus");
+        } else {
+            panic!("expected directive");
+        }
+        assert!(matches!(song.lines[11], Line::Lyrics(_))); // lyrics
+        // eoc
+        if let Line::Directive(ref d) = song.lines[12] {
+            assert_eq!(d.kind, DirectiveKind::EndOfChorus);
+            assert_eq!(d.name, "end_of_chorus");
+        } else {
+            panic!("expected directive");
+        }
     }
 }

--- a/crates/core/tests/fixtures/short_aliases.cho
+++ b/crates/core/tests/fixtures/short_aliases.cho
@@ -1,0 +1,17 @@
+{t: Short Title}
+{st: Short Subtitle}
+{c: A comment}
+{ci: Italic comment}
+{cb: Boxed comment}
+{soc}
+[Am]Hello [G]world
+{eoc}
+{sov}
+[C]Verse text
+{eov}
+{sob}
+[Dm]Bridge text
+{eob}
+{sot}
+e|---0---|
+{eot}

--- a/crates/core/tests/fixtures/standard_directives.cho
+++ b/crates/core/tests/fixtures/standard_directives.cho
@@ -1,0 +1,23 @@
+{title: Amazing Grace}
+{subtitle: A Hymn}
+{artist: John Newton}
+{composer: Unknown}
+{lyricist: John Newton}
+{album: Hymns}
+{year: 1779}
+{key: G}
+{tempo: 80}
+{time: 3/4}
+{capo: 2}
+{comment: Verse 1}
+{comment_italic: Play softly}
+{comment_box: Key change ahead}
+
+{start_of_verse}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound
+[G]That saved a [Em]wretch like [D]me
+{end_of_verse}
+
+{start_of_chorus}
+[G]I once was [G7]lost, but [C]now am [G]found
+{end_of_chorus}

--- a/crates/core/tests/golden_directives.rs
+++ b/crates/core/tests/golden_directives.rs
@@ -1,0 +1,206 @@
+//! Golden tests for standard directive parsing.
+//!
+//! These tests parse `.cho` fixture files and verify that the parser correctly
+//! classifies directives, populates metadata, and handles short aliases.
+
+use chordpro_core::ast::{CommentStyle, DirectiveKind, Line};
+use chordpro_core::parser::parse;
+
+/// Reads a fixture file relative to the fixtures directory.
+fn fixture(name: &str) -> String {
+    let path = format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"))
+}
+
+#[test]
+fn standard_directives_golden_test() {
+    let input = fixture("standard_directives.cho");
+    let song = parse(&input).expect("parse failed");
+
+    // -- Metadata -----------------------------------------------------------
+    assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
+    assert_eq!(song.metadata.subtitles, vec!["A Hymn"]);
+    assert_eq!(song.metadata.artists, vec!["John Newton"]);
+    assert_eq!(song.metadata.composers, vec!["Unknown"]);
+    assert_eq!(song.metadata.lyricists, vec!["John Newton"]);
+    assert_eq!(song.metadata.album.as_deref(), Some("Hymns"));
+    assert_eq!(song.metadata.year.as_deref(), Some("1779"));
+    assert_eq!(song.metadata.key.as_deref(), Some("G"));
+    assert_eq!(song.metadata.tempo.as_deref(), Some("80"));
+    assert_eq!(song.metadata.time.as_deref(), Some("3/4"));
+    assert_eq!(song.metadata.capo.as_deref(), Some("2"));
+
+    // -- Directive classification -------------------------------------------
+    // Lines 0-10: metadata directives
+    for i in 0..=10 {
+        assert!(
+            matches!(song.lines[i], Line::Directive(_)),
+            "line {i} should be a directive, got: {:?}",
+            song.lines[i]
+        );
+    }
+
+    // Check the directive kinds for first few
+    if let Line::Directive(ref d) = song.lines[0] {
+        assert_eq!(d.kind, DirectiveKind::Title);
+        assert_eq!(d.name, "title");
+    }
+    if let Line::Directive(ref d) = song.lines[1] {
+        assert_eq!(d.kind, DirectiveKind::Subtitle);
+    }
+    if let Line::Directive(ref d) = song.lines[2] {
+        assert_eq!(d.kind, DirectiveKind::Artist);
+    }
+
+    // Lines 11-13: comment directives
+    assert_eq!(
+        song.lines[11],
+        Line::Comment(CommentStyle::Normal, "Verse 1".to_string())
+    );
+    assert_eq!(
+        song.lines[12],
+        Line::Comment(CommentStyle::Italic, "Play softly".to_string())
+    );
+    assert_eq!(
+        song.lines[13],
+        Line::Comment(CommentStyle::Boxed, "Key change ahead".to_string())
+    );
+
+    // Line 14: empty
+    assert_eq!(song.lines[14], Line::Empty);
+
+    // Line 15: start_of_verse
+    if let Line::Directive(ref d) = song.lines[15] {
+        assert_eq!(d.kind, DirectiveKind::StartOfVerse);
+        assert_eq!(d.name, "start_of_verse");
+        assert!(d.is_section_start());
+        assert_eq!(d.section_name(), Some("verse"));
+    } else {
+        panic!("expected start_of_verse directive");
+    }
+
+    // Line 18: end_of_verse
+    if let Line::Directive(ref d) = song.lines[18] {
+        assert_eq!(d.kind, DirectiveKind::EndOfVerse);
+        assert!(d.is_section_end());
+    } else {
+        panic!("expected end_of_verse directive");
+    }
+
+    // Line 20: start_of_chorus
+    if let Line::Directive(ref d) = song.lines[20] {
+        assert_eq!(d.kind, DirectiveKind::StartOfChorus);
+    } else {
+        panic!("expected start_of_chorus directive");
+    }
+
+    // Line 22: end_of_chorus
+    if let Line::Directive(ref d) = song.lines[22] {
+        assert_eq!(d.kind, DirectiveKind::EndOfChorus);
+    } else {
+        panic!("expected end_of_chorus directive");
+    }
+}
+
+#[test]
+fn short_aliases_golden_test() {
+    let input = fixture("short_aliases.cho");
+    let song = parse(&input).expect("parse failed");
+
+    // Metadata via short aliases
+    assert_eq!(song.metadata.title.as_deref(), Some("Short Title"));
+    assert_eq!(song.metadata.subtitles, vec!["Short Subtitle"]);
+
+    // {t: Short Title} -> Directive with kind Title, canonical name "title"
+    if let Line::Directive(ref d) = song.lines[0] {
+        assert_eq!(d.kind, DirectiveKind::Title);
+        assert_eq!(d.name, "title");
+        assert_eq!(d.value.as_deref(), Some("Short Title"));
+    } else {
+        panic!("expected title directive");
+    }
+
+    // {st: Short Subtitle}
+    if let Line::Directive(ref d) = song.lines[1] {
+        assert_eq!(d.kind, DirectiveKind::Subtitle);
+        assert_eq!(d.name, "subtitle");
+    } else {
+        panic!("expected subtitle directive");
+    }
+
+    // {c: A comment}
+    assert_eq!(
+        song.lines[2],
+        Line::Comment(CommentStyle::Normal, "A comment".to_string())
+    );
+
+    // {ci: Italic comment}
+    assert_eq!(
+        song.lines[3],
+        Line::Comment(CommentStyle::Italic, "Italic comment".to_string())
+    );
+
+    // {cb: Boxed comment}
+    assert_eq!(
+        song.lines[4],
+        Line::Comment(CommentStyle::Boxed, "Boxed comment".to_string())
+    );
+
+    // {soc} -> start_of_chorus
+    if let Line::Directive(ref d) = song.lines[5] {
+        assert_eq!(d.kind, DirectiveKind::StartOfChorus);
+        assert_eq!(d.name, "start_of_chorus");
+    } else {
+        panic!("expected start_of_chorus directive");
+    }
+
+    // {eoc} -> end_of_chorus
+    if let Line::Directive(ref d) = song.lines[7] {
+        assert_eq!(d.kind, DirectiveKind::EndOfChorus);
+        assert_eq!(d.name, "end_of_chorus");
+    } else {
+        panic!("expected end_of_chorus directive");
+    }
+
+    // {sov} -> start_of_verse
+    if let Line::Directive(ref d) = song.lines[8] {
+        assert_eq!(d.kind, DirectiveKind::StartOfVerse);
+    } else {
+        panic!("expected start_of_verse directive");
+    }
+
+    // {eov} -> end_of_verse
+    if let Line::Directive(ref d) = song.lines[10] {
+        assert_eq!(d.kind, DirectiveKind::EndOfVerse);
+    } else {
+        panic!("expected end_of_verse directive");
+    }
+
+    // {sob} -> start_of_bridge
+    if let Line::Directive(ref d) = song.lines[11] {
+        assert_eq!(d.kind, DirectiveKind::StartOfBridge);
+    } else {
+        panic!("expected start_of_bridge directive");
+    }
+
+    // {eob} -> end_of_bridge
+    if let Line::Directive(ref d) = song.lines[13] {
+        assert_eq!(d.kind, DirectiveKind::EndOfBridge);
+    } else {
+        panic!("expected end_of_bridge directive");
+    }
+
+    // {sot} -> start_of_tab
+    if let Line::Directive(ref d) = song.lines[14] {
+        assert_eq!(d.kind, DirectiveKind::StartOfTab);
+    } else {
+        panic!("expected start_of_tab directive");
+    }
+
+    // {eot} -> end_of_tab
+    if let Line::Directive(ref d) = song.lines[16] {
+        assert_eq!(d.kind, DirectiveKind::EndOfTab);
+    } else {
+        panic!("expected end_of_tab directive");
+    }
+}


### PR DESCRIPTION
## What

Extend the ChordPro parser to classify directives into typed variants and automatically populate song metadata.

### Changes

**AST (`crates/core/src/ast.rs`)**:
- Add `DirectiveKind` enum with variants for metadata (Title, Subtitle, Artist, Composer, Lyricist, Album, Year, Key, Tempo, Time, Capo), formatting (Comment, CommentItalic, CommentBox), environment (StartOfChorus/EndOfChorus, StartOfVerse/EndOfVerse, StartOfBridge/EndOfBridge, StartOfTab/EndOfTab), and Unknown directives
- Add `kind` field to `Directive` struct; constructors now resolve aliases and normalize names automatically
- Change `Line::Comment(String)` to `Line::Comment(CommentStyle, String)` with new `CommentStyle` enum (Normal, Italic, Boxed)
- Add `time: Option<String>` field to `Metadata`
- Add category query methods on `DirectiveKind`: `is_metadata()`, `is_comment()`, `is_section_start()`, `is_section_end()`, `is_environment()`

**Parser (`crates/core/src/parser.rs`)**:
- Directive names are resolved case-insensitively per the ChordPro spec
- Short aliases recognized: `t`, `st`, `c`, `ci`, `cb`, `soc`, `eoc`, `sov`, `eov`, `sob`, `eob`, `sot`, `eot`
- Metadata directives (`{title}`, `{artist}`, etc.) now populate `Song::metadata` during parsing
- Comment directives (`{comment}`, `{comment_italic}`, `{comment_box}`) emit `Line::Comment` with appropriate `CommentStyle`

**Golden tests**:
- `crates/core/tests/fixtures/standard_directives.cho` — all standard directives with long-form names
- `crates/core/tests/fixtures/short_aliases.cho` — all short alias forms
- `crates/core/tests/golden_directives.rs` — integration tests validating classification, metadata, and alias resolution

## Why

The parser previously stored all directives as generic name/value pairs without classification. Downstream consumers (renderers, CLI) need to distinguish directive types without performing string comparisons. Metadata population during parsing is essential for song display and search.

## Test results

```
test result: ok. 135 passed; 0 failed; 0 ignored (unit tests)
test result: ok. 2 passed; 0 failed; 0 ignored (golden tests)
test result: ok. 5 passed; 0 failed; 0 ignored (doc-tests)
cargo clippy -- -D warnings: clean
cargo fmt --check: clean
```

## Review summary

- Zero external dependencies maintained for `chordpro-core`
- All public types have doc comments
- Existing `Directive::with_value` / `name_only` API preserved (extended with `kind` field)
- `Line::Comment` changed from single-field to tuple with `CommentStyle` — breaking change but no downstream crates use it yet
- Case-insensitive matching uses `to_ascii_lowercase()` (no Unicode folding needed for directive names)

Closes #22