### PR TITLE
Add maximum image count limit in PDF renderer

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -107,6 +107,9 @@ const MAX_IMAGE_FILE_SIZE: u64 = 50 * 1024 * 1024;
 /// points, producing a ~23-metre image.  Clamping to 10 000 keeps the default
 /// within a few A0-sized pages while still being generous for real photographs.
 const MAX_IMAGE_PIXELS: u32 = 10_000;
+/// Maximum number of images that can be embedded in a single PDF document.
+/// Prevents memory exhaustion from documents with many large image directives.
+const MAX_IMAGES: usize = 1_000;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -641,6 +644,11 @@ fn read_image_file(path: &str) -> Option<Vec<u8>> {
 /// column, and `"paper"` centres it on the full page.
 fn render_image(attrs: &ImageAttributes, doc: &mut PdfDocument) {
     if attrs.src.is_empty() {
+        return;
+    }
+
+    // Limit the number of embedded images to prevent memory exhaustion.
+    if doc.images.len() >= MAX_IMAGES {
         return;
     }
 


### PR DESCRIPTION
## What

Add `MAX_IMAGES` constant (1000) to limit the number of embedded images per PDF document.

## Why

From Phase 12 security review Round 2 (S5 on #97). The `images` vector grew without limit. A document with many `{image}` directives referencing large JPEGs could cause memory exhaustion. Matches the existing `MAX_PAGES` pattern.

## Test results

```
test result: ok. 133 passed; 0 failed; 0 ignored
```

## Review summary

Two additions: constant definition and guard clause at the top of `render_image`.

Closes #382