### PR TITLE
Replace eprintln! in library code with structured warning API

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -72,7 +72,11 @@ fn main() -> ExitCode {
     let mut config = if cli.no_default_configs {
         chordpro_core::config::Config::defaults()
     } else {
-        chordpro_core::config::Config::load(project_dir.as_deref(), None)
+        let result = chordpro_core::config::Config::load(project_dir.as_deref(), None);
+        for warning in &result.warnings {
+            eprintln!("warning: {warning}");
+        }
+        result.config
     };
 
     // Apply --config files/presets in order (preset names resolved first)

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -101,6 +101,16 @@ pub fn deep_merge(base: Value, overlay: Value) -> Value {
 // Config
 // ---------------------------------------------------------------------------
 
+/// Result of loading configuration, including any non-fatal warnings.
+#[derive(Debug)]
+pub struct ConfigLoadResult {
+    /// The loaded configuration.
+    pub config: Config,
+    /// Non-fatal warnings encountered during loading (parse errors in
+    /// optional config files, unsupported RRJSON directives, I/O issues).
+    pub warnings: Vec<String>,
+}
+
 /// A ChordPro configuration loaded from one or more sources.
 ///
 /// Wraps a [`Value::Object`] and provides convenience accessors.
@@ -271,31 +281,32 @@ impl Config {
     /// project-level config). `song_config` is an optional path to a
     /// song-specific config file.
     #[must_use]
-    pub fn load(project_dir: Option<&str>, song_config: Option<&str>) -> Self {
+    pub fn load(project_dir: Option<&str>, song_config: Option<&str>) -> ConfigLoadResult {
         let mut config = Self::defaults();
+        let mut warnings = Vec::new();
 
         // System config
         let system_path = PathBuf::from("/etc/chordpro.json");
-        if let Some(text) = read_file_if_exists(&system_path) {
-            match Self::parse(&text) {
+        if let Some(text) = read_file_if_exists(&system_path, &mut warnings) {
+            match Self::parse_collecting_warnings(&text, &mut warnings) {
                 Ok(sys) => config = config.merge(sys),
-                Err(e) => eprintln!(
-                    "warning: failed to parse config file {}: {e}",
+                Err(e) => warnings.push(format!(
+                    "failed to parse config file {}: {e}",
                     system_path.display()
-                ),
+                )),
             }
         }
 
         // User config: respect XDG_CONFIG_HOME, fall back to $HOME/.config
         if let Some(config_dir) = config_dir() {
             let user_path = config_dir.join("chordpro").join("chordpro.json");
-            if let Some(text) = read_file_if_exists(&user_path) {
-                match Self::parse(&text) {
+            if let Some(text) = read_file_if_exists(&user_path, &mut warnings) {
+                match Self::parse_collecting_warnings(&text, &mut warnings) {
                     Ok(user) => config = config.merge(user),
-                    Err(e) => eprintln!(
-                        "warning: failed to parse config file {}: {e}",
+                    Err(e) => warnings.push(format!(
+                        "failed to parse config file {}: {e}",
                         user_path.display()
-                    ),
+                    )),
                 }
             }
         }
@@ -303,28 +314,39 @@ impl Config {
         // Project config
         if let Some(dir) = project_dir {
             let project_path = PathBuf::from(dir).join("chordpro.json");
-            if let Some(text) = read_file_if_exists(&project_path) {
-                match Self::parse(&text) {
+            if let Some(text) = read_file_if_exists(&project_path, &mut warnings) {
+                match Self::parse_collecting_warnings(&text, &mut warnings) {
                     Ok(proj) => config = config.merge(proj),
-                    Err(e) => eprintln!(
-                        "warning: failed to parse config file {}: {e}",
+                    Err(e) => warnings.push(format!(
+                        "failed to parse config file {}: {e}",
                         project_path.display()
-                    ),
+                    )),
                 }
             }
         }
 
         // Song-specific config
         if let Some(path) = song_config {
-            if let Some(text) = read_file_if_exists(Path::new(path)) {
-                match Self::parse(&text) {
+            if let Some(text) = read_file_if_exists(Path::new(path), &mut warnings) {
+                match Self::parse_collecting_warnings(&text, &mut warnings) {
                     Ok(song) => config = config.merge(song),
-                    Err(e) => eprintln!("warning: failed to parse config file {path}: {e}"),
+                    Err(e) => warnings.push(format!("failed to parse config file {path}: {e}")),
                 }
             }
         }
 
-        config
+        ConfigLoadResult { config, warnings }
+    }
+
+    /// Parse a configuration from a RRJSON string, collecting warnings into
+    /// the provided vector.
+    fn parse_collecting_warnings(
+        input: &str,
+        warnings: &mut Vec<String>,
+    ) -> Result<Self, rrjson::ParseError> {
+        let result = rrjson::parse_rrjson_with_warnings(input)?;
+        warnings.extend(result.warnings);
+        Ok(Self { root: result.value })
     }
 }
 
@@ -396,12 +418,12 @@ fn read_config_file(path: &Path) -> Result<String, std::io::Error> {
 ///
 /// Rejects files that are symlinks or exceed [`MAX_CONFIG_FILE_SIZE`], emitting
 /// a warning to stderr in either case.
-fn read_file_if_exists(path: &Path) -> Option<String> {
+fn read_file_if_exists(path: &Path, warnings: &mut Vec<String>) -> Option<String> {
     match read_config_file(path) {
         Ok(contents) => Some(contents),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
         Err(e) => {
-            eprintln!("warning: skipping config file {}: {e}", path.display());
+            warnings.push(format!("skipping config file {}: {e}", path.display()));
             None
         }
     }
@@ -636,9 +658,9 @@ mod tests {
     fn test_load_with_no_files() {
         // load() should succeed even when no config files exist.
         // We use a non-existent project dir to ensure nothing loads.
-        let config = Config::load(Some("/nonexistent/path"), None);
+        let result = Config::load(Some("/nonexistent/path"), None);
         // Should still have defaults
-        assert!(!config.get("pdf").is_null());
+        assert!(!result.config.get("pdf").is_null());
     }
 
     #[test]
@@ -843,10 +865,16 @@ mod tests {
         )
         .unwrap();
 
-        let config = Config::load(Some(dir.path().to_str().unwrap()), None);
-        assert_eq!(config.get_path("settings.columns"), &Value::Number(3.0));
+        let result = Config::load(Some(dir.path().to_str().unwrap()), None);
+        assert_eq!(
+            result.config.get_path("settings.columns"),
+            &Value::Number(3.0)
+        );
         // Defaults should still be present for non-overridden keys
-        assert_eq!(config.get_path("pdf.margins.top"), &Value::Number(56.0));
+        assert_eq!(
+            result.config.get_path("pdf.margins.top"),
+            &Value::Number(56.0)
+        );
     }
 
     #[test]
@@ -855,9 +883,9 @@ mod tests {
         let song_path = dir.path().join("song.json");
         std::fs::write(&song_path, r#"{ "pdf": { "papersize": "letter" } }"#).unwrap();
 
-        let config = Config::load(None, Some(song_path.to_str().unwrap()));
+        let result = Config::load(None, Some(song_path.to_str().unwrap()));
         assert_eq!(
-            config.get_path("pdf.papersize"),
+            result.config.get_path("pdf.papersize"),
             &Value::String("letter".to_string())
         );
     }
@@ -878,14 +906,20 @@ mod tests {
         let song_path = song_dir.path().join("song.json");
         std::fs::write(&song_path, r#"{ "settings": { "columns": 4 } }"#).unwrap();
 
-        let config = Config::load(
+        let result = Config::load(
             Some(project_dir.path().to_str().unwrap()),
             Some(song_path.to_str().unwrap()),
         );
         // Song overrides project
-        assert_eq!(config.get_path("settings.columns"), &Value::Number(4.0));
+        assert_eq!(
+            result.config.get_path("settings.columns"),
+            &Value::Number(4.0)
+        );
         // Project setting not overridden by song
-        assert_eq!(config.get_path("settings.transpose"), &Value::Number(5.0));
+        assert_eq!(
+            result.config.get_path("settings.transpose"),
+            &Value::Number(5.0)
+        );
     }
 
     #[test]
@@ -894,8 +928,17 @@ mod tests {
         std::fs::write(dir.path().join("chordpro.json"), "{ invalid json !!!").unwrap();
 
         // Should not panic; defaults are still loaded
-        let config = Config::load(Some(dir.path().to_str().unwrap()), None);
-        assert!(!config.get("pdf").is_null());
+        let result = Config::load(Some(dir.path().to_str().unwrap()), None);
+        assert!(!result.config.get("pdf").is_null());
+        // Warning should be collected instead of printed to stderr
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("failed to parse")),
+            "expected parse warning, got: {:?}",
+            result.warnings
+        );
     }
 
     #[test]
@@ -916,15 +959,19 @@ mod tests {
         let file_path = dir.path().join("config.json");
         std::fs::write(&file_path, r#"{"key": "value"}"#).unwrap();
 
-        let result = read_file_if_exists(&file_path);
+        let mut warnings = Vec::new();
+        let result = read_file_if_exists(&file_path, &mut warnings);
         assert!(result.is_some());
         assert!(result.unwrap().contains("key"));
+        assert!(warnings.is_empty());
     }
 
     #[test]
     fn test_read_file_if_exists_nonexistent() {
-        let result = read_file_if_exists(Path::new("/nonexistent/path/config.json"));
+        let mut warnings = Vec::new();
+        let result = read_file_if_exists(Path::new("/nonexistent/path/config.json"), &mut warnings);
         assert!(result.is_none());
+        assert!(warnings.is_empty());
     }
 
     #[cfg(unix)]
@@ -936,8 +983,10 @@ mod tests {
         std::fs::write(&real_file, r#"{"key": "value"}"#).unwrap();
         std::os::unix::fs::symlink(&real_file, &link_path).unwrap();
 
-        let result = read_file_if_exists(&link_path);
+        let mut warnings = Vec::new();
+        let result = read_file_if_exists(&link_path, &mut warnings);
         assert!(result.is_none(), "symlink should be rejected");
+        assert!(!warnings.is_empty(), "should produce a warning for symlink");
     }
 
     // -- resolve() security tests ------------------------------------------------

--- a/crates/core/src/rrjson.rs
+++ b/crates/core/src/rrjson.rs
@@ -207,29 +207,56 @@ impl std::error::Error for ParseError {}
 // Public API
 // ---------------------------------------------------------------------------
 
+/// Result of parsing RRJSON, including any non-fatal warnings.
+#[derive(Debug)]
+pub struct ParseResult {
+    /// The parsed value.
+    pub value: Value,
+    /// Non-fatal warnings encountered during parsing (e.g., unsupported
+    /// include directives).
+    pub warnings: Vec<String>,
+}
+
 /// Parse a RRJSON string into a [`Value`].
 ///
 /// Accepts strict JSON, relaxed JSON, and RRJSON formats.
+/// Non-fatal warnings (e.g., unsupported include directives) are silently
+/// discarded. Use [`parse_rrjson_with_warnings`] to collect them.
 ///
 /// # Errors
 ///
 /// Returns a [`ParseError`] if the input is malformed.
 pub fn parse_rrjson(input: &str) -> Result<Value, ParseError> {
+    parse_rrjson_with_warnings(input).map(|r| r.value)
+}
+
+/// Parse a RRJSON string into a [`ParseResult`] containing the value and
+/// any non-fatal warnings.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] if the input is malformed.
+pub fn parse_rrjson_with_warnings(input: &str) -> Result<ParseResult, ParseError> {
     let mut parser = Parser::new(input);
     parser.skip_ws_and_comments()?;
 
     // RRJSON: if the input doesn't start with '{' or '[', treat it as
     // bare key-value pairs (implicit object).
-    if parser.peek() != Some('{') && parser.peek() != Some('[') {
-        return parser.parse_bare_object();
-    }
+    let value = if parser.peek() != Some('{') && parser.peek() != Some('[') {
+        parser.parse_bare_object()?
+    } else {
+        let value = parser.parse_value()?;
+        parser.skip_ws_and_comments()?;
+        if parser.pos < parser.input.len() {
+            return Err(parser.error("unexpected content after value"));
+        }
+        value
+    };
 
-    let value = parser.parse_value()?;
-    parser.skip_ws_and_comments()?;
-    if parser.pos < parser.input.len() {
-        return Err(parser.error("unexpected content after value"));
-    }
-    Ok(value)
+    Ok(ParseResult {
+        value,
+        warnings: parser.warnings,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +276,7 @@ struct Parser<'a> {
     input: &'a str,
     pos: usize,
     depth: usize,
+    warnings: Vec<String>,
 }
 
 impl<'a> Parser<'a> {
@@ -257,6 +285,7 @@ impl<'a> Parser<'a> {
             input,
             pos: 0,
             depth: 0,
+            warnings: Vec::new(),
         }
     }
 
@@ -698,6 +727,8 @@ impl<'a> Parser<'a> {
             // Skip "include" directives (not yet supported — warn and consume the line).
             // Check word boundary after "include" so keys like "includes" or
             // "include_path" are parsed normally as object keys.
+            // Also check that no ':' or '=' follows on the same line, which
+            // would indicate a valid key-value pair with key "include".
             if self.input[self.pos..].starts_with("include")
                 && self
                     .input
@@ -705,20 +736,26 @@ impl<'a> Parser<'a> {
                     .get(self.pos + 7)
                     .is_none_or(|&b| b == b' ' || b == b'\t' || b == b'"' || b == b'\'')
             {
-                let (line, col) = self.line_col();
-                let directive_line = if let Some(end) = self.input[self.pos..].find('\n') {
-                    let line_text = self.input[self.pos..self.pos + end].trim();
-                    self.pos += end + 1;
-                    line_text.to_string()
-                } else {
-                    let line_text = self.input[self.pos..].trim().to_string();
-                    self.pos = self.input.len();
-                    line_text
-                };
-                eprintln!(
-                    "warning: RRJSON include directives are not supported (line {line} column {col}): {directive_line}"
-                );
-                continue;
+                // Look ahead on the current line for ':' or '=' separator.
+                let rest_of_line = self.input[self.pos..].split('\n').next().unwrap_or("");
+                let has_separator = rest_of_line.contains(':') || rest_of_line.contains('=');
+
+                if !has_separator {
+                    let (line, col) = self.line_col();
+                    let directive_line = if let Some(end) = self.input[self.pos..].find('\n') {
+                        let line_text = self.input[self.pos..self.pos + end].trim();
+                        self.pos += end + 1;
+                        line_text.to_string()
+                    } else {
+                        let line_text = self.input[self.pos..].trim().to_string();
+                        self.pos = self.input.len();
+                        line_text
+                    };
+                    self.warnings.push(format!(
+                        "RRJSON include directives are not supported (line {line} column {col}): {directive_line}"
+                    ));
+                    continue;
+                }
             }
 
             let key = self.parse_key()?;
@@ -1222,6 +1259,38 @@ mod tests {
         let input = "included = true";
         let v = parse_rrjson(input).unwrap();
         assert_eq!(v["included"], Value::Bool(true));
+    }
+
+    #[test]
+    fn test_include_key_with_colon_separator() {
+        // "include" with a ':' separator should be parsed as a key-value pair
+        let input = "include : \"somefile.json\"";
+        let v = parse_rrjson(input).unwrap();
+        assert_eq!(v["include"], Value::String("somefile.json".to_string()));
+    }
+
+    #[test]
+    fn test_include_key_with_equals_separator() {
+        // "include" with an '=' separator should be parsed as a key-value pair
+        let input = "include = \"somefile.json\"";
+        let v = parse_rrjson(input).unwrap();
+        assert_eq!(v["include"], Value::String("somefile.json".to_string()));
+    }
+
+    #[test]
+    fn test_include_directive_produces_warning() {
+        let input = "include \"base.json\"\nkey = \"value\"";
+        let result = parse_rrjson_with_warnings(input).unwrap();
+        assert_eq!(result.value["key"], Value::String("value".to_string()));
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("include directives are not supported"));
+    }
+
+    #[test]
+    fn test_no_warnings_for_normal_input() {
+        let input = r#"{"key": "value"}"#;
+        let result = parse_rrjson_with_warnings(input).unwrap();
+        assert!(result.warnings.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

1. Replace all `eprintln!` calls in `chordpro-core` library code with structured warning collection
2. Fix include directive detection to not swallow valid key-value pairs with key `include`

## Why

- `eprintln!` in library code is inappropriate — it makes the library unsuitable for GUI apps, servers, or test harnesses that need to control output
- The include directive detection swallowed valid key-value pairs like `include : "somefile"` or `include = "value"`

## Changes

- **`rrjson.rs`**: Added `warnings` field to `Parser`, `ParseResult` struct, and `parse_rrjson_with_warnings()` function. Include directive warning uses `self.warnings.push()` instead of `eprintln!`. Include detection now checks for `:` or `=` on the same line before treating as a directive.
- **`config.rs`**: Added `ConfigLoadResult` struct. `Config::load()` returns `ConfigLoadResult` with collected warnings. `read_file_if_exists` accepts `&mut Vec<String>` for warnings.
- **`main.rs`**: CLI prints warnings from `ConfigLoadResult` to stderr.

## Test Results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅
```

- Zero `eprintln!` calls remaining in `crates/core/src/`
- New tests: `test_include_key_with_colon_separator`, `test_include_key_with_equals_separator`, `test_include_directive_produces_warning`, `test_no_warnings_for_normal_input`
- Updated tests: `test_load_invalid_project_config_continues` (now verifies warning collection), `test_read_file_if_exists_*` (updated for new signature)

## Review Summary

- `parse_rrjson()` remains backward-compatible (delegates to `parse_rrjson_with_warnings` and discards warnings)
- `Config::load()` return type changed from `Config` to `ConfigLoadResult` (breaking change for direct callers)

Closes #453
Closes #454