### PR TITLE
Add NaN/Infinity safety checks for f32 arithmetic in PDF renderer

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -2439,7 +2439,7 @@ mod jpeg_tests {
     #[test]
     fn test_fmt_f32_normal_values() {
         assert_eq!(fmt_f32(1.0), "1");
-        assert_eq!(fmt_f32(3.14), "3.14");
+        assert_eq!(fmt_f32(3.25), "3.25");
         assert_eq!(fmt_f32(0.0), "0");
         assert_eq!(fmt_f32(-5.5), "-5.5");
     }


### PR DESCRIPTION
## What

Add finiteness checks to prevent NaN/Infinity values from producing
malformed PDF output.

## Why

Multiple f32 calculations in the PDF renderer (coordinates, widths,
margins) could theoretically produce NaN or Infinity from edge case
input combinations. Non-finite values in PDF operators like `Td` or
`cm` would create invalid documents. This was identified as finding
M-5 from the security review.

## Changes

- `fmt_f32()`: Replace non-finite values with `"0"` instead of
  formatting `NaN`/`inf` strings into PDF operators
- `margin_left()`: Add `debug_assert!` for finiteness in the
  multi-column calculation
- Add 3 tests: NaN, Infinity, and normal value formatting

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all 93 PDF renderer tests pass including 3 new)
```

## Review summary

Defensive hardening with minimal runtime cost. The `fmt_f32` check is
the safety net — if any calculation path produces a non-finite value,
the PDF output will still be valid (coordinates default to 0).

Closes #240