### PR TITLE
Add ImageAttributes::has_src() helper and suppress empty image placeholder

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -441,6 +441,15 @@ impl ImageAttributes {
             ..Self::default()
         }
     }
+
+    /// Returns `true` if a non-empty `src` path is present.
+    ///
+    /// Renderers can use this to skip rendering when no image source was
+    /// provided, avoiding duplicated empty-string checks.
+    #[must_use]
+    pub fn has_src(&self) -> bool {
+        !self.src.is_empty()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2715,5 +2724,25 @@ mod chord_definition_tests {
     fn test_parse_keyboard_negative_keys() {
         let def = ChordDefinition::parse_value("Cm keys -1 0 3 7");
         assert_eq!(def.keys, Some(vec![-1, 0, 3, 7]));
+    }
+
+    // -- ImageAttributes ----------------------------------------------------
+
+    #[test]
+    fn has_src_returns_true_for_non_empty() {
+        let attrs = ImageAttributes::new("photo.jpg");
+        assert!(attrs.has_src());
+    }
+
+    #[test]
+    fn has_src_returns_false_for_empty() {
+        let attrs = ImageAttributes::default();
+        assert!(!attrs.has_src());
+    }
+
+    #[test]
+    fn has_src_returns_false_for_explicit_empty_string() {
+        let attrs = ImageAttributes::new("");
+        assert!(!attrs.has_src());
     }
 }

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -671,7 +671,7 @@ fn read_image_file(path: &str) -> Option<Vec<u8>> {
 /// places the image at the column margin, `"column"` centres it within the
 /// column, and `"paper"` centres it on the full page.
 fn render_image(attrs: &ImageAttributes, doc: &mut PdfDocument) {
-    if attrs.src.is_empty() {
+    if !attrs.has_src() {
         return;
     }
 

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -314,7 +314,9 @@ fn render_directive(directive: &chordpro_core::ast::Directive, output: &mut Vec<
             render_section_header(&label, &directive.value, output);
         }
         DirectiveKind::Image(attrs) => {
-            output.push(format!("[Image: {}]", attrs.src));
+            if attrs.has_src() {
+                output.push(format!("[Image: {}]", attrs.src));
+            }
         }
         // End-of-section, metadata, and unknown directives produce no output.
         _ => {}
@@ -942,6 +944,20 @@ mod delegate_tests {
         let input = "{image: src=images/cover.png width=200}";
         let output = render(input);
         assert!(output.contains("[Image: images/cover.png]"));
+    }
+
+    #[test]
+    fn test_render_image_empty_src_suppressed() {
+        let input = "{image}";
+        let output = render(input);
+        assert!(!output.contains("[Image"));
+    }
+
+    #[test]
+    fn test_render_image_empty_src_with_other_attrs_suppressed() {
+        let input = "{image: width=200 height=100}";
+        let output = render(input);
+        assert!(!output.contains("[Image"));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Add `ImageAttributes::has_src()` helper method to `chordpro-core` that centralizes the empty-src check
- Update the PDF renderer to use `has_src()` instead of manual `attrs.src.is_empty()` check
- Update the text renderer to suppress output when `src` is empty (previously rendered `[Image: ]`)

## Why

Each renderer was independently checking for empty `src` strings, which is error-prone and inconsistent. The text renderer had no check at all, producing a meaningless `[Image: ]` placeholder. A centralized helper ensures consistency and prevents future renderers from forgetting the check.

Found during Phase 12 completion gate review (#97, findings M1 and M10).

## Test results

- New unit tests for `has_src()` in `chordpro-core` (empty, non-empty, explicit empty string)
- New tests for text renderer empty-src suppression (`{image}` and `{image: width=200 height=100}`)
- All existing tests pass: `cargo test` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅

## Review summary

Minimal, focused change. Only three files modified:
- `crates/core/src/ast.rs` — new `has_src()` method + tests
- `crates/render-text/src/lib.rs` — guard image output with `has_src()` + tests
- `crates/render-pdf/src/lib.rs` — replace `is_empty()` with `has_src()`

The HTML renderer already rejects empty `src` via `is_safe_image_src()`, so no change needed there.

Closes #399
Closes #403