### PR TITLE
Add #[must_use] to try_render() and simplify redundant equality checks

### DIFF
--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -103,13 +103,13 @@ fn sanitize_abc_content(input: &str) -> String {
         let trimmed = line.trim();
 
         if in_js_block {
-            if trimmed == "%%endjs" || trimmed.eq_ignore_ascii_case("%%endjs") {
+            if trimmed.eq_ignore_ascii_case("%%endjs") {
                 in_js_block = false;
             }
             continue;
         }
 
-        if trimmed == "%%beginjs" || trimmed.eq_ignore_ascii_case("%%beginjs") {
+        if trimmed.eq_ignore_ascii_case("%%beginjs") {
             in_js_block = true;
             continue;
         }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -409,6 +409,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
 ///
 /// Returns `Ok(html)` on success, or the [`chordpro_core::ParseError`] if
 /// the input cannot be parsed.
+#[must_use = "parse errors should be handled"]
 pub fn try_render(input: &str) -> Result<String, chordpro_core::ParseError> {
     let song = chordpro_core::parse(input)?;
     Ok(render_song(&song))

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -359,6 +359,7 @@ fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
 }
 
 /// Parse and render a ChordPro source string to PDF bytes.
+#[must_use = "parse errors should be handled"]
 pub fn try_render(input: &str) -> Result<Vec<u8>, chordpro_core::ParseError> {
     let song = chordpro_core::parse(input)?;
     Ok(render_song(&song))

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -158,6 +158,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
 /// the input cannot be parsed.
 ///
 /// For pre-parsed input, use [`render_song`] directly.
+#[must_use = "parse errors should be handled"]
 pub fn try_render(input: &str) -> Result<String, chordpro_core::ParseError> {
     let song = chordpro_core::parse(input)?;
     Ok(render_song(&song))


### PR DESCRIPTION
## What

Two small code quality fixes from the Phase 13 completion review:

1. Add `#[must_use]` attribute to `try_render()` in all three renderer crates
2. Remove redundant exact equality checks in ABC javascript sanitizer

## Why

1. All other public rendering functions (`render_song`, `render_songs`, `render`) already have `#[must_use]`, but `try_render()` was missing it. Since it returns `Result`, callers should be warned if they discard the value.

2. In `sanitize_abc_content()`, both `trimmed == "%%endjs"` and `trimmed.eq_ignore_ascii_case("%%endjs")` were checked — the first is redundant since `eq_ignore_ascii_case` already matches the exact case.

## Test results

```
cargo fmt --check   # pass
cargo clippy        # pass
cargo test          # all 1,148 tests pass
```

## Review summary

- 4 files changed, 5 insertions, 2 deletions
- No behavioral changes, pure code quality improvement

Closes #490
Closes #491