### PR TITLE
Use display_name() for chord diagram titles in PDF and SVG renderers

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -11,6 +11,7 @@
 //!
 //! let data = DiagramData {
 //!     name: "Am".to_string(),
+//!     display_name: None,
 //!     strings: 6,
 //!     frets_shown: 5,
 //!     base_fret: 1,
@@ -25,8 +26,12 @@
 /// Data needed to render a chord diagram.
 #[derive(Debug, Clone)]
 pub struct DiagramData {
-    /// Chord name displayed above the diagram.
+    /// Chord name (identifier used for matching).
     pub name: String,
+    /// Display name override from `{define}` `display` attribute.
+    ///
+    /// When present, diagram titles should show this instead of `name`.
+    pub display_name: Option<String>,
     /// Number of strings (e.g., 6 for guitar, 4 for ukulele).
     pub strings: usize,
     /// Number of frets shown in the diagram.
@@ -37,6 +42,16 @@ pub struct DiagramData {
     pub frets: Vec<i32>,
     /// Optional finger numbers for each string (0 = none).
     pub fingers: Vec<u8>,
+}
+
+impl DiagramData {
+    /// Returns the title to display above the diagram.
+    ///
+    /// Uses the `display_name` override if present, otherwise falls back to `name`.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        self.display_name.as_deref().unwrap_or(&self.name)
+    }
 }
 
 impl DiagramData {
@@ -106,6 +121,7 @@ impl DiagramData {
 
         Some(Self {
             name: name.to_string(),
+            display_name: None,
             strings: num_strings.max(frets.len()),
             frets_shown: 5,
             base_fret,
@@ -141,12 +157,12 @@ pub fn render_svg(data: &DiagramData) -> String {
          viewBox=\"0 0 {total_w} {total_h}\" class=\"chord-diagram\">\n"
     );
 
-    // Chord name
+    // Chord name (uses display override if present)
     let name_x = LEFT_MARGIN + grid_w / 2.0;
     svg.push_str(&format!(
         "<text x=\"{name_x}\" y=\"15\" text-anchor=\"middle\" \
          font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\">{}</text>\n",
-        escape_xml(&data.name)
+        escape_xml(data.title())
     ));
 
     // Nut or base-fret indicator
@@ -240,6 +256,7 @@ mod tests {
     fn test_render_svg_basic() {
         let data = DiagramData {
             name: "Am".to_string(),
+            display_name: None,
             strings: 6,
             frets_shown: 5,
             base_fret: 1,
@@ -260,6 +277,7 @@ mod tests {
     fn test_render_svg_barre_chord() {
         let data = DiagramData {
             name: "F".to_string(),
+            display_name: None,
             strings: 6,
             frets_shown: 5,
             base_fret: 1,
@@ -274,6 +292,7 @@ mod tests {
     fn test_render_svg_high_position() {
         let data = DiagramData {
             name: "Bm".to_string(),
+            display_name: None,
             strings: 6,
             frets_shown: 5,
             base_fret: 7,
@@ -338,5 +357,55 @@ mod tests {
     fn test_escape_xml() {
         assert_eq!(escape_xml("A&B"), "A&amp;B");
         assert_eq!(escape_xml("A<B>C"), "A&lt;B&gt;C");
+    }
+
+    #[test]
+    fn test_title_returns_display_name_when_set() {
+        let data = DiagramData {
+            name: "Am".to_string(),
+            display_name: Some("A minor".to_string()),
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![],
+        };
+        assert_eq!(data.title(), "A minor");
+    }
+
+    #[test]
+    fn test_title_falls_back_to_name() {
+        let data = DiagramData {
+            name: "Am".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![],
+        };
+        assert_eq!(data.title(), "Am");
+    }
+
+    #[test]
+    fn test_render_svg_with_display_name() {
+        let data = DiagramData {
+            name: "Am".to_string(),
+            display_name: Some("A minor".to_string()),
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![],
+        };
+        let svg = render_svg(&data);
+        assert!(svg.contains("A minor"));
+        assert!(!svg.contains(">Am<"));
+    }
+
+    #[test]
+    fn test_from_raw_display_name_is_none() {
+        let data = DiagramData::from_raw_infer("Am", "base-fret 1 frets x 0 2 2 1 0").unwrap();
+        assert!(data.display_name.is_none());
     }
 }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -945,9 +945,10 @@ fn render_directive_inner(directive: &chordpro_core::ast::Directive, html: &mut 
             if let Some(ref value) = directive.value {
                 let def = chordpro_core::ast::ChordDefinition::parse_value(value);
                 if let Some(ref raw) = def.raw {
-                    if let Some(diagram) =
+                    if let Some(mut diagram) =
                         chordpro_core::chord_diagram::DiagramData::from_raw_infer(&def.name, raw)
                     {
+                        diagram.display_name = def.display.clone();
                         html.push_str("<div class=\"chord-diagram-container\">");
                         html.push_str(&chordpro_core::chord_diagram::render_svg(&diagram));
                         html.push_str("</div>\n");

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -528,9 +528,10 @@ fn render_directive(directive: &chordpro_core::ast::Directive, doc: &mut PdfDocu
         if let Some(ref value) = directive.value {
             let def = chordpro_core::ast::ChordDefinition::parse_value(value);
             if let Some(ref raw) = def.raw {
-                if let Some(diagram) =
+                if let Some(mut diagram) =
                     chordpro_core::chord_diagram::DiagramData::from_raw_infer(&def.name, raw)
                 {
+                    diagram.display_name = def.display.clone();
                     render_chord_diagram_pdf(&diagram, doc);
                     return;
                 }
@@ -855,8 +856,8 @@ fn render_chord_diagram_pdf(
     // PDF Y is bottom-up, so top of diagram is at doc.y
     let top_y = doc.y();
 
-    // Chord name
-    doc.text_at(&data.name, Font::HelveticaBold, 9.0, base_x, top_y);
+    // Chord name (uses display override if present)
+    doc.text_at(data.title(), Font::HelveticaBold, 9.0, base_x, top_y);
 
     let grid_top = top_y - 15.0; // below the name
 


### PR DESCRIPTION
## What

- Add `display_name: Option<String>` field to `DiagramData` for display name overrides from `{define}` directives
- Add `DiagramData::title()` helper that returns `display_name` when set, falling back to `name`
- Update `render_svg()` and `render_chord_diagram_pdf()` to use `title()` instead of `data.name`
- Pass `ChordDefinition.display` to `DiagramData.display_name` in both HTML and PDF renderers when creating diagrams from `{define}` directives

## Why

Chord diagram titles were hardcoded to use `data.name` (the raw chord name). When a `{define}` directive specifies a `display` attribute (e.g. `{define: Am ... display="A minor"}`), the diagram title should reflect that override. This completes the display attribute support across all rendering paths — chord names in lyrics were fixed in #433, and this PR extends it to diagram titles.

## Test results

```
test result: ok. 648 passed; 0 failed; 6 ignored (core)
test result: ok. 152 passed; 0 failed; 0 ignored (render-pdf)
test result: ok. 65 passed; 0 failed; 0 ignored (render-text)
test result: ok. 105 passed; 0 failed; 2 ignored (render-html)
```

New tests:
- `test_title_returns_display_name_when_set` — title() returns display override
- `test_title_falls_back_to_name` — title() returns name when no override
- `test_render_svg_with_display_name` — SVG contains display name, not raw name
- `test_from_raw_display_name_is_none` — from_raw() initializes display_name to None

## Review summary

| Area | Changes |
|---|---|
| `crates/core/src/chord_diagram.rs` | Added `display_name` field, `title()` method, updated `render_svg()`, new tests |
| `crates/render-pdf/src/lib.rs` | Pass display to DiagramData, use `title()` in PDF rendering |
| `crates/render-html/src/lib.rs` | Pass display to DiagramData when creating SVG |

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)