### PR TITLE
Distinguish NewPhysicalPage from NewPage for duplex printing

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -282,10 +282,14 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                     DirectiveKind::ColumnBreak => {
                         html.push_str("<div style=\"break-before: column;\"></div>\n");
                     }
-                    DirectiveKind::NewPage | DirectiveKind::NewPhysicalPage => {
-                        // TODO: NewPhysicalPage should eventually emit a
-                        // different CSS hint for duplex printing scenarios.
+                    DirectiveKind::NewPage => {
                         html.push_str("<div style=\"break-before: page;\"></div>\n");
+                    }
+                    DirectiveKind::NewPhysicalPage => {
+                        // Use CSS `break-before: recto` so the browser inserts
+                        // a blank page when needed to start on a right-hand page
+                        // in duplex printing.
+                        html.push_str("<div style=\"break-before: recto;\"></div>\n");
                     }
                     DirectiveKind::StartOfAbc if abc2svg_enabled => {
                         abc_buf = Some(String::new());
@@ -1731,9 +1735,16 @@ mod transpose_tests {
     }
 
     #[test]
-    fn test_new_physical_page_generates_page_break() {
+    fn test_new_physical_page_generates_recto_break() {
         let html = render("Page 1\n{new_physical_page}\nPage 2");
-        assert!(html.contains("break-before: page;"));
+        assert!(
+            html.contains("break-before: recto;"),
+            "new_physical_page should use break-before: recto for duplex printing"
+        );
+        assert!(
+            !html.contains("break-before: page;"),
+            "new_physical_page should not emit generic page break"
+        );
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -316,11 +316,18 @@ fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
                     // chorus buffer. These affect global page/column layout, and
                     // replaying them during {chorus} recall would produce unexpected
                     // layout changes (e.g., duplicate page breaks, column resets).
-                    DirectiveKind::NewPage | DirectiveKind::NewPhysicalPage => {
-                        // TODO: NewPhysicalPage should eventually handle duplex
-                        // printing differently (e.g., insert a blank page to
-                        // ensure the next content starts on a recto page).
+                    DirectiveKind::NewPage => {
                         doc.new_page();
+                    }
+                    DirectiveKind::NewPhysicalPage => {
+                        doc.new_page();
+                        // In duplex printing, recto pages are odd-numbered
+                        // (1, 3, 5, …).  If the new page is even (verso),
+                        // insert a blank page so the next content starts on
+                        // a recto page.
+                        if doc.page_count() % 2 == 0 {
+                            doc.new_page();
+                        }
                     }
                     DirectiveKind::Columns => {
                         let n: u32 = d
@@ -2547,12 +2554,29 @@ mod multipage_tests {
     }
 
     #[test]
-    fn test_new_physical_page_directive_creates_two_pages() {
+    fn test_new_physical_page_from_recto_inserts_blank() {
+        // Page 1 (recto) -> {npp} -> blank page 2 (verso) -> page 3 (recto)
         let input = "Page one\n{new_physical_page}\nPage two";
         let song = chordpro_core::parse(input).unwrap();
         let bytes = render_song(&song);
         let content = String::from_utf8_lossy(&bytes);
-        assert!(content.contains("/Count 2"));
+        assert!(
+            content.contains("/Count 3"),
+            "new_physical_page from recto should insert blank page to reach next recto"
+        );
+    }
+
+    #[test]
+    fn test_new_physical_page_from_verso_no_extra_blank() {
+        // Page 1 (recto) -> {np} -> page 2 (verso) -> {npp} -> page 3 (recto)
+        let input = "Page one\n{new_page}\nPage two\n{new_physical_page}\nPage three";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(
+            content.contains("/Count 3"),
+            "new_physical_page from verso should go directly to next recto (no extra blank)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Implement proper `{new_physical_page}` / `{npp}` handling that differs from `{new_page}` / `{np}` to support duplex printing scenarios.

### PDF renderer
- `{new_physical_page}` inserts a blank page when needed to ensure the next content starts on a recto (odd-numbered, right-hand) page
- From a recto page: inserts one blank verso page, then starts on the next recto
- From a verso page: goes directly to the next recto (same as `{new_page}`)

### HTML renderer
- `{new_physical_page}` emits `break-before: recto` instead of `break-before: page`
- This is the CSS Fragmentation Level 3 standard for duplex page alignment
- Browsers handle blank page insertion automatically when printing duplex

## Why

Both renderers previously treated `{new_physical_page}` identically to `{new_page}`, with TODO comments noting the distinction should be implemented. The ChordPro specification defines `{new_physical_page}` as guaranteeing the next content starts on a right-hand (recto) page.

Found during Phase 13 completion review (issue #98).

## Test results

```
cargo fmt --check   # pass
cargo clippy        # pass
cargo test          # all tests pass (render-html: 123, render-pdf: 156)
```

New/updated tests:
- `test_new_physical_page_generates_recto_break` — verifies CSS `break-before: recto`
- `test_new_physical_page_from_recto_inserts_blank` — verifies blank page insertion (3 pages)
- `test_new_physical_page_from_verso_no_extra_blank` — verifies no extra blank when already on verso (3 pages)

## Review summary

- 2 files changed, 46 insertions, 11 deletions
- Removed TODO comments and replaced with working implementations

Closes #493