### PR TITLE
Add path/URI validation to HTML renderer image src

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -729,8 +729,36 @@ fn render_abc_with_fallback(abc_content: &str, label: &Option<String>, html: &mu
     }
 }
 
+/// Check whether an image `src` value is safe to emit in HTML.
+///
+/// Rejects empty sources and dangerous URI schemes that could execute code or
+/// load unexpected external resources when the generated HTML is viewed.
+fn is_safe_image_src(src: &str) -> bool {
+    if src.is_empty() {
+        return false;
+    }
+
+    // Normalise for case-insensitive scheme comparison.  Strip leading
+    // whitespace so that " javascript:…" is still caught.
+    let normalised = src.trim_start().to_ascii_lowercase();
+
+    // Reject known dangerous URI schemes.
+    if normalised.starts_with("javascript:")
+        || normalised.starts_with("data:")
+        || normalised.starts_with("vbscript:")
+    {
+        return false;
+    }
+
+    true
+}
+
 /// Render an `{image}` directive as an HTML `<img>` element.
 fn render_image(attrs: &chordpro_core::ast::ImageAttributes, html: &mut String) {
+    if !is_safe_image_src(&attrs.src) {
+        return;
+    }
+
     let mut style = String::new();
     let mut img_attrs = format!("src=\"{}\"", escape(&attrs.src));
 
@@ -1390,6 +1418,61 @@ Verse text\n\
     fn test_image_with_scale() {
         let html = render("{image: src=photo.jpg scale=0.5}");
         assert!(html.contains("scale(0.5)"));
+    }
+
+    #[test]
+    fn test_image_empty_src_skipped() {
+        let html = render("{image: src=}");
+        assert!(
+            !html.contains("<img"),
+            "empty src should not produce an img element"
+        );
+    }
+
+    #[test]
+    fn test_image_javascript_uri_rejected() {
+        let html = render("{image: src=javascript:alert(1)}");
+        assert!(!html.contains("<img"), "javascript: URI must be rejected");
+    }
+
+    #[test]
+    fn test_image_data_uri_rejected() {
+        let html = render("{image: src=data:text/html,<script>alert(1)</script>}");
+        assert!(!html.contains("<img"), "data: URI must be rejected");
+    }
+
+    #[test]
+    fn test_image_vbscript_uri_rejected() {
+        let html = render("{image: src=vbscript:MsgBox}");
+        assert!(!html.contains("<img"), "vbscript: URI must be rejected");
+    }
+
+    #[test]
+    fn test_image_javascript_uri_case_insensitive() {
+        let html = render("{image: src=JaVaScRiPt:alert(1)}");
+        assert!(
+            !html.contains("<img"),
+            "scheme check must be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_image_safe_relative_path_allowed() {
+        let html = render("{image: src=images/photo.jpg}");
+        assert!(html.contains("<img src=\"images/photo.jpg\""));
+    }
+
+    #[test]
+    fn test_is_safe_image_src() {
+        assert!(is_safe_image_src("photo.jpg"));
+        assert!(is_safe_image_src("images/photo.jpg"));
+        assert!(is_safe_image_src("https://example.com/photo.jpg"));
+        assert!(!is_safe_image_src(""));
+        assert!(!is_safe_image_src("javascript:alert(1)"));
+        assert!(!is_safe_image_src("JAVASCRIPT:alert(1)"));
+        assert!(!is_safe_image_src("  javascript:alert(1)"));
+        assert!(!is_safe_image_src("data:image/png;base64,abc"));
+        assert!(!is_safe_image_src("vbscript:MsgBox"));
     }
 
     // -- chord diagram tests --------------------------------------------------


### PR DESCRIPTION
## What

Add `is_safe_image_src()` validation to the HTML renderer's `render_image` function:
- Skip rendering when `src` is empty (consistent with PDF renderer behavior)
- Reject dangerous URI schemes: `javascript:`, `data:`, `vbscript:` (case-insensitive, leading-whitespace tolerant)

## Why

Security review finding S1 (Medium) from Phase 12 completion gate (#97): the PDF renderer applies `is_safe_image_path()` before any file operations, but the HTML renderer had no equivalent validation. While `escape()` prevents HTML attribute injection, dangerous URI schemes could pass through. This is a defense-in-depth measure.

Also addresses code review finding M1 (Minor): inconsistency where PDF renderer returns early on empty `src` but HTML renderer unconditionally rendered `<img src="">`.

## Test results

```
test result: ok. 89 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

New tests:
- `test_image_empty_src_skipped`
- `test_image_javascript_uri_rejected`
- `test_image_data_uri_rejected`
- `test_image_vbscript_uri_rejected`
- `test_image_javascript_uri_case_insensitive`
- `test_image_safe_relative_path_allowed`
- `test_is_safe_image_src` (unit test for the validation function)

## Review summary

Straightforward addition of a validation function at the top of `render_image`. No changes to public API, no new dependencies.

Closes #282