### PR TITLE
Reject null bytes and empty paths in is_safe_image_path

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -541,10 +541,16 @@ fn render_directive(directive: &chordpro_core::ast::Directive, doc: &mut PdfDocu
 
 /// Check whether an image path is safe to open.
 ///
-/// Rejects absolute paths and paths containing `..` components to prevent
-/// directory traversal attacks. Only relative paths that stay within (or
-/// below) the current working directory are accepted.
+/// Rejects empty paths, paths containing null bytes, absolute paths, and
+/// paths containing `..` components to prevent directory traversal attacks.
+/// Only relative paths that stay within (or below) the current working
+/// directory are accepted.
 fn is_safe_image_path(path: &str) -> bool {
+    // Reject empty paths and paths with null bytes (defense-in-depth).
+    if path.is_empty() || path.contains('\0') {
+        return false;
+    }
+
     let p = std::path::Path::new(path);
 
     // Reject absolute paths (Unix `/…` and Windows `C:\…`).
@@ -3099,6 +3105,17 @@ mod jpeg_tests {
         assert!(is_safe_image_path("photo.jpg"));
         assert!(is_safe_image_path("images/photo.jpg"));
         assert!(is_safe_image_path("sub/dir/photo.jpg"));
+    }
+
+    #[test]
+    fn test_safe_image_path_rejects_empty() {
+        assert!(!is_safe_image_path(""));
+    }
+
+    #[test]
+    fn test_safe_image_path_rejects_null_bytes() {
+        assert!(!is_safe_image_path("photo\0.jpg"));
+        assert!(!is_safe_image_path("images/photo.jpg\0../../etc/shadow"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Add defense-in-depth checks for empty paths and null bytes in `is_safe_image_path`.

## Why

From Phase 12 completion gate reviews Round 2 (N1, N2, S3 on #97). While callers check for empty paths and the OS rejects null bytes, explicit checks make the defense platform-independent.

## Test results

```
test result: ok. 6 passed; 0 failed; 0 ignored
```

## Review summary

Two additional guard clauses at the top of `is_safe_image_path`. No behavioral change for valid paths.

Closes #380