### PR TITLE
Fix triple newline between songs in text renderer

### DIFF
--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -145,11 +145,19 @@ pub fn render_songs(songs: &[Song]) -> String {
 /// Render multiple [`Song`]s to plain text with transposition.
 #[must_use]
 pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &Config) -> String {
-    songs
+    let mut parts: Vec<String> = songs
         .iter()
-        .map(|song| render_song_with_transpose(song, cli_transpose, config))
-        .collect::<Vec<_>>()
-        .join("\n\n")
+        .map(|song| {
+            render_song_with_transpose(song, cli_transpose, config)
+                .trim_end()
+                .to_string()
+        })
+        .collect();
+    // Ensure the final output ends with a newline.
+    if let Some(last) = parts.last_mut() {
+        last.push('\n');
+    }
+    parts.join("\n\n")
 }
 
 /// Parse a ChordPro source string and render it to plain text.
@@ -638,8 +646,13 @@ mod multi_song_tests {
         assert!(output.contains("Hello"));
         assert!(output.contains("Song Two"));
         assert!(output.contains("G\nWorld"));
-        // Two songs are separated by a blank line (double newline between them)
+        // Two songs are separated by exactly one blank line (double newline).
         assert!(output.contains("\n\n"));
+        // Must NOT contain triple newline.
+        assert!(
+            !output.contains("\n\n\n"),
+            "Should not have triple newline between songs"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Fix inter-song spacing in the text renderer's multi-song output from triple newline to double newline.

## Why

Each song ended with `\n` from `render_song`, and songs were joined with `\n\n`, producing `\n` + `\n\n` = three newlines between songs. This was unintentional extra whitespace.

Found during Phase 13 completion gate code review (Minor-4).

## Test results

```
cargo test -p chordpro-render-text
test result: ok. 65 passed; 0 failed; 0 ignored
```

## Review summary

- Trim trailing whitespace from each rendered song before joining
- Ensure final output still ends with a single newline
- Added assertion that triple newline does not appear between songs

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)