### PR TITLE
Set up automated comparison against Perl reference implementation

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+# Comparison Scripts
+
+## compare-with-perl.sh
+
+Automated comparison tool that runs both chordpro-rs and the Perl ChordPro
+reference implementation on the same `.cho` input files and diffs the output.
+
+### Prerequisites
+
+- **Perl ChordPro**: Install via `cpanm App::Music::ChordPro`
+- **chordpro-rs**: Built with `cargo build --release`
+
+### Usage
+
+```bash
+# Compare text output (default)
+./scripts/compare-with-perl.sh
+
+# Compare HTML output
+./scripts/compare-with-perl.sh html
+
+# Use a custom corpus directory
+./scripts/compare-with-perl.sh text path/to/corpus
+```
+
+### Output
+
+- **PASS**: Both implementations produce identical output
+- **DIFF**: Output differs — diff saved to `/tmp/chordpro-comparison/diff/`
+- **SKIP**: One implementation failed to process the file
+
+### Reviewing Diffs
+
+```bash
+# List all diff files
+ls /tmp/chordpro-comparison/diff/
+
+# View a specific diff
+cat /tmp/chordpro-comparison/diff/basic_04-chords-and-lyrics.diff
+```

--- a/scripts/compare-with-perl.sh
+++ b/scripts/compare-with-perl.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# compare-with-perl.sh — Compare chordpro-rs output against Perl ChordPro
+#
+# Usage:
+#   ./scripts/compare-with-perl.sh [--format text|html] [corpus_dir]
+#
+# Requirements:
+#   - Perl ChordPro installed and available as 'chordpro' in PATH
+#   - chordpro-rs built (cargo build --release)
+#
+# The script runs both implementations on each .cho file in the test corpus
+# and produces a diff report.
+
+set -euo pipefail
+
+FORMAT="${1:-text}"
+CORPUS_DIR="${2:-tests/corpus}"
+RUST_BIN="./target/release/chordpro"
+PERL_BIN="chordpro"
+OUTPUT_DIR="/tmp/chordpro-comparison"
+PASS=0
+FAIL=0
+SKIP=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+# Check prerequisites
+if ! command -v "$PERL_BIN" &>/dev/null; then
+    echo -e "${YELLOW}Warning: Perl ChordPro not found in PATH.${NC}"
+    echo "Install with: cpanm App::Music::ChordPro"
+    echo "Or specify the path: PERL_BIN=/path/to/chordpro $0"
+    exit 1
+fi
+
+if [[ ! -x "$RUST_BIN" ]]; then
+    echo "Building chordpro-rs..."
+    cargo build --release
+fi
+
+if [[ ! -d "$CORPUS_DIR" ]]; then
+    echo "Error: corpus directory not found: $CORPUS_DIR"
+    exit 1
+fi
+
+# Set up output directories
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/rust" "$OUTPUT_DIR/perl" "$OUTPUT_DIR/diff"
+
+EXT="txt"
+if [[ "$FORMAT" == "html" ]]; then
+    EXT="html"
+fi
+
+echo "=== ChordPro Compatibility Comparison ==="
+echo "Format: $FORMAT"
+echo "Corpus: $CORPUS_DIR"
+echo ""
+
+# Process each .cho file
+find "$CORPUS_DIR" -name '*.cho' -type f | sort | while read -r cho_file; do
+    relative="${cho_file#"$CORPUS_DIR"/}"
+    base="${relative%.cho}"
+    safe_name="${base//\//_}"
+
+    rust_out="$OUTPUT_DIR/rust/${safe_name}.${EXT}"
+    perl_out="$OUTPUT_DIR/perl/${safe_name}.${EXT}"
+    diff_out="$OUTPUT_DIR/diff/${safe_name}.diff"
+
+    # Run Rust implementation
+    if ! "$RUST_BIN" --format "$FORMAT" "$cho_file" > "$rust_out" 2>/dev/null; then
+        echo -e "${YELLOW}SKIP${NC} $relative (Rust parse error)"
+        SKIP=$((SKIP + 1))
+        continue
+    fi
+
+    # Run Perl implementation
+    if ! "$PERL_BIN" --generate "$FORMAT" "$cho_file" > "$perl_out" 2>/dev/null; then
+        echo -e "${YELLOW}SKIP${NC} $relative (Perl error)"
+        SKIP=$((SKIP + 1))
+        continue
+    fi
+
+    # Compare outputs
+    if diff -u "$perl_out" "$rust_out" > "$diff_out" 2>/dev/null; then
+        echo -e "${GREEN}PASS${NC} $relative"
+        PASS=$((PASS + 1))
+        rm -f "$diff_out"  # No diff needed for passing files
+    else
+        echo -e "${RED}DIFF${NC} $relative"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Pass: $PASS${NC}"
+echo -e "${RED}Diff: $FAIL${NC}"
+echo -e "${YELLOW}Skip: $SKIP${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo "Diff files saved to: $OUTPUT_DIR/diff/"
+    echo "Review with: ls $OUTPUT_DIR/diff/"
+fi
+
+exit $( [[ $FAIL -eq 0 ]] && echo 0 || echo 1 )


### PR DESCRIPTION
## What

Add `scripts/compare-with-perl.sh` for automated compatibility comparison between chordpro-rs and the Perl ChordPro reference implementation.

- Runs both on each .cho file in the test corpus
- Color-coded PASS/DIFF/SKIP output
- Supports text and HTML format comparison
- Saves diffs for review

## Why

Enables systematic compatibility verification against the reference implementation (Phase 18).

## Test results

- Script only (no Rust code changes)
- All existing tests pass

Closes #141