### PR TITLE
Add sorttitle, sortartist, arranger, copyright, duration, tag metadata directives

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -107,6 +107,18 @@ pub struct Metadata {
     pub time: Option<String>,
     /// Capo position, from `{capo}`.
     pub capo: Option<String>,
+    /// Sortable title, from `{sorttitle}`.
+    pub sort_title: Option<String>,
+    /// Sortable artist name, from `{sortartist}`.
+    pub sort_artist: Option<String>,
+    /// Arranger names, from `{arranger}`. May appear multiple times.
+    pub arrangers: Vec<String>,
+    /// Copyright notice, from `{copyright}`.
+    pub copyright: Option<String>,
+    /// Song duration, from `{duration}`.
+    pub duration: Option<String>,
+    /// Tags for categorization, from `{tag}`. May appear multiple times.
+    pub tags: Vec<String>,
     /// Custom metadata directives not covered by the standard fields.
     /// Each entry is a `(name, value)` pair.
     pub custom: Vec<(String, String)>,
@@ -375,6 +387,18 @@ pub enum DirectiveKind {
     Time,
     /// `{capo}` — the capo position.
     Capo,
+    /// `{sorttitle}` — a sortable title.
+    SortTitle,
+    /// `{sortartist}` — a sortable artist name.
+    SortArtist,
+    /// `{arranger}` — the arranger name.
+    Arranger,
+    /// `{copyright}` — the copyright notice.
+    Copyright,
+    /// `{duration}` — the song duration.
+    Duration,
+    /// `{tag}` — a tag for categorization.
+    Tag,
 
     // -- Formatting directives (comment) ------------------------------------
     /// `{comment}` / `{c}` — a normal comment.
@@ -434,6 +458,12 @@ impl DirectiveKind {
             "tempo" => Self::Tempo,
             "time" => Self::Time,
             "capo" => Self::Capo,
+            "sorttitle" => Self::SortTitle,
+            "sortartist" => Self::SortArtist,
+            "arranger" => Self::Arranger,
+            "copyright" => Self::Copyright,
+            "duration" => Self::Duration,
+            "tag" => Self::Tag,
 
             // Formatting (comments)
             "comment" | "c" => Self::Comment,
@@ -476,6 +506,12 @@ impl DirectiveKind {
             Self::Tempo => "tempo",
             Self::Time => "time",
             Self::Capo => "capo",
+            Self::SortTitle => "sorttitle",
+            Self::SortArtist => "sortartist",
+            Self::Arranger => "arranger",
+            Self::Copyright => "copyright",
+            Self::Duration => "duration",
+            Self::Tag => "tag",
             Self::Comment => "comment",
             Self::CommentItalic => "comment_italic",
             Self::CommentBox => "comment_box",
@@ -509,6 +545,12 @@ impl DirectiveKind {
                 | Self::Tempo
                 | Self::Time
                 | Self::Capo
+                | Self::SortTitle
+                | Self::SortArtist
+                | Self::Arranger
+                | Self::Copyright
+                | Self::Duration
+                | Self::Tag
         )
     }
 
@@ -695,6 +737,12 @@ mod tests {
         assert_eq!(meta.tempo, None);
         assert_eq!(meta.time, None);
         assert_eq!(meta.capo, None);
+        assert_eq!(meta.sort_title, None);
+        assert_eq!(meta.sort_artist, None);
+        assert!(meta.arrangers.is_empty());
+        assert_eq!(meta.copyright, None);
+        assert_eq!(meta.duration, None);
+        assert!(meta.tags.is_empty());
         assert!(meta.custom.is_empty());
     }
 
@@ -829,6 +877,31 @@ mod tests {
         assert_eq!(DirectiveKind::from_name("tempo"), DirectiveKind::Tempo);
         assert_eq!(DirectiveKind::from_name("time"), DirectiveKind::Time);
         assert_eq!(DirectiveKind::from_name("capo"), DirectiveKind::Capo);
+        assert_eq!(
+            DirectiveKind::from_name("sorttitle"),
+            DirectiveKind::SortTitle
+        );
+        assert_eq!(
+            DirectiveKind::from_name("SORTTITLE"),
+            DirectiveKind::SortTitle
+        );
+        assert_eq!(
+            DirectiveKind::from_name("sortartist"),
+            DirectiveKind::SortArtist
+        );
+        assert_eq!(
+            DirectiveKind::from_name("arranger"),
+            DirectiveKind::Arranger
+        );
+        assert_eq!(
+            DirectiveKind::from_name("copyright"),
+            DirectiveKind::Copyright
+        );
+        assert_eq!(
+            DirectiveKind::from_name("duration"),
+            DirectiveKind::Duration
+        );
+        assert_eq!(DirectiveKind::from_name("tag"), DirectiveKind::Tag);
     }
 
     #[test]
@@ -929,6 +1002,12 @@ mod tests {
             DirectiveKind::Unknown("foo".to_string()).canonical_name(),
             "foo"
         );
+        assert_eq!(DirectiveKind::SortTitle.canonical_name(), "sorttitle");
+        assert_eq!(DirectiveKind::SortArtist.canonical_name(), "sortartist");
+        assert_eq!(DirectiveKind::Arranger.canonical_name(), "arranger");
+        assert_eq!(DirectiveKind::Copyright.canonical_name(), "copyright");
+        assert_eq!(DirectiveKind::Duration.canonical_name(), "duration");
+        assert_eq!(DirectiveKind::Tag.canonical_name(), "tag");
     }
 
     #[test]

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -271,6 +271,24 @@ impl Parser {
             DirectiveKind::Capo => {
                 metadata.capo = Some(value);
             }
+            DirectiveKind::SortTitle => {
+                metadata.sort_title = Some(value);
+            }
+            DirectiveKind::SortArtist => {
+                metadata.sort_artist = Some(value);
+            }
+            DirectiveKind::Arranger => {
+                metadata.arrangers.push(value);
+            }
+            DirectiveKind::Copyright => {
+                metadata.copyright = Some(value);
+            }
+            DirectiveKind::Duration => {
+                metadata.duration = Some(value);
+            }
+            DirectiveKind::Tag => {
+                metadata.tags.push(value);
+            }
             DirectiveKind::Unknown(ref name) => {
                 metadata.custom.push((name.clone(), value));
             }

--- a/crates/core/tests/fixtures/chords-in-lyrics/expected.txt
+++ b/crates/core/tests/fixtures/chords-in-lyrics/expected.txt
@@ -13,6 +13,12 @@ Song {
         tempo: None,
         time: None,
         capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
         custom: [],
     },
     lines: [

--- a/crates/core/tests/fixtures/define-chord-directives/expected.txt
+++ b/crates/core/tests/fixtures/define-chord-directives/expected.txt
@@ -11,6 +11,12 @@ Song {
         tempo: None,
         time: None,
         capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
         custom: [],
     },
     lines: [

--- a/crates/core/tests/fixtures/directives/expected.txt
+++ b/crates/core/tests/fixtures/directives/expected.txt
@@ -15,6 +15,12 @@ Song {
         tempo: None,
         time: None,
         capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
         custom: [],
     },
     lines: [

--- a/crates/core/tests/fixtures/metadata-extended/expected.txt
+++ b/crates/core/tests/fixtures/metadata-extended/expected.txt
@@ -1,0 +1,132 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Test Song",
+        ),
+        subtitles: [],
+        artists: [
+            "Jane Doe",
+        ],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: Some(
+            "Song, Test",
+        ),
+        sort_artist: Some(
+            "Doe, Jane",
+        ),
+        arrangers: [
+            "John Smith",
+            "Bob Jones",
+        ],
+        copyright: Some(
+            "2024 Jane Doe",
+        ),
+        duration: Some(
+            "3:45",
+        ),
+        tags: [
+            "folk",
+            "acoustic",
+        ],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Test Song",
+                ),
+                kind: Title,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "sorttitle",
+                value: Some(
+                    "Song, Test",
+                ),
+                kind: SortTitle,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "artist",
+                value: Some(
+                    "Jane Doe",
+                ),
+                kind: Artist,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "sortartist",
+                value: Some(
+                    "Doe, Jane",
+                ),
+                kind: SortArtist,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "arranger",
+                value: Some(
+                    "John Smith",
+                ),
+                kind: Arranger,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "arranger",
+                value: Some(
+                    "Bob Jones",
+                ),
+                kind: Arranger,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "copyright",
+                value: Some(
+                    "2024 Jane Doe",
+                ),
+                kind: Copyright,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "duration",
+                value: Some(
+                    "3:45",
+                ),
+                kind: Duration,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "tag",
+                value: Some(
+                    "folk",
+                ),
+                kind: Tag,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "tag",
+                value: Some(
+                    "acoustic",
+                ),
+                kind: Tag,
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/metadata-extended/input.cho
+++ b/crates/core/tests/fixtures/metadata-extended/input.cho
@@ -1,0 +1,10 @@
+{title: Test Song}
+{sorttitle: Song, Test}
+{artist: Jane Doe}
+{sortartist: Doe, Jane}
+{arranger: John Smith}
+{arranger: Bob Jones}
+{copyright: 2024 Jane Doe}
+{duration: 3:45}
+{tag: folk}
+{tag: acoustic}

--- a/crates/core/tests/fixtures/minimal-song/expected.txt
+++ b/crates/core/tests/fixtures/minimal-song/expected.txt
@@ -13,6 +13,12 @@ Song {
         tempo: None,
         time: None,
         capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
         custom: [],
     },
     lines: [

--- a/crates/core/tests/fixtures/tab-verbatim/expected.txt
+++ b/crates/core/tests/fixtures/tab-verbatim/expected.txt
@@ -11,6 +11,12 @@ Song {
         tempo: None,
         time: None,
         capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
         custom: [],
     },
     lines: [

--- a/crates/core/tests/golden_directives.rs
+++ b/crates/core/tests/golden_directives.rs
@@ -204,3 +204,106 @@ fn short_aliases_golden_test() {
         panic!("expected end_of_tab directive");
     }
 }
+
+#[test]
+fn extended_metadata_directives_golden_test() {
+    let input = fixture("metadata-extended/input.cho");
+    let song = parse(&input).expect("parse failed");
+
+    // -- Metadata -----------------------------------------------------------
+    assert_eq!(song.metadata.title.as_deref(), Some("Test Song"));
+    assert_eq!(song.metadata.sort_title.as_deref(), Some("Song, Test"));
+    assert_eq!(song.metadata.artists, vec!["Jane Doe"]);
+    assert_eq!(song.metadata.sort_artist.as_deref(), Some("Doe, Jane"));
+    assert_eq!(song.metadata.arrangers, vec!["John Smith", "Bob Jones"]);
+    assert_eq!(song.metadata.copyright.as_deref(), Some("2024 Jane Doe"));
+    assert_eq!(song.metadata.duration.as_deref(), Some("3:45"));
+    assert_eq!(song.metadata.tags, vec!["folk", "acoustic"]);
+
+    // -- Directive classification -------------------------------------------
+    // Line 0: title
+    if let Line::Directive(ref d) = song.lines[0] {
+        assert_eq!(d.kind, DirectiveKind::Title);
+        assert_eq!(d.name, "title");
+    } else {
+        panic!("expected title directive");
+    }
+
+    // Line 1: sorttitle
+    if let Line::Directive(ref d) = song.lines[1] {
+        assert_eq!(d.kind, DirectiveKind::SortTitle);
+        assert_eq!(d.name, "sorttitle");
+        assert_eq!(d.value.as_deref(), Some("Song, Test"));
+    } else {
+        panic!("expected sorttitle directive");
+    }
+
+    // Line 3: sortartist
+    if let Line::Directive(ref d) = song.lines[3] {
+        assert_eq!(d.kind, DirectiveKind::SortArtist);
+        assert_eq!(d.name, "sortartist");
+        assert_eq!(d.value.as_deref(), Some("Doe, Jane"));
+    } else {
+        panic!("expected sortartist directive");
+    }
+
+    // Line 4: arranger (first)
+    if let Line::Directive(ref d) = song.lines[4] {
+        assert_eq!(d.kind, DirectiveKind::Arranger);
+        assert_eq!(d.name, "arranger");
+        assert_eq!(d.value.as_deref(), Some("John Smith"));
+    } else {
+        panic!("expected arranger directive");
+    }
+
+    // Line 5: arranger (second)
+    if let Line::Directive(ref d) = song.lines[5] {
+        assert_eq!(d.kind, DirectiveKind::Arranger);
+        assert_eq!(d.value.as_deref(), Some("Bob Jones"));
+    } else {
+        panic!("expected second arranger directive");
+    }
+
+    // Line 6: copyright
+    if let Line::Directive(ref d) = song.lines[6] {
+        assert_eq!(d.kind, DirectiveKind::Copyright);
+        assert_eq!(d.name, "copyright");
+        assert_eq!(d.value.as_deref(), Some("2024 Jane Doe"));
+    } else {
+        panic!("expected copyright directive");
+    }
+
+    // Line 7: duration
+    if let Line::Directive(ref d) = song.lines[7] {
+        assert_eq!(d.kind, DirectiveKind::Duration);
+        assert_eq!(d.name, "duration");
+        assert_eq!(d.value.as_deref(), Some("3:45"));
+    } else {
+        panic!("expected duration directive");
+    }
+
+    // Line 8: tag (first)
+    if let Line::Directive(ref d) = song.lines[8] {
+        assert_eq!(d.kind, DirectiveKind::Tag);
+        assert_eq!(d.name, "tag");
+        assert_eq!(d.value.as_deref(), Some("folk"));
+    } else {
+        panic!("expected tag directive");
+    }
+
+    // Line 9: tag (second)
+    if let Line::Directive(ref d) = song.lines[9] {
+        assert_eq!(d.kind, DirectiveKind::Tag);
+        assert_eq!(d.value.as_deref(), Some("acoustic"));
+    } else {
+        panic!("expected second tag directive");
+    }
+
+    // All new metadata directives should be classified as metadata
+    assert!(DirectiveKind::SortTitle.is_metadata());
+    assert!(DirectiveKind::SortArtist.is_metadata());
+    assert!(DirectiveKind::Arranger.is_metadata());
+    assert!(DirectiveKind::Copyright.is_metadata());
+    assert!(DirectiveKind::Duration.is_metadata());
+    assert!(DirectiveKind::Tag.is_metadata());
+}


### PR DESCRIPTION
## Summary
- Add six new metadata directives to the parser: `{sorttitle}`, `{sortartist}`, `{arranger}`, `{copyright}`, `{duration}`, `{tag}`
- Extend the `Metadata` struct with corresponding fields
- Add golden test coverage for all new directives

## What
- New `Directive` variants: `SortTitle`, `SortArtist`, `Arranger`, `Copyright`, `Duration`, `Tag`
- New `Metadata` fields: `sort_title`, `sort_artist`, `arrangers`, `copyright`, `duration`, `tags`
- Parser recognition and metadata extraction for all new directives
- Renderer handling (metadata directives skipped in body via existing `is_metadata()` check)
- Golden tests for new directives including multi-value fields (`arranger`, `tag`)
- Updated existing golden test snapshots to include new `Metadata` fields

## Why
Phase 7 of the roadmap requires full ChordPro metadata support. These directives are defined in the ChordPro specification but were not yet implemented.

## Test results
- `cargo test` — all 333 tests pass (249 core + 16 CLI + 16 HTML + 6 PDF + 24 text + 6 golden + 10 doctests + 6 integration)
- `cargo clippy -- -D warnings` — no warnings
- `cargo fmt --check` — formatted

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)