### PR TITLE
Use CLAUDE_PAT in checkout so Claude pushes trigger CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,16 +35,17 @@ jobs:
       id-token: write
       actions: read
     steps:
+      # Use CLAUDE_PAT so that git pushes by Claude trigger CI workflows.
+      # GITHUB_TOKEN pushes do not trigger other workflows (GitHub anti-loop).
       - uses: actions/checkout@v6
         with:
+          token: ${{ secrets.CLAUDE_PAT }}
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
         id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Use PAT so that Claude's pushes trigger CI workflows
-          # (GITHUB_TOKEN pushes do not trigger other workflows)
           github_token: ${{ secrets.CLAUDE_PAT }}
           track_progress: true
           claude_args: "--allowedTools Edit,Write,Read,Bash"
@@ -58,17 +59,3 @@ jobs:
             - Title: concise, imperative mood
             - Body: include `Closes #N` referencing the issue number
             - Follow all rules in CLAUDE.md and .claude/rules/
-
-      # Re-trigger CI on the PR branch after Claude pushes commits.
-      # GITHUB_TOKEN pushes don't trigger workflows, so we explicitly
-      # dispatch CI using CLAUDE_PAT.
-      - name: Re-trigger CI if on a PR branch
-        if: github.event.issue.pull_request
-        env:
-          GH_TOKEN: ${{ secrets.CLAUDE_PAT }}
-        run: |
-          PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
-          HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
-          if [ -n "$HEAD_REF" ]; then
-            gh workflow run ci.yml --ref "$HEAD_REF" || true
-          fi


### PR DESCRIPTION
## What

Use `CLAUDE_PAT` in the `actions/checkout` step of `claude.yml` so that
git pushes by Claude Code Action trigger CI workflows. Remove the
now-unnecessary "Re-trigger CI" workaround step.

## Why

`claude.yml` used the default `GITHUB_TOKEN` for checkout. GitHub's
anti-loop policy prevents `GITHUB_TOKEN` pushes from triggering other
workflows. This caused PRs where Claude resolved merge conflicts (e.g.,
PR #219) to be stuck with no CI status checks indefinitely.

The existing workaround used `workflow_dispatch` to re-trigger CI, but
`workflow_dispatch` runs do not register as PR status checks — so the PR
still showed no checks.

`auto-rebase.yml` already uses `CLAUDE_PAT` in its checkout step and
does not have this problem.

## Test results

- Workflow syntax validated (YAML structure)
- Pattern matches existing `auto-rebase.yml` approach
- No code changes; CI/fmt/clippy/test not affected

## Review summary

Single-file change to `.github/workflows/claude.yml`:
1. Add `token: ${{ secrets.CLAUDE_PAT }}` to `actions/checkout`
2. Remove the 13-line "Re-trigger CI" workaround step
3. Move explanatory comment to the checkout step

Closes #226