### PR TITLE
Skip auto-review when head commit is authored by claude[bot]

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,6 +29,20 @@ jobs:
             const prNumber = prs[0].number;
             const headSha = context.payload.workflow_run.head_sha;
 
+            // Skip if head commit was authored by claude[bot] to prevent
+            // review loops (Claude pushes fix → CI → auto-review → Claude
+            // reviews again). Manual @claude requests still work.
+            const { data: commit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: headSha,
+            });
+            const commitAuthor = commit.author?.login || '';
+            if (commitAuthor === 'claude[bot]') {
+              console.log(`Skipping auto-review: head commit ${headSha.substring(0, 7)} authored by claude[bot]`);
+              return;
+            }
+
             // Skip Dependabot PRs (handled by claude-dependabot.yml)
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,


### PR DESCRIPTION
## What

Add a check in `claude-review.yml` to skip the auto-review request when the CI-triggering head commit was authored by `claude[bot]`.

## Why

Prevents the review feedback loop:
1. Human pushes → CI → auto-review → Claude reviews → pushes fix commit
2. Fix commit CI → auto-review fires again → Claude reviews its own fix → potentially pushes another fix...

This was observed in PR #69 where an empty commit to re-trigger CI caused `claude-review.yml` to fire again, creating a confusing timeline.

## Test plan

- [ ] Claude bot fix commits no longer trigger auto-review requests
- [ ] Human commits still trigger auto-review as before
- [ ] Manual `@claude` requests work regardless of commit author
- [ ] Existing safeguards (sha dedup, MAX_ITERATIONS) remain unchanged

Closes #70