### PR TITLE
Add max-width CSS default for images in HTML renderer

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -440,6 +440,7 @@ section > .section-label { font-weight: bold; font-style: italic; margin-bottom:
 .comment-box { border: 1px solid #999; padding: 0.2em 0.5em; display: inline-block; margin: 0.3em 0; }
 .chorus-recall { margin: 1em 0; }
 .chorus-recall > .section-label { font-weight: bold; font-style: italic; margin-bottom: 0.3em; }
+img { max-width: 100%; height: auto; }
 ";
 
 // ---------------------------------------------------------------------------
@@ -1857,6 +1858,15 @@ Verse text\n\
         // No anchor should produce a bare <div> without style
         assert!(html.contains("<div><img"));
         assert!(!html.contains("text-align"));
+    }
+
+    #[test]
+    fn test_image_max_width_css_present() {
+        let html = render("{image: src=photo.jpg}");
+        assert!(
+            html.contains("img { max-width: 100%; height: auto; }"),
+            "CSS should include img max-width rule to prevent overflow"
+        );
     }
 
     // -- chord diagram tests --------------------------------------------------

--- a/crates/render-html/tests/fixtures/image-directive/expected.html
+++ b/crates/render-html/tests/fixtures/image-directive/expected.html
@@ -18,6 +18,7 @@ section > .section-label { font-weight: bold; font-style: italic; margin-bottom:
 .comment-box { border: 1px solid #999; padding: 0.2em 0.5em; display: inline-block; margin: 0.3em 0; }
 .chorus-recall { margin: 1em 0; }
 .chorus-recall > .section-label { font-weight: bold; font-style: italic; margin-bottom: 0.3em; }
+img { max-width: 100%; height: auto; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## What

- Add `img { max-width: 100%; height: auto; }` to the HTML renderer's embedded CSS
- Update golden test snapshot for image directive

## Why

When `{image}` is used without explicit width/height attributes and the source image is wider than the container, it overflows. The CSS `max-width: 100%` rule constrains oversized images to the container width while preserving aspect ratio via `height: auto`. Images with explicit dimensions are unaffected since `max-width` only constrains the upper bound.

Found during Phase 12 completion gate review (#97, finding M5).

## Test results

- New test `test_image_max_width_css_present` verifies the CSS rule is included
- Golden test updated to include the new CSS rule
- All existing tests pass: `cargo test` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅

## Review summary

Two files changed:
- `crates/render-html/src/lib.rs` — one CSS rule added + one test
- `crates/render-html/tests/fixtures/image-directive/expected.html` — golden snapshot updated

Closes #401