### PR TITLE
Fix case-insensitive bypass in ABC javascript directive sanitizer

### DIFF
--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -114,9 +114,9 @@ fn sanitize_abc_content(input: &str) -> String {
             continue;
         }
 
-        // %%javascript <code> is a single-line JS directive.
-        if trimmed.starts_with("%%javascript") || trimmed.starts_with("%%JavaScript") {
-            let after = &trimmed["%%javascript".len()..];
+        // %%javascript <code> is a single-line JS directive (case-insensitive).
+        if trimmed.len() >= 12 && trimmed[..12].eq_ignore_ascii_case("%%javascript") {
+            let after = &trimmed[12..];
             if after.is_empty() || after.starts_with(' ') || after.starts_with('\t') {
                 continue;
             }
@@ -343,6 +343,29 @@ mod tests {
     #[test]
     fn sanitize_abc_case_insensitive_beginjs() {
         let input = "X:1\n%%BeginJS\nalert(1);\n%%EndJS\nK:C\n";
+        let result = super::sanitize_abc_content(input);
+        assert_eq!(result, "X:1\nK:C");
+    }
+
+    #[test]
+    fn sanitize_abc_case_insensitive_javascript() {
+        // All-caps
+        let input = "X:1\n%%JAVASCRIPT alert(1)\nK:C\n";
+        let result = super::sanitize_abc_content(input);
+        assert_eq!(result, "X:1\nK:C");
+
+        // Mixed case
+        let input = "X:1\n%%Javascript require('fs')\nK:C\n";
+        let result = super::sanitize_abc_content(input);
+        assert_eq!(result, "X:1\nK:C");
+
+        // Another mixed case variant
+        let input = "X:1\n%%jAvAsCrIpT evil()\nK:C\n";
+        let result = super::sanitize_abc_content(input);
+        assert_eq!(result, "X:1\nK:C");
+
+        // Bare directive without code
+        let input = "X:1\n%%JAVASCRIPT\nK:C\n";
         let result = super::sanitize_abc_content(input);
         assert_eq!(result, "X:1\nK:C");
     }


### PR DESCRIPTION
## What

Fix the `sanitize_abc_content` function to use fully case-insensitive matching for `%%javascript` directives, consistent with the existing `%%beginjs`/`%%endjs` handling.

## Why

The `%%javascript` check only matched two specific casings (`%%javascript` and `%%JavaScript`), allowing mixed-case variants like `%%JAVASCRIPT` or `%%jAvAsCrIpT` to bypass the sanitizer and potentially execute arbitrary JavaScript in the abc2svg Node.js runtime.

## Test Results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅
```

New tests cover:
- All-caps `%%JAVASCRIPT`
- Title case `%%Javascript`
- Random mixed case `%%jAvAsCrIpT`
- Bare directive without code `%%JAVASCRIPT`

## Review Summary

- Single-line change: replaced two `starts_with` checks with `eq_ignore_ascii_case` on the first 12 characters
- Word boundary check preserved (position 12 must be empty, space, or tab)
- Existing tests unchanged and passing

Closes #450