### PR TITLE
Parse delegate environment directives as verbatim content

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -506,6 +506,28 @@ pub enum DirectiveKind {
     /// `{chord}` — references a custom chord.
     ChordDirective,
 
+    // -- Delegate environment directives -------------------------------------
+    /// `{start_of_abc}` — begins an ABC music notation section.
+    /// Content is treated as verbatim text (no chord parsing).
+    StartOfAbc,
+    /// `{end_of_abc}` — ends an ABC music notation section.
+    EndOfAbc,
+    /// `{start_of_ly}` — begins a Lilypond notation section.
+    /// Content is treated as verbatim text (no chord parsing).
+    StartOfLy,
+    /// `{end_of_ly}` — ends a Lilypond notation section.
+    EndOfLy,
+    /// `{start_of_svg}` — begins an SVG graphics section.
+    /// Content is treated as verbatim text (no chord parsing).
+    StartOfSvg,
+    /// `{end_of_svg}` — ends an SVG graphics section.
+    EndOfSvg,
+    /// `{start_of_textblock}` — begins a preformatted text block section.
+    /// Content is treated as verbatim text (no chord parsing).
+    StartOfTextblock,
+    /// `{end_of_textblock}` — ends a preformatted text block section.
+    EndOfTextblock,
+
     // -- Custom section directives -------------------------------------------
     /// `{start_of_X}` — begins a custom section (e.g., intro, outro, solo).
     /// The contained `String` is the section type name (e.g., `"intro"`).
@@ -590,6 +612,16 @@ impl DirectiveKind {
             "tabsize" => Self::TabSize,
             "tabcolour" | "tabcolor" => Self::TabColour,
 
+            // Delegate environments (verbatim sections)
+            "start_of_abc" => Self::StartOfAbc,
+            "end_of_abc" => Self::EndOfAbc,
+            "start_of_ly" => Self::StartOfLy,
+            "end_of_ly" => Self::EndOfLy,
+            "start_of_svg" => Self::StartOfSvg,
+            "end_of_svg" => Self::EndOfSvg,
+            "start_of_textblock" => Self::StartOfTextblock,
+            "end_of_textblock" => Self::EndOfTextblock,
+
             // Chord definitions
             "define" => Self::Define,
             "chord" => Self::ChordDirective,
@@ -664,6 +696,14 @@ impl DirectiveKind {
             Self::TabFont => "tabfont",
             Self::TabSize => "tabsize",
             Self::TabColour => "tabcolour",
+            Self::StartOfAbc => "start_of_abc",
+            Self::EndOfAbc => "end_of_abc",
+            Self::StartOfLy => "start_of_ly",
+            Self::EndOfLy => "end_of_ly",
+            Self::StartOfSvg => "start_of_svg",
+            Self::EndOfSvg => "end_of_svg",
+            Self::StartOfTextblock => "start_of_textblock",
+            Self::EndOfTextblock => "end_of_textblock",
             Self::Define => "define",
             Self::ChordDirective => "chord",
             Self::Meta(_) => "meta",
@@ -748,6 +788,10 @@ impl DirectiveKind {
                 | Self::StartOfBridge
                 | Self::StartOfTab
                 | Self::StartOfGrid
+                | Self::StartOfAbc
+                | Self::StartOfLy
+                | Self::StartOfSvg
+                | Self::StartOfTextblock
                 | Self::StartOfSection(_)
         )
     }
@@ -762,6 +806,10 @@ impl DirectiveKind {
                 | Self::EndOfBridge
                 | Self::EndOfTab
                 | Self::EndOfGrid
+                | Self::EndOfAbc
+                | Self::EndOfLy
+                | Self::EndOfSvg
+                | Self::EndOfTextblock
                 | Self::EndOfSection(_)
         )
     }
@@ -1648,5 +1696,182 @@ mod tests {
         let eog = Directive::name_only("eog");
         assert!(eog.is_section_end());
         assert_eq!(eog.section_name(), Some("grid"));
+    }
+}
+
+#[cfg(test)]
+mod delegate_tests {
+    use super::*;
+
+    #[test]
+    fn directive_kind_from_name_delegate_abc() {
+        assert_eq!(
+            DirectiveKind::from_name("start_of_abc"),
+            DirectiveKind::StartOfAbc
+        );
+        assert_eq!(
+            DirectiveKind::from_name("end_of_abc"),
+            DirectiveKind::EndOfAbc
+        );
+    }
+
+    #[test]
+    fn directive_kind_from_name_delegate_ly() {
+        assert_eq!(
+            DirectiveKind::from_name("start_of_ly"),
+            DirectiveKind::StartOfLy
+        );
+        assert_eq!(
+            DirectiveKind::from_name("end_of_ly"),
+            DirectiveKind::EndOfLy
+        );
+    }
+
+    #[test]
+    fn directive_kind_from_name_delegate_svg() {
+        assert_eq!(
+            DirectiveKind::from_name("start_of_svg"),
+            DirectiveKind::StartOfSvg
+        );
+        assert_eq!(
+            DirectiveKind::from_name("end_of_svg"),
+            DirectiveKind::EndOfSvg
+        );
+    }
+
+    #[test]
+    fn directive_kind_from_name_delegate_textblock() {
+        assert_eq!(
+            DirectiveKind::from_name("start_of_textblock"),
+            DirectiveKind::StartOfTextblock
+        );
+        assert_eq!(
+            DirectiveKind::from_name("end_of_textblock"),
+            DirectiveKind::EndOfTextblock
+        );
+    }
+
+    #[test]
+    fn delegate_environments_case_insensitive() {
+        assert_eq!(
+            DirectiveKind::from_name("START_OF_ABC"),
+            DirectiveKind::StartOfAbc
+        );
+        assert_eq!(
+            DirectiveKind::from_name("End_Of_Ly"),
+            DirectiveKind::EndOfLy
+        );
+        assert_eq!(
+            DirectiveKind::from_name("START_OF_SVG"),
+            DirectiveKind::StartOfSvg
+        );
+        assert_eq!(
+            DirectiveKind::from_name("End_Of_Textblock"),
+            DirectiveKind::EndOfTextblock
+        );
+    }
+
+    #[test]
+    fn delegate_environments_are_section_start() {
+        assert!(DirectiveKind::StartOfAbc.is_section_start());
+        assert!(DirectiveKind::StartOfLy.is_section_start());
+        assert!(DirectiveKind::StartOfSvg.is_section_start());
+        assert!(DirectiveKind::StartOfTextblock.is_section_start());
+    }
+
+    #[test]
+    fn delegate_environments_are_section_end() {
+        assert!(DirectiveKind::EndOfAbc.is_section_end());
+        assert!(DirectiveKind::EndOfLy.is_section_end());
+        assert!(DirectiveKind::EndOfSvg.is_section_end());
+        assert!(DirectiveKind::EndOfTextblock.is_section_end());
+    }
+
+    #[test]
+    fn delegate_environments_are_environments() {
+        assert!(DirectiveKind::StartOfAbc.is_environment());
+        assert!(DirectiveKind::EndOfAbc.is_environment());
+        assert!(DirectiveKind::StartOfLy.is_environment());
+        assert!(DirectiveKind::EndOfLy.is_environment());
+        assert!(DirectiveKind::StartOfSvg.is_environment());
+        assert!(DirectiveKind::EndOfSvg.is_environment());
+        assert!(DirectiveKind::StartOfTextblock.is_environment());
+        assert!(DirectiveKind::EndOfTextblock.is_environment());
+    }
+
+    #[test]
+    fn delegate_environments_canonical_names() {
+        assert_eq!(DirectiveKind::StartOfAbc.canonical_name(), "start_of_abc");
+        assert_eq!(DirectiveKind::EndOfAbc.canonical_name(), "end_of_abc");
+        assert_eq!(DirectiveKind::StartOfLy.canonical_name(), "start_of_ly");
+        assert_eq!(DirectiveKind::EndOfLy.canonical_name(), "end_of_ly");
+        assert_eq!(DirectiveKind::StartOfSvg.canonical_name(), "start_of_svg");
+        assert_eq!(DirectiveKind::EndOfSvg.canonical_name(), "end_of_svg");
+        assert_eq!(
+            DirectiveKind::StartOfTextblock.canonical_name(),
+            "start_of_textblock"
+        );
+        assert_eq!(
+            DirectiveKind::EndOfTextblock.canonical_name(),
+            "end_of_textblock"
+        );
+    }
+
+    #[test]
+    fn delegate_not_metadata() {
+        assert!(!DirectiveKind::StartOfAbc.is_metadata());
+        assert!(!DirectiveKind::EndOfLy.is_metadata());
+        assert!(!DirectiveKind::StartOfSvg.is_metadata());
+        assert!(!DirectiveKind::EndOfTextblock.is_metadata());
+    }
+
+    #[test]
+    fn delegate_not_comment() {
+        assert!(!DirectiveKind::StartOfAbc.is_comment());
+        assert!(!DirectiveKind::EndOfLy.is_comment());
+    }
+
+    #[test]
+    fn delegate_directive_section_name() {
+        let d = Directive::name_only("start_of_abc");
+        assert_eq!(d.section_name(), Some("abc"));
+
+        let d = Directive::name_only("end_of_ly");
+        assert_eq!(d.section_name(), Some("ly"));
+
+        let d = Directive::name_only("start_of_svg");
+        assert_eq!(d.section_name(), Some("svg"));
+
+        let d = Directive::name_only("end_of_textblock");
+        assert_eq!(d.section_name(), Some("textblock"));
+    }
+
+    #[test]
+    fn delegate_directive_with_label() {
+        let d = Directive::with_value("start_of_abc", "Melody");
+        assert_eq!(d.name, "start_of_abc");
+        assert_eq!(d.value.as_deref(), Some("Melody"));
+        assert_eq!(d.kind, DirectiveKind::StartOfAbc);
+    }
+
+    #[test]
+    fn delegate_sections_not_custom() {
+        // Delegate section names must NOT produce StartOfSection variants
+        assert!(!matches!(
+            DirectiveKind::from_name("start_of_abc"),
+            DirectiveKind::StartOfSection(_)
+        ));
+        assert!(!matches!(
+            DirectiveKind::from_name("start_of_ly"),
+            DirectiveKind::StartOfSection(_)
+        ));
+        assert!(!matches!(
+            DirectiveKind::from_name("start_of_svg"),
+            DirectiveKind::StartOfSection(_)
+        ));
+        assert!(!matches!(
+            DirectiveKind::from_name("start_of_textblock"),
+            DirectiveKind::StartOfSection(_)
+        ));
     }
 }

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -144,12 +144,10 @@ pub struct Parser {
     tokens: Vec<Token>,
     /// Current index into `tokens`.
     pos: usize,
-    /// Whether we are currently inside a `{start_of_tab}`..`{end_of_tab}` block.
-    /// Lines inside tab sections are treated as verbatim text (no chord parsing).
-    in_tab: bool,
-    /// Whether we are currently inside a `{start_of_grid}`..`{end_of_grid}` block.
-    /// Lines inside grid sections are treated as verbatim text (no chord parsing).
-    in_grid: bool,
+    /// When inside a verbatim section (tab, grid, ABC, Lilypond, SVG, textblock),
+    /// this holds the end-directive name that will close the section.
+    /// Lines inside verbatim sections are treated as plain text (no chord parsing).
+    verbatim_end: Option<String>,
 }
 
 impl Parser {
@@ -159,8 +157,7 @@ impl Parser {
         Self {
             tokens,
             pos: 0,
-            in_tab: false,
-            in_grid: false,
+            verbatim_end: None,
         }
     }
 
@@ -354,6 +351,8 @@ impl Parser {
 
     /// Parses a single line (up to and including the next Newline or Eof).
     fn parse_line(&mut self) -> Result<Line, ParseError> {
+        let in_verbatim = self.verbatim_end.is_some();
+
         match self.peek_kind() {
             // An empty line: just a Newline token.
             TokenKind::Newline => {
@@ -362,67 +361,73 @@ impl Parser {
             }
             // A directive line: starts with `{`.
             TokenKind::DirectiveOpen => {
-                // Inside tab/grid: only the matching end directive is parsed;
-                // everything else is verbatim text.
-                if self.in_tab && !self.is_end_of_tab_ahead() {
-                    return self.parse_verbatim_line();
-                }
-                if self.in_grid && !self.is_end_of_grid_ahead() {
+                // Inside a verbatim section: only the matching end directive
+                // is parsed; everything else is verbatim text.
+                if in_verbatim && !self.is_verbatim_end_ahead() {
                     return self.parse_verbatim_line();
                 }
                 let line = self.parse_directive_line()?;
-                // Track tab/grid section state.
+                // Track verbatim section state.
                 if let Line::Directive(ref d) = line {
-                    match d.kind {
-                        DirectiveKind::StartOfTab => self.in_tab = true,
-                        DirectiveKind::EndOfTab => self.in_tab = false,
-                        DirectiveKind::StartOfGrid => self.in_grid = true,
-                        DirectiveKind::EndOfGrid => self.in_grid = false,
-                        _ => {}
+                    if let Some(end_name) = Self::verbatim_end_for(&d.kind) {
+                        self.verbatim_end = Some(end_name);
+                    } else if d.kind.is_section_end() && in_verbatim {
+                        self.verbatim_end = None;
                     }
                 }
                 Ok(line)
             }
-            // Inside a tab or grid section: treat as verbatim text (no chord parsing).
-            _ if self.in_tab || self.in_grid => self.parse_verbatim_line(),
+            // Inside a verbatim section: treat as plain text (no chord parsing).
+            _ if in_verbatim => self.parse_verbatim_line(),
             // Anything else: a lyrics line.
             _ => self.parse_lyrics_line(),
         }
     }
 
-    /// Peeks ahead to check if the current `{` starts an `{end_of_tab}` or
-    /// `{eot}` directive. This allows the parser to exit tab mode.
+    /// Returns the end-directive name for section types that use verbatim
+    /// content (tab, grid, ABC, Lilypond, SVG, textblock). Returns `None` for
+    /// sections that parse chords normally (chorus, verse, bridge, custom).
+    fn verbatim_end_for(kind: &DirectiveKind) -> Option<String> {
+        match kind {
+            DirectiveKind::StartOfTab => Some("end_of_tab".to_string()),
+            DirectiveKind::StartOfGrid => Some("end_of_grid".to_string()),
+            DirectiveKind::StartOfAbc => Some("end_of_abc".to_string()),
+            DirectiveKind::StartOfLy => Some("end_of_ly".to_string()),
+            DirectiveKind::StartOfSvg => Some("end_of_svg".to_string()),
+            DirectiveKind::StartOfTextblock => Some("end_of_textblock".to_string()),
+            _ => None,
+        }
+    }
+
+    /// Peeks ahead to check if the current `{` starts the end directive
+    /// that closes the current verbatim section. This allows the parser
+    /// to exit verbatim mode.
     ///
     /// Only checks the next token after `DirectiveOpen` for the directive
     /// name text; the full directive structure (including `DirectiveClose`)
     /// is validated later by `parse_directive_line`.
-    fn is_end_of_tab_ahead(&self) -> bool {
-        if self.pos + 1 < self.tokens.len() {
-            if let TokenKind::Text(ref text) = self.tokens[self.pos + 1].kind {
-                let trimmed = text.trim().to_ascii_lowercase();
-                return trimmed == "end_of_tab" || trimmed == "eot";
+    fn is_verbatim_end_ahead(&self) -> bool {
+        if let Some(ref end_name) = self.verbatim_end {
+            if self.pos + 1 < self.tokens.len() {
+                if let TokenKind::Text(ref text) = self.tokens[self.pos + 1].kind {
+                    let trimmed = text.trim().to_ascii_lowercase();
+                    // Check full name
+                    if trimmed == *end_name {
+                        return true;
+                    }
+                    // Check short aliases
+                    return match end_name.as_str() {
+                        "end_of_tab" => trimmed == "eot",
+                        "end_of_grid" => trimmed == "eog",
+                        _ => false,
+                    };
+                }
             }
         }
         false
     }
 
-    /// Peeks ahead to check if the current `{` starts an `{end_of_grid}` or
-    /// `{eog}` directive. This allows the parser to exit grid mode.
-    ///
-    /// Only checks the next token after `DirectiveOpen` for the directive
-    /// name text; the full directive structure (including `DirectiveClose`)
-    /// is validated later by `parse_directive_line`.
-    fn is_end_of_grid_ahead(&self) -> bool {
-        if self.pos + 1 < self.tokens.len() {
-            if let TokenKind::Text(ref text) = self.tokens[self.pos + 1].kind {
-                let trimmed = text.trim().to_ascii_lowercase();
-                return trimmed == "end_of_grid" || trimmed == "eog";
-            }
-        }
-        false
-    }
-
-    /// Parses a verbatim text line (used inside tab and grid sections).
+    /// Parses a verbatim text line (used inside tab, grid, and delegate environment sections).
     ///
     /// All tokens until the next Newline/Eof are collected as plain text,
     /// with no chord bracket interpretation. The result is a lyrics line
@@ -2665,5 +2670,169 @@ mod tests {
     fn split_key_value_pairs_empty() {
         let pairs = super::split_key_value_pairs("");
         assert!(pairs.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod delegate_tests {
+    use super::*;
+    use crate::ast::{DirectiveKind, Line};
+
+    fn lines(input: &str) -> Vec<Line> {
+        parse(input).expect("parse failed").lines
+    }
+
+    #[test]
+    fn abc_content_is_verbatim() {
+        let song = parse("{start_of_abc}\nX:1\nK:G\n{end_of_abc}").unwrap();
+        assert_eq!(song.lines.len(), 4);
+        if let Line::Lyrics(ref l) = song.lines[1] {
+            assert_eq!(l.segments.len(), 1);
+            assert!(l.segments[0].chord.is_none());
+            assert_eq!(l.segments[0].text, "X:1");
+        } else {
+            panic!("expected lyrics line for ABC content");
+        }
+    }
+
+    #[test]
+    fn abc_preserves_brackets() {
+        let song = parse("{start_of_abc}\n|:GABc|[1d2d2:|[2d4d4:|\n{end_of_abc}").unwrap();
+        if let Line::Lyrics(ref l) = song.lines[1] {
+            assert_eq!(l.segments[0].text, "|:GABc|[1d2d2:|[2d4d4:|");
+        } else {
+            panic!("expected verbatim lyrics line");
+        }
+    }
+
+    #[test]
+    fn ly_content_is_verbatim() {
+        let song = parse("{start_of_ly}\n\\relative c' { c4 d e f }\n{end_of_ly}").unwrap();
+        assert_eq!(song.lines.len(), 3);
+        if let Line::Lyrics(ref l) = song.lines[1] {
+            assert!(l.segments[0].chord.is_none());
+        } else {
+            panic!("expected lyrics line for Lilypond content");
+        }
+    }
+
+    #[test]
+    fn svg_content_is_verbatim() {
+        let song = parse("{start_of_svg}\n<svg><rect/></svg>\n{end_of_svg}").unwrap();
+        assert_eq!(song.lines.len(), 3);
+        if let Line::Lyrics(ref l) = song.lines[1] {
+            assert!(l.segments[0].chord.is_none());
+        } else {
+            panic!("expected lyrics line for SVG content");
+        }
+    }
+
+    #[test]
+    fn textblock_content_is_verbatim() {
+        let song = parse("{start_of_textblock}\n[Am]Not a chord\n{end_of_textblock}").unwrap();
+        assert_eq!(song.lines.len(), 3);
+        if let Line::Lyrics(ref l) = song.lines[1] {
+            assert_eq!(l.segments.len(), 1);
+            assert!(l.segments[0].chord.is_none());
+            assert_eq!(l.segments[0].text, "[Am]Not a chord");
+        } else {
+            panic!("expected lyrics line for textblock content");
+        }
+    }
+
+    #[test]
+    fn textblock_preserves_braces() {
+        let song = parse("{start_of_textblock}\n{some directive}\n{end_of_textblock}").unwrap();
+        if let Line::Lyrics(ref l) = song.lines[1] {
+            assert_eq!(l.segments[0].text, "{some directive}");
+        } else {
+            panic!("expected verbatim lyrics line");
+        }
+    }
+
+    #[test]
+    fn chords_parsed_after_abc_ends() {
+        let song = parse("{start_of_abc}\nX:1\n{end_of_abc}\n[Am]Hello").unwrap();
+        if let Line::Lyrics(ref l) = song.lines[3] {
+            assert!(l.segments[0].chord.is_some());
+            assert_eq!(l.segments[0].chord.as_ref().unwrap().name, "Am");
+        } else {
+            panic!("expected lyrics line with chord after ABC section");
+        }
+    }
+
+    #[test]
+    fn chords_parsed_after_ly_ends() {
+        let song = parse("{start_of_ly}\nnotes\n{end_of_ly}\n[G]Hello").unwrap();
+        if let Line::Lyrics(ref l) = song.lines[3] {
+            assert!(l.segments[0].chord.is_some());
+            assert_eq!(l.segments[0].chord.as_ref().unwrap().name, "G");
+        } else {
+            panic!("expected lyrics line with chord after Lilypond section");
+        }
+    }
+
+    #[test]
+    fn chords_parsed_after_svg_ends() {
+        let song = parse("{start_of_svg}\n<svg/>\n{end_of_svg}\n[C]Hello").unwrap();
+        if let Line::Lyrics(ref l) = song.lines[3] {
+            assert!(l.segments[0].chord.is_some());
+            assert_eq!(l.segments[0].chord.as_ref().unwrap().name, "C");
+        } else {
+            panic!("expected lyrics line with chord after SVG section");
+        }
+    }
+
+    #[test]
+    fn chords_parsed_after_textblock_ends() {
+        let song = parse("{start_of_textblock}\ntext\n{end_of_textblock}\n[D]Hello").unwrap();
+        if let Line::Lyrics(ref l) = song.lines[3] {
+            assert!(l.segments[0].chord.is_some());
+            assert_eq!(l.segments[0].chord.as_ref().unwrap().name, "D");
+        } else {
+            panic!("expected lyrics line with chord after textblock section");
+        }
+    }
+
+    #[test]
+    fn abc_directive_with_label() {
+        let result = lines("{start_of_abc: My Melody}");
+        if let Line::Directive(ref d) = result[0] {
+            assert_eq!(d.kind, DirectiveKind::StartOfAbc);
+            assert_eq!(d.value.as_deref(), Some("My Melody"));
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    #[test]
+    fn textblock_directive_with_label() {
+        let result = lines("{start_of_textblock: Notes}");
+        if let Line::Directive(ref d) = result[0] {
+            assert_eq!(d.kind, DirectiveKind::StartOfTextblock);
+            assert_eq!(d.value.as_deref(), Some("Notes"));
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    #[test]
+    fn delegate_sections_not_custom() {
+        assert_eq!(
+            DirectiveKind::from_name("start_of_abc"),
+            DirectiveKind::StartOfAbc
+        );
+        assert_eq!(
+            DirectiveKind::from_name("start_of_ly"),
+            DirectiveKind::StartOfLy
+        );
+        assert_eq!(
+            DirectiveKind::from_name("start_of_svg"),
+            DirectiveKind::StartOfSvg
+        );
+        assert_eq!(
+            DirectiveKind::from_name("start_of_textblock"),
+            DirectiveKind::StartOfTextblock
+        );
     }
 }

--- a/crates/core/tests/fixtures/delegate-environments/expected.txt
+++ b/crates/core/tests/fixtures/delegate-environments/expected.txt
@@ -1,0 +1,193 @@
+Song {
+    metadata: Metadata {
+        title: None,
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "start_of_abc",
+                value: None,
+                kind: StartOfAbc,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "X:1",
+                    },
+                ],
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "T:Test",
+                    },
+                ],
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "M:4/4",
+                    },
+                ],
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "K:G",
+                    },
+                ],
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "|:GABc|d2d2:|",
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "end_of_abc",
+                value: None,
+                kind: EndOfAbc,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "start_of_ly",
+                value: None,
+                kind: StartOfLy,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "\\relative c' { c4 d e f | g1 }",
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "end_of_ly",
+                value: None,
+                kind: EndOfLy,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "start_of_svg",
+                value: None,
+                kind: StartOfSvg,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "<svg><circle cx=\"50\" cy=\"50\" r=\"40\"/></svg>",
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "end_of_svg",
+                value: None,
+                kind: EndOfSvg,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "start_of_textblock",
+                value: None,
+                kind: StartOfTextblock,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "This is [verbatim] text with {braces} and [brackets].",
+                    },
+                ],
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: None,
+                        text: "No chord parsing here.",
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "end_of_textblock",
+                value: None,
+                kind: EndOfTextblock,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        text: "After delegate sections",
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/delegate-environments/input.cho
+++ b/crates/core/tests/fixtures/delegate-environments/input.cho
@@ -1,0 +1,18 @@
+{start_of_abc}
+X:1
+T:Test
+M:4/4
+K:G
+|:GABc|d2d2:|
+{end_of_abc}
+{start_of_ly}
+\relative c' { c4 d e f | g1 }
+{end_of_ly}
+{start_of_svg}
+<svg><circle cx="50" cy="50" r="40"/></svg>
+{end_of_svg}
+{start_of_textblock}
+This is [verbatim] text with {braces} and [brackets].
+No chord parsing here.
+{end_of_textblock}
+[Am]After delegate sections

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -200,6 +200,18 @@ fn render_directive(directive: &chordpro_core::ast::Directive, html: &mut String
         DirectiveKind::StartOfGrid => {
             render_section_open("grid", "Grid", &directive.value, html);
         }
+        DirectiveKind::StartOfAbc => {
+            render_section_open("abc", "ABC", &directive.value, html);
+        }
+        DirectiveKind::StartOfLy => {
+            render_section_open("ly", "Lilypond", &directive.value, html);
+        }
+        DirectiveKind::StartOfSvg => {
+            render_section_open("svg", "SVG", &directive.value, html);
+        }
+        DirectiveKind::StartOfTextblock => {
+            render_section_open("textblock", "Textblock", &directive.value, html);
+        }
         DirectiveKind::StartOfSection(section_name) => {
             let class = format!("section-{}", section_name);
             let label = capitalize(section_name);
@@ -210,6 +222,10 @@ fn render_directive(directive: &chordpro_core::ast::Directive, html: &mut String
         | DirectiveKind::EndOfBridge
         | DirectiveKind::EndOfTab
         | DirectiveKind::EndOfGrid
+        | DirectiveKind::EndOfAbc
+        | DirectiveKind::EndOfLy
+        | DirectiveKind::EndOfSvg
+        | DirectiveKind::EndOfTextblock
         | DirectiveKind::EndOfSection(_) => {
             html.push_str("</section>\n");
         }
@@ -472,5 +488,49 @@ mod transpose_tests {
         let html = render_song_with_transpose(&song, 3);
         // 2 + 3 = 5, C+5=F
         assert!(html.contains("<span class=\"chord\">F</span>"));
+    }
+}
+
+#[cfg(test)]
+mod delegate_tests {
+    use super::*;
+
+    #[test]
+    fn test_render_abc_section() {
+        let html = render("{start_of_abc}\nX:1\n{end_of_abc}");
+        assert!(html.contains("<section class=\"abc\">"));
+        assert!(html.contains("ABC"));
+        assert!(html.contains("</section>"));
+    }
+
+    #[test]
+    fn test_render_abc_section_with_label() {
+        let html = render("{start_of_abc: Melody}\nX:1\n{end_of_abc}");
+        assert!(html.contains("<section class=\"abc\">"));
+        assert!(html.contains("ABC: Melody"));
+    }
+
+    #[test]
+    fn test_render_ly_section() {
+        let html = render("{start_of_ly}\nnotes\n{end_of_ly}");
+        assert!(html.contains("<section class=\"ly\">"));
+        assert!(html.contains("Lilypond"));
+        assert!(html.contains("</section>"));
+    }
+
+    #[test]
+    fn test_render_svg_section() {
+        let html = render("{start_of_svg}\n<svg/>\n{end_of_svg}");
+        assert!(html.contains("<section class=\"svg\">"));
+        assert!(html.contains("SVG"));
+        assert!(html.contains("</section>"));
+    }
+
+    #[test]
+    fn test_render_textblock_section() {
+        let html = render("{start_of_textblock}\nPreformatted\n{end_of_textblock}");
+        assert!(html.contains("<section class=\"textblock\">"));
+        assert!(html.contains("Textblock"));
+        assert!(html.contains("</section>"));
     }
 }

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -143,6 +143,10 @@ fn render_directive(directive: &chordpro_core::ast::Directive, page: &mut PageBu
         DirectiveKind::StartOfBridge => Some("Bridge".to_string()),
         DirectiveKind::StartOfTab => Some("Tab".to_string()),
         DirectiveKind::StartOfGrid => Some("Grid".to_string()),
+        DirectiveKind::StartOfAbc => Some("ABC".to_string()),
+        DirectiveKind::StartOfLy => Some("Lilypond".to_string()),
+        DirectiveKind::StartOfSvg => Some("SVG".to_string()),
+        DirectiveKind::StartOfTextblock => Some("Textblock".to_string()),
         DirectiveKind::StartOfSection(section_name) => Some(capitalize(section_name)),
         _ => None,
     };
@@ -492,5 +496,47 @@ mod transpose_tests {
         // 2+3=5, C+5=F
         let content = String::from_utf8_lossy(&bytes);
         assert!(content.contains("(F)"));
+    }
+}
+
+#[cfg(test)]
+mod delegate_tests {
+    use super::*;
+
+    #[test]
+    fn test_abc_section_in_pdf() {
+        let input = "{start_of_abc: Melody}\nX:1\n{end_of_abc}";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        assert!(bytes.starts_with(b"%PDF"));
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(content.contains("ABC: Melody"));
+    }
+
+    #[test]
+    fn test_ly_section_in_pdf() {
+        let input = "{start_of_ly}\nnotes\n{end_of_ly}";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(content.contains("Lilypond"));
+    }
+
+    #[test]
+    fn test_svg_section_in_pdf() {
+        let input = "{start_of_svg}\n<svg/>\n{end_of_svg}";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(content.contains("SVG"));
+    }
+
+    #[test]
+    fn test_textblock_section_in_pdf() {
+        let input = "{start_of_textblock}\nText\n{end_of_textblock}";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(content.contains("Textblock"));
     }
 }

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -216,6 +216,18 @@ fn render_directive(directive: &chordpro_core::ast::Directive, output: &mut Vec<
         DirectiveKind::StartOfGrid => {
             render_section_header("Grid", &directive.value, output);
         }
+        DirectiveKind::StartOfAbc => {
+            render_section_header("ABC", &directive.value, output);
+        }
+        DirectiveKind::StartOfLy => {
+            render_section_header("Lilypond", &directive.value, output);
+        }
+        DirectiveKind::StartOfSvg => {
+            render_section_header("SVG", &directive.value, output);
+        }
+        DirectiveKind::StartOfTextblock => {
+            render_section_header("Textblock", &directive.value, output);
+        }
         DirectiveKind::StartOfSection(section_name) => {
             // Capitalize the first letter of the section name for display.
             let label = capitalize(section_name);
@@ -617,5 +629,54 @@ mod transpose_tests {
         let output = render_song(&song);
         // No value -> treated as 0
         assert!(output.contains("G\nHello"));
+    }
+}
+
+#[cfg(test)]
+mod delegate_tests {
+    use super::*;
+
+    #[test]
+    fn test_render_abc_section() {
+        let input = "{start_of_abc}\nX:1\nK:G\n{end_of_abc}";
+        let output = render(input);
+        assert!(output.contains("[ABC]"));
+        assert!(output.contains("X:1"));
+    }
+
+    #[test]
+    fn test_render_abc_section_with_label() {
+        let input = "{start_of_abc: Melody}\nX:1\n{end_of_abc}";
+        let output = render(input);
+        assert_eq!(output, "[ABC: Melody]\nX:1\n");
+    }
+
+    #[test]
+    fn test_render_ly_section() {
+        let input = "{start_of_ly}\nnotes\n{end_of_ly}";
+        let output = render(input);
+        assert!(output.contains("[Lilypond]"));
+    }
+
+    #[test]
+    fn test_render_svg_section() {
+        let input = "{start_of_svg}\n<svg/>\n{end_of_svg}";
+        let output = render(input);
+        assert!(output.contains("[SVG]"));
+    }
+
+    #[test]
+    fn test_render_textblock_section() {
+        let input = "{start_of_textblock}\nPreformatted text\n{end_of_textblock}";
+        let output = render(input);
+        assert!(output.contains("[Textblock]"));
+        assert!(output.contains("Preformatted text"));
+    }
+
+    #[test]
+    fn test_delegate_verbatim_no_chords() {
+        let input = "{start_of_textblock}\n[Am]Not a chord\n{end_of_textblock}";
+        let output = render(input);
+        assert!(output.contains("[Am]Not a chord"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `{start_of_abc}`, `{start_of_ly}`, `{start_of_svg}`, `{start_of_textblock}` delegate environments with 8 new `DirectiveKind` variants
- Content within delegate environments is treated as verbatim text (no chord parsing), matching the ChordPro specification
- Generalizes the parser's verbatim handling by replacing separate `in_tab`/`in_grid` booleans with a single `verbatim_end` tracker
- All three renderers (text, HTML, PDF) display delegate environment sections with appropriate labels

## What
- 8 new `DirectiveKind` variants: `StartOfAbc`, `EndOfAbc`, `StartOfLy`, `EndOfLy`, `StartOfSvg`, `EndOfSvg`, `StartOfTextblock`, `EndOfTextblock`
- Case-insensitive directive name recognition in `from_name()`
- `canonical_name()`, `is_section_start()`, `is_section_end()` updated for all new variants
- Parser verbatim handling generalized: `in_tab: bool` + `in_grid: bool` replaced with `verbatim_end: Option<String>` that stores the expected end-directive name
- Text renderer shows `[ABC]`, `[Lilypond]`, `[SVG]`, `[Textblock]` headers
- HTML renderer uses `<section class="abc">`, `<section class="ly">`, etc.
- PDF renderer includes section labels in the content stream
- Golden test fixture (`delegate-environments/`) covering all 4 delegate types
- 38 new unit tests across AST, parser, and all 3 renderers

## Why
Delegate environments allow embedding external notation systems (ABC music notation, Lilypond, SVG graphics, preformatted text blocks) in ChordPro files. This is part of the Phase 15 roadmap. Content between the start/end directives must be preserved verbatim since it uses different syntax that would be corrupted by chord parsing.

## Test results
- `cargo test` -- all tests pass (405+ tests, 0 failures)
- `cargo clippy -- -D warnings` -- no warnings
- `cargo fmt --check` -- formatted

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)