### PR TITLE
Wire configuration into renderer functions

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -74,10 +74,6 @@ fn main() -> ExitCode {
         config = config.with_define(define);
     }
 
-    // Config is now built but not yet used by renderers.
-    // Future work will pass it to render functions.
-    let _ = config;
-
     let mut all_songs: Vec<chordpro_core::ast::Song> = Vec::new();
     let is_binary = matches!(cli.format, Format::Pdf);
     let mut had_error = false;
@@ -112,17 +108,21 @@ fn main() -> ExitCode {
 
     if is_binary {
         combined_bytes =
-            chordpro_render_pdf::render_songs_with_transpose(&all_songs, cli.transpose);
+            chordpro_render_pdf::render_songs_with_transpose(&all_songs, cli.transpose, &config);
         combined_text = String::new();
     } else {
         combined_bytes = Vec::new();
         combined_text = match cli.format {
-            Format::Text => {
-                chordpro_render_text::render_songs_with_transpose(&all_songs, cli.transpose)
-            }
-            Format::Html => {
-                chordpro_render_html::render_songs_with_transpose(&all_songs, cli.transpose)
-            }
+            Format::Text => chordpro_render_text::render_songs_with_transpose(
+                &all_songs,
+                cli.transpose,
+                &config,
+            ),
+            Format::Html => chordpro_render_html::render_songs_with_transpose(
+                &all_songs,
+                cli.transpose,
+                &config,
+            ),
             Format::Pdf => unreachable!(),
         };
     }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -13,6 +13,7 @@
 //! (CSP) headers or sandbox the HTML output to mitigate script injection.
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordpro_core::config::Config;
 use chordpro_core::inline_markup::{SpanAttributes, TextSpan};
 use chordpro_core::transpose::transpose_chord;
 
@@ -115,7 +116,7 @@ impl FormattingState {
 /// includes the full chorus body.
 #[must_use]
 pub fn render_song(song: &Song) -> String {
-    render_song_with_transpose(song, 0)
+    render_song_with_transpose(song, 0, &Config::defaults())
 }
 
 /// Render a [`Song`] AST to an HTML5 document with an additional CLI transposition offset.
@@ -123,7 +124,8 @@ pub fn render_song(song: &Song) -> String {
 /// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
 /// values, allowing the CLI `--transpose` flag to combine with in-file directives.
 #[must_use]
-pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
+pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Config) -> String {
+    let _ = config;
     let mut html = String::new();
     let mut transpose_offset: i8 = cli_transpose;
     let mut fmt_state = FormattingState::default();
@@ -292,7 +294,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
 /// Render multiple [`Song`]s into a single HTML5 document.
 #[must_use]
 pub fn render_songs(songs: &[Song]) -> String {
-    render_songs_with_transpose(songs, 0)
+    render_songs_with_transpose(songs, 0, &Config::defaults())
 }
 
 /// Render multiple [`Song`]s into a single HTML5 document with transposition.
@@ -301,11 +303,11 @@ pub fn render_songs(songs: &[Song]) -> String {
 /// For multiple songs, the document uses the first song's title and separates
 /// each song with an `<hr class="song-separator">`.
 #[must_use]
-pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8) -> String {
+pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &Config) -> String {
     if songs.len() <= 1 {
         return songs
             .first()
-            .map(|s| render_song_with_transpose(s, cli_transpose))
+            .map(|s| render_song_with_transpose(s, cli_transpose, config))
             .unwrap_or_default();
     }
     // Use the first song's title for the document
@@ -327,7 +329,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8) -> String 
             html.push_str("<hr class=\"song-separator\">\n");
         }
         // Render each song as a full document, then extract the <div class="song">...</div> body.
-        let song_html = render_song_with_transpose(song, cli_transpose);
+        let song_html = render_song_with_transpose(song, cli_transpose, config);
         if let Some(start) = song_html.find("<div class=\"song\">") {
             if let Some(end) = song_html.rfind("</div>\n</body>") {
                 html.push_str(&song_html[start..end + 6]); // include </div>
@@ -990,7 +992,7 @@ mod transpose_tests {
     fn test_transpose_directive_with_cli_offset() {
         let input = "{transpose: 2}\n[C]Hello";
         let song = chordpro_core::parse(input).unwrap();
-        let html = render_song_with_transpose(&song, 3);
+        let html = render_song_with_transpose(&song, 3, &Config::defaults());
         // 2 + 3 = 5, C+5=F
         assert!(html.contains("<span class=\"chord\">F</span>"));
     }
@@ -1410,7 +1412,7 @@ mod delegate_tests {
         let songs =
             chordpro_core::parse_multi("{title: S1}\n[C]Do\n{new_song}\n{title: S2}\n[G]Re")
                 .unwrap();
-        let html = render_songs_with_transpose(&songs, 2);
+        let html = render_songs_with_transpose(&songs, 2, &Config::defaults());
         // C+2=D, G+2=A
         assert!(html.contains(">D<"));
         assert!(html.contains(">A<"));

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -9,6 +9,7 @@
 //! directives trigger explicit page breaks.
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, ImageAttributes, Line, LyricsLine, Song};
+use chordpro_core::config::Config;
 use chordpro_core::inline_markup::TextSpan;
 use chordpro_core::transpose::transpose_chord;
 
@@ -118,7 +119,7 @@ const MAX_IMAGE_FILE_SIZE: u64 = 50 * 1024 * 1024;
 /// `{new_physical_page}` directives trigger explicit page breaks.
 #[must_use]
 pub fn render_song(song: &Song) -> Vec<u8> {
-    render_song_with_transpose(song, 0)
+    render_song_with_transpose(song, 0, &Config::defaults())
 }
 
 /// Render a [`Song`] AST to PDF bytes with an additional CLI transposition offset.
@@ -126,7 +127,8 @@ pub fn render_song(song: &Song) -> Vec<u8> {
 /// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
 /// values, allowing the CLI `--transpose` flag to combine with in-file directives.
 #[must_use]
-pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
+pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Config) -> Vec<u8> {
+    let _ = config;
     let mut doc = PdfDocument::new();
     render_song_into_doc(song, cli_transpose, &mut doc);
     doc.build_pdf()
@@ -137,7 +139,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> Vec<u8> {
 /// Each song starts on a new page.
 #[must_use]
 pub fn render_songs(songs: &[Song]) -> Vec<u8> {
-    render_songs_with_transpose(songs, 0)
+    render_songs_with_transpose(songs, 0, &Config::defaults())
 }
 
 /// Render multiple [`Song`]s into a single PDF with transposition.
@@ -146,9 +148,9 @@ pub fn render_songs(songs: &[Song]) -> Vec<u8> {
 /// more songs, a Table of Contents page is prepended with song titles and
 /// page numbers.
 #[must_use]
-pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8) -> Vec<u8> {
+pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &Config) -> Vec<u8> {
     if songs.len() == 1 {
-        return render_song_with_transpose(&songs[0], cli_transpose);
+        return render_song_with_transpose(&songs[0], cli_transpose, config);
     }
 
     // Phase 1: render all songs and record which page each starts on.
@@ -1458,7 +1460,7 @@ mod transpose_tests {
     fn test_transpose_with_cli_offset() {
         let input = "{transpose: 2}\n[C]Hello";
         let song = chordpro_core::parse(input).unwrap();
-        let bytes = render_song_with_transpose(&song, 3);
+        let bytes = render_song_with_transpose(&song, 3, &Config::defaults());
         // 2+3=5, C+5=F
         let content = String::from_utf8_lossy(&bytes);
         assert!(content.contains("(F)"));
@@ -1956,7 +1958,7 @@ mod column_tests {
         let songs =
             chordpro_core::parse_multi("{title: S1}\n[C]Do\n{new_song}\n{title: S2}\n[G]Re")
                 .unwrap();
-        let bytes = render_songs_with_transpose(&songs, 2);
+        let bytes = render_songs_with_transpose(&songs, 2, &Config::defaults());
         let content = String::from_utf8_lossy(&bytes);
         // C+2=D, G+2=A — both transposed chords should appear
         assert!(content.contains("(D)"));

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -4,6 +4,7 @@
 //! formatted plain text with chords aligned above their corresponding lyrics.
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordpro_core::config::Config;
 use chordpro_core::transpose::transpose_chord;
 
 /// Render a [`Song`] AST to plain text.
@@ -22,7 +23,7 @@ use chordpro_core::transpose::transpose_chord;
 /// - Empty lines are preserved.
 #[must_use]
 pub fn render_song(song: &Song) -> String {
-    render_song_with_transpose(song, 0)
+    render_song_with_transpose(song, 0, &Config::defaults())
 }
 
 /// Render a [`Song`] AST to plain text with an additional CLI transposition offset.
@@ -30,7 +31,9 @@ pub fn render_song(song: &Song) -> String {
 /// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
 /// values, allowing the CLI `--transpose` flag to combine with in-file directives.
 #[must_use]
-pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
+pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Config) -> String {
+    // Config is plumbed through for future use (e.g., suppress_empty_chords).
+    let _ = config;
     let mut output = Vec::new();
     let mut transpose_offset: i8 = cli_transpose;
     // Stores the rendered text lines of the most recently defined chorus,
@@ -127,15 +130,15 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8) -> String {
 /// Render multiple [`Song`]s to plain text, separated by a blank line.
 #[must_use]
 pub fn render_songs(songs: &[Song]) -> String {
-    render_songs_with_transpose(songs, 0)
+    render_songs_with_transpose(songs, 0, &Config::defaults())
 }
 
 /// Render multiple [`Song`]s to plain text with transposition.
 #[must_use]
-pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8) -> String {
+pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &Config) -> String {
     songs
         .iter()
-        .map(|song| render_song_with_transpose(song, cli_transpose))
+        .map(|song| render_song_with_transpose(song, cli_transpose, config))
         .collect::<Vec<_>>()
         .join("\n\n")
 }
@@ -636,7 +639,7 @@ mod multi_song_tests {
         let songs =
             chordpro_core::parse_multi("{title: S1}\n[C]Do\n{new_song}\n{title: S2}\n[G]Re")
                 .unwrap();
-        let output = render_songs_with_transpose(&songs, 2);
+        let output = render_songs_with_transpose(&songs, 2, &Config::defaults());
         // C+2=D, G+2=A
         assert!(output.contains("D\nDo"));
         assert!(output.contains("A\nRe"));
@@ -689,7 +692,7 @@ mod transpose_tests {
     fn test_transpose_directive_with_cli_offset() {
         let input = "{transpose: 2}\n[C]Hello";
         let song = chordpro_core::parse(input).unwrap();
-        let output = render_song_with_transpose(&song, 3);
+        let output = render_song_with_transpose(&song, 3, &Config::defaults());
         // In-file 2 + CLI 3 = 5 total. C+5=F
         assert!(output.contains("F\nHello"));
     }
@@ -698,7 +701,7 @@ mod transpose_tests {
     fn test_cli_transpose_without_directive() {
         let input = "[G]Hello [C]world";
         let song = chordpro_core::parse(input).unwrap();
-        let output = render_song_with_transpose(&song, 2);
+        let output = render_song_with_transpose(&song, 2, &Config::defaults());
         // CLI offset only: G+2=A, C+2=D
         assert_eq!(output, "A     D\nHello world\n");
     }
@@ -707,7 +710,7 @@ mod transpose_tests {
     fn test_transpose_directive_replaces_with_cli_additive() {
         let input = "{transpose: 2}\n[C]First\n{transpose: -1}\n[C]Second";
         let song = chordpro_core::parse(input).unwrap();
-        let output = render_song_with_transpose(&song, 1);
+        let output = render_song_with_transpose(&song, 1, &Config::defaults());
         // First: 2+1=3, C+3=D#. Second: -1+1=0, C+0=C
         assert!(output.contains("D#\nFirst"));
         assert!(output.contains("C\nSecond"));


### PR DESCRIPTION
## What

Add `&Config` parameter to all renderer public APIs and pass the loaded
configuration from the CLI to all three renderers.

## Why

The configuration system (RRJSON parser, hierarchical loading, CLI `--config`
and `--define` flags) was fully implemented but the built config was immediately
discarded in main.rs (`let _ = config;`). This blocked Phase 13 completion and
Phase 16 (conditional selectors need config to know the active instrument).

## Changes

- **render-text**: `render_song_with_transpose` and `render_songs_with_transpose`
  now accept `&Config`
- **render-html**: Same API change
- **render-pdf**: Same API change
- **CLI**: Passes the fully-built config to all three renderers
- Convenience functions (`render_song`, `render_songs`, `try_render`, `render`)
  continue to use `Config::defaults()` — no breaking change for library users
  who use these entry points
- All existing tests updated to pass `&Config::defaults()` where needed

Config values are not yet read by renderers (placeholder `let _ = config;`).
Actual config consumption (margins, fonts, styles) will be added in follow-up
issues.

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all tests pass)
```

## Review summary

Pure plumbing change — adds the config parameter to function signatures and
wires it through the call chain. No behavioral changes. Follow-up work will
read config values in each renderer.

Closes #247