### PR TITLE
Extract shared image path validation utilities to chordpro-core

### DIFF
--- a/crates/core/src/image_path.rs
+++ b/crates/core/src/image_path.rs
@@ -1,0 +1,118 @@
+//! Shared image-path validation utilities.
+//!
+//! These helpers are used by multiple renderers to reject unsafe image
+//! paths (directory traversal, absolute paths, Windows-style paths).
+//! Centralising them in `chordpro-core` avoids duplication and ensures
+//! consistent security behaviour across all renderers.
+
+/// Check whether a path string looks like a Windows absolute path.
+///
+/// Detects drive-letter paths (`C:\…`, `C:/…`) and UNC paths (`\\…`)
+/// using string-level checks so the result is consistent across platforms.
+///
+/// # Examples
+///
+/// ```
+/// use chordpro_core::image_path::is_windows_absolute;
+///
+/// assert!(is_windows_absolute(r"C:\photo.jpg"));
+/// assert!(is_windows_absolute(r"\\server\share"));
+/// assert!(!is_windows_absolute("images/photo.jpg"));
+/// ```
+#[must_use]
+pub fn is_windows_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    // Drive letter: e.g. `C:\` or `C:/`
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        return true;
+    }
+    // UNC path: `\\server\share`
+    if bytes.len() >= 2 && bytes[0] == b'\\' && bytes[1] == b'\\' {
+        return true;
+    }
+    false
+}
+
+/// Check whether a path contains `..` directory-traversal components.
+///
+/// Splits on both `/` and `\` so the check works for both Unix and
+/// Windows-style separators.
+///
+/// # Examples
+///
+/// ```
+/// use chordpro_core::image_path::has_traversal;
+///
+/// assert!(has_traversal("../photo.jpg"));
+/// assert!(has_traversal(r"images\..\..\etc\passwd"));
+/// assert!(!has_traversal("images/photo.jpg"));
+/// ```
+#[must_use]
+pub fn has_traversal(path: &str) -> bool {
+    path.split(['/', '\\']).any(|seg| seg == "..")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- is_windows_absolute ------------------------------------------------
+
+    #[test]
+    fn windows_drive_letter_backslash() {
+        assert!(is_windows_absolute(r"C:\photo.jpg"));
+        assert!(is_windows_absolute(r"D:\Users\photo.jpg"));
+    }
+
+    #[test]
+    fn windows_drive_letter_forward_slash() {
+        assert!(is_windows_absolute("C:/photo.jpg"));
+    }
+
+    #[test]
+    fn windows_unc_path() {
+        assert!(is_windows_absolute(r"\\server\share\photo.jpg"));
+    }
+
+    #[test]
+    fn relative_path_not_windows_absolute() {
+        assert!(!is_windows_absolute("images/photo.jpg"));
+        assert!(!is_windows_absolute("photo.jpg"));
+    }
+
+    #[test]
+    fn unix_absolute_not_windows_absolute() {
+        assert!(!is_windows_absolute("/etc/passwd"));
+    }
+
+    // -- has_traversal ------------------------------------------------------
+
+    #[test]
+    fn forward_slash_traversal() {
+        assert!(has_traversal("../photo.jpg"));
+        assert!(has_traversal("images/../../etc/passwd"));
+    }
+
+    #[test]
+    fn backslash_traversal() {
+        assert!(has_traversal(r"..\photo.jpg"));
+        assert!(has_traversal(r"images\..\..\etc\passwd"));
+    }
+
+    #[test]
+    fn no_traversal() {
+        assert!(!has_traversal("images/photo.jpg"));
+        assert!(!has_traversal("photo.jpg"));
+        assert!(!has_traversal(r"images\photo.jpg"));
+    }
+
+    #[test]
+    fn double_dot_in_filename_not_traversal() {
+        // "file..name" contains ".." but not as a path component.
+        assert!(!has_traversal("file..name.jpg"));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod chord;
 pub mod chord_diagram;
 pub mod config;
 pub mod external_tool;
+pub mod image_path;
 pub mod inline_markup;
 pub mod lexer;
 pub mod parser;

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1031,34 +1031,8 @@ fn is_safe_image_src(src: &str) -> bool {
     true
 }
 
-/// Check whether a path string looks like a Windows absolute path.
-///
-/// Detects drive-letter paths (`C:\…`, `C:/…`) and UNC paths (`\\…`)
-/// using string-level checks so the result is consistent across platforms.
-fn is_windows_absolute(path: &str) -> bool {
-    let bytes = path.as_bytes();
-    // Drive letter: e.g. `C:\` or `C:/`
-    if bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && (bytes[2] == b'\\' || bytes[2] == b'/')
-    {
-        return true;
-    }
-    // UNC path: `\\server\share`
-    if bytes.len() >= 2 && bytes[0] == b'\\' && bytes[1] == b'\\' {
-        return true;
-    }
-    false
-}
-
-/// Check whether a path contains `..` directory-traversal components.
-///
-/// Splits on both `/` and `\` so the check works for both Unix and
-/// Windows-style separators.
-fn has_traversal(path: &str) -> bool {
-    path.split(['/', '\\']).any(|seg| seg == "..")
-}
+/// Re-export shared path-validation helpers from `chordpro-core`.
+use chordpro_core::image_path::{has_traversal, is_windows_absolute};
 
 /// Render Lilypond notation content using lilypond, falling back to preformatted text.
 ///

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -557,7 +557,7 @@ fn is_safe_image_path(path: &str) -> bool {
     // Reject Windows-style absolute paths on all platforms.  On Unix,
     // `Path::is_absolute()` does not flag `C:\…` or `\\…` as absolute,
     // so we perform string-level checks for drive letters and UNC paths.
-    if is_windows_absolute(path) {
+    if chordpro_core::image_path::is_windows_absolute(path) {
         return false;
     }
 
@@ -570,35 +570,16 @@ fn is_safe_image_path(path: &str) -> bool {
         return false;
     }
 
-    // Reject any path component that is `..`.
-    for component in p.components() {
-        if matches!(component, std::path::Component::ParentDir) {
-            return false;
-        }
+    // Reject directory traversal (`..` path components).
+    // Uses the shared helper that splits on both `/` and `\`, so
+    // backslash-separated traversal like `images\..\..\etc\passwd` is
+    // also caught on Unix (where `Path::components()` treats `\` as a
+    // literal character).
+    if chordpro_core::image_path::has_traversal(path) {
+        return false;
     }
 
     true
-}
-
-/// Check whether a path string looks like a Windows absolute path.
-///
-/// Detects drive-letter paths (`C:\…`, `C:/…`) and UNC paths (`\\…`)
-/// using string-level checks so the result is consistent across platforms.
-fn is_windows_absolute(path: &str) -> bool {
-    let bytes = path.as_bytes();
-    // Drive letter: e.g. `C:\` or `C:/`
-    if bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && (bytes[2] == b'\\' || bytes[2] == b'/')
-    {
-        return true;
-    }
-    // UNC path: `\\server\share`
-    if bytes.len() >= 2 && bytes[0] == b'\\' && bytes[1] == b'\\' {
-        return true;
-    }
-    false
 }
 
 /// Read an image file, rejecting symlinks and files exceeding
@@ -3249,9 +3230,10 @@ mod jpeg_tests {
         assert!(!is_safe_image_path("C:/photo.jpg"));
     }
 
-    #[cfg(windows)]
     #[test]
-    fn test_safe_image_path_windows_traversal_rejected() {
+    fn test_safe_image_path_backslash_traversal_rejected() {
+        // The shared `has_traversal` helper splits on both `/` and `\`,
+        // so backslash-based traversal is now detected on all platforms.
         assert!(!is_safe_image_path(r"..\photo.jpg"));
         assert!(!is_safe_image_path(r"images\..\..\photo.jpg"));
     }


### PR DESCRIPTION
## What

- Add new `chordpro_core::image_path` module with shared `is_windows_absolute` and `has_traversal` functions
- Update HTML renderer to use shared utilities (replacing local duplicates)
- Update PDF renderer to use shared utilities, replacing `Path::components()`-based traversal detection with string-level `has_traversal`
- Promote PDF's `#[cfg(windows)]` backslash traversal test to all platforms

## Why

`is_windows_absolute` was duplicated identically in both renderers. Traversal detection differed: HTML used string splitting on `/` and `\`, while PDF used `Path::components()` which on Unix treats `\` as a literal character, missing backslash-separated traversal like `images\..\..\etc\passwd`. Centralising in core eliminates duplication and ensures consistent security behaviour.

Found during Phase 12 completion gate review (#97, findings M3 and M6).

## Test results

- New unit tests in `chordpro_core::image_path` for both functions (drive letters, UNC, forward/backslash traversal, double-dot-in-filename edge case)
- PDF backslash traversal test now runs on all platforms (was `#[cfg(windows)]` only)
- All existing tests pass: `cargo test` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅

## Review summary

Four files changed:
- `crates/core/src/image_path.rs` — new module with shared validation + tests
- `crates/core/src/lib.rs` — register new module
- `crates/render-html/src/lib.rs` — replace local functions with `use` import
- `crates/render-pdf/src/lib.rs` — replace local functions with shared versions; traversal now string-level

No external dependencies added to `chordpro-core`.

Closes #400
Closes #402