### PR TITLE
Fix panic in extract_attribute on unclosed quoted values

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -578,9 +578,15 @@ fn extract_attribute(s: &mut String, key: &str) -> Option<String> {
     let after = &s[pos + needle.len()..];
 
     let (val, token_end) = if let Some(stripped) = after.strip_prefix('"') {
-        let v = stripped.split('"').next().map(|t| t.to_string());
-        let len = v.as_ref().map_or(0, |t| t.len());
-        (v, pos + needle.len() + 1 + len + 1)
+        // Find the closing quote, if present.
+        let close = stripped.find('"').unwrap_or(stripped.len());
+        let v = stripped[..close].to_string();
+        // Only count the closing quote in token_end when it actually exists.
+        let has_close = close < stripped.len();
+        (
+            Some(v),
+            pos + needle.len() + 1 + close + usize::from(has_close),
+        )
     } else {
         let v = after.split_whitespace().next().map(|t| t.to_string());
         let len = v.as_ref().map_or(0, |t| t.len());
@@ -629,7 +635,7 @@ pub struct ChordDefinition {
     pub copyall: Option<String>,
     /// Display name override.
     pub display: Option<String>,
-    /// Format pattern for chord name rendering (e.g., `"%{root}%{qual}"`).
+    /// Format pattern for chord name rendering (e.g., `"%{root}%{quality}"`).
     ///
     /// When present, the pattern is expanded using the chord's parsed
     /// components. Supported placeholders: `%{root}`, `%{quality}`,
@@ -2953,6 +2959,20 @@ mod chord_definition_tests {
         let def = ChordDefinition::parse_value("Am format=\"%{root}-%{quality}\"");
         assert_eq!(def.format, Some("%{root}-%{quality}".to_string()));
         assert!(def.raw.is_none());
+    }
+
+    #[test]
+    fn test_parse_format_unclosed_quote_no_panic() {
+        // Malformed input: missing closing quote must not panic.
+        let def = ChordDefinition::parse_value("Am display=\"unclosed");
+        assert_eq!(def.display, Some("unclosed".to_string()));
+        assert!(def.raw.is_none());
+    }
+
+    #[test]
+    fn test_parse_format_unclosed_quote_format_attr() {
+        let def = ChordDefinition::parse_value("Am format=\"%{root}%{quality}");
+        assert_eq!(def.format, Some("%{root}%{quality}".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Fix panic in `extract_attribute()` when a `{define}` directive attribute has an unclosed quoted value (e.g., `display="unclosed`)
- Fix doc typo in `ChordDefinition.format` field: `%{qual}` → `%{quality}`
- Add 2 regression tests for the unclosed-quote case

## Why

`extract_attribute` computed `token_end` assuming the closing `"` is always present. When it is absent, `token_end` overshot the string length and the subsequent slice `s[token_end..]` panicked. Malformed `.cho` files with unclosed quotes in `{define}` directives could crash the parser.

## Fix

Use `stripped.find('"')` to locate the closing quote explicitly. Only add `1` for it when it actually exists.

## Test results

```
test result: ok. 669 passed; 0 failed; 6 ignored
```

(+2 new regression tests over the 667 in PR #443)

Closes #444

Generated with [Claude Code](https://claude.ai/code)