### PR TITLE
Document --config flag trust boundary

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,7 +29,10 @@ struct Cli {
     #[arg(short, long, default_value = "0")]
     transpose: i8,
 
-    /// Load a custom configuration file (may be specified multiple times).
+    /// Load a custom configuration file or preset name (may be specified multiple times).
+    ///
+    /// Paths are treated as trusted input — the file is read without path restrictions.
+    /// Do not pass untrusted paths when invoking chordpro programmatically.
     #[arg(short = 'c', long = "config")]
     configs: Vec<String>,
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -192,6 +192,15 @@ impl Config {
     ///
     /// Returns `Ok(Config)` on success, or a [`ConfigError`] on failure.
     ///
+    /// # Trust boundary
+    ///
+    /// When `name` is not a preset, it is used directly as a file path.
+    /// No path validation or restriction is applied — the caller must
+    /// ensure the path comes from trusted input. This is safe for a local
+    /// CLI tool where the user already has filesystem access, but callers
+    /// invoking this programmatically with partially untrusted input should
+    /// validate the path first.
+    ///
     /// # Errors
     ///
     /// Returns [`ConfigError::Io`] if the file cannot be read, or


### PR DESCRIPTION
## What

Document that `--config` paths are trusted input, noting the security consideration for programmatic invocation.

## Why

`--config` accepts arbitrary file paths without restriction. For a local CLI tool this is expected (the user already has filesystem access), but it should be documented as a trust boundary consideration for anyone invoking chordpro programmatically.

## Changes

- Updated CLI `--config` help text to note paths are trusted input
- Added "Trust boundary" section to `Config::resolve()` doc comment

## Test results

```
All tests pass, clippy clean
```

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)