### PR TITLE
Update Architecture table for render-html and render-pdf crates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ This is a Cargo workspace with three crates:
 |---|---|---|---|
 | `chordpro-core` | `crates/core` | lib | *none* (zero external deps) |
 | `chordpro-render-text` | `crates/render-text` | lib | `chordpro-core` |
-| `chordpro` (CLI) | `crates/cli` | bin | `chordpro-core`, `chordpro-render-text` |
+| `chordpro-render-html` | `crates/render-html` | lib | `chordpro-core` |
+| `chordpro-render-pdf` | `crates/render-pdf` | lib | `chordpro-core` |
+| `chordpro` (CLI) | `crates/cli` | bin | `chordpro-core`, `chordpro-render-text`, `chordpro-render-html`, `chordpro-render-pdf` |
 
 ### Dependency Policy
 


### PR DESCRIPTION
## What

Update CLAUDE.md Architecture table to include the two new renderer crates from Phase 6 and update CLI dependency list.

## Why

Phase 6 completion gate `/review` finding.

## Test plan

- [ ] Documentation-only change

Closes #90