### PR TITLE
Remove redundant escape() call on span CSS style attribute

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -535,7 +535,9 @@ fn render_spans(spans: &[TextSpan], html: &mut String) {
                 if css.is_empty() {
                     html.push_str("<span>");
                 } else {
-                    html.push_str(&format!("<span style=\"{}\">", escape(&css)));
+                    // CSS values are already sanitized by sanitize_css_value();
+                    // applying escape() would double-encode (e.g., & → &amp;).
+                    html.push_str(&format!("<span style=\"{css}\">"));
                 }
                 render_spans(children, html);
                 html.push_str("</span>");


### PR DESCRIPTION
## What

Remove the `escape()` wrapper on the CSS style attribute for inline spans.

## Why

CSS values from `span_attrs_to_css()` are already sanitized by
`sanitize_css_value()`. The additional `escape()` could double-encode
HTML entities (e.g., `&` in CSS would become `&amp;`). Finding n-7
from code review.

## Changes

- Remove `escape()` call on line 538, use the sanitized CSS directly
- Add comment explaining why escape is not needed

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all 82 HTML renderer tests pass)
```

## Review summary

One-line fix removing double-encoding. CSS sanitization remains in place.

Closes #254