### PR TITLE
Add --no-default-configs CLI flag

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -36,6 +36,11 @@ struct Cli {
     /// Set a config value at runtime (highest precedence). Format: key=value.
     #[arg(short = 'D', long = "define")]
     defines: Vec<String>,
+
+    /// Skip loading system, user, and project config files.
+    /// Only built-in defaults are used as the base. --config and --define still apply.
+    #[arg(long = "no-default-configs")]
+    no_default_configs: bool,
 }
 
 /// Supported output formats.
@@ -61,7 +66,11 @@ fn main() -> ExitCode {
         .map(|s| s.to_string());
 
     // Build configuration: defaults → system → user → project → custom config files → defines
-    let mut config = chordpro_core::config::Config::load(project_dir.as_deref(), None);
+    let mut config = if cli.no_default_configs {
+        chordpro_core::config::Config::defaults()
+    } else {
+        chordpro_core::config::Config::load(project_dir.as_deref(), None)
+    };
 
     // Apply --config files/presets in order (preset names resolved first)
     for config_name in &cli.configs {


### PR DESCRIPTION
## What

Add `--no-default-configs` flag to skip hierarchical config file loading.

## Why

Users may want to bypass system/user/project configs for testing or reproducibility. This flag starts from built-in defaults only, while `--config` and `--define` still work.

## Changes

- New `--no-default-configs` boolean flag in CLI args
- When set, uses `Config::defaults()` instead of `Config::load()`
- `--config` and `--define` still apply on top of defaults

## Test results

```
All tests pass, clippy clean
```

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)