### PR TITLE
Replace unreachable!() with fallback in comment directive parsing

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -547,7 +547,7 @@ impl Parser {
                 DirectiveKind::Comment => CommentStyle::Normal,
                 DirectiveKind::CommentItalic => CommentStyle::Italic,
                 DirectiveKind::CommentBox => CommentStyle::Boxed,
-                _ => unreachable!(),
+                _ => CommentStyle::Normal,
             };
             let text = value.unwrap_or_default();
             return Ok(Line::Comment(style, text));


### PR DESCRIPTION
## What

Replace `_ => unreachable!()` with `_ => CommentStyle::Normal` in the
comment directive style match.

## Why

The `unreachable!()` assumes `is_comment()` only returns true for three
`DirectiveKind` variants. If a fourth comment variant is added in the
future, this would panic instead of handling it gracefully. Finding m-1
from code review.

## Changes

- One line change: `_ => unreachable!()` → `_ => CommentStyle::Normal`

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅
```

## Review summary

Trivial defensive change. No behavioral difference for current code.

Closes #241