### PR TITLE
Add phase completion gate requiring review before closing tracking issues

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -36,7 +36,22 @@
 - Individual tasks are created as **GitHub sub-issues** of the tracking issue.
 - Sub-issues follow the same rules as regular issues (imperative title, English only, Goal, Acceptance Criteria, labels).
 - Sub-issues inherit the `phase:N` label from their parent tracking issue.
-- When all sub-issues are closed, close the tracking issue.
+- A phase tracking issue may only be closed after the **Phase Completion Gate**
+  (see below).
+
+### Phase Completion Gate
+
+Before closing a phase tracking issue, perform the following review against
+`main`:
+
+1. **`/review`** — full code review of the phase's changes on `main`.
+2. **`/security-review`** — security review of the phase's changes on `main`.
+3. If either review finds issues, create new sub-issues under the phase tracking
+   issue for each finding. These sub-issues follow normal workflow (implement,
+   PR, CI, review, merge).
+4. Repeat steps 1–3 until a review pass produces **no new findings**.
+5. Only when both `/review` and `/security-review` pass with no new sub-issues
+   may the phase tracking issue be closed.
 
 ### Creating Sub-Issue Relationships
 


### PR DESCRIPTION
## What

Add a "Phase Completion Gate" section to `.claude/rules/issue-workflow.md`
that mandates `/review` and `/security-review` against `main` before a
phase tracking issue can be closed.

## Why

Previously, the rule was simply "when all sub-issues are closed, close the
tracking issue." This misses the opportunity to catch cross-cutting issues
that may only be visible when reviewing the phase's work as a whole on
`main`. Adding a review gate ensures quality and security are validated
at the phase level, not just per-PR.

## Test results

```
cargo fmt --check  # N/A (no Rust code changed)
cargo clippy       # N/A
cargo test         # N/A
```

Documentation-only change.

## Review summary

Single file change to `.claude/rules/issue-workflow.md`:
- Replaced "When all sub-issues are closed, close the tracking issue" with
  a reference to the new Phase Completion Gate
- Added new subsection documenting the 5-step gate process:
  1. `/review` against `main`
  2. `/security-review` against `main`
  3. Create sub-issues for findings
  4. Repeat until no new findings
  5. Close tracking issue only when reviews pass clean

Closes #55