### PR TITLE
Remove dead SVG handler from render_directive_inner()

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -640,9 +640,8 @@ fn render_directive_inner(directive: &chordpro_core::ast::Directive, html: &mut 
         DirectiveKind::StartOfLy => {
             render_section_open("ly", "Lilypond", &directive.value, html);
         }
-        DirectiveKind::StartOfSvg => {
-            render_section_open("svg", "SVG", &directive.value, html);
-        }
+        // StartOfSvg is handled in the main rendering loop with raw HTML
+        // embedding (<div class="svg-section">), not via render_section_open.
         DirectiveKind::StartOfTextblock => {
             render_section_open("textblock", "Textblock", &directive.value, html);
         }


### PR DESCRIPTION
## What

Remove the dead `StartOfSvg` handler from `render_directive_inner()`.

## Why

The SVG section directive is handled in the main rendering loop with
a `<div class=\"svg-section\">` wrapper for raw HTML embedding. The
`render_directive_inner()` handler used `render_section_open()` which
produces a different `<section class=\"svg\">` wrapper — but it was
unreachable dead code because the main loop intercepts `StartOfSvg`
before delegation. Finding n-6 from code review.

## Changes

- Remove `StartOfSvg` arm from `render_directive_inner()`
- Add comment explaining why SVG is handled in the main loop

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all 82 HTML renderer tests pass)
```

## Review summary

Dead code removal. Existing SVG tests verify the main loop path.

Closes #253