### PR TITLE
Implement {transpose: N} in-file directive

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -72,12 +72,6 @@ fn main() -> ExitCode {
             }
         };
 
-        let song = if cli.transpose != 0 {
-            chordpro_core::transpose::transpose(&song, cli.transpose)
-        } else {
-            song
-        };
-
         if is_binary {
             // PDF: each file produces a separate PDF. For multiple files,
             // only the last one is written (PDF doesn't support concatenation).
@@ -86,11 +80,15 @@ fn main() -> ExitCode {
                     "warning: PDF output supports one file at a time; previous output discarded"
                 );
             }
-            combined_bytes = chordpro_render_pdf::render_song(&song);
+            combined_bytes = chordpro_render_pdf::render_song_with_transpose(&song, cli.transpose);
         } else {
             let text = match cli.format {
-                Format::Text => chordpro_render_text::render_song(&song),
-                Format::Html => chordpro_render_html::render_song(&song),
+                Format::Text => {
+                    chordpro_render_text::render_song_with_transpose(&song, cli.transpose)
+                }
+                Format::Html => {
+                    chordpro_render_html::render_song_with_transpose(&song, cli.transpose)
+                }
                 Format::Pdf => unreachable!(),
             };
             if !combined_text.is_empty() {

--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -400,6 +400,10 @@ pub enum DirectiveKind {
     /// `{tag}` — a tag for categorization.
     Tag,
 
+    // -- Transpose directive ------------------------------------------------
+    /// `{transpose}` — in-file transposition offset in semitones.
+    Transpose,
+
     // -- Formatting directives (comment) ------------------------------------
     /// `{comment}` / `{c}` — a normal comment.
     Comment,
@@ -465,6 +469,9 @@ impl DirectiveKind {
             "duration" => Self::Duration,
             "tag" => Self::Tag,
 
+            // Transpose
+            "transpose" => Self::Transpose,
+
             // Formatting (comments)
             "comment" | "c" => Self::Comment,
             "comment_italic" | "ci" => Self::CommentItalic,
@@ -512,6 +519,7 @@ impl DirectiveKind {
             Self::Copyright => "copyright",
             Self::Duration => "duration",
             Self::Tag => "tag",
+            Self::Transpose => "transpose",
             Self::Comment => "comment",
             Self::CommentItalic => "comment_italic",
             Self::CommentBox => "comment_box",

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -2047,4 +2047,57 @@ mod tests {
         assert_eq!(result.errors.len(), 1);
         assert!(result.errors[0].message.contains("exceeds maximum"));
     }
+
+    #[test]
+    fn transpose_directive_parsed() {
+        let song = parse("{transpose: 2}").expect("parse failed");
+        assert_eq!(song.lines.len(), 1);
+        if let Line::Directive(ref d) = song.lines[0] {
+            assert_eq!(d.kind, DirectiveKind::Transpose);
+            assert_eq!(d.name, "transpose");
+            assert_eq!(d.value.as_deref(), Some("2"));
+        } else {
+            panic!("expected transpose directive");
+        }
+    }
+
+    #[test]
+    fn transpose_directive_negative_value() {
+        let song = parse("{transpose: -3}").expect("parse failed");
+        if let Line::Directive(ref d) = song.lines[0] {
+            assert_eq!(d.kind, DirectiveKind::Transpose);
+            assert_eq!(d.value.as_deref(), Some("-3"));
+        } else {
+            panic!("expected transpose directive");
+        }
+    }
+
+    #[test]
+    fn transpose_directive_no_value() {
+        let song = parse("{transpose}").expect("parse failed");
+        if let Line::Directive(ref d) = song.lines[0] {
+            assert_eq!(d.kind, DirectiveKind::Transpose);
+            assert!(d.value.is_none());
+        } else {
+            panic!("expected transpose directive");
+        }
+    }
+
+    #[test]
+    fn transpose_directive_is_not_metadata() {
+        let kind = DirectiveKind::Transpose;
+        assert!(!kind.is_metadata());
+    }
+
+    #[test]
+    fn transpose_directive_case_insensitive() {
+        let song = parse("{Transpose: 5}").expect("parse failed");
+        if let Line::Directive(ref d) = song.lines[0] {
+            assert_eq!(d.kind, DirectiveKind::Transpose);
+            assert_eq!(d.name, "transpose");
+            assert_eq!(d.value.as_deref(), Some("5"));
+        } else {
+            panic!("expected transpose directive");
+        }
+    }
 }

--- a/crates/core/tests/fixtures/transpose-directive/expected.txt
+++ b/crates/core/tests/fixtures/transpose-directive/expected.txt
@@ -1,0 +1,182 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Transpose Test",
+        ),
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Transpose Test",
+                ),
+                kind: Title,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "transpose",
+                value: Some(
+                    "2",
+                ),
+                kind: Transpose,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "G",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: G,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "Hello ",
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "C",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: C,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "world",
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "transpose",
+                value: Some(
+                    "-3",
+                ),
+                kind: Transpose,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "Second ",
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Em",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: E,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "line",
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "transpose",
+                value: Some(
+                    "0",
+                ),
+                kind: Transpose,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "D",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: D,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "Back to ",
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "A",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "normal",
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/transpose-directive/input.cho
+++ b/crates/core/tests/fixtures/transpose-directive/input.cho
@@ -1,0 +1,7 @@
+{title: Transpose Test}
+{transpose: 2}
+[G]Hello [C]world
+{transpose: -3}
+[Am]Second [Em]line
+{transpose: 0}
+[D]Back to [A]normal

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -4,6 +4,7 @@
 //! embedded CSS for chord-over-lyrics layout.
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordpro_core::transpose::transpose_chord;
 
 /// Render a [`Song`] AST to an HTML5 document string.
 ///
@@ -11,7 +12,17 @@ use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 /// that positions chords above their corresponding lyrics.
 #[must_use]
 pub fn render_song(song: &Song) -> String {
+    render_song_with_transpose(song, 0)
+}
+
+/// Render a [`Song`] AST to an HTML5 document with an additional CLI transposition offset.
+///
+/// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
+/// values, allowing the CLI `--transpose` flag to combine with in-file directives.
+#[must_use]
+pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
     let mut html = String::new();
+    let mut transpose_offset: i8 = cli_transpose;
 
     let title = song.metadata.title.as_deref().unwrap_or("Untitled");
     html.push_str(&format!(
@@ -26,9 +37,16 @@ pub fn render_song(song: &Song) -> String {
 
     for line in &song.lines {
         match line {
-            Line::Lyrics(lyrics_line) => render_lyrics(lyrics_line, &mut html),
+            Line::Lyrics(lyrics_line) => render_lyrics(lyrics_line, transpose_offset, &mut html),
             Line::Directive(directive) => {
-                if !directive.kind.is_metadata() {
+                if directive.kind == DirectiveKind::Transpose {
+                    let file_offset: i8 = directive
+                        .value
+                        .as_deref()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+                    transpose_offset = file_offset.saturating_add(cli_transpose);
+                } else if !directive.kind.is_metadata() {
                     render_directive(directive, &mut html);
                 }
             }
@@ -128,16 +146,22 @@ fn render_metadata(metadata: &chordpro_core::ast::Metadata, html: &mut String) {
 ///
 /// Each chord+text pair is wrapped in a `<span class="chord-block">` with
 /// the chord in `<span class="chord">` and the text in `<span class="lyrics">`.
-fn render_lyrics(lyrics_line: &LyricsLine, html: &mut String) {
+fn render_lyrics(lyrics_line: &LyricsLine, transpose_offset: i8, html: &mut String) {
     html.push_str("<div class=\"line\">");
 
     for segment in &lyrics_line.segments {
         html.push_str("<span class=\"chord-block\">");
 
         if let Some(chord) = &segment.chord {
+            let display_name = if transpose_offset != 0 {
+                let transposed = transpose_chord(chord, transpose_offset);
+                transposed.name
+            } else {
+                chord.name.clone()
+            };
             html.push_str(&format!(
                 "<span class=\"chord\">{}</span>",
-                escape(&chord.name)
+                escape(&display_name)
             ));
         } else if lyrics_line.has_chords() {
             // Empty chord placeholder to maintain vertical alignment.
@@ -339,5 +363,41 @@ mod tests {
     fn test_empty_line() {
         let html = render("Line one\n\nLine two");
         assert!(html.contains("empty-line"));
+    }
+}
+
+#[cfg(test)]
+mod transpose_tests {
+    use super::*;
+
+    #[test]
+    fn test_transpose_directive_up_2() {
+        let input = "{transpose: 2}\n[G]Hello [C]world";
+        let song = chordpro_core::parse(input).unwrap();
+        let html = render_song(&song);
+        // G+2=A, C+2=D
+        assert!(html.contains("<span class=\"chord\">A</span>"));
+        assert!(html.contains("<span class=\"chord\">D</span>"));
+        assert!(!html.contains("<span class=\"chord\">G</span>"));
+        assert!(!html.contains("<span class=\"chord\">C</span>"));
+    }
+
+    #[test]
+    fn test_transpose_directive_replaces_previous() {
+        let input = "{transpose: 2}\n[G]First\n{transpose: 0}\n[G]Second";
+        let song = chordpro_core::parse(input).unwrap();
+        let html = render_song(&song);
+        // First G transposed +2 = A, second G at 0 = G
+        assert!(html.contains("<span class=\"chord\">A</span>"));
+        assert!(html.contains("<span class=\"chord\">G</span>"));
+    }
+
+    #[test]
+    fn test_transpose_directive_with_cli_offset() {
+        let input = "{transpose: 2}\n[C]Hello";
+        let song = chordpro_core::parse(input).unwrap();
+        let html = render_song_with_transpose(&song, 3);
+        // 2 + 3 = 5, C+5=F
+        assert!(html.contains("<span class=\"chord\">F</span>"));
     }
 }

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -5,6 +5,7 @@
 //! generated directly from raw PDF object structures.
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordpro_core::transpose::transpose_chord;
 
 // ---------------------------------------------------------------------------
 // Layout constants (units: PDF points, 1 pt = 1/72 inch)
@@ -45,7 +46,17 @@ const CHAR_WIDTH: f32 = 0.52;
 /// fonts. No external font files are required.
 #[must_use]
 pub fn render_song(song: &Song) -> Vec<u8> {
+    render_song_with_transpose(song, 0)
+}
+
+/// Render a [`Song`] AST to PDF bytes with an additional CLI transposition offset.
+///
+/// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
+/// values, allowing the CLI `--transpose` flag to combine with in-file directives.
+#[must_use]
+pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
     let mut page = PageBuilder::new();
+    let mut transpose_offset: i8 = cli_transpose;
 
     // Title
     if let Some(title) = &song.metadata.title {
@@ -60,11 +71,18 @@ pub fn render_song(song: &Song) -> Vec<u8> {
 
     for line in &song.lines {
         match line {
-            Line::Lyrics(lyrics) => render_lyrics(lyrics, &mut page),
-            Line::Directive(d) if !d.kind.is_metadata() => render_directive(d, &mut page),
+            Line::Lyrics(lyrics) => render_lyrics(lyrics, transpose_offset, &mut page),
+            Line::Directive(d) => {
+                if d.kind == DirectiveKind::Transpose {
+                    let file_offset: i8 =
+                        d.value.as_deref().and_then(|v| v.parse().ok()).unwrap_or(0);
+                    transpose_offset = file_offset.saturating_add(cli_transpose);
+                } else if !d.kind.is_metadata() {
+                    render_directive(d, &mut page);
+                }
+            }
             Line::Comment(style, text) => render_comment(*style, text, &mut page),
             Line::Empty => page.newline(LINE_GAP * 2.0),
-            _ => {}
         }
     }
 
@@ -81,7 +99,7 @@ pub fn try_render(input: &str) -> Result<Vec<u8>, chordpro_core::ParseError> {
 // Content builders
 // ---------------------------------------------------------------------------
 
-fn render_lyrics(lyrics: &LyricsLine, page: &mut PageBuilder) {
+fn render_lyrics(lyrics: &LyricsLine, transpose_offset: i8, page: &mut PageBuilder) {
     if !lyrics.has_chords() {
         page.text(&lyrics.text(), Font::Helvetica, LYRICS_SIZE);
         page.newline(LYRICS_SIZE + LINE_GAP);
@@ -93,11 +111,21 @@ fn render_lyrics(lyrics: &LyricsLine, page: &mut PageBuilder) {
     let start_y = page.y;
     for seg in &lyrics.segments {
         if let Some(chord) = &seg.chord {
-            page.text_at(&chord.name, Font::HelveticaBold, CHORD_SIZE, x, start_y);
+            let display_name = if transpose_offset != 0 {
+                transpose_chord(chord, transpose_offset).name
+            } else {
+                chord.name.clone()
+            };
+            page.text_at(&display_name, Font::HelveticaBold, CHORD_SIZE, x, start_y);
         }
         let text_w = seg.text.chars().count() as f32 * LYRICS_SIZE * CHAR_WIDTH;
         let chord_w = seg.chord.as_ref().map_or(0.0, |c| {
-            c.name.chars().count() as f32 * CHORD_SIZE * CHAR_WIDTH + 2.0
+            let display_len = if transpose_offset != 0 {
+                transpose_chord(c, transpose_offset).name.chars().count()
+            } else {
+                c.name.chars().count()
+            };
+            display_len as f32 * CHORD_SIZE * CHAR_WIDTH + 2.0
         });
         x += text_w.max(chord_w);
     }
@@ -381,5 +409,32 @@ mod tests {
         assert_eq!(pdf_escape("hello"), "hello");
         assert_eq!(pdf_escape("a(b)c"), "a\\(b\\)c");
         assert_eq!(pdf_escape("back\\slash"), "back\\\\slash");
+    }
+}
+
+#[cfg(test)]
+mod transpose_tests {
+    use super::*;
+
+    #[test]
+    fn test_transpose_directive_produces_pdf() {
+        let input = "{transpose: 2}\n[G]Hello [C]world";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        assert!(bytes.starts_with(b"%PDF"));
+        // Transposed chords should appear in the PDF content: G+2=A, C+2=D
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(content.contains("(A)"));
+        assert!(content.contains("(D)"));
+    }
+
+    #[test]
+    fn test_transpose_with_cli_offset() {
+        let input = "{transpose: 2}\n[C]Hello";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song_with_transpose(&song, 3);
+        // 2+3=5, C+5=F
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(content.contains("(F)"));
     }
 }

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -4,6 +4,7 @@
 //! formatted plain text with chords aligned above their corresponding lyrics.
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordpro_core::transpose::transpose_chord;
 
 /// Render a [`Song`] AST to plain text.
 ///
@@ -18,17 +19,37 @@ use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 /// - Empty lines are preserved.
 #[must_use]
 pub fn render_song(song: &Song) -> String {
+    render_song_with_transpose(song, 0)
+}
+
+/// Render a [`Song`] AST to plain text with an additional CLI transposition offset.
+///
+/// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
+/// values, allowing the CLI `--transpose` flag to combine with in-file directives.
+#[must_use]
+pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
     let mut output = Vec::new();
+    let mut transpose_offset: i8 = cli_transpose;
 
     render_metadata(&song.metadata, &mut output);
 
     for line in &song.lines {
         match line {
-            Line::Lyrics(lyrics_line) => render_lyrics(lyrics_line, &mut output),
+            Line::Lyrics(lyrics_line) => {
+                render_lyrics(lyrics_line, transpose_offset, &mut output);
+            }
             Line::Directive(directive) => {
-                // Metadata directives are already rendered via song.metadata;
-                // skip them in the body to avoid duplicate output.
-                if !directive.kind.is_metadata() {
+                if directive.kind == DirectiveKind::Transpose {
+                    // {transpose: N} sets the in-file transposition amount.
+                    // A subsequent {transpose} replaces (not adds to) the
+                    // previous in-file value. CLI offset is always added.
+                    let file_offset: i8 = directive
+                        .value
+                        .as_deref()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+                    transpose_offset = file_offset.saturating_add(cli_transpose);
+                } else if !directive.kind.is_metadata() {
                     render_directive(directive, &mut output);
                 }
             }
@@ -112,7 +133,7 @@ fn render_metadata(metadata: &chordpro_core::ast::Metadata, output: &mut Vec<Str
 ///
 /// Alignment is based on character count (`chars().count()`), which correctly
 /// handles multi-byte UTF-8 sequences in lyrics text.
-fn render_lyrics(lyrics_line: &LyricsLine, output: &mut Vec<String>) {
+fn render_lyrics(lyrics_line: &LyricsLine, transpose_offset: i8, output: &mut Vec<String>) {
     if !lyrics_line.has_chords() {
         output.push(lyrics_line.text());
         return;
@@ -122,7 +143,17 @@ fn render_lyrics(lyrics_line: &LyricsLine, output: &mut Vec<String>) {
     let mut lyric_line = String::new();
 
     for segment in &lyrics_line.segments {
-        let chord_name = segment.chord.as_ref().map_or("", |c| c.name.as_str());
+        let transposed;
+        let chord_name = if transpose_offset != 0 {
+            if let Some(chord) = &segment.chord {
+                transposed = transpose_chord(chord, transpose_offset);
+                transposed.name.as_str()
+            } else {
+                ""
+            }
+        } else {
+            segment.chord.as_ref().map_or("", |c| c.name.as_str())
+        };
         let text = &segment.text;
 
         let chord_len = chord_name.chars().count();
@@ -419,5 +450,102 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.line(), 1);
+    }
+}
+
+#[cfg(test)]
+mod transpose_tests {
+    use super::*;
+
+    #[test]
+    fn test_transpose_directive_up_2() {
+        let input = "{transpose: 2}\n[G]Hello [C]world";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song(&song);
+        // G+2=A, C+2=D
+        assert_eq!(output, "A     D\nHello world\n");
+    }
+
+    #[test]
+    fn test_transpose_directive_down_3() {
+        let input = "{transpose: -3}\n[Am]Hello [Em]world";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song(&song);
+        // Am-3=F#m, Em-3=C#m
+        assert_eq!(output, "F#m   C#m\nHello world\n");
+    }
+
+    #[test]
+    fn test_transpose_directive_replaces_previous() {
+        let input = "{transpose: 2}\n[G]First\n{transpose: -1}\n[G]Second";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song(&song);
+        // First line: G+2=A, Second line: G-1=F#
+        assert!(output.contains("A\nFirst"));
+        assert!(output.contains("F#\nSecond"));
+    }
+
+    #[test]
+    fn test_transpose_directive_zero_resets() {
+        let input = "{transpose: 5}\n[C]Up\n{transpose: 0}\n[C]Normal";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song(&song);
+        // First line: C+5=F, Second line: C+0=C
+        assert!(output.contains("F\nUp"));
+        assert!(output.contains("C\nNormal"));
+    }
+
+    #[test]
+    fn test_transpose_directive_with_cli_offset() {
+        let input = "{transpose: 2}\n[C]Hello";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song_with_transpose(&song, 3);
+        // In-file 2 + CLI 3 = 5 total. C+5=F
+        assert!(output.contains("F\nHello"));
+    }
+
+    #[test]
+    fn test_cli_transpose_without_directive() {
+        let input = "[G]Hello [C]world";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song_with_transpose(&song, 2);
+        // CLI offset only: G+2=A, C+2=D
+        assert_eq!(output, "A     D\nHello world\n");
+    }
+
+    #[test]
+    fn test_transpose_directive_replaces_with_cli_additive() {
+        let input = "{transpose: 2}\n[C]First\n{transpose: -1}\n[C]Second";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song_with_transpose(&song, 1);
+        // First: 2+1=3, C+3=D#. Second: -1+1=0, C+0=C
+        assert!(output.contains("D#\nFirst"));
+        assert!(output.contains("C\nSecond"));
+    }
+
+    #[test]
+    fn test_transpose_no_chord_lyrics_unaffected() {
+        let input = "{transpose: 5}\nPlain lyrics no chords";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song(&song);
+        assert_eq!(output, "Plain lyrics no chords\n");
+    }
+
+    #[test]
+    fn test_transpose_invalid_value_treated_as_zero() {
+        let input = "{transpose: abc}\n[G]Hello";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song(&song);
+        // Invalid value -> treated as 0
+        assert!(output.contains("G\nHello"));
+    }
+
+    #[test]
+    fn test_transpose_no_value_treated_as_zero() {
+        let input = "{transpose}\n[G]Hello";
+        let song = chordpro_core::parse(input).unwrap();
+        let output = render_song(&song);
+        // No value -> treated as 0
+        assert!(output.contains("G\nHello"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `{transpose: N}` directive support for in-file chord transposition
- All three renderers (text, HTML, PDF) track and apply transposition state
- CLI `--transpose` flag combines additively with in-file `{transpose}` directives

## What
- New `DirectiveKind::Transpose` variant in the AST, recognized by the parser (case-insensitive)
- Text, HTML, and PDF renderers track a `transpose_offset` as they iterate through lines
- When encountering `{transpose: N}`, the offset is **replaced** (not accumulated), per ChordPro spec
- New `render_song_with_transpose(song, cli_offset)` public API on each renderer
- CLI passes `--transpose` value to renderer instead of pre-transposing the whole song
- Invalid or missing values are treated as 0 (no transposition)

## Why
The `{transpose}` directive is part of the ChordPro specification (Phase 7 roadmap item) and allows song authors to embed transposition instructions directly in the `.cho` file. Unlike the CLI `--transpose` flag (which applies uniformly), the in-file directive can appear at any point and affect only subsequent chords, enabling key changes within a song.

## Test results
- `cargo test` -- 338 tests pass (254 core + 16 CLI + 34 text + 19 HTML + 8 PDF + 7 golden/integration)
- `cargo clippy -- -D warnings` -- no warnings
- `cargo fmt --check` -- formatted

Closes #106