### PR TITLE
Implement {meta: key value} directive for arbitrary metadata

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -444,6 +444,14 @@ pub enum DirectiveKind {
     /// The contained `String` is the section type name (e.g., `"intro"`).
     EndOfSection(String),
 
+    // -- Generic metadata directive -----------------------------------------
+    /// `{meta: key value}` — a generic metadata directive.
+    ///
+    /// The first word of the value is the metadata key name (e.g., `"artist"`),
+    /// and the remainder is the metadata value. This allows setting any metadata
+    /// field using the generic `{meta}` directive syntax.
+    Meta(String),
+
     // -- Unknown ------------------------------------------------------------
     /// A directive not recognized as a standard ChordPro directive.
     /// The original directive name (lowercased) is preserved.
@@ -499,6 +507,9 @@ impl DirectiveKind {
             "define" => Self::Define,
             "chord" => Self::ChordDirective,
 
+            // Generic metadata
+            "meta" => Self::Meta(String::new()),
+
             // Custom sections (start_of_X / end_of_X)
             other => {
                 if let Some(section) = other.strip_prefix("start_of_") {
@@ -553,6 +564,7 @@ impl DirectiveKind {
             Self::EndOfTab => "end_of_tab",
             Self::Define => "define",
             Self::ChordDirective => "chord",
+            Self::Meta(_) => "meta",
             Self::StartOfSection(name) | Self::EndOfSection(name) | Self::Unknown(name) => {
                 name.as_str()
             }
@@ -595,6 +607,7 @@ impl DirectiveKind {
                 | Self::Copyright
                 | Self::Duration
                 | Self::Tag
+                | Self::Meta(_)
         )
     }
 

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -289,6 +289,26 @@ impl Parser {
             DirectiveKind::Tag => {
                 metadata.tags.push(value);
             }
+            DirectiveKind::Meta(ref key) => match key.to_ascii_lowercase().as_str() {
+                "title" | "t" => metadata.title = Some(value),
+                "subtitle" | "st" => metadata.subtitles.push(value),
+                "artist" => metadata.artists.push(value),
+                "composer" => metadata.composers.push(value),
+                "lyricist" => metadata.lyricists.push(value),
+                "album" => metadata.album = Some(value),
+                "year" => metadata.year = Some(value),
+                "key" => metadata.key = Some(value),
+                "tempo" => metadata.tempo = Some(value),
+                "time" => metadata.time = Some(value),
+                "capo" => metadata.capo = Some(value),
+                "sorttitle" => metadata.sort_title = Some(value),
+                "sortartist" => metadata.sort_artist = Some(value),
+                "arranger" => metadata.arrangers.push(value),
+                "copyright" => metadata.copyright = Some(value),
+                "duration" => metadata.duration = Some(value),
+                "tag" => metadata.tags.push(value),
+                _ => metadata.custom.push((key.clone(), value)),
+            },
             DirectiveKind::Unknown(ref name) => {
                 metadata.custom.push((name.clone(), value));
             }
@@ -479,6 +499,45 @@ impl Parser {
             };
             let text = value.unwrap_or_default();
             return Ok(Line::Comment(style, text));
+        }
+
+        // Meta directive: split value into key + remaining value.
+        if matches!(kind, DirectiveKind::Meta(_)) {
+            if let Some(ref val) = value {
+                let trimmed = val.trim();
+                if let Some(pos) = trimmed.find(|c: char| c.is_whitespace()) {
+                    let meta_key = trimmed[..pos].to_string();
+                    let meta_value = trimmed[pos..].trim().to_string();
+                    let kind = DirectiveKind::Meta(meta_key.clone());
+                    let directive = Directive {
+                        name: "meta".to_string(),
+                        value: if meta_value.is_empty() {
+                            None
+                        } else {
+                            Some(meta_value)
+                        },
+                        kind,
+                    };
+                    return Ok(Line::Directive(directive));
+                } else if !trimmed.is_empty() {
+                    // Only a key, no value
+                    let meta_key = trimmed.to_string();
+                    let kind = DirectiveKind::Meta(meta_key);
+                    let directive = Directive {
+                        name: "meta".to_string(),
+                        value: None,
+                        kind,
+                    };
+                    return Ok(Line::Directive(directive));
+                }
+            }
+            // {meta} without value — treat as unknown
+            let directive = Directive {
+                name: "meta".to_string(),
+                value: None,
+                kind: DirectiveKind::Unknown("meta".to_string()),
+            };
+            return Ok(Line::Directive(directive));
         }
 
         // Build the directive with canonical name and kind.
@@ -1640,13 +1699,27 @@ mod tests {
     #[test]
     fn multiple_colons_in_directive_value() {
         // Extra colons after the first are treated as part of the value.
+        // When the directive is "meta", it is parsed as a Meta directive.
+        // Since "key:value:extra" has no whitespace, the whole string
+        // becomes the meta key with no value.
         let result = lines("{meta: key:value:extra}");
         assert_eq!(
             result,
             vec![Line::Directive(Directive {
                 name: "meta".to_string(),
+                value: None,
+                kind: DirectiveKind::Meta("key:value:extra".to_string()),
+            })],
+        );
+
+        // For non-meta directives, extra colons remain in the value.
+        let result = lines("{custom_dir: key:value:extra}");
+        assert_eq!(
+            result,
+            vec![Line::Directive(Directive {
+                name: "custom_dir".to_string(),
                 value: Some("key:value:extra".to_string()),
-                kind: DirectiveKind::Unknown("meta".to_string()),
+                kind: DirectiveKind::Unknown("custom_dir".to_string()),
             })],
         );
     }

--- a/crates/core/tests/fixtures/meta-directive/expected.txt
+++ b/crates/core/tests/fixtures/meta-directive/expected.txt
@@ -1,0 +1,238 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Test Song",
+        ),
+        subtitles: [],
+        artists: [
+            "Someone Famous",
+        ],
+        composers: [
+            "J.S. Bach",
+        ],
+        lyricists: [
+            "William Blake",
+        ],
+        album: Some(
+            "Greatest Hits",
+        ),
+        year: Some(
+            "2024",
+        ),
+        key: Some(
+            "Am",
+        ),
+        tempo: Some(
+            "120",
+        ),
+        time: Some(
+            "4/4",
+        ),
+        capo: Some(
+            "3",
+        ),
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [
+            (
+                "custom_field",
+                "some custom value",
+            ),
+            (
+                "mood",
+                "melancholy",
+            ),
+        ],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Test Song",
+                ),
+                kind: Title,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "Someone Famous",
+                ),
+                kind: Meta(
+                    "artist",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "Am",
+                ),
+                kind: Meta(
+                    "key",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "J.S. Bach",
+                ),
+                kind: Meta(
+                    "composer",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "William Blake",
+                ),
+                kind: Meta(
+                    "lyricist",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "Greatest Hits",
+                ),
+                kind: Meta(
+                    "album",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "2024",
+                ),
+                kind: Meta(
+                    "year",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "120",
+                ),
+                kind: Meta(
+                    "tempo",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "4/4",
+                ),
+                kind: Meta(
+                    "time",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "3",
+                ),
+                kind: Meta(
+                    "capo",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "some custom value",
+                ),
+                kind: Meta(
+                    "custom_field",
+                ),
+            },
+        ),
+        Directive(
+            Directive {
+                name: "meta",
+                value: Some(
+                    "melancholy",
+                ),
+                kind: Meta(
+                    "mood",
+                ),
+            },
+        ),
+        Empty,
+        Directive(
+            Directive {
+                name: "start_of_verse",
+                value: None,
+                kind: StartOfVerse,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "Hello ",
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "G",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: G,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "world",
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "end_of_verse",
+                value: None,
+                kind: EndOfVerse,
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/meta-directive/input.cho
+++ b/crates/core/tests/fixtures/meta-directive/input.cho
@@ -1,0 +1,16 @@
+{title: Test Song}
+{meta: artist Someone Famous}
+{meta: key Am}
+{meta: composer J.S. Bach}
+{meta: lyricist William Blake}
+{meta: album Greatest Hits}
+{meta: year 2024}
+{meta: tempo 120}
+{meta: time 4/4}
+{meta: capo 3}
+{meta: custom_field some custom value}
+{meta: mood melancholy}
+
+{start_of_verse}
+[Am]Hello [G]world
+{end_of_verse}

--- a/crates/core/tests/golden_meta.rs
+++ b/crates/core/tests/golden_meta.rs
@@ -1,0 +1,157 @@
+//! Golden tests for the `{meta: key value}` directive.
+//!
+//! These tests verify that the parser correctly handles the generic `{meta}`
+//! directive, routing known metadata keys to their respective fields and
+//! storing unknown keys in the custom metadata vector.
+
+use chordpro_core::ast::{DirectiveKind, Line};
+use chordpro_core::parser::parse;
+
+/// Reads a fixture file relative to the fixtures directory.
+fn fixture(name: &str) -> String {
+    let path = format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"))
+}
+
+#[test]
+fn meta_directive_known_keys_populate_metadata() {
+    let input = fixture("meta-directive/input.cho");
+    let song = parse(&input).expect("parse failed");
+
+    // Title comes from {title: Test Song}, not from meta
+    assert_eq!(song.metadata.title.as_deref(), Some("Test Song"));
+
+    // These come from {meta: ...} directives
+    assert_eq!(song.metadata.artists, vec!["Someone Famous"]);
+    assert_eq!(song.metadata.key.as_deref(), Some("Am"));
+    assert_eq!(song.metadata.composers, vec!["J.S. Bach"]);
+    assert_eq!(song.metadata.lyricists, vec!["William Blake"]);
+    assert_eq!(song.metadata.album.as_deref(), Some("Greatest Hits"));
+    assert_eq!(song.metadata.year.as_deref(), Some("2024"));
+    assert_eq!(song.metadata.tempo.as_deref(), Some("120"));
+    assert_eq!(song.metadata.time.as_deref(), Some("4/4"));
+    assert_eq!(song.metadata.capo.as_deref(), Some("3"));
+}
+
+#[test]
+fn meta_directive_custom_keys_go_to_custom() {
+    let input = fixture("meta-directive/input.cho");
+    let song = parse(&input).expect("parse failed");
+
+    assert_eq!(
+        song.metadata.custom,
+        vec![
+            ("custom_field".to_string(), "some custom value".to_string()),
+            ("mood".to_string(), "melancholy".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn meta_directive_kind_is_meta() {
+    let input = fixture("meta-directive/input.cho");
+    let song = parse(&input).expect("parse failed");
+
+    // Line 1 (index 1) is {meta: artist Someone Famous}
+    if let Line::Directive(ref d) = song.lines[1] {
+        assert_eq!(d.name, "meta");
+        assert_eq!(d.kind, DirectiveKind::Meta("artist".to_string()));
+        assert_eq!(d.value.as_deref(), Some("Someone Famous"));
+    } else {
+        panic!(
+            "expected meta directive at index 1, got: {:?}",
+            song.lines[1]
+        );
+    }
+
+    // Line 2 (index 2) is {meta: key Am}
+    if let Line::Directive(ref d) = song.lines[2] {
+        assert_eq!(d.name, "meta");
+        assert_eq!(d.kind, DirectiveKind::Meta("key".to_string()));
+        assert_eq!(d.value.as_deref(), Some("Am"));
+    } else {
+        panic!(
+            "expected meta directive at index 2, got: {:?}",
+            song.lines[2]
+        );
+    }
+}
+
+#[test]
+fn meta_directive_is_metadata() {
+    let kind = DirectiveKind::Meta("artist".to_string());
+    assert!(kind.is_metadata());
+
+    let kind = DirectiveKind::Meta("custom_field".to_string());
+    assert!(kind.is_metadata());
+}
+
+#[test]
+fn meta_directive_canonical_name() {
+    let kind = DirectiveKind::Meta("artist".to_string());
+    assert_eq!(kind.canonical_name(), "meta");
+}
+
+#[test]
+fn meta_directive_key_only_no_value() {
+    // {meta: solo_key} — key with no value
+    let song = parse("{meta: solo_key}").expect("parse failed");
+
+    if let Line::Directive(ref d) = song.lines[0] {
+        assert_eq!(d.name, "meta");
+        assert_eq!(d.kind, DirectiveKind::Meta("solo_key".to_string()));
+        assert!(d.value.is_none());
+    } else {
+        panic!("expected meta directive");
+    }
+
+    // Since there's no value, custom metadata should not be populated
+    assert!(song.metadata.custom.is_empty());
+}
+
+#[test]
+fn meta_directive_without_value_is_unknown() {
+    // {meta} with no value at all — treated as unknown
+    let song = parse("{meta}").expect("parse failed");
+
+    if let Line::Directive(ref d) = song.lines[0] {
+        assert_eq!(d.kind, DirectiveKind::Unknown("meta".to_string()));
+    } else {
+        panic!("expected directive");
+    }
+}
+
+#[test]
+fn meta_directive_overrides_existing_metadata() {
+    // {key: G} followed by {meta: key Am} — meta should override
+    let song = parse("{key: G}\n{meta: key Am}").expect("parse failed");
+    assert_eq!(song.metadata.key.as_deref(), Some("Am"));
+}
+
+#[test]
+fn meta_directive_appends_to_vec_fields() {
+    // Multiple artists via meta
+    let song = parse("{meta: artist Alice}\n{meta: artist Bob}").expect("parse failed");
+    assert_eq!(song.metadata.artists, vec!["Alice", "Bob"]);
+}
+
+#[test]
+fn meta_directive_title_via_meta() {
+    // {meta: title My Song} — sets title through meta
+    let song = parse("{meta: title My Song}").expect("parse failed");
+    assert_eq!(song.metadata.title.as_deref(), Some("My Song"));
+
+    if let Line::Directive(ref d) = song.lines[0] {
+        assert_eq!(d.kind, DirectiveKind::Meta("title".to_string()));
+        assert_eq!(d.value.as_deref(), Some("My Song"));
+    } else {
+        panic!("expected meta directive");
+    }
+}
+
+#[test]
+fn meta_directive_subtitle_via_meta() {
+    // {meta: subtitle Another Name} — sets subtitle through meta
+    let song = parse("{meta: subtitle Another Name}").expect("parse failed");
+    assert_eq!(song.metadata.subtitles, vec!["Another Name"]);
+}


### PR DESCRIPTION
## Summary
- Add `DirectiveKind::Meta(String)` variant for the generic `{meta: key value}` directive
- Parser splits the meta value into key (first word) and value (remainder)
- Known metadata keys (title, artist, key, tempo, etc.) route to their respective `Metadata` fields
- Unknown keys are stored in `Metadata::custom` as key-value pairs
- Golden test fixture and 11 integration tests covering all meta directive behaviors

## What
- **AST** (`crates/core/src/ast.rs`): Added `Meta(String)` variant to `DirectiveKind` enum, with support in `from_name()`, `canonical_name()`, and `is_metadata()`
- **Parser** (`crates/core/src/parser.rs`): Added meta directive handling in `parse_directive_line()` to split value into key+value, and in `populate_metadata()` to route known keys to proper fields
- **Tests** (`crates/core/tests/golden_meta.rs`): 11 tests covering known key routing, custom keys, key-only (no value), bare `{meta}`, override behavior, vec-field appending, and title/subtitle via meta
- **Golden fixture** (`crates/core/tests/fixtures/meta-directive/`): Input `.cho` and expected `.txt` snapshot

## Why
The `{meta}` directive is part of the ChordPro specification (https://www.chordpro.org/chordpro/directives-meta/) and allows flexible metadata assignment using a single generic directive. This is needed for Phase 7 roadmap completion.

## Test results
- `cargo test` -- all tests pass (249 core unit tests + 11 meta integration tests + all renderer and CLI tests)
- `cargo clippy -- -D warnings` -- no warnings
- `cargo fmt --all --check` -- formatted

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)