### PR TITLE
Add page control directive semantic tests and non-numeric columns test

### DIFF
--- a/crates/core/tests/golden_directives.rs
+++ b/crates/core/tests/golden_directives.rs
@@ -527,3 +527,68 @@ fn formatting_directives_golden_test() {
         }
     }
 }
+
+#[test]
+fn page_control_directives_golden_test() {
+    let input = fixture("page-control-directives/input.cho");
+    let song = parse(&input).expect("parse failed");
+
+    // Collect all page control directives from the parsed output.
+    let page_control_directives: Vec<_> = song
+        .lines
+        .iter()
+        .filter_map(|line| {
+            if let Line::Directive(d) = line {
+                if d.kind.is_page_control() {
+                    return Some(d);
+                }
+            }
+            None
+        })
+        .collect();
+
+    // The fixture should contain at least one of each page control directive.
+    let kinds: Vec<_> = page_control_directives.iter().map(|d| &d.kind).collect();
+    assert!(
+        kinds.contains(&&DirectiveKind::NewPage),
+        "expected NewPage directive"
+    );
+    assert!(
+        kinds.contains(&&DirectiveKind::NewPhysicalPage),
+        "expected NewPhysicalPage directive"
+    );
+    assert!(
+        kinds.contains(&&DirectiveKind::ColumnBreak),
+        "expected ColumnBreak directive"
+    );
+    assert!(
+        kinds.contains(&&DirectiveKind::Columns),
+        "expected Columns directive"
+    );
+
+    // Verify classification: all page control directives are NOT metadata.
+    for d in &page_control_directives {
+        assert!(
+            d.kind.is_page_control(),
+            "{:?} should be page_control",
+            d.kind
+        );
+        assert!(!d.kind.is_metadata(), "{:?} should not be metadata", d.kind);
+        assert!(
+            !d.kind.is_font_size_color(),
+            "{:?} should not be font_size_color",
+            d.kind
+        );
+    }
+
+    // Verify canonical names for short aliases.
+    for d in &page_control_directives {
+        match d.kind {
+            DirectiveKind::NewPage => assert_eq!(d.name, "new_page"),
+            DirectiveKind::NewPhysicalPage => assert_eq!(d.name, "new_physical_page"),
+            DirectiveKind::ColumnBreak => assert_eq!(d.name, "column_break"),
+            DirectiveKind::Columns => assert_eq!(d.name, "columns"),
+            _ => {}
+        }
+    }
+}

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1240,6 +1240,13 @@ mod transpose_tests {
     }
 
     #[test]
+    fn test_columns_non_numeric_defaults_to_one() {
+        let html = render("{columns: abc}\nHello");
+        // Non-numeric value should default to 1, so no multi-column div.
+        assert!(!html.contains("column-count"));
+    }
+
+    #[test]
     fn test_new_page_generates_page_break() {
         let html = render("Page 1\n{new_page}\nPage 2");
         assert!(html.contains("break-before: page;"));

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -1867,6 +1867,17 @@ mod column_tests {
         assert_eq!(doc.current_column, 0);
     }
 
+    #[test]
+    fn test_columns_non_numeric_defaults_to_one() {
+        let input = "{columns: abc}\n[Am]Hello";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        let content = String::from_utf8_lossy(&bytes);
+        // Non-numeric value defaults to 1 column — should still render.
+        assert!(content.contains("Am"));
+        assert!(content.contains("Hello"));
+    }
+
     // --- Multi-song rendering ---
 
     #[test]


### PR DESCRIPTION
## What

Add structured golden test for page control directives and non-numeric `{columns}`
fallback tests.

## Why

Page control directives lacked a `golden_directives.rs` test validating their semantic
properties (`is_page_control()`, `!is_metadata()`, canonical names). Non-numeric
`{columns}` input defaulting to 1 was untested. Found during Phase 11 code review
(Minor-4, Nit-3).

## Test results

- `page_control_directives_golden_test` — validates all 4 directives
- `test_columns_non_numeric_defaults_to_one` in both HTML and PDF renderers
- All tests pass across all crates

```
cargo test
cargo clippy -- -D warnings
```

## Review summary

1 new golden test + 2 renderer tests. No behavioral changes.

Closes #213