### PR TITLE
Document intentional cell dimension difference between SVG and PDF

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -175,7 +175,14 @@ impl DiagramData {
 // SVG rendering constants
 // ---------------------------------------------------------------------------
 
+/// Cell width in SVG user units (pixels at 1:1 zoom).
+///
+/// Intentionally larger than the PDF renderer's 10.0 pt because SVG
+/// diagrams target on-screen display where more generous spacing
+/// improves readability. The PDF renderer uses smaller values (10x12 pt)
+/// suited for printed page layout.
 const CELL_W: f32 = 16.0;
+/// Cell height in SVG user units. See [`CELL_W`] for rationale.
 const CELL_H: f32 = 20.0;
 const TOP_MARGIN: f32 = 30.0;
 const LEFT_MARGIN: f32 = 20.0;

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -842,6 +842,9 @@ fn render_chord_diagram_pdf(
     data: &chordpro_core::chord_diagram::DiagramData,
     doc: &mut PdfDocument,
 ) {
+    // PDF cell dimensions in points (1 pt = 1/72 inch). Intentionally
+    // smaller than the SVG renderer's 16x20 px because PDF targets printed
+    // pages where diagrams sit alongside text and must be compact.
     let cell_w: f32 = 10.0;
     let cell_h: f32 = 12.0;
     let num_strings = data.strings;


### PR DESCRIPTION
## What

Add doc comments explaining why the SVG and PDF chord diagram renderers
use different cell dimensions.

## Why

The dimension difference was flagged as a potential inconsistency during
Phase 14 review. The difference is intentional: SVG targets on-screen
display (16x20 px for readability) while PDF targets printed pages
(10x12 pt for compact layout).

## Changes

- Added doc comments to `CELL_W`/`CELL_H` constants in `chord_diagram.rs`
- Added inline comment to PDF renderer's `cell_w`/`cell_h` values
- Both comments cross-reference the other renderer

## Test results

```
cargo fmt --check   ✅
cargo clippy        ✅
cargo test          ✅
```

Closes #470