### PR TITLE
Implement plain text renderer with chord-over-lyrics formatting

### DIFF
--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -1,10 +1,204 @@
 //! Plain text renderer for ChordPro documents.
+//!
+//! This crate converts a parsed ChordPro AST (from `chordpro-core`) into
+//! formatted plain text with chords aligned above their corresponding lyrics.
+
+use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+
+/// Render a [`Song`] AST to plain text.
+///
+/// The output format:
+/// - Title and subtitle are rendered as header lines.
+/// - Section markers (chorus, verse, bridge, tab) render as labeled headers.
+/// - Lyrics with chords produce two lines: chords above, lyrics below.
+/// - Lyrics without chords produce a single lyrics line.
+/// - Comments are rendered with style markers.
+/// - Metadata directives (artist, key, capo, etc.) are silently consumed
+///   (they populate [`Song::metadata`] but do not appear in the text body).
+/// - Empty lines are preserved.
+#[must_use]
+pub fn render_song(song: &Song) -> String {
+    let mut output = Vec::new();
+
+    render_metadata(&song.metadata, &mut output);
+
+    for line in &song.lines {
+        match line {
+            Line::Lyrics(lyrics_line) => render_lyrics(lyrics_line, &mut output),
+            Line::Directive(directive) => {
+                // Metadata directives are already rendered via song.metadata;
+                // skip them in the body to avoid duplicate output.
+                if !directive.kind.is_metadata() {
+                    render_directive(directive, &mut output);
+                }
+            }
+            Line::Comment(style, text) => render_comment(*style, text, &mut output),
+            Line::Empty => output.push(String::new()),
+        }
+    }
+
+    // Remove trailing empty lines, then add a final newline.
+    while output.last().is_some_and(|l| l.is_empty()) {
+        output.pop();
+    }
+
+    if output.is_empty() {
+        return String::new();
+    }
+
+    let mut result = output.join("\n");
+    result.push('\n');
+    result
+}
 
 /// Render a ChordPro source string to plain text.
+///
+/// This is a convenience function that parses the input and renders it.
+/// If parsing fails, the error message is returned as the output.
 #[must_use]
-pub fn render(_input: &str) -> String {
-    String::new()
+pub fn render(input: &str) -> String {
+    match chordpro_core::parse(input) {
+        Ok(song) => render_song(&song),
+        Err(e) => format!(
+            "Parse error at line {} column {}: {}\n",
+            e.line(),
+            e.column(),
+            e.message
+        ),
+    }
 }
+
+// ---------------------------------------------------------------------------
+// Metadata header
+// ---------------------------------------------------------------------------
+
+/// Render the song metadata (title, subtitle) as a header block.
+///
+/// No trailing blank line is added — the document's own empty lines
+/// provide spacing between the metadata header and the song body.
+fn render_metadata(metadata: &chordpro_core::ast::Metadata, output: &mut Vec<String>) {
+    if let Some(title) = &metadata.title {
+        output.push(title.clone());
+    }
+    for subtitle in &metadata.subtitles {
+        output.push(subtitle.clone());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lyrics rendering (chord-over-lyrics alignment)
+// ---------------------------------------------------------------------------
+
+/// Render a lyrics line with chords aligned above the lyrics.
+///
+/// If the line has chords, two lines are produced:
+///   1. A chord line with each chord positioned above its lyrics segment.
+///   2. The lyrics text.
+///
+/// If the line has no chords, only the lyrics text is emitted.
+fn render_lyrics(lyrics_line: &LyricsLine, output: &mut Vec<String>) {
+    if !lyrics_line.has_chords() {
+        output.push(lyrics_line.text());
+        return;
+    }
+
+    let mut chord_line = String::new();
+    let mut lyric_line = String::new();
+
+    for segment in &lyrics_line.segments {
+        let chord_name = segment.chord.as_ref().map_or("", |c| c.name.as_str());
+        let text = &segment.text;
+
+        let chord_len = chord_name.len();
+        let text_len = text.len();
+
+        // Write the chord (or equivalent spacing) on the chord line.
+        chord_line.push_str(chord_name);
+
+        // Write the text on the lyric line.
+        lyric_line.push_str(text);
+
+        // Ensure alignment: both lines must advance to at least the same column.
+        // If the chord is longer than the text, pad the lyric line.
+        // If the text is longer than the chord, pad the chord line.
+        // Add 1 space of padding after chord when chord >= text length,
+        // so chords don't run together.
+        if chord_len > 0 && chord_len >= text_len {
+            let padding = chord_len - text_len + 1;
+            lyric_line.extend(std::iter::repeat_n(' ', padding));
+            chord_line.push(' ');
+        } else if chord_len > 0 && text_len > chord_len {
+            let padding = text_len - chord_len;
+            chord_line.extend(std::iter::repeat_n(' ', padding));
+        }
+        // If chord_len == 0 (no chord), text just advances lyric_line naturally
+        // and chord_line needs to keep up.
+        if chord_len == 0 && text_len > 0 {
+            chord_line.extend(std::iter::repeat_n(' ', text_len));
+        }
+    }
+
+    output.push(chord_line.trim_end().to_string());
+    output.push(lyric_line.trim_end().to_string());
+}
+
+// ---------------------------------------------------------------------------
+// Directive rendering
+// ---------------------------------------------------------------------------
+
+/// Render a directive to text output.
+///
+/// - Section start directives produce a labeled header (e.g., "Chorus").
+/// - Section end directives are not rendered (they are structural markers).
+/// - Metadata directives are not rendered here (handled by `render_metadata`).
+/// - Unknown directives are silently ignored.
+fn render_directive(directive: &chordpro_core::ast::Directive, output: &mut Vec<String>) {
+    match &directive.kind {
+        DirectiveKind::StartOfChorus => {
+            render_section_header("Chorus", &directive.value, output);
+        }
+        DirectiveKind::StartOfVerse => {
+            render_section_header("Verse", &directive.value, output);
+        }
+        DirectiveKind::StartOfBridge => {
+            render_section_header("Bridge", &directive.value, output);
+        }
+        DirectiveKind::StartOfTab => {
+            render_section_header("Tab", &directive.value, output);
+        }
+        // End-of-section, metadata, and unknown directives produce no output.
+        _ => {}
+    }
+}
+
+/// Render a section header like "Chorus" or "Verse 1".
+fn render_section_header(label: &str, value: &Option<String>, output: &mut Vec<String>) {
+    match value {
+        Some(v) if !v.is_empty() => output.push(format!("[{label}: {v}]")),
+        _ => output.push(format!("[{label}]")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Comment rendering
+// ---------------------------------------------------------------------------
+
+/// Render a comment with its style marker.
+///
+/// - Normal comments: `(comment text)`
+/// - Italic comments: `(*comment text*)`
+/// - Boxed comments:  `[comment text]`
+fn render_comment(style: CommentStyle, text: &str, output: &mut Vec<String>) {
+    match style {
+        CommentStyle::Normal => output.push(format!("({text})")),
+        CommentStyle::Italic => output.push(format!("(*{text}*)")),
+        CommentStyle::Boxed => output.push(format!("[{text}]")),
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
@@ -13,5 +207,147 @@ mod tests {
     #[test]
     fn test_render_empty() {
         assert_eq!(render(""), "");
+    }
+
+    #[test]
+    fn test_render_title_only() {
+        let input = "{title: Amazing Grace}";
+        let output = render(input);
+        assert_eq!(output, "Amazing Grace\n");
+    }
+
+    #[test]
+    fn test_render_title_and_subtitle() {
+        let input = "{title: Amazing Grace}\n{subtitle: Traditional}";
+        let output = render(input);
+        assert_eq!(output, "Amazing Grace\nTraditional\n");
+    }
+
+    #[test]
+    fn test_render_plain_lyrics() {
+        let input = "Hello world\nSecond line";
+        let output = render(input);
+        assert_eq!(output, "Hello world\nSecond line\n");
+    }
+
+    #[test]
+    fn test_render_lyrics_with_chords() {
+        let input = "[Am]Hello [G]world";
+        let output = render(input);
+        assert_eq!(output, "Am    G\nHello world\n");
+    }
+
+    #[test]
+    fn test_render_chord_longer_than_text() {
+        // Chord "Cmaj7" is 5 chars, text "I" is 1 char
+        let input = "[Cmaj7]I [G]see";
+        let output = render(input);
+        assert_eq!(output, "Cmaj7 G\nI     see\n");
+    }
+
+    #[test]
+    fn test_render_chorus_section() {
+        let input = "{start_of_chorus}\n[G]La la la\n{end_of_chorus}";
+        let output = render(input);
+        assert_eq!(output, "[Chorus]\nG\nLa la la\n");
+    }
+
+    #[test]
+    fn test_render_verse_with_label() {
+        let input = "{start_of_verse: Verse 1}\nSome lyrics\n{end_of_verse}";
+        let output = render(input);
+        assert_eq!(output, "[Verse: Verse 1]\nSome lyrics\n");
+    }
+
+    #[test]
+    fn test_render_comment_normal() {
+        let input = "{comment: This is a comment}";
+        let output = render(input);
+        assert_eq!(output, "(This is a comment)\n");
+    }
+
+    #[test]
+    fn test_render_comment_italic() {
+        let input = "{comment_italic: Softly}";
+        let output = render(input);
+        assert_eq!(output, "(*Softly*)\n");
+    }
+
+    #[test]
+    fn test_render_comment_box() {
+        let input = "{comment_box: Important}";
+        let output = render(input);
+        assert_eq!(output, "[Important]\n");
+    }
+
+    #[test]
+    fn test_render_empty_lines_preserved() {
+        let input = "Line one\n\nLine two";
+        let output = render(input);
+        assert_eq!(output, "Line one\n\nLine two\n");
+    }
+
+    #[test]
+    fn test_render_metadata_not_duplicated() {
+        // Metadata directives like {artist} should NOT appear in body text
+        let input = "{title: Test}\n{artist: Someone}\n{key: G}\nLyrics here";
+        let output = render(input);
+        assert_eq!(output, "Test\nLyrics here\n");
+    }
+
+    #[test]
+    fn test_render_full_song() {
+        let input = "\
+{title: Amazing Grace}
+{subtitle: Traditional}
+{key: G}
+
+{start_of_verse}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound
+[G]That saved a [Em]wretch like [D]me
+{end_of_verse}
+
+{start_of_chorus}
+[G]I once was [G7]lost, but [C]now am [G]found
+{end_of_chorus}";
+        let output = render(input);
+        // Just verify it doesn't panic and produces non-empty output
+        assert!(!output.is_empty());
+        assert!(output.contains("Amazing Grace"));
+        assert!(output.contains("[Verse]"));
+        assert!(output.contains("[Chorus]"));
+    }
+
+    #[test]
+    fn test_render_song_api() {
+        let song = chordpro_core::parse("{title: Test}\n[Am]Hello").unwrap();
+        let output = render_song(&song);
+        assert!(output.contains("Test"));
+        assert!(output.contains("Am"));
+        assert!(output.contains("Hello"));
+    }
+
+    #[test]
+    fn test_render_chord_only_segment() {
+        // A chord at end of line with no following text
+        let input = "[Am]Hello [G]";
+        let output = render(input);
+        assert!(output.contains("Am"));
+        assert!(output.contains("G"));
+        assert!(output.contains("Hello"));
+    }
+
+    #[test]
+    fn test_render_bridge_section() {
+        let input = "{start_of_bridge}\nBridge lyrics\n{end_of_bridge}";
+        let output = render(input);
+        assert_eq!(output, "[Bridge]\nBridge lyrics\n");
+    }
+
+    #[test]
+    fn test_render_tab_section() {
+        let input = "{start_of_tab}\ne|---0---|\n{end_of_tab}";
+        let output = render(input);
+        assert_eq!(output, "[Tab]\ne|---0---|\n");
     }
 }

--- a/crates/render-text/tests/fixtures/chord-alignment/expected.txt
+++ b/crates/render-text/tests/fixtures/chord-alignment/expected.txt
@@ -1,0 +1,6 @@
+Cmaj7 G
+I     see
+Am                       D
+A very long text segment end
+F#m   Bb G7sus4
+Short x  done

--- a/crates/render-text/tests/fixtures/chord-alignment/input.cho
+++ b/crates/render-text/tests/fixtures/chord-alignment/input.cho
@@ -1,0 +1,3 @@
+[Cmaj7]I [G]see
+[Am]A very long text segment [D]end
+[F#m]Short [Bb]x [G7sus4]done

--- a/crates/render-text/tests/fixtures/chords-over-lyrics/expected.txt
+++ b/crates/render-text/tests/fixtures/chords-over-lyrics/expected.txt
@@ -1,0 +1,4 @@
+Am    G
+Hello world
+C         D7   Em
+Just text here now

--- a/crates/render-text/tests/fixtures/chords-over-lyrics/input.cho
+++ b/crates/render-text/tests/fixtures/chords-over-lyrics/input.cho
@@ -1,0 +1,2 @@
+[Am]Hello [G]world
+[C]Just text [D7]here [Em]now

--- a/crates/render-text/tests/fixtures/comments/expected.txt
+++ b/crates/render-text/tests/fixtures/comments/expected.txt
@@ -1,0 +1,3 @@
+(This is a normal comment)
+(*This is italic*)
+[This is boxed]

--- a/crates/render-text/tests/fixtures/comments/input.cho
+++ b/crates/render-text/tests/fixtures/comments/input.cho
@@ -1,0 +1,3 @@
+{comment: This is a normal comment}
+{comment_italic: This is italic}
+{comment_box: This is boxed}

--- a/crates/render-text/tests/fixtures/directives-and-sections/expected.txt
+++ b/crates/render-text/tests/fixtures/directives-and-sections/expected.txt
@@ -1,0 +1,16 @@
+Test Song
+A Subtitle
+
+[Verse: Verse 1]
+G             C
+First line of verse
+
+[Chorus]
+D      G
+Chorus line
+
+[Bridge]
+Bridge text
+
+[Tab]
+e|---0---|

--- a/crates/render-text/tests/fixtures/directives-and-sections/input.cho
+++ b/crates/render-text/tests/fixtures/directives-and-sections/input.cho
@@ -1,0 +1,18 @@
+{title: Test Song}
+{subtitle: A Subtitle}
+
+{start_of_verse: Verse 1}
+[G]First line of [C]verse
+{end_of_verse}
+
+{start_of_chorus}
+[D]Chorus [G]line
+{end_of_chorus}
+
+{start_of_bridge}
+Bridge text
+{end_of_bridge}
+
+{start_of_tab}
+e|---0---|
+{end_of_tab}

--- a/crates/render-text/tests/fixtures/empty-lines/expected.txt
+++ b/crates/render-text/tests/fixtures/empty-lines/expected.txt
@@ -1,0 +1,5 @@
+First line
+
+Second line
+
+Third line

--- a/crates/render-text/tests/fixtures/empty-lines/input.cho
+++ b/crates/render-text/tests/fixtures/empty-lines/input.cho
@@ -1,0 +1,5 @@
+First line
+
+Second line
+
+Third line

--- a/crates/render-text/tests/fixtures/full-song/expected.txt
+++ b/crates/render-text/tests/fixtures/full-song/expected.txt
@@ -1,0 +1,20 @@
+Amazing Grace
+Traditional
+
+[Verse: Verse 1]
+G       G7         C         G
+Amazing grace, how sweet the sound
+G            Em          D
+That saved a wretch like me
+
+[Verse: Verse 2]
+G          G7        C      G
+I once was lost, but now am found
+G              Em    D
+Was blind, but now I see
+
+[Chorus]
+G   C         G
+How sweet the sound
+
+(Repeat chorus)

--- a/crates/render-text/tests/fixtures/full-song/input.cho
+++ b/crates/render-text/tests/fixtures/full-song/input.cho
@@ -1,0 +1,20 @@
+{title: Amazing Grace}
+{subtitle: Traditional}
+{artist: John Newton}
+{key: G}
+
+{start_of_verse: Verse 1}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound
+[G]That saved a [Em]wretch like [D]me
+{end_of_verse}
+
+{start_of_verse: Verse 2}
+[G]I once was [G7]lost, but [C]now am [G]found
+[G]Was blind, but [Em]now I [D]see
+{end_of_verse}
+
+{start_of_chorus}
+[G]How [C]sweet the [G]sound
+{end_of_chorus}
+
+{comment: Repeat chorus}

--- a/crates/render-text/tests/fixtures/metadata-header/expected.txt
+++ b/crates/render-text/tests/fixtures/metadata-header/expected.txt
@@ -1,0 +1,5 @@
+Amazing Grace
+Traditional Hymn
+
+G
+Amazing grace

--- a/crates/render-text/tests/fixtures/metadata-header/input.cho
+++ b/crates/render-text/tests/fixtures/metadata-header/input.cho
@@ -1,0 +1,7 @@
+{title: Amazing Grace}
+{subtitle: Traditional Hymn}
+{artist: John Newton}
+{key: G}
+{capo: 2}
+
+[G]Amazing grace

--- a/crates/render-text/tests/fixtures/minimal-song/expected.txt
+++ b/crates/render-text/tests/fixtures/minimal-song/expected.txt
@@ -1,0 +1,3 @@
+Hello World
+
+Hello world

--- a/crates/render-text/tests/fixtures/minimal-song/input.cho
+++ b/crates/render-text/tests/fixtures/minimal-song/input.cho
@@ -1,0 +1,3 @@
+{title: Hello World}
+
+Hello world

--- a/crates/render-text/tests/golden.rs
+++ b/crates/render-text/tests/golden.rs
@@ -1,0 +1,202 @@
+//! Golden tests for the plain text renderer.
+//!
+//! This integration test discovers all subdirectories under `tests/fixtures/`,
+//! parses each `input.cho` file through [`chordpro_core::parse`], renders it
+//! to plain text via [`chordpro_render_text::render_song`], and compares the
+//! output against the corresponding `expected.txt` file.
+//!
+//! # Adding a new golden test
+//!
+//! 1. Create a new subdirectory under `crates/render-text/tests/fixtures/` with
+//!    a descriptive kebab-case name.
+//! 2. Add an `input.cho` file containing the ChordPro source to render.
+//! 3. Run `UPDATE_GOLDEN=1 cargo test -p chordpro-render-text --test golden` to
+//!    automatically generate the `expected.txt` file from the current renderer
+//!    output.
+//! 4. Review the generated `expected.txt` to confirm it matches the intended
+//!    behavior, then commit both files.
+//!
+//! # Updating golden snapshots
+//!
+//! When the renderer output changes intentionally, run:
+//!
+//! ```sh
+//! UPDATE_GOLDEN=1 cargo test -p chordpro-render-text --test golden
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Returns the path to the `tests/fixtures/` directory.
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+/// Collects all fixture subdirectories (each must contain `input.cho`).
+fn discover_fixtures() -> Vec<PathBuf> {
+    let dir = fixtures_dir();
+    let mut fixtures: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("cannot read fixtures directory {}: {}", dir.display(), e))
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.is_dir() && path.join("input.cho").exists() {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    fixtures.sort();
+    fixtures
+}
+
+/// Produces a unified-diff-style comparison between two strings.
+fn diff_strings(expected: &str, actual: &str) -> Option<String> {
+    let expected_lines: Vec<&str> = expected.lines().collect();
+    let actual_lines: Vec<&str> = actual.lines().collect();
+
+    if expected_lines == actual_lines {
+        return None;
+    }
+
+    let mut output = String::new();
+    let max_len = expected_lines.len().max(actual_lines.len());
+    let context = 3;
+    let mut last_printed = None;
+
+    for i in 0..max_len {
+        let exp = expected_lines.get(i).copied();
+        let act = actual_lines.get(i).copied();
+
+        if exp != act {
+            let start = i.saturating_sub(context);
+            for (j, line) in expected_lines.iter().enumerate().take(i).skip(start) {
+                if last_printed.is_none() || last_printed.unwrap() < j {
+                    output.push_str(&format!("  {:4} | {}\n", j + 1, line));
+                }
+            }
+
+            match (exp, act) {
+                (Some(e), Some(a)) => {
+                    output.push_str(&format!("- {:4} | {}\n", i + 1, e));
+                    output.push_str(&format!("+ {:4} | {}\n", i + 1, a));
+                }
+                (Some(e), None) => {
+                    output.push_str(&format!("- {:4} | {}\n", i + 1, e));
+                }
+                (None, Some(a)) => {
+                    output.push_str(&format!("+ {:4} | {}\n", i + 1, a));
+                }
+                (None, None) => unreachable!(),
+            }
+
+            let end = (i + context + 1).min(max_len);
+            last_printed = Some(i);
+            for j in (i + 1)..end {
+                if let (Some(e), Some(a)) = (expected_lines.get(j), actual_lines.get(j)) {
+                    if e == a {
+                        output.push_str(&format!("  {:4} | {}\n", j + 1, e));
+                        last_printed = Some(j);
+                    }
+                }
+            }
+        }
+    }
+
+    Some(output)
+}
+
+/// Runs a single golden test for the given fixture directory.
+fn run_golden_test(fixture_dir: &Path) {
+    let name = fixture_dir
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    let input_path = fixture_dir.join("input.cho");
+    let expected_path = fixture_dir.join("expected.txt");
+
+    let input = fs::read_to_string(&input_path)
+        .unwrap_or_else(|e| panic!("[{name}] cannot read {}: {e}", input_path.display()));
+
+    let song = chordpro_core::parse(&input).unwrap_or_else(|e| panic!("[{name}] parse error: {e}"));
+
+    let actual = chordpro_render_text::render_song(&song);
+
+    if std::env::var("UPDATE_GOLDEN").is_ok() {
+        fs::write(&expected_path, &actual)
+            .unwrap_or_else(|e| panic!("[{name}] cannot write {}: {e}", expected_path.display()));
+        eprintln!("[{name}] updated {}", expected_path.display());
+        return;
+    }
+
+    let expected = fs::read_to_string(&expected_path).unwrap_or_else(|e| {
+        panic!(
+            "[{name}] cannot read {} (run `UPDATE_GOLDEN=1 cargo test -p chordpro-render-text --test golden` to create it): {e}",
+            expected_path.display()
+        )
+    });
+
+    if let Some(diff) = diff_strings(&expected, &actual) {
+        panic!(
+            "\n\ngolden test '{name}' failed!\n\
+             \n\
+             Fixture: {}\n\
+             Expected file: {}\n\
+             \n\
+             Diff (- expected, + actual):\n\
+             {diff}\n\
+             \n\
+             If this change is intentional, run:\n\
+             UPDATE_GOLDEN=1 cargo test -p chordpro-render-text --test golden\n",
+            fixture_dir.display(),
+            expected_path.display(),
+        );
+    }
+}
+
+#[test]
+fn golden_tests() {
+    let fixtures = discover_fixtures();
+    assert!(
+        !fixtures.is_empty(),
+        "no golden test fixtures found in {}",
+        fixtures_dir().display()
+    );
+
+    let mut failures = Vec::new();
+
+    for fixture in &fixtures {
+        let name = fixture.file_name().unwrap().to_string_lossy().to_string();
+
+        let result = std::panic::catch_unwind(|| {
+            run_golden_test(fixture);
+        });
+
+        if let Err(e) = result {
+            let msg = if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = e.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else {
+                "unknown panic".to_string()
+            };
+            failures.push((name, msg));
+        }
+    }
+
+    if !failures.is_empty() {
+        let mut report = format!("\n{} golden test(s) failed:\n", failures.len());
+        for (name, msg) in &failures {
+            report.push_str(&format!("\n--- {name} ---\n{msg}\n"));
+        }
+        panic!("{report}");
+    }
+
+    eprintln!("all {} golden test(s) passed", fixtures.len());
+}


### PR DESCRIPTION
## What

Implement the `chordpro-render-text` crate that converts a parsed ChordPro AST into formatted plain text output with chord-over-lyrics alignment.

### Features
- `render_song(&Song) -> String` — renders a Song AST to plain text
- `render(input: &str) -> String` — convenience function that parses and renders
- **Chord-over-lyrics alignment**: chords are positioned above their corresponding lyrics with proper padding
- **Directive rendering**: section headers (`[Chorus]`, `[Verse: Verse 1]`, `[Bridge]`, `[Tab]`)
- **Comment rendering**: normal `(text)`, italic `(*text*)`, boxed `[text]`
- **Metadata header**: title and subtitle rendered at the top; other metadata directives silently consumed
- **Golden test framework** with 8 fixture sets covering all rendering cases

## Why

Phase 3 of the project roadmap — the plain text renderer is the first output format, establishing the rendering pipeline from AST to human-readable output.

## Test results

```
running 18 tests — all passed (unit tests)
running 1 test — golden_tests ok (8 fixtures)
Full workspace: 241 tests passed, 0 failed
cargo clippy -- -D warnings: clean
cargo fmt --check: clean
```

## Review summary

- No external dependencies added (only depends on `chordpro-core`)
- All public items have doc comments
- Golden test framework follows the same pattern as `chordpro-core`'s golden tests
- `UPDATE_GOLDEN=1` support for regenerating snapshots

Closes #26
Closes #27
Closes #28
Closes #29