### PR TITLE
Wire Config::load() into CLI for hierarchical config loading

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,6 +4,7 @@
 
 use std::fs;
 use std::io::{self, Write};
+use std::path::Path;
 use std::process::ExitCode;
 
 use clap::Parser;
@@ -51,8 +52,16 @@ enum Format {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    // Build configuration: defaults → system → user → custom config files → defines
-    let mut config = chordpro_core::config::Config::defaults();
+    // Derive project directory from the first input file for project-level config.
+    let project_dir = cli
+        .files
+        .first()
+        .and_then(|f| Path::new(f).parent())
+        .and_then(|p| p.to_str())
+        .map(|s| s.to_string());
+
+    // Build configuration: defaults → system → user → project → custom config files → defines
+    let mut config = chordpro_core::config::Config::load(project_dir.as_deref(), None);
 
     // Apply --config files/presets in order (preset names resolved first)
     for config_name in &cli.configs {


### PR DESCRIPTION
## What

Replace `Config::defaults()` with `Config::load()` in the CLI entry point so that system, user, and project-level configuration files are automatically loaded.

## Why

The CLI was only loading `Config::defaults()` and applying `--config` / `--define` flags. Users expected system (`/etc/chordpro.json`), user (`~/.config/chordpro/chordpro.json`), and project-level (`chordpro.json` in the song file directory) config files to be loaded automatically, as documented in the `config` module comments. The project directory is now derived from the parent directory of the first input song file.

## Precedence order

1. Built-in defaults
2. System config (`/etc/chordpro.json`)
3. User config (`~/.config/chordpro/chordpro.json`)
4. Project config (`chordpro.json` in song file directory)
5. `--config` files/presets
6. Auto-detected delegates (abc2svg, lilypond)
7. `--define` overrides (highest precedence)

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all tests pass)
```

## Review summary

- Single file change in `crates/cli/src/main.rs`
- Derives project directory from the first input file's parent directory
- Missing config files at any level are silently skipped (existing behavior of `Config::load()`)
- `--config` and `--define` still have highest precedence

Closes #296