### PR TITLE
Fix 0-based Position in input size limit error spans

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -882,8 +882,8 @@ pub fn parse_with_options(input: &str, options: &ParseOptions) -> Result<Song, P
                 options.max_input_size
             ),
             Span::new(
-                crate::token::Position::new(0, 0),
-                crate::token::Position::new(0, 0),
+                crate::token::Position::new(1, 1),
+                crate::token::Position::new(1, 1),
             ),
         ));
     }
@@ -927,8 +927,8 @@ pub fn parse_lenient_with_options(input: &str, options: &ParseOptions) -> ParseR
                     options.max_input_size
                 ),
                 Span::new(
-                    crate::token::Position::new(0, 0),
-                    crate::token::Position::new(0, 0),
+                    crate::token::Position::new(1, 1),
+                    crate::token::Position::new(1, 1),
                 ),
             )],
         };
@@ -1084,8 +1084,8 @@ pub fn parse_multi_with_options(
                 options.max_input_size
             ),
             Span::new(
-                crate::token::Position::new(0, 0),
-                crate::token::Position::new(0, 0),
+                crate::token::Position::new(1, 1),
+                crate::token::Position::new(1, 1),
             ),
         ));
     }
@@ -1139,8 +1139,8 @@ pub fn parse_multi_lenient_with_options(input: &str, options: &ParseOptions) -> 
                         options.max_input_size
                     ),
                     Span::new(
-                        crate::token::Position::new(0, 0),
-                        crate::token::Position::new(0, 0),
+                        crate::token::Position::new(1, 1),
+                        crate::token::Position::new(1, 1),
                     ),
                 )],
             }],


### PR DESCRIPTION
## What

Replace all `Position::new(0, 0)` with `Position::new(1, 1)` in input size limit error spans across 4 parser functions.

## Why

The `Position` struct documents 1-based line and column values, but error spans for input size limit violations used `(0, 0)`. This inconsistency could confuse error reporting tools.

## Test results

```
cargo test          — all tests pass
cargo clippy        — no warnings
cargo fmt --check   — formatted
```

## Review summary

Trivial mechanical fix — 8 lines changed (4 pairs of Position::new calls).

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)