### PR TITLE
Add HTML renderer tests for image anchor attribute

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1063,9 +1063,7 @@ fn render_image(attrs: &chordpro_core::ast::ImageAttributes, html: &mut String) 
 
     // Determine wrapper alignment
     let align_css = match attrs.anchor.as_deref() {
-        Some("line") | None => "",
-        Some("column") => "text-align: center;",
-        Some("paper") => "text-align: center;",
+        Some("column") | Some("paper") => "text-align: center;",
         _ => "",
     };
 
@@ -1759,6 +1757,40 @@ Verse text\n\
         assert!(!is_safe_image_src("  javascript:alert(1)"));
         assert!(!is_safe_image_src("data:image/png;base64,abc"));
         assert!(!is_safe_image_src("vbscript:MsgBox"));
+    }
+
+    #[test]
+    fn test_image_anchor_column_centers() {
+        let html = render("{image: src=photo.jpg anchor=column}");
+        assert!(
+            html.contains("<div style=\"text-align: center;\">"),
+            "anchor=column should produce centered div"
+        );
+    }
+
+    #[test]
+    fn test_image_anchor_paper_centers() {
+        let html = render("{image: src=photo.jpg anchor=paper}");
+        assert!(
+            html.contains("<div style=\"text-align: center;\">"),
+            "anchor=paper should produce centered div"
+        );
+    }
+
+    #[test]
+    fn test_image_anchor_line_no_style() {
+        let html = render("{image: src=photo.jpg anchor=line}");
+        // anchor=line should produce a bare <div> without style
+        assert!(html.contains("<div><img"));
+        assert!(!html.contains("text-align"));
+    }
+
+    #[test]
+    fn test_image_no_anchor_no_style() {
+        let html = render("{image: src=photo.jpg}");
+        // No anchor should produce a bare <div> without style
+        assert!(html.contains("<div><img"));
+        assert!(!html.contains("text-align"));
     }
 
     // -- chord diagram tests --------------------------------------------------


### PR DESCRIPTION
## What

Add test coverage for the `anchor` attribute in the HTML renderer's `render_image` function and collapse duplicate match arms.

## Why

From Phase 12 completion gate code review (P12-R5, P12-R6 on #97). The HTML renderer treats `anchor=column` and `anchor=paper` identically but had separate match arms and zero test coverage.

## Changes

- Collapse `Some("column")` and `Some("paper")` match arms with `|`
- Remove redundant `Some("line") | None` arm (already covered by `_` wildcard)
- Add 4 tests: column centering, paper centering, line no-style, absent anchor no-style

## Test results

```
test result: ok. 104 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

## Review summary

Minor cleanup + test coverage. No behavioral changes.

Closes #361