### PR TITLE
Warn when RRJSON include directives are encountered

### DIFF
--- a/crates/core/src/rrjson.rs
+++ b/crates/core/src/rrjson.rs
@@ -536,13 +536,21 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            // Skip "include" directives (just consume the line)
+            // Skip "include" directives (not yet supported — warn and consume the line)
             if self.input[self.pos..].starts_with("include") {
-                if let Some(end) = self.input[self.pos..].find('\n') {
+                let (line, col) = self.line_col();
+                let directive_line = if let Some(end) = self.input[self.pos..].find('\n') {
+                    let line_text = self.input[self.pos..self.pos + end].trim();
                     self.pos += end + 1;
+                    line_text.to_string()
                 } else {
+                    let line_text = self.input[self.pos..].trim().to_string();
                     self.pos = self.input.len();
-                }
+                    line_text
+                };
+                eprintln!(
+                    "warning: RRJSON include directives are not supported (line {line} column {col}): {directive_line}"
+                );
                 continue;
             }
 


### PR DESCRIPTION
## What

Emit a warning to stderr when a bare-object `include` directive is encountered in RRJSON parsing.

## Why

The RRJSON parser recognized `include "filename"` directives but silently dropped them. Users with `include` directives in their config files would lose the included content without any indication. Now they get a clear warning with line/column and the directive text.

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test -p chordpro-core  ✅ (all tests pass)
```

## Review summary

- When an `include` directive is encountered, a warning is printed to stderr with the line/column and directive text
- The include is still skipped (not processed) — the warning informs users that their include was ignored
- No API changes; existing test `test_include_directive_skipped` still passes

Closes #300