### PR TITLE
Add comprehensive tests for Chord::expand_format() method

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -3237,4 +3237,45 @@ mod expand_format_tests {
         };
         assert_eq!(chord.expand_format("%{root}"), None);
     }
+
+    #[test]
+    fn unknown_placeholder_passes_through() {
+        let chord = Chord::new("Am");
+        let result = chord.expand_format("%{root}%{unknown}");
+        assert_eq!(result, Some("A%{unknown}".to_string()));
+    }
+
+    #[test]
+    fn empty_format_string() {
+        let chord = Chord::new("Am");
+        assert_eq!(chord.expand_format(""), Some(String::new()));
+    }
+
+    #[test]
+    fn slash_chord_bass_with_accidental() {
+        let chord = Chord::new("G/Bb");
+        let result = chord.expand_format("%{root}/%{bass}");
+        assert_eq!(result, Some("G/Bb".to_string()));
+    }
+
+    #[test]
+    fn no_bass_produces_empty_string() {
+        let chord = Chord::new("Am");
+        let result = chord.expand_format("%{root}%{quality} (bass: %{bass})");
+        assert_eq!(result, Some("Am (bass: )".to_string()));
+    }
+
+    #[test]
+    fn all_placeholders_combined() {
+        let chord = Chord::new("Bbm7/Eb");
+        let result = chord.expand_format("%{root}%{quality}%{ext}/%{bass}");
+        assert_eq!(result, Some("Bbm7/Eb".to_string()));
+    }
+
+    #[test]
+    fn literal_text_with_no_placeholders() {
+        let chord = Chord::new("Am");
+        let result = chord.expand_format("just text");
+        assert_eq!(result, Some("just text".to_string()));
+    }
 }


### PR DESCRIPTION
## What

Add unit tests for `Chord::expand_format()` covering previously untested edge cases.

## Why

`expand_format()` had zero coverage for edge cases: unknown placeholders, empty format
strings, bass notes with accidentals, and literal-only patterns. These gaps mean a
future refactor could silently break format expansion.

## Changes

6 new unit tests in `expand_format_tests`:
- `unknown_placeholder_passes_through` — `%{unknown}` passes through as literal text
- `empty_format_string` — returns `Some("")`
- `slash_chord_bass_with_accidental` — `G/Bb` produces correct bass output
- `no_bass_produces_empty_string` — non-slash chord renders `%{bass}` as empty
- `all_placeholders_combined` — `Bbm7/Eb` with all four placeholders
- `literal_text_with_no_placeholders` — returns literal text unchanged

Note: A golden test for `format=` in rendered output is not feasible because the
lexer treats `}` inside directives as `DirectiveClose`, preventing `%{root}` patterns
from being parsed correctly in `{define}` directives.

## Test results

```
cargo fmt --check   ✅
cargo clippy        ✅
cargo test          ✅
```

Closes #468