### PR TITLE
Extract shared capitalize() function to reduce duplication

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -28,6 +28,19 @@ pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+/// Capitalize the first character of a string.
+///
+/// Returns a new string with the first character uppercased and the
+/// rest unchanged. Returns an empty string for empty input.
+#[must_use]
+pub fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -600,7 +600,7 @@ fn render_directive_inner(directive: &chordpro_core::ast::Directive, html: &mut 
         DirectiveKind::StartOfSection(section_name) => {
             let escaped = escape(section_name);
             let class = format!("section-{}", escaped);
-            let label = capitalize(&escaped);
+            let label = chordpro_core::capitalize(&escaped);
             render_section_open(&class, &label, &directive.value, html);
         }
         DirectiveKind::EndOfChorus
@@ -678,15 +678,6 @@ fn render_image(attrs: &chordpro_core::ast::ImageAttributes, html: &mut String) 
         html.push_str(&format!(" style=\"{}\"", escape(&style)));
     }
     html.push_str("></div>\n");
-}
-
-/// Capitalize the first character of a string.
-fn capitalize(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
-    }
 }
 
 /// Open a `<section>` with a class and optional label.

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -475,7 +475,9 @@ fn render_section_label(directive: &chordpro_core::ast::Directive, doc: &mut Pdf
         DirectiveKind::StartOfLy => Some("Lilypond".to_string()),
         DirectiveKind::StartOfSvg => Some("SVG".to_string()),
         DirectiveKind::StartOfTextblock => Some("Textblock".to_string()),
-        DirectiveKind::StartOfSection(section_name) => Some(capitalize(section_name)),
+        DirectiveKind::StartOfSection(section_name) => {
+            Some(chordpro_core::capitalize(section_name))
+        }
         _ => None,
     };
     if let Some(label) = label {
@@ -486,15 +488,6 @@ fn render_section_label(directive: &chordpro_core::ast::Directive, doc: &mut Pdf
         doc.ensure_space(SECTION_SIZE + LINE_GAP);
         doc.text(&text, Font::HelveticaBoldOblique, SECTION_SIZE);
         doc.newline(SECTION_SIZE + LINE_GAP);
-    }
-}
-
-/// Capitalize the first character of a string.
-fn capitalize(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
     }
 }
 

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -298,20 +298,11 @@ fn render_directive(directive: &chordpro_core::ast::Directive, output: &mut Vec<
         }
         DirectiveKind::StartOfSection(section_name) => {
             // Capitalize the first letter of the section name for display.
-            let label = capitalize(section_name);
+            let label = chordpro_core::capitalize(section_name);
             render_section_header(&label, &directive.value, output);
         }
         // End-of-section, metadata, and unknown directives produce no output.
         _ => {}
-    }
-}
-
-/// Capitalize the first character of a string.
-fn capitalize(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
     }
 }
 


### PR DESCRIPTION
## What

Move `capitalize()` to `chordpro_core::capitalize()` and remove the three identical copies in renderer crates.

## Why

Reduces code duplication (finding n1 from Phase 11 review).

## Test results

- No behavioral change
- All existing tests pass
- `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean

Closes #191