### PR TITLE
Remove redundant escape() on span CSS style attributes

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -470,7 +470,7 @@ fn render_lyrics(
             } else {
                 html.push_str(&format!(
                     "<span class=\"chord\" style=\"{}\">{}</span>",
-                    escape(&chord_css),
+                    chord_css,
                     escape(&display_name)
                 ));
             }
@@ -483,10 +483,7 @@ fn render_lyrics(
         if text_css.is_empty() {
             html.push_str("<span class=\"lyrics\">");
         } else {
-            html.push_str(&format!(
-                "<span class=\"lyrics\" style=\"{}\">",
-                escape(&text_css)
-            ));
+            html.push_str(&format!("<span class=\"lyrics\" style=\"{}\">", text_css));
         }
         if segment.has_markup() {
             render_spans(&segment.spans, html);


### PR DESCRIPTION
## What

Remove the unnecessary `escape()` call wrapping CSS output in chord and lyrics span `style` attributes.

## Why

The CSS values in `to_css()` are already sanitized via `sanitize_css_value()`, which uses a whitelist (#272) that only allows `[a-zA-Z0-9#.-, %+]`. No HTML-special characters (`&`, `<`, `>`, `"`, `'`) can survive sanitization, making the `escape()` wrapper redundant and potentially introducing double-escaping.

Closes #254

## Test Results

```
cargo test    — all 82 HTML renderer tests pass (no regressions)
cargo clippy  — clean
cargo fmt     — clean
```