### PR TITLE
Replace magic number with explicit string length in HTML render_songs()

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -338,9 +338,11 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
         }
         // Render each song as a full document, then extract the <div class="song">...</div> body.
         let song_html = render_song_with_transpose(song, cli_transpose, config);
-        if let Some(start) = song_html.find("<div class=\"song\">") {
-            if let Some(end) = song_html.rfind("</div>\n</body>") {
-                html.push_str(&song_html[start..end + 6]); // include </div>
+        let song_start = "<div class=\"song\">";
+        let body_end = "</div>\n</body>";
+        if let Some(start) = song_html.find(song_start) {
+            if let Some(end) = song_html.rfind(body_end) {
+                html.push_str(&song_html[start..end + "</div>".len()]);
                 html.push('\n');
             }
         }


### PR DESCRIPTION
## What

Replace the opaque `end + 6` offset with `end + \"</div>\".len()` in
the multi-song HTML extraction logic.

## Why

The magic number 6 was the length of `</div>` but this was unclear and
fragile. If the HTML structure changed, the extraction would silently
break. Finding m-7 from code review.

## Changes

- Extract marker strings (`song_start`, `body_end`) into local variables
- Use `\"</div>\".len()` instead of the magic number 6
- No behavioral change

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all 82 HTML renderer tests pass)
```

## Review summary

Clarity improvement only. The existing multi-song rendering tests verify
correct output.

Closes #246