### PR TITLE
Add missing Cargo.lock update for tempfile dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,9 @@ dependencies = [
 [[package]]
 name = "chordpro-core"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "chordpro-render-html"


### PR DESCRIPTION
## What

Commit the `Cargo.lock` update that was missed in #448.

## Why

PR #448 added `tempfile` as a dev-dependency to `chordpro-core` in `Cargo.toml` but did not include the corresponding `Cargo.lock` change. This leaves the working tree dirty (`M Cargo.lock`) after running any `cargo` command on a fresh checkout.

## Test results

```
cargo test  — all 1,149 tests pass
cargo clippy — no warnings
cargo fmt --check — clean
```

## Review summary

Single-file lockfile update, no code changes.

Closes #512