### PR TITLE
Improve image directive documentation and minor cleanups

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -402,6 +402,10 @@ impl core::fmt::Display for Chord {
 /// The `{image}` directive embeds an image in the song. The `src` attribute
 /// is required; all other attributes are optional.
 ///
+/// Format support is renderer-specific: the PDF renderer supports JPEG only
+/// (`.jpg` / `.jpeg`), while the HTML renderer delegates to the browser and
+/// can display any web-supported format.
+///
 /// # Examples
 ///
 /// ```

--- a/crates/core/tests/fixtures/image-directive/expected.txt
+++ b/crates/core/tests/fixtures/image-directive/expected.txt
@@ -97,5 +97,28 @@ Song {
                 selector: None,
             },
         ),
+        Directive(
+            Directive {
+                name: "image",
+                value: Some(
+                    "src=banner.jpg anchor=paper width=50%",
+                ),
+                kind: Image(
+                    ImageAttributes {
+                        src: "banner.jpg",
+                        width: Some(
+                            "50%",
+                        ),
+                        height: None,
+                        scale: None,
+                        title: None,
+                        anchor: Some(
+                            "paper",
+                        ),
+                    },
+                ),
+                selector: None,
+            },
+        ),
     ],
 }

--- a/crates/core/tests/fixtures/image-directive/input.cho
+++ b/crates/core/tests/fixtures/image-directive/input.cho
@@ -2,3 +2,4 @@
 {image: src=photo.jpg}
 {image: src=logo.png width=200 height=100}
 {image: src=cover.jpg scale=0.5 title="Album Cover"}
+{image: src=banner.jpg anchor=paper width=50%}

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1028,6 +1028,13 @@ fn render_ly_with_fallback(ly_content: &str, label: &Option<String>, html: &mut 
 }
 
 /// Render an `{image}` directive as an HTML `<img>` element.
+///
+/// Generates a `<div>` wrapper (with optional alignment from the `anchor`
+/// attribute) containing an `<img>` tag.  The `src`, `width`, `height`, and
+/// `title` (as `alt`) attributes are forwarded.  A `scale` value is applied
+/// via a CSS `transform: scale(…)` style.
+///
+/// Paths that fail [`is_safe_image_src`] are silently skipped.
 fn render_image(attrs: &chordpro_core::ast::ImageAttributes, html: &mut String) {
     if !is_safe_image_src(&attrs.src) {
         return;
@@ -1070,6 +1077,11 @@ fn render_image(attrs: &chordpro_core::ast::ImageAttributes, html: &mut String) 
 
     html.push_str(&format!("<img {}", img_attrs));
     if !style.is_empty() {
+        // The style string is first sanitised (sanitize_css_value removes
+        // dangerous characters) and then HTML-escaped here.  The double
+        // processing is intentional: sanitisation makes the CSS value safe,
+        // while escape() ensures the surrounding attribute context is safe
+        // (e.g. a `"` in the style cannot break out of the attribute).
         html.push_str(&format!(" style=\"{}\"", escape(&style)));
     }
     html.push_str("></div>\n");

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -619,9 +619,15 @@ fn read_image_file(path: &str) -> Option<Vec<u8>> {
 
 /// Render an `{image}` directive by embedding a JPEG file into the PDF.
 ///
-/// Only JPEG files (`.jpg` / `.jpeg` extension) are supported. If the file
-/// cannot be read, has no recognisable JPEG header, or is not a JPEG
-/// extension, the directive is silently skipped.
+/// Only JPEG files (`.jpg` / `.jpeg` extension) are currently supported.
+/// The image is read from disk, validated, and embedded as a DCTDecode
+/// XObject.  If the file cannot be read, has no recognisable JPEG header,
+/// is not a JPEG extension, is a symlink, or exceeds [`MAX_IMAGE_FILE_SIZE`],
+/// the directive is silently skipped.
+///
+/// The `anchor` attribute controls horizontal alignment: `"line"` (default)
+/// places the image at the column margin, `"column"` centres it within the
+/// column, and `"paper"` centres it on the full page.
 fn render_image(attrs: &ImageAttributes, doc: &mut PdfDocument) {
     if attrs.src.is_empty() {
         return;


### PR DESCRIPTION
## What

Address documentation gaps and minor code quality items from Phase 12 completion gate reviews:

- **M6**: Add renderer-specific format support note to `ImageAttributes` doc comment
- **N1**: Expand PDF `render_image` doc with all skip conditions and anchor behavior
- **N2**: Add parameter documentation to HTML `render_image`
- **N3**: Add explanatory comment for the intentional double-processing of style attributes (sanitize CSS value, then HTML-escape the attribute context)
- **N5**: Add golden test case for `anchor=paper` with percentage width

## Why

From Phase 12 completion gate reviews (M6, N1-N3, N5 on #97). Documentation and test coverage gaps identified during review.

## Test results

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test -p chordpro-core --test golden` ✅

## Review summary

Changes across 5 files:
- `crates/core/src/ast.rs`: Added format support note to `ImageAttributes` doc
- `crates/render-pdf/src/lib.rs`: Expanded `render_image` doc comment
- `crates/render-html/src/lib.rs`: Added `render_image` doc comment + style processing comment
- `crates/core/tests/fixtures/image-directive/input.cho`: Added anchor test case
- `crates/core/tests/fixtures/image-directive/expected.txt`: Updated golden snapshot

Closes #290