### PR TITLE
Add HTML renderer test for {new_physical_page} directive

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1213,6 +1213,12 @@ mod transpose_tests {
         assert!(html.contains("break-before: page;"));
     }
 
+    #[test]
+    fn test_new_physical_page_generates_page_break() {
+        let html = render("Page 1\n{new_physical_page}\nPage 2");
+        assert!(html.contains("break-before: page;"));
+    }
+
     // -- image directive tests ------------------------------------------------
 
     #[test]


### PR DESCRIPTION
## What

Add missing test for `{new_physical_page}` in the HTML renderer, verifying it produces `break-before: page` CSS.

## Why

Finding m4 from Phase 11 completion review. The PDF renderer had this test but HTML did not.

## Test results

- 1 new test added
- All existing tests pass

Closes #192