### PR TITLE
Validate config transpose value before f64-to-i8 cast

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -116,10 +116,21 @@ fn main() -> ExitCode {
 
     // Combine CLI --transpose with settings.transpose from config.
     // CLI flag takes additive precedence: final = config + CLI.
-    let config_transpose = config
+    let config_transpose_f64 = config
         .get_path("settings.transpose")
         .as_f64()
-        .unwrap_or(0.0) as i8;
+        .unwrap_or(0.0);
+    let config_transpose =
+        if config_transpose_f64 < f64::from(i8::MIN) || config_transpose_f64 > f64::from(i8::MAX) {
+            let clamped = config_transpose_f64.clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
+            eprintln!(
+                "warning: settings.transpose value {} is out of i8 range, clamped to {}",
+                config_transpose_f64, clamped
+            );
+            clamped
+        } else {
+            config_transpose_f64 as i8
+        };
     let (effective_transpose, saturated) =
         chordpro_core::transpose::combine_transpose(config_transpose, cli.transpose);
     if saturated {

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -350,6 +350,46 @@ fn test_config_transpose_combined_with_cli() {
 }
 
 #[test]
+fn test_config_transpose_out_of_range_positive() {
+    let mut config_file = NamedTempFile::new().unwrap();
+    write!(config_file, r#"{{ "settings": {{ "transpose": 300 }} }}"#).unwrap();
+    config_file.flush().unwrap();
+
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args([
+            "--config",
+            config_file.path().to_str().unwrap(),
+            &fixture("simple.cho"),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "warning: settings.transpose value 300 is out of i8 range, clamped to 127",
+        ));
+}
+
+#[test]
+fn test_config_transpose_out_of_range_negative() {
+    let mut config_file = NamedTempFile::new().unwrap();
+    write!(config_file, r#"{{ "settings": {{ "transpose": -200 }} }}"#).unwrap();
+    config_file.flush().unwrap();
+
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args([
+            "--config",
+            config_file.path().to_str().unwrap(),
+            &fixture("simple.cho"),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "warning: settings.transpose value -200 is out of i8 range, clamped to -128",
+        ));
+}
+
+#[test]
 fn test_no_default_configs() {
     Command::cargo_bin("chordpro")
         .unwrap()


### PR DESCRIPTION
## What

Add range validation when casting `settings.transpose` config value from `f64` to `i8` in the CLI. Out-of-range values are clamped to `i8::MIN..=i8::MAX` with a warning.

## Why

The `as i8` cast silently saturates out-of-range values (e.g., `300.0` → `127`). While the CLI `--transpose` flag is properly constrained by clap's `i8` parsing, config file values bypass this validation.

Found during Phase 13 completion gate review.

## Test results

```
cargo test --test cli test_config_transpose_out_of_range
running 2 tests
test test_config_transpose_out_of_range_negative ... ok
test test_config_transpose_out_of_range_positive ... ok
test result: ok. 2 passed; 0 failed
```

## Review summary

- Added range check before `f64` to `i8` cast in `crates/cli/src/main.rs`
- Emits warning to stderr when config value is out of range
- Two new integration tests covering positive and negative overflow

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)