### PR TITLE
Fix doc comment placement for parse_image_attributes

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -1190,21 +1190,6 @@ pub fn parse_multi_lenient_with_options(input: &str, options: &ParseOptions) -> 
 // Image attribute parsing
 // ---------------------------------------------------------------------------
 
-/// Parses the value string of an `{image}` directive into [`ImageAttributes`].
-///
-/// The value string is expected to contain `key=value` pairs separated by
-/// whitespace. Quoted values (e.g., `title="Album Cover"`) are supported.
-/// Unknown keys are silently ignored.
-///
-/// # Examples
-///
-/// ```
-/// # use chordpro_core::parser::parse_image_attributes;
-/// # use chordpro_core::ast::ImageAttributes;
-/// let attrs = parse_image_attributes("src=photo.jpg width=200");
-/// assert_eq!(attrs.src, "photo.jpg");
-/// assert_eq!(attrs.width.as_deref(), Some("200"));
-/// ```
 /// Maximum byte length for the `src` attribute value.
 const IMAGE_SRC_MAX_BYTES: usize = 4096;
 
@@ -1224,6 +1209,21 @@ fn truncate_string(s: String, max_bytes: usize) -> String {
     s[..end].to_string()
 }
 
+/// Parses the value string of an `{image}` directive into [`ImageAttributes`].
+///
+/// The value string is expected to contain `key=value` pairs separated by
+/// whitespace. Quoted values (e.g., `title="Album Cover"`) are supported.
+/// Unknown keys are silently ignored.
+///
+/// # Examples
+///
+/// ```
+/// # use chordpro_core::parser::parse_image_attributes;
+/// # use chordpro_core::ast::ImageAttributes;
+/// let attrs = parse_image_attributes("src=photo.jpg width=200");
+/// assert_eq!(attrs.src, "photo.jpg");
+/// assert_eq!(attrs.width.as_deref(), Some("200"));
+/// ```
 #[must_use]
 pub fn parse_image_attributes(input: &str) -> ImageAttributes {
     let mut attrs = ImageAttributes::default();


### PR DESCRIPTION
## What

Move the doc comment block (including doctest) from above the private constant `IMAGE_SRC_MAX_BYTES` to directly above `pub fn parse_image_attributes`.

## Why

The contiguous `///` doc block was attached to `IMAGE_SRC_MAX_BYTES` because it was the next syntactic item. This left `parse_image_attributes` without documentation, violating the code style rule that all public items must have doc comments. Identified as P12-R1 / Nit finding during Phase 12 completion gate reviews (#97, #334, #358).

## Test results

- `cargo test --doc` passes — doctest runs correctly on the function
- `cargo doc` generates correct documentation for `parse_image_attributes`

```
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Review summary

Pure doc comment relocation — no logic changes. Resolves two duplicate issues (#334 and #358) that tracked the same finding.

Closes #334
Closes #358