### PR TITLE
Harden image path validators with traversal, null byte, and Windows path checks

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -992,6 +992,11 @@ fn is_safe_image_src(src: &str) -> bool {
         return false;
     }
 
+    // Reject null bytes (defense-in-depth).
+    if src.contains('\0') {
+        return false;
+    }
+
     // Normalise for case-insensitive scheme comparison.  Strip leading
     // whitespace so that " javascript:…" is still caught.
     let normalised = src.trim_start().to_ascii_lowercase();
@@ -999,6 +1004,16 @@ fn is_safe_image_src(src: &str) -> bool {
     // Reject absolute filesystem paths (defense-in-depth, similar to
     // is_safe_image_path in the PDF renderer).
     if normalised.starts_with('/') {
+        return false;
+    }
+
+    // Reject Windows-style absolute paths on all platforms.
+    if is_windows_absolute(src.trim_start()) {
+        return false;
+    }
+
+    // Reject directory traversal (`..` path components).
+    if has_traversal(src) {
         return false;
     }
 
@@ -1013,6 +1028,35 @@ fn is_safe_image_src(src: &str) -> bool {
     }
 
     true
+}
+
+/// Check whether a path string looks like a Windows absolute path.
+///
+/// Detects drive-letter paths (`C:\…`, `C:/…`) and UNC paths (`\\…`)
+/// using string-level checks so the result is consistent across platforms.
+fn is_windows_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    // Drive letter: e.g. `C:\` or `C:/`
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        return true;
+    }
+    // UNC path: `\\server\share`
+    if bytes.len() >= 2 && bytes[0] == b'\\' && bytes[1] == b'\\' {
+        return true;
+    }
+    false
+}
+
+/// Check whether a path contains `..` directory-traversal components.
+///
+/// Splits on both `/` and `\` so the check works for both Unix and
+/// Windows-style separators.
+fn has_traversal(path: &str) -> bool {
+    path.split(['/', '\\']).any(|seg| seg == "..")
 }
 
 /// Render Lilypond notation content using lilypond, falling back to preformatted text.
@@ -1788,6 +1832,22 @@ Verse text\n\
         // Rejected: absolute filesystem paths
         assert!(!is_safe_image_src("/etc/passwd"));
         assert!(!is_safe_image_src("/home/user/photo.jpg"));
+
+        // Rejected: null bytes
+        assert!(!is_safe_image_src("photo\0.jpg"));
+        assert!(!is_safe_image_src("\0"));
+
+        // Rejected: directory traversal
+        assert!(!is_safe_image_src("../photo.jpg"));
+        assert!(!is_safe_image_src("images/../../etc/passwd"));
+        assert!(!is_safe_image_src(r"..\photo.jpg"));
+        assert!(!is_safe_image_src(r"images\..\..\photo.jpg"));
+
+        // Rejected: Windows-style absolute paths (all platforms)
+        assert!(!is_safe_image_src(r"C:\photo.jpg"));
+        assert!(!is_safe_image_src(r"D:\Users\photo.jpg"));
+        assert!(!is_safe_image_src(r"\\server\share\photo.jpg"));
+        assert!(!is_safe_image_src("C:/photo.jpg"));
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -554,6 +554,13 @@ fn is_safe_image_path(path: &str) -> bool {
         return false;
     }
 
+    // Reject Windows-style absolute paths on all platforms.  On Unix,
+    // `Path::is_absolute()` does not flag `C:\…` or `\\…` as absolute,
+    // so we perform string-level checks for drive letters and UNC paths.
+    if is_windows_absolute(path) {
+        return false;
+    }
+
     let p = std::path::Path::new(path);
 
     // Reject absolute paths (Unix `/…` and Windows `C:\…`).
@@ -571,6 +578,27 @@ fn is_safe_image_path(path: &str) -> bool {
     }
 
     true
+}
+
+/// Check whether a path string looks like a Windows absolute path.
+///
+/// Detects drive-letter paths (`C:\…`, `C:/…`) and UNC paths (`\\…`)
+/// using string-level checks so the result is consistent across platforms.
+fn is_windows_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    // Drive letter: e.g. `C:\` or `C:/`
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        return true;
+    }
+    // UNC path: `\\server\share`
+    if bytes.len() >= 2 && bytes[0] == b'\\' && bytes[1] == b'\\' {
+        return true;
+    }
+    false
 }
 
 /// Read an image file, rejecting symlinks and files exceeding
@@ -3212,13 +3240,13 @@ mod jpeg_tests {
         assert!(!is_safe_image_path("/images/photo.jpg"));
     }
 
-    #[cfg(windows)]
     #[test]
     fn test_safe_image_path_windows_absolute_rejected() {
-        // These are absolute on Windows and should be rejected there.
+        // String-level checks reject Windows-style absolute paths on all platforms.
         assert!(!is_safe_image_path(r"C:\photo.jpg"));
         assert!(!is_safe_image_path(r"D:\Users\photo.jpg"));
         assert!(!is_safe_image_path(r"\\server\share\photo.jpg"));
+        assert!(!is_safe_image_path("C:/photo.jpg"));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## What

Add defense-in-depth checks to both HTML and PDF image path validators for directory traversal, null bytes, and Windows-style absolute paths.

## Why

Found in Phase 12 Completion Gate Round 3 reviews:
- **R3-2, R3-3 (Minor)**: HTML `is_safe_image_src` lacked directory traversal and null byte checks that the PDF validator already had
- **R3-01, R3-02 (Low)**: Neither validator rejected Windows-style absolute paths (`C:\…`, `\\…`) on non-Windows platforms

## Changes

**HTML renderer (`is_safe_image_src`)**:
- Reject paths containing null bytes (`\0`)
- Reject paths with `..` directory-traversal components (splits on both `/` and `\`)
- Reject Windows-style absolute paths (drive letters `C:\`, UNC `\\server\share`)
- Added `is_windows_absolute()` and `has_traversal()` helper functions

**PDF renderer (`is_safe_image_path`)**:
- Add string-level `is_windows_absolute()` check that works on all platforms (previously relied on `Path::is_absolute()` which only detects Windows paths on Windows)
- Removed `#[cfg(windows)]` gate from Windows path rejection tests

## Test results

```
cargo fmt --check  # pass
cargo clippy -- -D warnings  # pass
cargo test  # all pass
```

Closes #391
Closes #393