### PR TITLE
Apply HTML escape to CSS style attributes consistently across HTML renderer

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -512,7 +512,7 @@ fn render_lyrics(
             } else {
                 html.push_str(&format!(
                     "<span class=\"chord\" style=\"{}\">{}</span>",
-                    chord_css,
+                    escape(&chord_css),
                     escape(&display_name)
                 ));
             }
@@ -525,7 +525,10 @@ fn render_lyrics(
         if text_css.is_empty() {
             html.push_str("<span class=\"lyrics\">");
         } else {
-            html.push_str(&format!("<span class=\"lyrics\" style=\"{}\">", text_css));
+            html.push_str(&format!(
+                "<span class=\"lyrics\" style=\"{}\">",
+                escape(&text_css)
+            ));
         }
         if segment.has_markup() {
             render_spans(&segment.spans, html);
@@ -576,9 +579,7 @@ fn render_spans(spans: &[TextSpan], html: &mut String) {
                 if css.is_empty() {
                     html.push_str("<span>");
                 } else {
-                    // CSS values are already sanitized by sanitize_css_value();
-                    // applying escape() would double-encode (e.g., & → &amp;).
-                    html.push_str(&format!("<span style=\"{css}\">"));
+                    html.push_str(&format!("<span style=\"{}\">", escape(&css)));
                 }
                 render_spans(children, html);
                 html.push_str("</span>");


### PR DESCRIPTION
## What

Add `escape()` calls to all CSS `style` attribute insertions in the HTML renderer for defense-in-depth consistency.

## Why

Found in Phase 12 Completion Gate Round 3 security review (R3-03, Low).

The `render_image` function already applies `escape()` after `sanitize_css_value()` as defense-in-depth. Three other sites inserted sanitized CSS directly into `style` attributes without the additional `escape()` layer:

1. Chord spans (`chord_css` from `ElementStyle::to_css()`)
2. Lyrics spans (`text_css` from `ElementStyle::to_css()`)
3. Inline markup spans (`css` from `span_attrs_to_css()`)

While `sanitize_css_value()` already strips all HTML-special characters (`<`, `>`, `"`, `&`), applying `escape()` consistently guards against future changes to the sanitizer and follows the defense-in-depth principle.

## Changes

- Apply `escape()` to `chord_css` in chord span style attribute
- Apply `escape()` to `text_css` in lyrics span style attribute
- Apply `escape()` to `css` in inline markup span style attribute
- Removed stale comment about double-encoding (no longer applicable)

## Test results

```
cargo fmt --check  # pass
cargo clippy -- -D warnings  # pass
cargo test  # all pass (no visual change in output)
```

Closes #394