### PR TITLE
Fix is_end_of_tab_ahead doc comment to match implementation

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -258,8 +258,11 @@ impl Parser {
 
     /// Peeks ahead to check if the current `{` starts an `{end_of_tab}` or
     /// `{eot}` directive. This allows the parser to exit tab mode.
+    ///
+    /// Only checks the next token after `DirectiveOpen` for the directive
+    /// name text; the full directive structure (including `DirectiveClose`)
+    /// is validated later by `parse_directive_line`.
     fn is_end_of_tab_ahead(&self) -> bool {
-        // Look for pattern: DirectiveOpen, Text("end_of_tab" | "eot"), DirectiveClose
         if self.pos + 1 < self.tokens.len() {
             if let TokenKind::Text(ref text) = self.tokens[self.pos + 1].kind {
                 let trimmed = text.trim().to_ascii_lowercase();


### PR DESCRIPTION
## What

Update the doc comment on `is_end_of_tab_ahead` to accurately describe the lookahead logic. The comment previously implied it checked for `DirectiveClose` at `pos+2`, but the implementation only checks `pos+1` for the directive name text.

## Why

Phase 5 review finding from PR #75 auto-review.

## Test plan

- [ ] Comment-only change, no behavior change
- [ ] All existing tests pass

Closes #79