### PR TITLE
Add auto-update-branch workflow for out-of-date PRs

### DIFF
--- a/.github/workflows/auto-update-branch.yml
+++ b/.github/workflows/auto-update-branch.yml
@@ -1,0 +1,96 @@
+name: Auto Update PR Branches
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: auto-update-branch
+  cancel-in-progress: true
+
+jobs:
+  update-branches:
+    name: Update out-of-date PR branches
+    runs-on: ubuntu-latest
+    # Minimal permissions — CLAUDE_PAT (passed to github-script) provides
+    # the access needed for the update-branch API call and ensures the
+    # resulting commits trigger CI on the updated branches.
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - name: Update PR branches
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLAUDE_PAT }}
+          script: |
+            const DELAY_BETWEEN_UPDATES_MS = 3000;
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'main',
+              per_page: 100,
+            });
+
+            console.log(`Found ${prs.length} open PR(s) targeting main`);
+
+            let updated = 0;
+            let alreadyUpToDate = 0;
+            let skipped = 0;
+            let failed = 0;
+
+            for (let i = 0; i < prs.length; i++) {
+              const pr = prs[i];
+
+              // Skip dependabot PRs — they manage their own updates
+              if (pr.user.login === 'dependabot[bot]') {
+                console.log(`PR #${pr.number}: skipping (dependabot)`);
+                skipped++;
+                continue;
+              }
+
+              // Skip draft PRs — authors control their own update cadence
+              if (pr.draft) {
+                console.log(`PR #${pr.number}: skipping (draft)`);
+                skipped++;
+                continue;
+              }
+
+              console.log(`PR #${pr.number} (${pr.head.ref}): updating branch...`);
+
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                console.log(`PR #${pr.number}: branch updated successfully`);
+                updated++;
+              } catch (error) {
+                if (error.status === 422) {
+                  console.log(`PR #${pr.number}: already up to date`);
+                  alreadyUpToDate++;
+                } else if (error.status === 409) {
+                  console.log(`PR #${pr.number}: has merge conflicts, skipping (handled by auto-rebase)`);
+                  skipped++;
+                } else {
+                  console.log(`::warning::PR #${pr.number}: update failed (${error.status}: ${error.message})`);
+                  failed++;
+                }
+                continue;
+              }
+
+              // Delay between updates to avoid API pressure
+              if (i < prs.length - 1) {
+                await new Promise(r => setTimeout(r, DELAY_BETWEEN_UPDATES_MS));
+              }
+            }
+
+            console.log('');
+            console.log('=== Summary ===');
+            console.log(`Updated:           ${updated}`);
+            console.log(`Already up to date: ${alreadyUpToDate}`);
+            console.log(`Skipped:           ${skipped}`);
+            console.log(`Failed:            ${failed}`);


### PR DESCRIPTION
## What

Add a new GitHub Actions workflow (`.github/workflows/auto-update-branch.yml`) that
automatically updates open PR branches when `main` advances.

## Why

Branch protection on `main` has `strict: true`, requiring PR branches to be up-to-date
before merging. When other PRs merge to main, remaining open PRs show "This branch is
out-of-date with the base branch" and cannot merge until manually updated. This adds
friction and delays.

The existing `auto-rebase.yml` only handles PRs **with merge conflicts**. This new
workflow complements it by handling the common case: PRs that are simply behind main
with no conflicts.

## How it works

1. Triggers on push to `main`
2. Lists all open PRs targeting `main`
3. Skips dependabot PRs (they manage their own updates) and draft PRs
4. Calls `github.rest.pulls.updateBranch()` for each remaining PR
5. Handles 422 (already up to date) and 409 (merge conflicts) gracefully
6. Uses `CLAUDE_PAT` so the resulting merge commits trigger CI

## Test results

- Workflow YAML syntax verified
- Logic follows established patterns from `auto-rebase.yml` (paginated PR listing, dependabot skip, CLAUDE_PAT usage, delay between operations)
- Error handling covers all expected API responses (success, 422, 409, other errors)

## Review summary

Awaiting review.

Closes #222