### PR TITLE
Add safety doc comments and platform notes for security-sensitive code

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -429,13 +429,19 @@ fn open_no_follow(path: &Path) -> Result<File, std::io::Error> {
     {
         use std::os::unix::fs::OpenOptionsExt;
         // O_NOFOLLOW value from POSIX / Linux headers. The constant is
-        // stable across Linux (0o400000), macOS/FreeBSD (0x0100).
+        // stable across Linux (0o400000) and macOS (0x0100).
+        // Note: chordpro-core has a zero-dependency policy, so we cannot
+        // use the `libc` crate for portable O_NOFOLLOW constants.
         #[cfg(target_os = "linux")]
         const O_NOFOLLOW: i32 = 0o400000;
         #[cfg(target_os = "macos")]
         const O_NOFOLLOW: i32 = 0x0100;
+        // On other Unix platforms (FreeBSD, OpenBSD, etc.) the O_NOFOLLOW
+        // value differs and we fall back to 0, which disables kernel-level
+        // symlink protection. The pre-open symlink_metadata() check in
+        // read_config_file() still provides TOCTOU-window-limited defense.
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-        const O_NOFOLLOW: i32 = 0; // fallback: no effect
+        const O_NOFOLLOW: i32 = 0;
 
         std::fs::OpenOptions::new()
             .read(true)

--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -19,6 +19,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// successfully). Returns `false` if the command is not found or cannot
 /// be executed.
 ///
+/// # Security
+///
+/// The `command` parameter is passed directly to [`std::process::Command::new`].
+/// Callers **must not** pass user-controlled or untrusted input as the command
+/// name, as this could lead to arbitrary command execution. This function is
+/// intended only for checking hardcoded tool names (e.g., `"lilypond"`,
+/// `"abc2svg"`).
+///
 /// # Examples
 ///
 /// ```no_run


### PR DESCRIPTION
## What

Add documentation improvements for security-sensitive code paths:
1. Add `# Security` doc section to `is_available()` warning against user-controlled input
2. Add detailed comment explaining `O_NOFOLLOW` fallback on non-Linux/macOS Unix

## Why

Found during Phase 13 completion gate reviews:
- SEC-09: `is_available()` is `pub` and could be misused with untrusted input
- Minor-1: `O_NOFOLLOW` fallback silently disables symlink protection on BSDs

## Test results

```
cargo test -p chordpro-core
test result: ok. 748 passed; 0 failed; 6 ignored
```

## Review summary

- Doc-only changes, no behavior modification
- `external_tool.rs`: Added `# Security` section to `is_available()`
- `config.rs`: Expanded O_NOFOLLOW fallback comment explaining zero-dep constraint

Closes #509
Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)