### PR TITLE
Add Lilypond process invocation and image capture

### DIFF
--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -106,6 +106,60 @@ fn extract_body_content(html: &str) -> Option<String> {
     Some(html[content_start..content_end].trim().to_string())
 }
 
+/// Invoke `lilypond` on Lilypond notation content and return the rendered SVG.
+///
+/// Creates a temporary directory, writes `ly_content` to a `.ly` file, runs
+/// `lilypond --svg -o <prefix> <file>`, and reads the resulting SVG file.
+/// The returned string is a complete SVG document suitable for inline embedding.
+///
+/// # Errors
+///
+/// Returns an error string if:
+/// - The temporary directory or file cannot be created
+/// - `lilypond` is not available or fails to execute
+/// - The output SVG file cannot be read
+pub fn invoke_lilypond(ly_content: &str) -> Result<String, String> {
+    let tmp_dir = std::env::temp_dir().join(format!("chordpro_ly_{}", std::process::id()));
+
+    std::fs::create_dir_all(&tmp_dir)
+        .map_err(|e| format!("failed to create temp directory: {e}"))?;
+
+    let ly_path = tmp_dir.join("input.ly");
+    let output_prefix = tmp_dir.join("output");
+
+    std::fs::write(&ly_path, ly_content).map_err(|e| {
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        format!("failed to write temp file: {e}")
+    })?;
+
+    let result = Command::new("lilypond")
+        .arg("--svg")
+        .arg(format!("-o{}", output_prefix.display()))
+        .arg(&ly_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|e| {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            format!("failed to invoke lilypond: {e}")
+        })?;
+
+    if !result.status.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        return Err(format!("lilypond exited with error: {stderr}"));
+    }
+
+    let svg_path = tmp_dir.join("output.svg");
+    let svg = std::fs::read_to_string(&svg_path).map_err(|e| {
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        format!("failed to read lilypond SVG output: {e}")
+    })?;
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+    Ok(svg)
+}
+
 /// Returns `true` if the Perl `chordpro` reference implementation is available.
 #[must_use]
 pub fn has_perl_chordpro() -> bool {
@@ -173,6 +227,25 @@ mod tests {
     #[ignore]
     fn lilypond_detection() {
         assert!(has_lilypond(), "lilypond not found in PATH");
+    }
+
+    #[test]
+    #[ignore]
+    fn invoke_lilypond_produces_svg() {
+        let ly = "\\relative c' { c4 d e f | g2 g | }\n";
+        let result = invoke_lilypond(ly);
+        assert!(result.is_ok(), "invoke_lilypond failed: {:?}", result.err());
+        let svg = result.unwrap();
+        assert!(svg.contains("<svg"), "output should contain SVG element");
+    }
+
+    #[test]
+    fn invoke_lilypond_fails_gracefully_without_tool() {
+        if has_lilypond() {
+            return;
+        }
+        let result = invoke_lilypond("{ c4 }\n");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -152,6 +152,13 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
         .unwrap_or(false);
     let mut abc_buf: Option<String> = None;
     let mut abc_label: Option<String> = None;
+    // Buffer for collecting Lilypond notation content when lilypond rendering is enabled.
+    let lilypond_enabled = config
+        .get_path("delegates.lilypond")
+        .as_bool()
+        .unwrap_or(false);
+    let mut ly_buf: Option<String> = None;
+    let mut ly_label: Option<String> = None;
 
     // Stores the rendered HTML of the most recently defined chorus body
     // (everything between StartOfChorus and EndOfChorus, excluding the
@@ -177,6 +184,11 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                     html.push('\n');
                 } else if let Some(ref mut buf) = abc_buf {
                     // Inside ABC section with abc2svg enabled: collect content.
+                    let raw = lyrics_line.text();
+                    buf.push_str(&raw);
+                    buf.push('\n');
+                } else if let Some(ref mut buf) = ly_buf {
+                    // Inside Lilypond section with lilypond enabled: collect content.
                     let raw = lyrics_line.text();
                     buf.push_str(&raw);
                     buf.push('\n');
@@ -274,6 +286,16 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                         if let Some(abc_content) = abc_buf.take() {
                             render_abc_with_fallback(&abc_content, &abc_label, &mut html);
                             abc_label = None;
+                        }
+                    }
+                    DirectiveKind::StartOfLy if lilypond_enabled => {
+                        ly_buf = Some(String::new());
+                        ly_label = directive.value.clone();
+                    }
+                    DirectiveKind::EndOfLy if ly_buf.is_some() => {
+                        if let Some(ly_content) = ly_buf.take() {
+                            render_ly_with_fallback(&ly_content, &ly_label, &mut html);
+                            ly_label = None;
                         }
                     }
                     DirectiveKind::StartOfSvg => {
@@ -751,6 +773,29 @@ fn is_safe_image_src(src: &str) -> bool {
     }
 
     true
+}
+
+/// Render Lilypond notation content using lilypond, falling back to preformatted text.
+///
+/// When lilypond is available and produces valid output, the SVG is embedded
+/// inside a `<section class="ly">` element. When lilypond is unavailable or
+/// fails, the raw notation is rendered as preformatted text.
+fn render_ly_with_fallback(ly_content: &str, label: &Option<String>, html: &mut String) {
+    match chordpro_core::external_tool::invoke_lilypond(ly_content) {
+        Ok(svg) => {
+            render_section_open("ly", "Lilypond", label, html);
+            html.push_str(&svg);
+            html.push('\n');
+            html.push_str("</section>\n");
+        }
+        Err(_) => {
+            render_section_open("ly", "Lilypond", label, html);
+            html.push_str("<pre>");
+            html.push_str(&escape(ly_content));
+            html.push_str("</pre>\n");
+            html.push_str("</section>\n");
+        }
+    }
 }
 
 /// Render an `{image}` directive as an HTML `<img>` element.
@@ -1547,6 +1592,49 @@ Verse text\n\
         assert!(
             html.contains("<svg"),
             "should contain rendered SVG from abc2svg"
+        );
+        assert!(html.contains("</section>"));
+    }
+
+    // -- lilypond delegate rendering tests ----------------------------------------
+
+    #[test]
+    fn test_ly_section_without_delegate_config() {
+        // Default config has delegates.lilypond=false, so Ly renders as text
+        let html = render("{start_of_ly}\n\\relative c' { c4 }\n{end_of_ly}");
+        assert!(html.contains("<section class=\"ly\">"));
+        assert!(html.contains("Lilypond"));
+        assert!(html.contains("</section>"));
+    }
+
+    #[test]
+    fn test_ly_section_fallback_preformatted() {
+        if chordpro_core::external_tool::has_lilypond() {
+            return;
+        }
+        let input = "{start_of_ly}\n\\relative c' { c4 }\n{end_of_ly}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config =
+            chordpro_core::config::Config::defaults().with_define("delegates.lilypond=true");
+        let html = render_song_with_transpose(&song, 0, &config);
+        assert!(html.contains("<section class=\"ly\">"));
+        assert!(html.contains("<pre>"));
+        assert!(html.contains("</pre>"));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_ly_section_renders_svg_with_lilypond() {
+        // Requires lilypond installed. Run with: cargo test -- --ignored
+        let input = "{start_of_ly}\n\\relative c' { c4 d e f | g2 g | }\n{end_of_ly}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config =
+            chordpro_core::config::Config::defaults().with_define("delegates.lilypond=true");
+        let html = render_song_with_transpose(&song, 0, &config);
+        assert!(html.contains("<section class=\"ly\">"));
+        assert!(
+            html.contains("<svg"),
+            "should contain rendered SVG from lilypond"
         );
         assert!(html.contains("</section>"));
     }


### PR DESCRIPTION
## What

Implement the Lilypond delegate rendering pipeline for Ly notation blocks (`{start_of_ly}`...`{end_of_ly}`). When lilypond is installed, Ly content is compiled to SVG and embedded inline in HTML output.

## Why

Phase 15 requires external tool integration for delegate environments. This is the implementation side of #127 — adding process invocation for Lilypond to convert notation into rendered music scores (SVG).

## Changes

- **`crates/core/src/external_tool.rs`**: Add `invoke_lilypond()` function that writes Ly content to a temp directory, runs `lilypond --svg`, and reads the resulting SVG file
- **`crates/render-html/src/lib.rs`**: When `delegates.lilypond=true`, collect Ly section content and invoke lilypond; embed SVG on success, fall back to `<pre>` on failure

## Design decisions

- **Config-gated**: Like abc2svg, delegate rendering uses the `delegates.lilypond` config option (default: `false`), auto-enabled by CLI when lilypond is detected
- **Temp directory**: Lilypond outputs to files rather than stdout, so we create a temp directory, run lilypond, read the SVG, and clean up
- **Graceful fallback**: When lilypond is unavailable or fails, Ly content renders as preformatted text

## Test results

```
test result: ok. 856 passed; 0 failed; 7 ignored
```

Integration tests (--ignored) with lilypond installed:
```
test external_tool::tests::invoke_lilypond_produces_svg ... ok
test transpose_tests::test_ly_section_renders_svg_with_lilypond ... ok
```

Closes #201