### PR TITLE
Clamp column count to prevent resource exhaustion and f32 overflow

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -190,11 +190,15 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
                         render_chorus_recall(&directive.value, &chorus_html, &mut html);
                     }
                     DirectiveKind::Columns => {
+                        // Clamp to 1..=32 to prevent degenerate CSS output.
+                        // Parsing as u32 already rejects non-numeric input;
+                        // clamping ensures the formatted value is always safe.
                         let n: u32 = directive
                             .value
                             .as_deref()
                             .and_then(|v| v.trim().parse().ok())
-                            .unwrap_or(1);
+                            .unwrap_or(1)
+                            .clamp(1, 32);
                         if columns_open {
                             html.push_str("</div>\n");
                             columns_open = false;
@@ -1177,6 +1181,20 @@ mod transpose_tests {
     fn test_column_break_generates_css() {
         let html = render("{columns: 2}\nCol 1\n{column_break}\nCol 2");
         assert!(html.contains("break-before: column;"));
+    }
+
+    #[test]
+    fn test_columns_clamped_to_max() {
+        let html = render("{columns: 999}\nContent");
+        // Should be clamped to 32
+        assert!(html.contains("column-count: 32"));
+    }
+
+    #[test]
+    fn test_columns_zero_treated_as_one() {
+        let html = render("{columns: 0}\nContent");
+        // 0 is clamped to 1, so no multi-column div should be opened
+        assert!(!html.contains("column-count"));
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -89,6 +89,9 @@ const TOC_ENTRY_SIZE: f32 = 11.0;
 /// Maximum number of pages a single document can contain.
 /// Prevents resource exhaustion from malicious input.
 const MAX_PAGES: usize = 10_000;
+/// Maximum number of columns allowed.
+/// Prevents degenerate layout and f32 overflow from extreme values.
+const MAX_COLUMNS: u32 = 32;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -588,9 +591,9 @@ impl PdfDocument {
         MARGIN_LEFT + self.current_column as f32 * (col_width + COLUMN_GAP)
     }
 
-    /// Set the number of columns. Resets to column 0.
+    /// Set the number of columns (clamped to 1..=[`MAX_COLUMNS`]). Resets to column 0.
     fn set_columns(&mut self, n: u32) {
-        self.num_columns = n.max(1);
+        self.num_columns = n.clamp(1, MAX_COLUMNS);
         self.current_column = 0;
     }
 
@@ -1349,6 +1352,36 @@ mod column_tests {
         assert_eq!(doc.current_column, 0);
         doc.column_break();
         assert_eq!(doc.current_column, 1);
+    }
+
+    #[test]
+    fn test_set_columns_clamps_to_max() {
+        let mut doc = PdfDocument::new();
+        doc.set_columns(999);
+        assert_eq!(doc.num_columns, MAX_COLUMNS);
+    }
+
+    #[test]
+    fn test_set_columns_clamps_zero_to_one() {
+        let mut doc = PdfDocument::new();
+        doc.set_columns(0);
+        assert_eq!(doc.num_columns, 1);
+    }
+
+    #[test]
+    fn test_margin_left_at_max_columns_no_overflow() {
+        let mut doc = PdfDocument::new();
+        doc.set_columns(MAX_COLUMNS);
+        // Verify margin_left produces a finite, non-negative value for every column.
+        for col in 0..MAX_COLUMNS {
+            doc.current_column = col;
+            let m = doc.margin_left();
+            assert!(m.is_finite(), "margin_left must be finite for column {col}");
+            assert!(
+                m >= 0.0,
+                "margin_left must be non-negative for column {col}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

- Add `MAX_COLUMNS` constant (32) to the PDF renderer and clamp `set_columns()` to `1..=32`.
- Clamp the `{columns}` directive value to `1..=32` in the HTML renderer before inserting into CSS.
- Add comment documenting that `u32` parsing provides equivalent CSS injection protection.

## Why

Phase 11 Completion Gate review found:

- **S-M2**: `{columns: 4294967295}` causes f32 overflow (infinity/NaN) in PDF column width calculations and degenerate CSS in HTML.
- **S-M3**: Column count CSS value bypassed `sanitize_css_value()`, inconsistent with the project's defense-in-depth pattern. Since it's parsed as `u32` and clamped, the formatted output is always a safe numeric string — documented with a comment.
- **S-L1**: f32 arithmetic anomalies with extreme column counts — resolved by clamping.

## Test results

```
test column_tests::test_set_columns_clamps_to_max ... ok
test column_tests::test_set_columns_clamps_zero_to_one ... ok
test column_tests::test_margin_left_at_max_columns_no_overflow ... ok
test transpose_tests::test_columns_clamped_to_max ... ok
test transpose_tests::test_columns_zero_treated_as_one ... ok

128 total tests passed (55 PDF + 73 HTML), clippy and fmt clean.
```

## Review summary

- PDF: `set_columns()` now uses `n.clamp(1, MAX_COLUMNS)` instead of `n.max(1)`
- HTML: Value clamped to `1..=32` after `u32` parsing, before CSS insertion
- 5 new tests verify clamping behavior and f32 safety at max columns

Closes #181