### PR TITLE
Handle multi-song output in CLI and renderers

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -78,8 +78,7 @@ fn main() -> ExitCode {
     // Future work will pass it to render functions.
     let _ = config;
 
-    let mut combined_text = String::new();
-    let mut combined_bytes: Vec<u8> = Vec::new();
+    let mut all_songs: Vec<chordpro_core::ast::Song> = Vec::new();
     let is_binary = matches!(cli.format, Format::Pdf);
     let mut had_error = false;
 
@@ -93,9 +92,9 @@ fn main() -> ExitCode {
             }
         };
 
-        let song = match chordpro_core::parse(&input) {
-            Ok(song) => song,
-            Err(e) => {
+        let result = chordpro_core::parse_multi_lenient(&input);
+        for parse_result in &result.results {
+            for e in &parse_result.errors {
                 eprintln!(
                     "error: {path}: parse error at line {} column {}: {}",
                     e.line(),
@@ -103,34 +102,29 @@ fn main() -> ExitCode {
                     e.message
                 );
                 had_error = true;
-                continue;
             }
-        };
-
-        if is_binary {
-            // PDF: each file produces a separate PDF. For multiple files,
-            // only the last one is written (PDF doesn't support concatenation).
-            if !combined_bytes.is_empty() {
-                eprintln!(
-                    "warning: PDF output supports one file at a time; previous output discarded"
-                );
-            }
-            combined_bytes = chordpro_render_pdf::render_song_with_transpose(&song, cli.transpose);
-        } else {
-            let text = match cli.format {
-                Format::Text => {
-                    chordpro_render_text::render_song_with_transpose(&song, cli.transpose)
-                }
-                Format::Html => {
-                    chordpro_render_html::render_song_with_transpose(&song, cli.transpose)
-                }
-                Format::Pdf => unreachable!(),
-            };
-            if !combined_text.is_empty() {
-                combined_text.push('\n');
-            }
-            combined_text.push_str(&text);
         }
+        all_songs.extend(result.results.into_iter().map(|r| r.song));
+    }
+
+    let combined_text;
+    let combined_bytes;
+
+    if is_binary {
+        combined_bytes =
+            chordpro_render_pdf::render_songs_with_transpose(&all_songs, cli.transpose);
+        combined_text = String::new();
+    } else {
+        combined_bytes = Vec::new();
+        combined_text = match cli.format {
+            Format::Text => {
+                chordpro_render_text::render_songs_with_transpose(&all_songs, cli.transpose)
+            }
+            Format::Html => {
+                chordpro_render_html::render_songs_with_transpose(&all_songs, cli.transpose)
+            }
+            Format::Pdf => unreachable!(),
+        };
     }
 
     if had_error && combined_text.is_empty() && combined_bytes.is_empty() {

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -237,6 +237,57 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
     html
 }
 
+/// Render multiple [`Song`]s into a single HTML5 document.
+#[must_use]
+pub fn render_songs(songs: &[Song]) -> String {
+    render_songs_with_transpose(songs, 0)
+}
+
+/// Render multiple [`Song`]s into a single HTML5 document with transposition.
+///
+/// When there is only one song, this is identical to [`render_song_with_transpose`].
+/// For multiple songs, the document uses the first song's title and separates
+/// each song with an `<hr class="song-separator">`.
+#[must_use]
+pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8) -> String {
+    if songs.len() <= 1 {
+        return songs
+            .first()
+            .map(|s| render_song_with_transpose(s, cli_transpose))
+            .unwrap_or_default();
+    }
+    // Use the first song's title for the document
+    let mut html = String::new();
+    let title = songs
+        .first()
+        .and_then(|s| s.metadata.title.as_deref())
+        .unwrap_or("Untitled");
+    html.push_str(&format!(
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>{}</title>\n",
+        escape(title)
+    ));
+    html.push_str("<style>\n");
+    html.push_str(CSS);
+    html.push_str("</style>\n</head>\n<body>\n");
+
+    for (i, song) in songs.iter().enumerate() {
+        if i > 0 {
+            html.push_str("<hr class=\"song-separator\">\n");
+        }
+        // Render each song as a full document, then extract the <div class="song">...</div> body.
+        let song_html = render_song_with_transpose(song, cli_transpose);
+        if let Some(start) = song_html.find("<div class=\"song\">") {
+            if let Some(end) = song_html.rfind("</div>\n</body>") {
+                html.push_str(&song_html[start..end + 6]); // include </div>
+                html.push('\n');
+            }
+        }
+    }
+
+    html.push_str("</body>\n</html>\n");
+    html
+}
+
 /// Parse a ChordPro source string and render it to HTML.
 ///
 /// Returns `Ok(html)` on success, or the [`chordpro_core::ParseError`] if
@@ -1124,5 +1175,47 @@ mod delegate_tests {
         assert!(html.contains("<section class=\"textblock\">"));
         assert!(html.contains("Textblock"));
         assert!(html.contains("</section>"));
+    }
+
+    // --- Multi-song rendering ---
+
+    #[test]
+    fn test_render_songs_single() {
+        let songs = chordpro_core::parse_multi("{title: Only}").unwrap();
+        let html = render_songs(&songs);
+        // Single song: should be identical to render_song
+        assert_eq!(html, render_song(&songs[0]));
+    }
+
+    #[test]
+    fn test_render_songs_two_songs_with_hr_separator() {
+        let songs = chordpro_core::parse_multi(
+            "{title: Song A}\n[Am]Hello\n{new_song}\n{title: Song B}\n[G]World",
+        )
+        .unwrap();
+        let html = render_songs(&songs);
+        // Document title from first song
+        assert!(html.contains("<title>Song A</title>"));
+        // Both songs present
+        assert!(html.contains("<h1>Song A</h1>"));
+        assert!(html.contains("<h1>Song B</h1>"));
+        // Separator between songs
+        assert!(html.contains("<hr class=\"song-separator\">"));
+        // Each song in its own div.song
+        assert_eq!(html.matches("<div class=\"song\">").count(), 2);
+        // Single HTML document wrapper
+        assert_eq!(html.matches("<!DOCTYPE html>").count(), 1);
+        assert_eq!(html.matches("</html>").count(), 1);
+    }
+
+    #[test]
+    fn test_render_songs_with_transpose() {
+        let songs =
+            chordpro_core::parse_multi("{title: S1}\n[C]Do\n{new_song}\n{title: S2}\n[G]Re")
+                .unwrap();
+        let html = render_songs_with_transpose(&songs, 2);
+        // C+2=D, G+2=A
+        assert!(html.contains(">D<"));
+        assert!(html.contains(">A<"));
     }
 }

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -111,6 +111,45 @@ pub fn render_song(song: &Song) -> Vec<u8> {
 #[must_use]
 pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
     let mut doc = PdfDocument::new();
+    render_song_into_doc(song, cli_transpose, &mut doc);
+    doc.build_pdf()
+}
+
+/// Render multiple [`Song`]s into a single multi-page PDF document.
+///
+/// Each song starts on a new page.
+#[must_use]
+pub fn render_songs(songs: &[Song]) -> Vec<u8> {
+    render_songs_with_transpose(songs, 0)
+}
+
+/// Render multiple [`Song`]s into a single PDF with transposition.
+///
+/// Each song starts on a new page (except the first).
+#[must_use]
+pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8) -> Vec<u8> {
+    if songs.len() == 1 {
+        return render_song_with_transpose(&songs[0], cli_transpose);
+    }
+
+    let mut doc = PdfDocument::new();
+
+    for (i, song) in songs.iter().enumerate() {
+        if i > 0 {
+            doc.new_page();
+        }
+        render_song_into_doc(song, cli_transpose, &mut doc);
+    }
+
+    doc.build_pdf()
+}
+
+/// Render a single song's content into an existing [`PdfDocument`].
+///
+/// This is the shared implementation used by both [`render_song_with_transpose`]
+/// and [`render_songs_with_transpose`]. It does not call `build_pdf`; the caller
+/// is responsible for finalising the document.
+fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
     let mut transpose_offset: i8 = cli_transpose;
     let mut fmt_state = PdfFormattingState::default();
 
@@ -136,7 +175,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
                 if let Some(buf) = chorus_buf.as_mut() {
                     buf.push(line.clone());
                 }
-                render_lyrics(lyrics, transpose_offset, &fmt_state, &mut doc);
+                render_lyrics(lyrics, transpose_offset, &fmt_state, doc);
             }
             Line::Directive(d) if !d.kind.is_metadata() => {
                 if d.kind == DirectiveKind::Transpose {
@@ -151,7 +190,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
                 }
                 match &d.kind {
                     DirectiveKind::StartOfChorus => {
-                        render_section_label(d, &mut doc);
+                        render_section_label(d, doc);
                         chorus_buf = Some(Vec::new());
                     }
                     DirectiveKind::EndOfChorus => {
@@ -165,7 +204,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
                             &chorus_body,
                             transpose_offset,
                             &fmt_state,
-                            &mut doc,
+                            doc,
                         );
                     }
                     DirectiveKind::NewPage | DirectiveKind::NewPhysicalPage => {
@@ -186,7 +225,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
                         if let Some(buf) = chorus_buf.as_mut() {
                             buf.push(line.clone());
                         }
-                        render_directive(d, &mut doc);
+                        render_directive(d, doc);
                     }
                 }
             }
@@ -194,7 +233,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
                 if let Some(buf) = chorus_buf.as_mut() {
                     buf.push(line.clone());
                 }
-                render_comment(*style, text, &mut doc);
+                render_comment(*style, text, doc);
             }
             Line::Empty => {
                 if let Some(buf) = chorus_buf.as_mut() {
@@ -205,8 +244,6 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
             _ => {}
         }
     }
-
-    doc.build_pdf()
 }
 
 /// Parse and render a ChordPro source string to PDF bytes.
@@ -1202,5 +1239,59 @@ mod column_tests {
         doc.column_break(); // → new page, column 0
         assert_eq!(doc.page_count(), 2);
         assert_eq!(doc.current_column, 0);
+    }
+
+    // --- Multi-song rendering ---
+
+    #[test]
+    fn test_render_songs_single() {
+        let songs = chordpro_core::parse_multi("{title: Only}\n[Am]Hello").unwrap();
+        let bytes = render_songs(&songs);
+        assert!(bytes.starts_with(b"%PDF-1.4"));
+        assert!(bytes.ends_with(b"%%EOF\n"));
+        // Single song: output should match render_song
+        assert_eq!(bytes, render_song(&songs[0]));
+    }
+
+    #[test]
+    fn test_render_songs_two_songs_multi_page() {
+        let songs = chordpro_core::parse_multi(
+            "{title: Song A}\n[Am]Hello\n{new_song}\n{title: Song B}\n[G]World",
+        )
+        .unwrap();
+        let bytes = render_songs(&songs);
+        assert!(bytes.starts_with(b"%PDF-1.4"));
+        assert!(bytes.ends_with(b"%%EOF\n"));
+        let content = String::from_utf8_lossy(&bytes);
+        // Both songs should be present
+        assert!(content.contains("Song A"));
+        assert!(content.contains("Song B"));
+        // Pages node should have /Count 2
+        assert!(content.contains("/Count 2"));
+    }
+
+    #[test]
+    fn test_render_songs_with_transpose() {
+        let songs =
+            chordpro_core::parse_multi("{title: S1}\n[C]Do\n{new_song}\n{title: S2}\n[G]Re")
+                .unwrap();
+        let bytes = render_songs_with_transpose(&songs, 2);
+        let content = String::from_utf8_lossy(&bytes);
+        // C+2=D, G+2=A — both transposed chords should appear
+        assert!(content.contains("(D)"));
+        assert!(content.contains("(A)"));
+    }
+
+    #[test]
+    fn test_render_song_into_doc_helper() {
+        let song = chordpro_core::parse("{title: Test}\n[Am]Hello").unwrap();
+        let mut doc = PdfDocument::new();
+        render_song_into_doc(&song, 0, &mut doc);
+        // Document should have 1 page with content
+        assert_eq!(doc.page_count(), 1);
+        let pdf = doc.build_pdf();
+        assert!(pdf.starts_with(b"%PDF-1.4"));
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("Test"));
     }
 }

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -124,6 +124,22 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
     result
 }
 
+/// Render multiple [`Song`]s to plain text, separated by a blank line.
+#[must_use]
+pub fn render_songs(songs: &[Song]) -> String {
+    render_songs_with_transpose(songs, 0)
+}
+
+/// Render multiple [`Song`]s to plain text with transposition.
+#[must_use]
+pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8) -> String {
+    songs
+        .iter()
+        .map(|song| render_song_with_transpose(song, cli_transpose))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
 /// Parse a ChordPro source string and render it to plain text.
 ///
 /// Returns `Ok(text)` on success, or the [`chordpro_core::ParseError`] if
@@ -594,6 +610,45 @@ mod tests {
         let input = "{start_of_solo}\n[Em]Solo line\n{end_of_solo}";
         let output = render(input);
         assert!(output.contains("[Solo]"));
+    }
+}
+
+#[cfg(test)]
+mod multi_song_tests {
+    use super::*;
+
+    #[test]
+    fn test_render_songs_two_songs() {
+        let songs = chordpro_core::parse_multi(
+            "{title: Song One}\n[Am]Hello\n{new_song}\n{title: Song Two}\n[G]World",
+        )
+        .unwrap();
+        let output = render_songs(&songs);
+        assert!(output.contains("Song One"));
+        assert!(output.contains("Am"));
+        assert!(output.contains("Hello"));
+        assert!(output.contains("Song Two"));
+        assert!(output.contains("G\nWorld"));
+        // Two songs are separated by a blank line (double newline between them)
+        assert!(output.contains("\n\n"));
+    }
+
+    #[test]
+    fn test_render_songs_single_song() {
+        let songs = chordpro_core::parse_multi("{title: Only One}\nLyrics").unwrap();
+        let output = render_songs(&songs);
+        assert_eq!(output, render_song(&songs[0]));
+    }
+
+    #[test]
+    fn test_render_songs_with_transpose() {
+        let songs =
+            chordpro_core::parse_multi("{title: S1}\n[C]Do\n{new_song}\n{title: S2}\n[G]Re")
+                .unwrap();
+        let output = render_songs_with_transpose(&songs, 2);
+        // C+2=D, G+2=A
+        assert!(output.contains("D\nDo"));
+        assert!(output.contains("A\nRe"));
     }
 }
 


### PR DESCRIPTION
## What

Add multi-song rendering support to all three renderers and update the CLI.

- **Text**: `render_songs()` — concatenates songs separated by blank line
- **HTML**: `render_songs()` — single HTML5 document with `<hr>` separators
- **PDF**: `render_songs()` — multi-page PDF with page breaks between songs
- **CLI**: uses `parse_multi_lenient()` for `{new_song}` support

## Why

Multi-song files (split by `{new_song}`) were parsed (#154) but renderers only handled single songs. The CLI used `parse()` which ignores `{new_song}`.

## Test results

- 10 new multi-song tests across all renderers
- All 740+ existing tests pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

## Review summary

- PDF renderer refactored: `render_song_into_doc()` helper enables shared PdfDocument
- HTML extracts song body from individual renders for combining
- CLI collects all songs from all files before rendering

Closes #137