### PR TITLE
Validate empty key in --define CLI argument

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -106,6 +106,11 @@ fn main() -> ExitCode {
             eprintln!("error: invalid --define syntax: {define} (expected key=value)");
             return ExitCode::FAILURE;
         }
+        let key = define.split('=').next().unwrap_or("");
+        if key.trim().is_empty() {
+            eprintln!("error: invalid --define syntax: {define} (key must not be empty)");
+            return ExitCode::FAILURE;
+        }
         config = config.with_define(define);
     }
 

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -305,6 +305,28 @@ fn test_define_invalid_syntax() {
 }
 
 #[test]
+fn test_define_empty_key_rejected() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--define", "=value", &fixture("simple.cho")])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains("key must not be empty"));
+}
+
+#[test]
+fn test_define_whitespace_key_rejected() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--define", "  =value", &fixture("simple.cho")])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains("key must not be empty"));
+}
+
+#[test]
 fn test_config_transpose_combined_with_cli() {
     let mut config_file = NamedTempFile::new().unwrap();
     // Config sets transpose=2


### PR DESCRIPTION
## What

Reject `--define "=value"` and `--define "  =value"` with a descriptive error.

## Why

CLI validation only checked `!define.contains('=')`, which passes for `--define "=value"`. The empty key was then silently ignored by `with_define`. An explicit error message is more helpful.

## Test Results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅
```

New tests: `test_define_empty_key_rejected`, `test_define_whitespace_key_rejected`

Closes #460