### PR TITLE
Implement {diagrams} directive to control chord diagram visibility

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -938,6 +938,12 @@ pub enum DirectiveKind {
     /// field using the generic `{meta}` directive syntax.
     Meta(String),
 
+    // -- Chord diagram control ------------------------------------------------
+    /// `{diagrams}` / `{diagrams: on}` / `{diagrams: off}` — control chord
+    /// diagram visibility. When set to "off", renderers suppress automatic
+    /// chord diagrams for the current song.
+    Diagrams,
+
     // -- Image directive ----------------------------------------------------
     /// `{image: src=filename}` — embeds an image with optional attributes.
     Image(ImageAttributes),
@@ -1051,9 +1057,10 @@ impl DirectiveKind {
             "tocsize" => Self::TocSize,
             "toccolour" | "toccolor" => Self::TocColour,
 
-            // Chord definitions
+            // Chord definitions and diagrams
             "define" => Self::Define,
             "chord" => Self::ChordDirective,
+            "diagrams" => Self::Diagrams,
 
             // Generic metadata
             "meta" => Self::Meta(String::new()),
@@ -1216,6 +1223,7 @@ impl DirectiveKind {
             Self::Columns => "columns",
             Self::Define => "define",
             Self::ChordDirective => "chord",
+            Self::Diagrams => "diagrams",
             Self::Meta(_) => "meta",
 
             Self::Image(_) => "image",

--- a/crates/core/tests/fixtures/diagrams-directive/expected.txt
+++ b/crates/core/tests/fixtures/diagrams-directive/expected.txt
@@ -1,0 +1,125 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Diagrams Directive Test",
+        ),
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Diagrams Directive Test",
+                ),
+                kind: Title,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "diagrams",
+                value: Some(
+                    "off",
+                ),
+                kind: Diagrams,
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "Hello ",
+                        spans: [],
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "G",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: G,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "world",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+        Directive(
+            Directive {
+                name: "diagrams",
+                value: Some(
+                    "on",
+                ),
+                kind: Diagrams,
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "C",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: C,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "Again",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/diagrams-directive/input.cho
+++ b/crates/core/tests/fixtures/diagrams-directive/input.cho
@@ -1,0 +1,5 @@
+{title: Diagrams Directive Test}
+{diagrams: off}
+[Am]Hello [G]world
+{diagrams: on}
+[C]Again

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -164,6 +164,9 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
     let mut ly_buf: Option<String> = None;
     let mut ly_label: Option<String> = None;
 
+    // Controls whether chord diagrams are rendered. Set by {diagrams: off/on}.
+    let mut show_diagrams = true;
+
     // Stores the rendered HTML of the most recently defined chorus body
     // (everything between StartOfChorus and EndOfChorus, excluding the
     // section open/close tags). Used by `{chorus}` recall.
@@ -202,6 +205,13 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
             }
             Line::Directive(directive) => {
                 if directive.kind.is_metadata() {
+                    continue;
+                }
+                if directive.kind == DirectiveKind::Diagrams {
+                    show_diagrams = match directive.value.as_deref() {
+                        Some("off") => false,
+                        _ => true, // "on", empty, or any other value
+                    };
                     continue;
                 }
                 if directive.kind == DirectiveKind::Transpose {
@@ -307,7 +317,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                     }
                     _ => {
                         let mut target = String::new();
-                        render_directive_inner(directive, &mut target);
+                        render_directive_inner(directive, show_diagrams, &mut target);
                         if let Some(buf) = chorus_buf.as_mut() {
                             buf.push_str(&target);
                         }
@@ -920,7 +930,11 @@ fn sanitize_tag_attrs(tag: &str) -> String {
 ///
 /// StartOfChorus, EndOfChorus, and Chorus are handled directly in
 /// `render_song` for chorus-recall state tracking.
-fn render_directive_inner(directive: &chordpro_core::ast::Directive, html: &mut String) {
+fn render_directive_inner(
+    directive: &chordpro_core::ast::Directive,
+    show_diagrams: bool,
+    html: &mut String,
+) {
     match &directive.kind {
         DirectiveKind::StartOfChorus => {
             render_section_open("chorus", "Chorus", &directive.value, html);
@@ -969,16 +983,20 @@ fn render_directive_inner(directive: &chordpro_core::ast::Directive, html: &mut 
             render_image(attrs, html);
         }
         DirectiveKind::Define => {
-            if let Some(ref value) = directive.value {
-                let def = chordpro_core::ast::ChordDefinition::parse_value(value);
-                if let Some(ref raw) = def.raw {
-                    if let Some(mut diagram) =
-                        chordpro_core::chord_diagram::DiagramData::from_raw_infer(&def.name, raw)
-                    {
-                        diagram.display_name = def.display.clone();
-                        html.push_str("<div class=\"chord-diagram-container\">");
-                        html.push_str(&chordpro_core::chord_diagram::render_svg(&diagram));
-                        html.push_str("</div>\n");
+            if show_diagrams {
+                if let Some(ref value) = directive.value {
+                    let def = chordpro_core::ast::ChordDefinition::parse_value(value);
+                    if let Some(ref raw) = def.raw {
+                        if let Some(mut diagram) =
+                            chordpro_core::chord_diagram::DiagramData::from_raw_infer(
+                                &def.name, raw,
+                            )
+                        {
+                            diagram.display_name = def.display.clone();
+                            html.push_str("<div class=\"chord-diagram-container\">");
+                            html.push_str(&chordpro_core::chord_diagram::render_svg(&diagram));
+                            html.push_str("</div>\n");
+                        }
                     }
                 }
             }
@@ -1935,6 +1953,60 @@ Verse text\n\
             html.contains("width=\"104\""),
             "Expected 5-string SVG width (104)"
         );
+    }
+
+    // -- {diagrams} directive tests -----------------------------------------------
+
+    #[test]
+    fn test_diagrams_off_suppresses_chord_diagrams() {
+        let html = render("{diagrams: off}\n{define: Am base-fret 1 frets x 0 2 2 1 0}");
+        assert!(
+            !html.contains("<svg"),
+            "chord diagram SVG should be suppressed when diagrams=off"
+        );
+    }
+
+    #[test]
+    fn test_diagrams_on_shows_chord_diagrams() {
+        let html = render("{diagrams: on}\n{define: Am base-fret 1 frets x 0 2 2 1 0}");
+        assert!(
+            html.contains("<svg"),
+            "chord diagram SVG should be shown when diagrams=on"
+        );
+    }
+
+    #[test]
+    fn test_diagrams_default_shows_chord_diagrams() {
+        let html = render("{define: Am base-fret 1 frets x 0 2 2 1 0}");
+        assert!(
+            html.contains("<svg"),
+            "chord diagram SVG should be shown by default"
+        );
+    }
+
+    #[test]
+    fn test_diagrams_off_then_on_restores() {
+        let html = render(
+            "{diagrams: off}\n{define: Am base-fret 1 frets x 0 2 2 1 0}\n{diagrams: on}\n{define: G base-fret 1 frets 3 2 0 0 0 3}",
+        );
+        // Am should be suppressed, G should be shown
+        assert!(!html.contains(">Am<"), "Am diagram should be suppressed");
+        assert!(html.contains(">G<"), "G diagram should be rendered");
+    }
+
+    #[test]
+    fn test_diagrams_parsed_as_known_directive() {
+        let song = chordpro_core::parse("{diagrams: off}").unwrap();
+        if let chordpro_core::ast::Line::Directive(d) = &song.lines[0] {
+            assert_eq!(
+                d.kind,
+                chordpro_core::ast::DirectiveKind::Diagrams,
+                "diagrams should parse as DirectiveKind::Diagrams"
+            );
+            assert_eq!(d.value, Some("off".to_string()));
+        } else {
+            panic!("expected a directive line");
+        }
     }
 
     // -- abc2svg delegate rendering tests -----------------------------------------

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -253,6 +253,9 @@ fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
         doc.newline(SUBTITLE_SIZE + LINE_GAP);
     }
 
+    // Controls whether chord diagrams are rendered. Set by {diagrams: off/on}.
+    let mut show_diagrams = true;
+
     // Stores the AST lines of the most recently defined chorus body for replay.
     let mut chorus_body: Vec<Line> = Vec::new();
     // Temporary buffer for collecting chorus content while inside a chorus section.
@@ -267,6 +270,10 @@ fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
                 render_lyrics(lyrics, transpose_offset, &fmt_state, doc);
             }
             Line::Directive(d) if !d.kind.is_metadata() => {
+                if d.kind == DirectiveKind::Diagrams {
+                    show_diagrams = !matches!(d.value.as_deref(), Some("off"));
+                    continue;
+                }
                 if d.kind == DirectiveKind::Transpose {
                     let file_offset: i8 =
                         d.value.as_deref().and_then(|v| v.parse().ok()).unwrap_or(0);
@@ -330,7 +337,7 @@ fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
                         if let Some(buf) = chorus_buf.as_mut() {
                             buf.push(line.clone());
                         }
-                        render_directive(d, doc);
+                        render_directive(d, show_diagrams, doc);
                     }
                 }
             }
@@ -523,8 +530,12 @@ fn render_section_label(directive: &chordpro_core::ast::Directive, doc: &mut Pdf
     }
 }
 
-fn render_directive(directive: &chordpro_core::ast::Directive, doc: &mut PdfDocument) {
-    if directive.kind == DirectiveKind::Define {
+fn render_directive(
+    directive: &chordpro_core::ast::Directive,
+    show_diagrams: bool,
+    doc: &mut PdfDocument,
+) {
+    if directive.kind == DirectiveKind::Define && show_diagrams {
         if let Some(ref value) = directive.value {
             let def = chordpro_core::ast::ChordDefinition::parse_value(value);
             if let Some(ref raw) = def.raw {
@@ -939,7 +950,7 @@ fn render_chorus_recall(
             Line::Lyrics(lyrics) => render_lyrics(lyrics, transpose_offset, fmt_state, doc),
             Line::Comment(style, text) => render_comment(*style, text, doc),
             Line::Empty => doc.newline(LINE_GAP * 2.0),
-            Line::Directive(d) if !d.kind.is_metadata() => render_directive(d, doc),
+            Line::Directive(d) if !d.kind.is_metadata() => render_directive(d, true, doc),
             _ => {}
         }
     }


### PR DESCRIPTION
## What

Add support for the `{diagrams}` directive to control whether chord diagrams
from `{define}` directives are rendered.

## Why

The ChordPro specification includes a `{diagrams}` directive for toggling
chord diagram visibility. This was the last missing piece for full chord
diagram control in Phase 14.

## Changes

### Parser (crates/core/src/ast.rs)
- New `DirectiveKind::Diagrams` variant
- Name resolution: `"diagrams"` maps to `Diagrams`

### HTML Renderer
- `show_diagrams` state variable tracks directive
- `{diagrams: off}` suppresses SVG diagram output from `{define}`
- `{diagrams: on}` (or any non-"off" value) re-enables

### PDF Renderer
- Same `show_diagrams` state tracking
- Gates `render_chord_diagram_pdf()` calls

### Tests
- 5 HTML renderer tests (off, on, default, toggle, parser recognition)
- Golden test fixture for parser AST

## Test results

```
cargo fmt --check   ✅
cargo clippy        ✅
cargo test          ✅
```

Closes #471