### PR TITLE
Render finger numbers inside chord diagram fret dots

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -276,6 +276,17 @@ pub fn render_svg(data: &DiagramData) -> String {
             svg.push_str(&format!(
                 "<circle cx=\"{x}\" cy=\"{y}\" r=\"{DOT_RADIUS}\" fill=\"black\"/>\n"
             ));
+            // Finger number inside the dot (if available and non-zero)
+            if let Some(&finger) = data.fingers.get(i) {
+                if finger > 0 {
+                    svg.push_str(&format!(
+                        "<text x=\"{x}\" y=\"{}\" text-anchor=\"middle\" \
+                         font-family=\"sans-serif\" font-size=\"8\" \
+                         fill=\"white\">{finger}</text>\n",
+                        y + 3.0
+                    ));
+                }
+            }
         }
     }
 
@@ -440,6 +451,79 @@ mod tests {
     fn test_from_raw_display_name_is_none() {
         let data = DiagramData::from_raw_infer("Am", "base-fret 1 frets x 0 2 2 1 0").unwrap();
         assert!(data.display_name.is_none());
+    }
+
+    // --- Finger number rendering (#473) ---
+
+    #[test]
+    fn test_render_svg_with_finger_numbers() {
+        let data = DiagramData {
+            name: "C".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 3, 2, 0, 1, 0],
+            fingers: vec![0, 3, 2, 0, 1, 0],
+        };
+        let svg = render_svg(&data);
+        // Fingers 3, 2, 1 should appear as white text inside dots
+        assert!(svg.contains("fill=\"white\">3</text>"));
+        assert!(svg.contains("fill=\"white\">2</text>"));
+        assert!(svg.contains("fill=\"white\">1</text>"));
+    }
+
+    #[test]
+    fn test_render_svg_zero_finger_not_shown() {
+        let data = DiagramData {
+            name: "Am".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![0, 0, 2, 3, 1, 0],
+        };
+        let svg = render_svg(&data);
+        // Finger 0 should NOT appear
+        assert!(!svg.contains("fill=\"white\">0</text>"));
+        // Non-zero fingers should appear
+        assert!(svg.contains("fill=\"white\">2</text>"));
+        assert!(svg.contains("fill=\"white\">3</text>"));
+        assert!(svg.contains("fill=\"white\">1</text>"));
+    }
+
+    #[test]
+    fn test_render_svg_no_fingers_no_crash() {
+        let data = DiagramData {
+            name: "G".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![3, 2, 0, 0, 0, 3],
+            fingers: vec![],
+        };
+        let svg = render_svg(&data);
+        assert!(svg.contains("<svg"));
+        assert!(!svg.contains("fill=\"white\""));
+    }
+
+    #[test]
+    fn test_render_svg_fewer_fingers_than_frets() {
+        let data = DiagramData {
+            name: "Am".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![0, 0, 2],
+        };
+        let svg = render_svg(&data);
+        // Should only render finger 2, no crash for missing fingers
+        assert!(svg.contains("fill=\"white\">2</text>"));
+        assert!(svg.contains("<svg"));
     }
 
     // --- num_strings validation (#467) ---

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -918,6 +918,13 @@ fn render_chord_diagram_pdf(
             // Fretted: filled dot
             let y = grid_top - (fret as f32 - 0.5) * cell_h;
             doc.filled_circle_at(x, y, 3.0);
+            // Finger number inside the dot (if available and non-zero)
+            if let Some(&finger) = data.fingers.get(i) {
+                if finger > 0 {
+                    let label = finger.to_string();
+                    doc.white_text_at(&label, Font::Helvetica, 5.0, x - 1.5, y - 1.5);
+                }
+            }
         }
     }
 
@@ -1580,6 +1587,20 @@ impl PdfDocument {
         ops.push(format!("{} {} Td", fmt_f32(x), fmt_f32(y)));
         ops.push(format!("({}) Tj", pdf_escape(text)));
         ops.push("ET".to_string());
+    }
+
+    /// Emit a text string at absolute coordinates in white.
+    ///
+    /// Used for finger numbers inside filled dots in chord diagrams.
+    fn white_text_at(&mut self, text: &str, font: Font, size: f32, x: f32, y: f32) {
+        let ops = self.current_page_mut();
+        ops.push("BT".to_string());
+        ops.push("1 1 1 rg".to_string()); // white fill color
+        ops.push(format!("{} {} Tf", font.pdf_name(), fmt_f32(size)));
+        ops.push(format!("{} {} Td", fmt_f32(x), fmt_f32(y)));
+        ops.push(format!("({}) Tj", pdf_escape(text)));
+        ops.push("ET".to_string());
+        ops.push("0 0 0 rg".to_string()); // reset to black
     }
 
     /// Move the Y cursor down. May trigger a column/page break if past bottom margin.


### PR DESCRIPTION
## What

Render finger numbers (1-4) as white text inside filled fret dots in chord
diagram SVG and PDF output.

## Why

The `fingers` field was parsed and stored in `DiagramData` but never rendered.
Finger numbers help players know which finger to use for each fret position.

## Changes

### SVG (crates/core/src/chord_diagram.rs)
- After rendering each fretted dot circle, check for a corresponding
  non-zero finger number and render it as white `<text>` inside the dot

### PDF (crates/render-pdf/src/lib.rs)
- Add `white_text_at()` method to `PdfDocument` for rendering white text
- Render finger numbers inside filled circles in the PDF chord diagram

### Tests
- `test_render_svg_with_finger_numbers` — C chord with fingers 3, 2, 1
- `test_render_svg_zero_finger_not_shown` — finger=0 is suppressed
- `test_render_svg_no_fingers_no_crash` — empty fingers array is safe
- `test_render_svg_fewer_fingers_than_frets` — partial fingers array

## Test results

```
cargo fmt --check   ✅
cargo clippy        ✅
cargo test          ✅
```

Closes #473