### PR TITLE
Fix PDF ToC second pass using default margins instead of config

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -202,7 +202,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
     };
 
     // Phase 3: rebuild ToC with correct page numbers (offset by toc_page_count).
-    let mut toc_doc = PdfDocument::new();
+    let mut toc_doc = PdfDocument::from_config(config);
     toc_doc.text("Table of Contents", Font::HelveticaBold, TITLE_SIZE);
     toc_doc.newline(TITLE_SIZE + LINE_GAP * 2.0);
 
@@ -1433,6 +1433,7 @@ struct PdfDocument {
 
 impl PdfDocument {
     /// Create a new document with one empty page using default margins.
+    #[cfg(test)]
     fn new() -> Self {
         Self::with_margins(MARGIN_TOP, MARGIN_BOTTOM, MARGIN_LEFT, MARGIN_RIGHT)
     }
@@ -2962,6 +2963,24 @@ mod toc_tests {
         let bytes = render_songs(&songs);
         assert!(bytes.starts_with(b"%PDF-1.4"));
         assert!(bytes.ends_with(b"%%EOF\n"));
+    }
+
+    #[test]
+    fn test_toc_with_custom_margins_produces_valid_pdf() {
+        use chordpro_core::config::Config;
+        let songs =
+            chordpro_core::parse_multi("{title: Song A}\nA\n{new_song}\n{title: Song B}\nB")
+                .unwrap();
+        // Use large custom margins to exercise the from_config path in the ToC rebuild.
+        let config = Config::parse(
+            r#"{ "pdf": { "margintop": 100, "marginbottom": 100, "marginleft": 100, "marginright": 100 } }"#,
+        )
+        .unwrap();
+        let bytes = render_songs_with_transpose(&songs, 0, &config);
+        assert!(bytes.starts_with(b"%PDF-1.4"));
+        assert!(bytes.ends_with(b"%%EOF\n"));
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(content.contains("Table of Contents"));
     }
 }
 


### PR DESCRIPTION
## What

Change the ToC rebuild phase (Phase 3) in `render_songs_with_transpose` to use `PdfDocument::from_config(config)` instead of `PdfDocument::new()`.

## Why

The second ToC rendering pass created a `PdfDocument` with default margins, while the first pass (Phase 2) and body rendering (Phase 1) both used `from_config(config)`. If custom margins affect line spacing, the ToC could overflow to a different number of pages than calculated, causing incorrect page numbers.

Found during Phase 13 completion gate code review (Minor-8).

## Test results

```
cargo test -p chordpro-render-pdf toc
running 6 tests
test toc_tests::test_toc_not_generated_for_single_song ... ok
test toc_tests::test_toc_page_numbers_present ... ok
test toc_tests::test_toc_generated_for_multi_song ... ok
test toc_tests::test_toc_with_custom_margins_produces_valid_pdf ... ok
test multipage_tests::test_combined_toc_and_body_respects_max_limit ... ok
test toc_tests::test_toc_valid_pdf_structure ... ok
test result: ok. 6 passed; 0 failed
```

## Review summary

- Changed line 205: `PdfDocument::new()` → `PdfDocument::from_config(config)`
- Marked `PdfDocument::new()` as `#[cfg(test)]` since it's no longer used outside tests
- Added test with large custom margins to verify ToC consistency

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)