### PR TITLE
Add review finding accountability rule to issue workflow

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -53,6 +53,23 @@ Before closing a phase tracking issue, perform the following review against
 5. Only when both `/review` and `/security-review` pass with no new sub-issues
    may the phase tracking issue be closed.
 
+### Review Finding Accountability
+
+All review findings — regardless of severity (Major, Minor, Nit, Low,
+Informational) — must be:
+
+1. **Individually documented** in the review comment on the tracking issue or PR,
+   with a clear description of each finding.
+2. **Resolved or tracked** before the phase or PR is closed:
+   - **Fixed** in the current cycle, or
+   - **Issue created** for deferred items (with a link in the review comment).
+3. **Never silently dropped.** Aggregate counts like "14 Low findings" without
+   enumeration are not acceptable. Every finding must be enumerable and
+   traceable.
+
+Non-blocking findings (Nit, Low) may be deferred to future work, but a GitHub
+Issue must exist for each deferred finding so it is not lost.
+
 ### Creating Sub-Issue Relationships
 
 ```bash


### PR DESCRIPTION
## Summary

- Add "Review Finding Accountability" section to `.claude/rules/issue-workflow.md`
- Requires all review findings (regardless of severity) to be individually documented and tracked
- Prevents Low/Nit findings from being silently dropped during phase completion gate reviews

## Why

During retroactive review of past phases, we discovered that Phase 2 had ~17 Low-severity findings that were never individually documented (only aggregate counts recorded), and Phase 7 used ambiguous "no blocking issues" language. This rule ensures all findings are enumerable and traceable going forward.

## Test results

Documentation-only change. No code affected.

```
cargo fmt --check  # N/A (no Rust changes)
cargo clippy       # N/A
cargo test         # N/A
```

## Review summary

Straightforward rule addition. No existing rules modified.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)