### PR TITLE
Switch CSS sanitization from blacklist to whitelist approach

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -569,18 +569,16 @@ fn span_attrs_to_css(attrs: &SpanAttributes) -> String {
     css
 }
 
-/// Strip characters that could break out of a CSS property value context.
+/// Sanitize a user-provided value for use in a CSS property value context.
 ///
-/// This prevents CSS injection by removing `;` (property boundary), `{`/`}`
-/// (rule boundaries), `(`/`)` (function calls like `url()`), quotes, and
-/// backslashes from user-provided attribute values.
+/// Uses a whitelist approach: only characters safe in CSS values are retained.
+/// Allowed: ASCII alphanumeric, `#` (hex colors), `.` (decimals), `-` (negatives,
+/// hyphenated names), ` ` (multi-word font names), `,` (font family lists),
+/// `%` (percentages), `+` (font-weight values like `+lighter`).
 fn sanitize_css_value(s: &str) -> String {
     s.chars()
         .filter(|c| {
-            !matches!(
-                c,
-                ';' | '{' | '}' | '(' | ')' | '\'' | '\\' | '<' | '>' | '"'
-            )
+            c.is_ascii_alphanumeric() || matches!(c, '#' | '.' | '-' | ' ' | ',' | '%' | '+')
         })
         .collect()
 }


### PR DESCRIPTION
## What

Replace the blacklist-based `sanitize_css_value()` with a whitelist that only allows safe CSS characters.

## Why

The previous blacklist filtered 10 specific dangerous characters but was inherently incomplete — newlines, backticks, CSS unicode escapes, and other characters could potentially bypass it. A whitelist approach is more robust: only explicitly allowed characters pass through.

**Allowed characters**: ASCII alphanumeric, `#` (hex colors), `.` (decimals), `-` (negatives/hyphens), ` ` (multi-word font names), `,` (font family lists), `%` (percentages), `+` (font-weight).

Closes #238

## Test Results

```
cargo test    — all 82 HTML renderer tests pass (no regressions)
cargo clippy  — clean
cargo fmt     — clean
```

Existing CSS injection tests continue to pass since the whitelist is strictly more restrictive than the old blacklist.