### PR TITLE
Consolidate XML/HTML escape functions into shared module

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -162,7 +162,7 @@ pub fn render_svg(data: &DiagramData) -> String {
     svg.push_str(&format!(
         "<text x=\"{name_x}\" y=\"15\" text-anchor=\"middle\" \
          font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\">{}</text>\n",
-        escape_xml(data.title())
+        crate::escape::escape_xml(data.title())
     ));
 
     // Nut or base-fret indicator
@@ -234,14 +234,6 @@ pub fn render_svg(data: &DiagramData) -> String {
 
     svg.push_str("</svg>");
     svg
-}
-
-/// Escape XML special characters.
-fn escape_xml(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
 }
 
 // ===========================================================================
@@ -351,12 +343,6 @@ mod tests {
         let data = DiagramData::from_raw_infer("G", "frets 0 0 0 0 0").unwrap();
         assert_eq!(data.strings, 5);
         assert_eq!(data.frets, vec![0, 0, 0, 0, 0]);
-    }
-
-    #[test]
-    fn test_escape_xml() {
-        assert_eq!(escape_xml("A&B"), "A&amp;B");
-        assert_eq!(escape_xml("A<B>C"), "A&lt;B&gt;C");
     }
 
     #[test]

--- a/crates/core/src/escape.rs
+++ b/crates/core/src/escape.rs
@@ -1,0 +1,74 @@
+//! XML/HTML character escaping utilities.
+//!
+//! Provides a single shared escape function used by both the SVG chord diagram
+//! generator in `chordpro-core` and the HTML renderer.
+
+/// Escape the five XML special characters.
+///
+/// Replaces `&`, `<`, `>`, `"`, and `'` with their corresponding XML
+/// character references. This is sufficient for both XML attribute values
+/// and HTML text content.
+///
+/// # Examples
+///
+/// ```
+/// use chordpro_core::escape::escape_xml;
+///
+/// assert_eq!(escape_xml("A&B"), "A&amp;B");
+/// assert_eq!(escape_xml("it's"), "it&apos;s");
+/// ```
+#[must_use]
+pub fn escape_xml(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_ampersand() {
+        assert_eq!(escape_xml("A&B"), "A&amp;B");
+    }
+
+    #[test]
+    fn escapes_angle_brackets() {
+        assert_eq!(escape_xml("A<B>C"), "A&lt;B&gt;C");
+    }
+
+    #[test]
+    fn escapes_double_quote() {
+        assert_eq!(escape_xml(r#"say "hi""#), "say &quot;hi&quot;");
+    }
+
+    #[test]
+    fn escapes_single_quote() {
+        assert_eq!(escape_xml("it's"), "it&apos;s");
+    }
+
+    #[test]
+    fn no_escaping_needed() {
+        assert_eq!(escape_xml("Am7"), "Am7");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(escape_xml(""), "");
+    }
+
+    #[test]
+    fn all_special_chars() {
+        assert_eq!(escape_xml("&<>\"'"), "&amp;&lt;&gt;&quot;&apos;");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ast;
 pub mod chord;
 pub mod chord_diagram;
 pub mod config;
+pub mod escape;
 pub mod external_tool;
 pub mod image_path;
 pub mod inline_markup;

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -17,6 +17,7 @@
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordpro_core::config::Config;
+use chordpro_core::escape::escape_xml as escape;
 use chordpro_core::inline_markup::{SpanAttributes, TextSpan};
 use chordpro_core::transpose::transpose_chord;
 
@@ -446,22 +447,6 @@ img { max-width: 100%; height: auto; }
 // ---------------------------------------------------------------------------
 // Escape
 // ---------------------------------------------------------------------------
-
-/// Escape HTML special characters.
-fn escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#39;"),
-            _ => out.push(c),
-        }
-    }
-    out
-}
 
 // ---------------------------------------------------------------------------
 // Metadata
@@ -1367,9 +1352,9 @@ mod tests {
     #[test]
     fn test_custom_section_name_single_quotes_escaped() {
         let html = render("{start_of_x' onclick='alert(1)}\ntext\n{end_of_x' onclick='alert(1)}");
-        // The `'` must be escaped to `&#39;` so single-quote attribute boundaries
-        // cannot be broken.
-        assert!(html.contains("&#39;"));
+        // The `'` must be escaped so single-quote attribute boundaries
+        // cannot be broken. Both `&#39;` and `&apos;` are acceptable.
+        assert!(html.contains("&apos;") || html.contains("&#39;"));
         assert!(!html.contains("onclick='alert"));
     }
 


### PR DESCRIPTION
## What

- Add `escape` module to `chordpro-core` with `escape_xml()` covering all five XML special characters (`&`, `<`, `>`, `"`, `'`)
- Remove private `escape_xml()` from `chord_diagram.rs`, replaced with shared function
- Remove private `escape()` from `render-html`, replaced with shared function via import alias
- Single-quote escaping now uses `&apos;` (XML standard entity) instead of `&#39;` (numeric reference)

## Why

Two separate escape implementations existed: `escape_xml()` in `chord_diagram.rs` (missing single-quote) and `escape()` in `render-html` (complete but duplicated). Having two implementations increases maintenance risk and the core version was incomplete for full XML spec compliance. A single shared function in `chordpro-core` eliminates the duplication and ensures consistent escaping across all crates.

## Test results

```
test result: ok. 654 passed; 0 failed; 6 ignored (core)
test result: ok. 152 passed; 0 failed; 0 ignored (render-pdf)
test result: ok. 65 passed; 0 failed; 0 ignored (render-text)
test result: ok. 105 passed; 0 failed; 2 ignored (render-html)
```

New tests in `escape.rs`: escapes_ampersand, escapes_angle_brackets, escapes_double_quote, escapes_single_quote, no_escaping_needed, empty_string, all_special_chars

## Review summary

| Area | Changes |
|---|---|
| `crates/core/src/escape.rs` | New shared module with `escape_xml()` and tests |
| `crates/core/src/lib.rs` | Register `escape` module |
| `crates/core/src/chord_diagram.rs` | Use shared `crate::escape::escape_xml`, remove old function and its test |
| `crates/render-html/src/lib.rs` | Import shared function, remove local `escape()`, update test assertion |

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)