### PR TITLE
Add root cause fixes rule

### DIFF
--- a/.claude/rules/root-cause-fixes.md
+++ b/.claude/rules/root-cause-fixes.md
@@ -1,0 +1,21 @@
+# Root Cause Fixes
+
+When encountering a problem — whether a bug, test failure, build error, or unexpected
+behavior — always investigate and fix the **root cause**, not the symptom.
+
+## Rules
+
+- **No workarounds without justification.** Do not suppress warnings, skip tests, add
+  special-case patches, or apply band-aid fixes. If a workaround is truly necessary
+  (e.g., upstream bug outside our control), document the reason and link to a tracking
+  issue for the proper fix.
+- **Diagnose before fixing.** Read the error, trace the cause, and understand *why* the
+  problem occurs before writing any fix. A fix you don't understand is not a fix.
+- **Fix at the right layer.** If the bug is in the parser, fix the parser — don't add
+  compensating logic in the renderer. If the issue is in the data model, fix the data
+  model — don't patch every call site.
+- **Avoid `#[allow(...)]` or `// nolint` to silence legitimate warnings.** These hide
+  real problems. Fix the code that triggers the warning instead.
+- **Tests must validate the root cause.** When adding a regression test, ensure it
+  covers the actual root cause, not just the surface-level symptom. The test should fail
+  if the root cause is reintroduced.


### PR DESCRIPTION
## What

Add `.claude/rules/root-cause-fixes.md` — a project rule requiring root cause analysis and fixes instead of symptomatic workarounds.

## Why

Ensure consistent problem-solving approach across all contributors: always diagnose and fix the underlying cause rather than applying band-aid fixes.

## Rules added

- No workarounds without justification and a tracking issue
- Diagnose before fixing — understand *why* before writing code
- Fix at the right layer — don't compensate in the wrong module
- No suppressing legitimate warnings with `#[allow(...)]`
- Regression tests must validate the root cause, not just the symptom

## Test results

Documentation-only change — no code or test impact.

```
cargo fmt --check  # pass
cargo clippy       # pass
cargo test         # pass
```

## Review summary

Single new Markdown file under `.claude/rules/`. No code changes.

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)