### PR TITLE
Apply settings.transpose config value in rendering pipeline

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -105,6 +105,21 @@ fn main() -> ExitCode {
         config = config.with_define(define);
     }
 
+    // Combine CLI --transpose with settings.transpose from config.
+    // CLI flag takes additive precedence: final = config + CLI.
+    let config_transpose = config
+        .get_path("settings.transpose")
+        .as_f64()
+        .unwrap_or(0.0) as i8;
+    let (effective_transpose, saturated) =
+        chordpro_core::transpose::combine_transpose(config_transpose, cli.transpose);
+    if saturated {
+        eprintln!(
+            "warning: transpose offset {} + {} exceeds i8 range, clamped to {}",
+            config_transpose, cli.transpose, effective_transpose
+        );
+    }
+
     let mut all_songs: Vec<chordpro_core::ast::Song> = Vec::new();
     let is_binary = matches!(cli.format, Format::Pdf);
     let mut had_error = false;
@@ -138,20 +153,23 @@ fn main() -> ExitCode {
     let combined_bytes;
 
     if is_binary {
-        combined_bytes =
-            chordpro_render_pdf::render_songs_with_transpose(&all_songs, cli.transpose, &config);
+        combined_bytes = chordpro_render_pdf::render_songs_with_transpose(
+            &all_songs,
+            effective_transpose,
+            &config,
+        );
         combined_text = String::new();
     } else {
         combined_bytes = Vec::new();
         combined_text = match cli.format {
             Format::Text => chordpro_render_text::render_songs_with_transpose(
                 &all_songs,
-                cli.transpose,
+                effective_transpose,
                 &config,
             ),
             Format::Html => chordpro_render_html::render_songs_with_transpose(
                 &all_songs,
-                cli.transpose,
+                effective_transpose,
                 &config,
             ),
             Format::Pdf => unreachable!(),

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -253,6 +253,7 @@ fn test_config_file() {
     write!(config_file, r#"{{ "settings": {{ "transpose": 2 }} }}"#).unwrap();
     config_file.flush().unwrap();
 
+    // Config sets transpose=2, so G→A and C→D
     Command::cargo_bin("chordpro")
         .unwrap()
         .args([
@@ -262,6 +263,7 @@ fn test_config_file() {
         ])
         .assert()
         .success()
+        .stdout(predicate::str::contains("A     D"))
         .stdout(predicate::str::contains("Hello world"));
 }
 
@@ -281,11 +283,13 @@ fn test_config_nonexistent_file() {
 
 #[test]
 fn test_define_valid() {
+    // --define settings.transpose=3 should transpose G→A# and C→D#
     Command::cargo_bin("chordpro")
         .unwrap()
-        .args(["--define", "settings.columns=2", &fixture("simple.cho")])
+        .args(["--define", "settings.transpose=3", &fixture("simple.cho")])
         .assert()
         .success()
+        .stdout(predicate::str::contains("A#"))
         .stdout(predicate::str::contains("Hello world"));
 }
 
@@ -298,6 +302,29 @@ fn test_define_invalid_syntax() {
         .failure()
         .stderr(predicate::str::contains("error:"))
         .stderr(predicate::str::contains("key=value"));
+}
+
+#[test]
+fn test_config_transpose_combined_with_cli() {
+    let mut config_file = NamedTempFile::new().unwrap();
+    // Config sets transpose=2
+    write!(config_file, r#"{{ "settings": {{ "transpose": 2 }} }}"#).unwrap();
+    config_file.flush().unwrap();
+
+    // CLI adds --transpose 1, total = 3 semitones: G→A# and C→D#
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args([
+            "--config",
+            config_file.path().to_str().unwrap(),
+            "--transpose",
+            "1",
+            &fixture("simple.cho"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("A#"))
+        .stdout(predicate::str::contains("Hello world"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Read `settings.transpose` from the loaded configuration and combine it additively with the CLI `--transpose` flag before passing to renderers.

## Why

The config system stored `settings.transpose` but no code ever read or applied it. Users setting `--config` or `--define settings.transpose=2` had no effect on chord transposition.

**Precedence**: `effective_transpose = config_transpose + cli_transpose`. When `--transpose` is not specified (default 0), only the config value applies. When both are specified, they are combined additively. Saturation is applied if the sum exceeds `i8` range.

## Test Results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅
```

Updated/new tests:
- `test_config_file`: now verifies transpose=2 in config produces transposed chords (G→A, C→D)
- `test_define_valid`: verifies `--define settings.transpose=3` transposes chords
- `test_config_transpose_combined_with_cli`: verifies config transpose=2 + CLI transpose=1 = 3 semitones

## Review Summary

- 1 file changed in `crates/cli/src/main.rs`: read config value and combine with CLI flag
- Integration tests updated to verify config values have observable effects on output

Closes #451
Closes #459