### PR TITLE
Add CLI integration tests for --config, --define, and --no-default-configs

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -2,6 +2,7 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::io::Write;
 use std::path::Path;
 use tempfile::NamedTempFile;
 
@@ -232,4 +233,79 @@ fn test_format_pdf_with_transpose() {
 
     let content = std::fs::read(&output_path).unwrap();
     assert!(content.starts_with(b"%PDF"));
+}
+
+// --- --config, --define, --no-default-configs ---
+
+#[test]
+fn test_config_preset() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--config", "guitar", &fixture("simple.cho")])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Hello world"));
+}
+
+#[test]
+fn test_config_file() {
+    let mut config_file = NamedTempFile::new().unwrap();
+    write!(config_file, r#"{{ "settings": {{ "transpose": 2 }} }}"#).unwrap();
+    config_file.flush().unwrap();
+
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args([
+            "--config",
+            config_file.path().to_str().unwrap(),
+            &fixture("simple.cho"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Hello world"));
+}
+
+#[test]
+fn test_config_nonexistent_file() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args([
+            "--config",
+            "/nonexistent/chordpro-test-config.json",
+            &fixture("simple.cho"),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error:"));
+}
+
+#[test]
+fn test_define_valid() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--define", "settings.columns=2", &fixture("simple.cho")])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Hello world"));
+}
+
+#[test]
+fn test_define_invalid_syntax() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--define", "noequalssign", &fixture("simple.cho")])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains("key=value"));
+}
+
+#[test]
+fn test_no_default_configs() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--no-default-configs", &fixture("simple.cho")])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Hello world"));
 }


### PR DESCRIPTION
## What

Add 6 CLI integration tests covering the Phase 13 configuration flags.

## Why

The CLI integration tests had no coverage for `--config`, `--define`, and `--no-default-configs` flags introduced in Phase 13 (#439).

## Changes

New tests in `crates/cli/tests/cli.rs`:
- `test_config_preset` — `--config guitar` applies preset successfully
- `test_config_file` — `--config <file>` loads a custom config file
- `test_config_nonexistent_file` — `--config` with nonexistent file exits with error
- `test_define_valid` — `--define settings.columns=2` applies override
- `test_define_invalid_syntax` — `--define noequalssign` exits with error mentioning `key=value`
- `test_no_default_configs` — `--no-default-configs` skips hierarchical loading

## Test results

All 22 CLI tests pass:
```
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo clippy` and `cargo fmt --check` clean.

## Review summary

Test-only change. No production code modified.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)