### PR TITLE
Fix chord slash parsing to split on first slash

### DIFF
--- a/crates/core/src/chord.rs
+++ b/crates/core/src/chord.rs
@@ -240,7 +240,7 @@ pub fn parse_chord(input: &str) -> Option<ChordDetail> {
     let rest: String = chars.collect();
 
     // --- Split off bass note (slash chord) ---
-    let (quality_ext_str, bass_str) = if let Some(slash_pos) = rest.rfind('/') {
+    let (quality_ext_str, bass_str) = if let Some(slash_pos) = rest.find('/') {
         let (before, after) = rest.split_at(slash_pos);
         // `after` starts with '/', skip it.
         (before, Some(&after[1..]))
@@ -732,6 +732,13 @@ mod tests {
     fn slash_bass_too_long() {
         // Bass should be just a note + optional accidental.
         assert!(parse_chord("G/Bm").is_none());
+    }
+
+    #[test]
+    fn multi_slash_is_invalid() {
+        // Multiple slashes: split on first slash so bass becomes "D/E",
+        // which is not a valid note+accidental. The chord is unparseable.
+        assert!(parse_chord("C/D/E").is_none());
     }
 
     // -- Display (round-trip) ------------------------------------------------


### PR DESCRIPTION
## What

Change `parse_chord` in `crates/core/src/chord.rs` to use `find('/')` instead of `rfind('/')` when splitting slash chords. This ensures the chord splits on the **first** slash rather than the last.

Added a test case (`multi_slash_is_invalid`) to verify that multi-slash input like `C/D/E` is correctly treated as unparseable (the bass portion `D/E` fails note validation).

## Why

Standard chord notation uses a single slash to separate the chord from its bass note (e.g., `G/B`). Using `rfind` caused incorrect splitting when multiple slashes were present: `C/D/E` would split as chord=`C/D`, bass=`E`, when it should split as chord=`C`, bass=`D/E` (which is then correctly rejected as invalid).

Closes #58

## Test results

- All 210 existing unit tests pass
- New `multi_slash_is_invalid` test passes
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- All golden tests pass

## Review summary

Single-character change from `rfind` to `find` plus one new test case. No changes to public API or behavior for valid single-slash chords.