### PR TITLE
Add permission comment and paginate PR listing in auto-rebase

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -17,6 +17,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN only needs read access; git push uses CLAUDE_PAT
+    # (configured via actions/checkout token) to trigger CI on the pushed branch.
     permissions:
       pull-requests: read
       contents: read
@@ -28,7 +30,8 @@ jobs:
           script: |
             const MAX_PRS = 5;
 
-            const { data: prs } = await github.rest.pulls.list({
+            // Fetch all open PRs targeting main (paginated)
+            const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',


### PR DESCRIPTION
## What

Follow-up fixes to the auto-rebase workflow (#86, merged as #87) based on code review findings.

### Changes

1. **Permission comment** — Clarify that `GITHUB_TOKEN` only needs read access; `git push` uses `CLAUDE_PAT` configured via `actions/checkout` token
2. **Paginated PR listing** — Replace single `pulls.list` call with `github.paginate()` to handle >100 open PRs, consistent with `conflict-check.yml`

## Why

Code review identified these as improvements for clarity and consistency.

## Test results

YAML-only change — no Rust code modified.

## Review summary

- Minor improvements to existing workflow file
- No new dependencies or secrets

Closes #88