### PR TITLE
Add abc2svg process invocation and SVG capture

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -65,6 +65,16 @@ fn main() -> ExitCode {
         }
     }
 
+    // Auto-detect external delegate tools and enable them in config.
+    // This runs after user configs but before --define, so explicit
+    // --define delegates.abc2svg=false can still override.
+    if chordpro_core::external_tool::has_abc2svg() {
+        config = config.with_define("delegates.abc2svg=true");
+    }
+    if chordpro_core::external_tool::has_lilypond() {
+        config = config.with_define("delegates.lilypond=true");
+    }
+
     // Apply --define overrides (highest precedence)
     for define in &cli.defines {
         if !define.contains('=') {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -349,6 +349,12 @@ const DEFAULT_CONFIG: &str = r#"{
     // Metadata
     metadata: {
         separator: "; "
+    },
+
+    // Delegate environments (external tool integration)
+    delegates: {
+        abc2svg: false,
+        lilypond: false
     }
 }"#;
 

--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -1,10 +1,11 @@
-//! Utilities for detecting external tool availability.
+//! Utilities for detecting and invoking external tools.
 //!
 //! The delegate rendering pipeline (ABC, Lilypond) requires external tools
 //! to convert notation into SVG/PNG. This module provides functions to check
-//! whether these tools are installed and accessible on the current system.
+//! whether these tools are installed and accessible on the current system,
+//! and to invoke them on delegate environment content.
 //!
-//! All functions in this module are safe to call even when the tools are not
+//! All detection functions are safe to call even when the tools are not
 //! installed — they return `false` rather than panicking.
 
 use std::process::Command;
@@ -46,6 +47,65 @@ pub fn has_lilypond() -> bool {
     is_available("lilypond")
 }
 
+/// Invoke `abc2svg` on ABC notation content and return the rendered SVG fragment.
+///
+/// Writes `abc_content` to a temporary file, runs `abc2svg tosvg.js <file>`,
+/// and extracts the `<body>` content from the HTML output. The returned string
+/// is an HTML fragment containing one or more `<svg>` elements suitable for
+/// direct embedding.
+///
+/// # Errors
+///
+/// Returns an error string if:
+/// - The temporary file cannot be written
+/// - `abc2svg` is not available or fails to execute
+/// - The output does not contain a recognizable `<body>` section
+pub fn invoke_abc2svg(abc_content: &str) -> Result<String, String> {
+    let tmp_dir = std::env::temp_dir();
+    let tmp_path = tmp_dir.join(format!("chordpro_abc_{}.abc", std::process::id()));
+
+    std::fs::write(&tmp_path, abc_content)
+        .map_err(|e| format!("failed to write temp file: {e}"))?;
+
+    let output = Command::new("abc2svg")
+        .arg("tosvg.js")
+        .arg(&tmp_path)
+        .output()
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            format!("failed to invoke abc2svg: {e}")
+        })?;
+
+    let _ = std::fs::remove_file(&tmp_path);
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("abc2svg exited with error: {stderr}"));
+    }
+
+    let html = String::from_utf8_lossy(&output.stdout);
+    extract_body_content(&html)
+        .ok_or_else(|| "failed to extract SVG from abc2svg output".to_string())
+}
+
+/// Extract content after `<body>` from an HTML string.
+///
+/// Looks for a `</body>` closing tag first; if absent (abc2svg omits it),
+/// falls back to `</html>`. Returns the trimmed content between the opening
+/// tag and whichever closing marker is found.
+fn extract_body_content(html: &str) -> Option<String> {
+    let body_open = html.find("<body>")?;
+    let content_start = body_open + "<body>".len();
+    let content_end = html
+        .find("</body>")
+        .or_else(|| html.find("</html>"))
+        .unwrap_or(html.len());
+    if content_start > content_end {
+        return None;
+    }
+    Some(html[content_start..content_end].trim().to_string())
+}
+
 /// Returns `true` if the Perl `chordpro` reference implementation is available.
 #[must_use]
 pub fn has_perl_chordpro() -> bool {
@@ -65,9 +125,48 @@ mod tests {
     // Run with: cargo test -p chordpro-core -- --ignored
 
     #[test]
+    fn extract_body_content_basic() {
+        let html = "<html><body>\n<svg>hello</svg>\n</body></html>";
+        let result = super::extract_body_content(html);
+        assert_eq!(result, Some("<svg>hello</svg>".to_string()));
+    }
+
+    #[test]
+    fn extract_body_content_missing_body() {
+        let html = "<html><div>no body tag</div></html>";
+        assert!(super::extract_body_content(html).is_none());
+    }
+
+    #[test]
+    fn extract_body_content_empty_body() {
+        let html = "<html><body></body></html>";
+        assert_eq!(super::extract_body_content(html), Some(String::new()));
+    }
+
+    #[test]
     #[ignore]
     fn abc2svg_detection() {
         assert!(has_abc2svg(), "abc2svg not found in PATH");
+    }
+
+    #[test]
+    #[ignore]
+    fn invoke_abc2svg_produces_svg() {
+        let abc = "X:1\nT:Test\nM:4/4\nK:C\nCDEF|GABc|\n";
+        let result = invoke_abc2svg(abc);
+        assert!(result.is_ok(), "invoke_abc2svg failed: {:?}", result.err());
+        let svg = result.unwrap();
+        assert!(svg.contains("<svg"), "output should contain SVG element");
+    }
+
+    #[test]
+    fn invoke_abc2svg_fails_gracefully_without_tool() {
+        if has_abc2svg() {
+            // Skip if abc2svg is available — this test is for the missing-tool path.
+            return;
+        }
+        let result = invoke_abc2svg("X:1\n");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -145,6 +145,13 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
     let mut columns_open = false;
     // Tracks whether we are inside an SVG delegate section.
     let mut in_svg_section = false;
+    // Buffer for collecting ABC notation content when abc2svg rendering is enabled.
+    let abc2svg_enabled = config
+        .get_path("delegates.abc2svg")
+        .as_bool()
+        .unwrap_or(false);
+    let mut abc_buf: Option<String> = None;
+    let mut abc_label: Option<String> = None;
 
     // Stores the rendered HTML of the most recently defined chorus body
     // (everything between StartOfChorus and EndOfChorus, excluding the
@@ -168,6 +175,11 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                     let raw = lyrics_line.text();
                     html.push_str(&raw);
                     html.push('\n');
+                } else if let Some(ref mut buf) = abc_buf {
+                    // Inside ABC section with abc2svg enabled: collect content.
+                    let raw = lyrics_line.text();
+                    buf.push_str(&raw);
+                    buf.push('\n');
                 } else {
                     let mut target = String::new();
                     render_lyrics(lyrics_line, transpose_offset, &fmt_state, &mut target);
@@ -253,6 +265,16 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                         // TODO: NewPhysicalPage should eventually emit a
                         // different CSS hint for duplex printing scenarios.
                         html.push_str("<div style=\"break-before: page;\"></div>\n");
+                    }
+                    DirectiveKind::StartOfAbc if abc2svg_enabled => {
+                        abc_buf = Some(String::new());
+                        abc_label = directive.value.clone();
+                    }
+                    DirectiveKind::EndOfAbc if abc_buf.is_some() => {
+                        if let Some(abc_content) = abc_buf.take() {
+                            render_abc_with_fallback(&abc_content, &abc_label, &mut html);
+                            abc_label = None;
+                        }
                     }
                     DirectiveKind::StartOfSvg => {
                         html.push_str("<div class=\"svg-section\">\n");
@@ -681,6 +703,29 @@ fn render_directive_inner(directive: &chordpro_core::ast::Directive, html: &mut 
             }
         }
         _ => {}
+    }
+}
+
+/// Render ABC notation content using abc2svg, falling back to preformatted text.
+///
+/// When abc2svg is available and produces valid output, the SVG fragment is
+/// embedded inside a `<section class="abc">` element. When abc2svg is
+/// unavailable or fails, the raw ABC notation is rendered as preformatted text.
+fn render_abc_with_fallback(abc_content: &str, label: &Option<String>, html: &mut String) {
+    match chordpro_core::external_tool::invoke_abc2svg(abc_content) {
+        Ok(svg_fragment) => {
+            render_section_open("abc", "ABC", label, html);
+            html.push_str(&svg_fragment);
+            html.push('\n');
+            html.push_str("</section>\n");
+        }
+        Err(_) => {
+            render_section_open("abc", "ABC", label, html);
+            html.push_str("<pre>");
+            html.push_str(&escape(abc_content));
+            html.push_str("</pre>\n");
+            html.push_str("</section>\n");
+        }
     }
 }
 
@@ -1362,6 +1407,65 @@ Verse text\n\
         let html = render("{define: Am keys 0 3 7}");
         // Keyboard definitions don't produce SVG diagrams
         assert!(!html.contains("<svg"));
+    }
+
+    // -- abc2svg delegate rendering tests -----------------------------------------
+
+    #[test]
+    fn test_abc_section_without_delegate_config() {
+        // Default config has delegates.abc2svg=false, so ABC renders as text
+        let html = render("{start_of_abc}\nX:1\n{end_of_abc}");
+        assert!(html.contains("<section class=\"abc\">"));
+        assert!(html.contains("ABC"));
+        assert!(html.contains("</section>"));
+    }
+
+    #[test]
+    fn test_abc_section_fallback_preformatted() {
+        // With delegate enabled but abc2svg not available, falls back to <pre>
+        if chordpro_core::external_tool::has_abc2svg() {
+            return; // Skip on machines with abc2svg installed
+        }
+        let input = "{start_of_abc}\nX:1\nT:Test\nK:C\n{end_of_abc}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config =
+            chordpro_core::config::Config::defaults().with_define("delegates.abc2svg=true");
+        let html = render_song_with_transpose(&song, 0, &config);
+        assert!(html.contains("<section class=\"abc\">"));
+        assert!(html.contains("<pre>"));
+        assert!(html.contains("X:1"));
+        assert!(html.contains("</pre>"));
+    }
+
+    #[test]
+    fn test_abc_section_with_label_delegate_fallback() {
+        if chordpro_core::external_tool::has_abc2svg() {
+            return;
+        }
+        let input = "{start_of_abc: Melody}\nX:1\n{end_of_abc}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config =
+            chordpro_core::config::Config::defaults().with_define("delegates.abc2svg=true");
+        let html = render_song_with_transpose(&song, 0, &config);
+        assert!(html.contains("ABC: Melody"));
+        assert!(html.contains("<pre>"));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_abc_section_renders_svg_with_abc2svg() {
+        // Requires abc2svg installed. Run with: cargo test -- --ignored
+        let input = "{start_of_abc}\nX:1\nT:Test\nM:4/4\nK:C\nCDEF|GABc|\n{end_of_abc}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config =
+            chordpro_core::config::Config::defaults().with_define("delegates.abc2svg=true");
+        let html = render_song_with_transpose(&song, 0, &config);
+        assert!(html.contains("<section class=\"abc\">"));
+        assert!(
+            html.contains("<svg"),
+            "should contain rendered SVG from abc2svg"
+        );
+        assert!(html.contains("</section>"));
     }
 }
 


### PR DESCRIPTION
## What

Implement the abc2svg delegate rendering pipeline for ABC notation blocks (`{start_of_abc}`...`{end_of_abc}`). When abc2svg is installed, ABC content is converted to SVG and embedded inline in HTML output.

## Why

Phase 15 requires external tool integration for delegate environments. This is the implementation side of #125 — adding process invocation for abc2svg to convert ABC notation into rendered music notation (SVG).

## Changes

- **`crates/core/src/external_tool.rs`**: Add `invoke_abc2svg()` function that writes ABC content to a temp file, runs `abc2svg tosvg.js`, and extracts the SVG fragment from the HTML output
- **`crates/core/src/config.rs`**: Add `delegates.abc2svg` config option (default: `false`)
- **`crates/cli/src/main.rs`**: Auto-detect abc2svg/lilypond availability and enable delegate config
- **`crates/render-html/src/lib.rs`**: When `delegates.abc2svg=true`, collect ABC section content and invoke abc2svg; embed SVG on success, fall back to `<pre>` on failure

## Design decisions

- **Config-gated**: Delegate rendering is off by default (`delegates.abc2svg: false`), enabled by CLI auto-detection. This preserves backward compatibility and test stability.
- **Graceful fallback**: When abc2svg is unavailable or fails, ABC content renders as preformatted text in a `<section class="abc">` element.
- **PDF placeholder**: PDF renderer continues to render section labels only (SVG→PDF rasterization deferred per acceptance criteria).

## Test results

```
test result: ok. 853 passed; 0 failed; 5 ignored
```

Integration tests (--ignored) with abc2svg installed:
```
test external_tool::tests::invoke_abc2svg_produces_svg ... ok
test transpose_tests::test_abc_section_renders_svg_with_abc2svg ... ok
```

Closes #200