### PR TITLE
Add multi-song input size limit tests

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -3634,4 +3634,46 @@ mod delegate_tests {
     fn parser_new_panics_on_empty_tokens() {
         let _parser = Parser::new(Vec::new());
     }
+
+    // -- Multi-song input size limits -----------------------------------------
+
+    #[test]
+    fn multi_song_oversized_input_rejected() {
+        let opts = ParseOptions {
+            max_input_size: 10,
+            ..Default::default()
+        };
+        let input = "{title: A}\n{new_song}\n{title: B}";
+        let result = parse_multi_with_options(input, &opts);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn multi_song_lenient_oversized_input_rejected() {
+        let opts = ParseOptions {
+            max_input_size: 10,
+            ..Default::default()
+        };
+        let input = "{title: A}\n{new_song}\n{title: B}";
+        let result = parse_multi_lenient_with_options(input, &opts);
+        assert_eq!(result.results.len(), 1);
+        assert!(
+            result.results[0].errors[0]
+                .message
+                .contains("exceeds maximum")
+        );
+    }
+
+    #[test]
+    fn multi_song_within_limit_succeeds() {
+        let opts = ParseOptions {
+            max_input_size: 1000,
+            ..Default::default()
+        };
+        let input = "{title: A}\n{new_song}\n{title: B}";
+        let result = parse_multi_with_options(input, &opts);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 2);
+    }
 }


### PR DESCRIPTION
## What

Add test coverage for the total input size check in the multi-song
parser functions.

## Why

The total input size check before `{new_song}` splitting was already
implemented in both `parse_multi_with_options` and
`parse_multi_lenient_with_options`, but had no test coverage. Finding
M-4 from security review identified this as a gap. The implementation
was correct — only tests were missing.

## Changes

- Add `multi_song_oversized_input_rejected` test for strict parser
- Add `multi_song_lenient_oversized_input_rejected` test for lenient parser
- Add `multi_song_within_limit_succeeds` positive test

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all tests pass including 3 new)
```

## Review summary

Test-only change. No behavioral modifications — the input size checks
were already in place.

Closes #239