### PR TITLE
Add .serena/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 # OS
 .DS_Store
 Thumbs.db
+
+# Tools
+.serena/


### PR DESCRIPTION
## What

Add `.serena/` directory to `.gitignore` under a new "Tools" section.

## Why

The `.serena/` directory contains Serena MCP plugin local configuration, cache, and memory files that are specific to each developer's environment and should not be committed to the repository.

## Test results

N/A — `.gitignore` only change, no code affected.

## Review summary

Single-line addition to `.gitignore`.

Closes #280