### PR TITLE
Replace eprintln! with structured warning mechanism in library crates

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -173,25 +173,41 @@ fn main() -> ExitCode {
     let combined_bytes;
 
     if is_binary {
-        combined_bytes = chordpro_render_pdf::render_songs_with_transpose(
+        let result = chordpro_render_pdf::render_songs_with_warnings(
             &all_songs,
             effective_transpose,
             &config,
         );
+        for w in &result.warnings {
+            eprintln!("warning: {w}");
+        }
+        combined_bytes = result.output;
         combined_text = String::new();
     } else {
         combined_bytes = Vec::new();
         combined_text = match cli.format {
-            Format::Text => chordpro_render_text::render_songs_with_transpose(
-                &all_songs,
-                effective_transpose,
-                &config,
-            ),
-            Format::Html => chordpro_render_html::render_songs_with_transpose(
-                &all_songs,
-                effective_transpose,
-                &config,
-            ),
+            Format::Text => {
+                let result = chordpro_render_text::render_songs_with_warnings(
+                    &all_songs,
+                    effective_transpose,
+                    &config,
+                );
+                for w in &result.warnings {
+                    eprintln!("warning: {w}");
+                }
+                result.output
+            }
+            Format::Html => {
+                let result = chordpro_render_html::render_songs_with_warnings(
+                    &all_songs,
+                    effective_transpose,
+                    &config,
+                );
+                for w in &result.warnings {
+                    eprintln!("warning: {w}");
+                }
+                result.output
+            }
             Format::Pdf => unreachable!(),
         };
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod image_path;
 pub mod inline_markup;
 pub mod lexer;
 pub mod parser;
+pub mod render_result;
 pub mod rrjson;
 pub mod selector;
 pub mod token;
@@ -23,6 +24,7 @@ pub use parser::{
     parse_lenient, parse_lenient_with_options, parse_multi, parse_multi_lenient,
     parse_multi_lenient_with_options, parse_multi_with_options, parse_with_options,
 };
+pub use render_result::RenderResult;
 pub use token::{Position, Span, Token, TokenKind};
 
 /// Returns the library version.

--- a/crates/core/src/render_result.rs
+++ b/crates/core/src/render_result.rs
@@ -1,0 +1,64 @@
+//! Structured render result type for capturing warnings during rendering.
+
+/// Result of a render operation, containing both the rendered output
+/// and any warnings produced during rendering.
+///
+/// Renderers collect warnings (e.g., transpose saturation, chorus recall
+/// limits) into [`warnings`](Self::warnings) instead of printing them
+/// directly. Callers can inspect and display warnings as they see fit.
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct RenderResult<T> {
+    /// The rendered output.
+    pub output: T,
+    /// Warnings emitted during rendering.
+    pub warnings: Vec<String>,
+}
+
+impl<T> RenderResult<T> {
+    /// Create a new `RenderResult` with the given output and no warnings.
+    pub fn new(output: T) -> Self {
+        Self {
+            output,
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Create a new `RenderResult` with the given output and warnings.
+    pub fn with_warnings(output: T, warnings: Vec<String>) -> Self {
+        Self { output, warnings }
+    }
+
+    /// Returns `true` if there are no warnings.
+    pub fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_has_no_warnings() {
+        let result = RenderResult::new("hello");
+        assert_eq!(result.output, "hello");
+        assert!(result.warnings.is_empty());
+        assert!(!result.has_warnings());
+    }
+
+    #[test]
+    fn test_with_warnings() {
+        let result = RenderResult::with_warnings("output", vec!["warning 1".to_string()]);
+        assert_eq!(result.output, "output");
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.has_warnings());
+    }
+
+    #[test]
+    fn test_with_empty_warnings() {
+        let result = RenderResult::with_warnings(42, Vec::new());
+        assert_eq!(result.output, 42);
+        assert!(!result.has_warnings());
+    }
+}

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -19,6 +19,7 @@ use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordpro_core::config::Config;
 use chordpro_core::escape::escape_xml as escape;
 use chordpro_core::inline_markup::{SpanAttributes, TextSpan};
+use chordpro_core::render_result::RenderResult;
 use chordpro_core::transpose::transpose_chord;
 
 /// Maximum number of chorus recall directives allowed per song.
@@ -131,8 +132,29 @@ pub fn render_song(song: &Song) -> String {
 ///
 /// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
 /// values, allowing the CLI `--transpose` flag to combine with in-file directives.
+///
+/// Warnings are printed to stderr via `eprintln!`. Use
+/// [`render_song_with_warnings`] to capture them programmatically.
 #[must_use]
 pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Config) -> String {
+    let result = render_song_with_warnings(song, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render a [`Song`] AST to an HTML5 document, returning warnings programmatically.
+///
+/// This is the structured variant of [`render_song_with_transpose`]. Instead
+/// of printing warnings to stderr, they are collected into
+/// [`RenderResult::warnings`].
+pub fn render_song_with_warnings(
+    song: &Song,
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<String> {
+    let mut warnings = Vec::new();
     let title = song.metadata.title.as_deref().unwrap_or("Untitled");
     let mut html = String::new();
     html.push_str(&format!(
@@ -142,9 +164,9 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
     html.push_str("<style>\n");
     html.push_str(CSS);
     html.push_str("</style>\n</head>\n<body>\n");
-    render_song_body(song, cli_transpose, config, &mut html);
+    render_song_body(song, cli_transpose, config, &mut html, &mut warnings);
     html.push_str("</body>\n</html>\n");
-    html
+    RenderResult::with_warnings(html, warnings)
 }
 
 /// Render the `<div class="song">...</div>` body for a single song into `html`.
@@ -152,7 +174,13 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
 /// This is the shared implementation used by both single-song and multi-song
 /// rendering. It appends directly to the provided buffer without any document
 /// wrapper (`<html>`, `<head>`, etc.).
-fn render_song_body(song: &Song, cli_transpose: i8, config: &Config, html: &mut String) {
+fn render_song_body(
+    song: &Song,
+    cli_transpose: i8,
+    config: &Config,
+    html: &mut String,
+    warnings: &mut Vec<String>,
+) {
     let _ = config;
     let mut transpose_offset: i8 = cli_transpose;
     let mut fmt_state = FormattingState::default();
@@ -239,10 +267,10 @@ fn render_song_body(song: &Song, cli_transpose: i8, config: &Config, html: &mut 
                     let (combined, saturated) =
                         chordpro_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
-                        eprintln!(
-                            "warning: transpose offset {file_offset} + {cli_transpose} \
+                        warnings.push(format!(
+                            "transpose offset {file_offset} + {cli_transpose} \
                              exceeds i8 range, clamped to {combined}"
-                        );
+                        ));
                     }
                     transpose_offset = combined;
                     continue;
@@ -270,10 +298,10 @@ fn render_song_body(song: &Song, cli_transpose: i8, config: &Config, html: &mut 
                             render_chorus_recall(&directive.value, &chorus_html, html);
                             chorus_recall_count += 1;
                         } else if chorus_recall_count == MAX_CHORUS_RECALLS {
-                            eprintln!(
-                                "warning: chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
+                            warnings.push(format!(
+                                "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
                                  further recalls suppressed"
-                            );
+                            ));
                             chorus_recall_count += 1;
                         }
                     }
@@ -391,13 +419,40 @@ pub fn render_songs(songs: &[Song]) -> String {
 /// When there is only one song, this is identical to [`render_song_with_transpose`].
 /// For multiple songs, the document uses the first song's title and separates
 /// each song with an `<hr class="song-separator">`.
+///
+/// Warnings are printed to stderr via `eprintln!`. Use
+/// [`render_songs_with_warnings`] to capture them programmatically.
 #[must_use]
 pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &Config) -> String {
+    let result = render_songs_with_warnings(songs, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render multiple [`Song`]s into a single HTML5 document, returning warnings
+/// programmatically.
+///
+/// This is the structured variant of [`render_songs_with_transpose`]. Instead
+/// of printing warnings to stderr, they are collected into
+/// [`RenderResult::warnings`].
+pub fn render_songs_with_warnings(
+    songs: &[Song],
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<String> {
+    let mut warnings = Vec::new();
     if songs.len() <= 1 {
-        return songs
+        let output = songs
             .first()
-            .map(|s| render_song_with_transpose(s, cli_transpose, config))
+            .map(|s| {
+                let r = render_song_with_warnings(s, cli_transpose, config);
+                warnings = r.warnings;
+                r.output
+            })
             .unwrap_or_default();
+        return RenderResult::with_warnings(output, warnings);
     }
     // Use the first song's title for the document
     let mut html = String::new();
@@ -417,11 +472,11 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
         if i > 0 {
             html.push_str("<hr class=\"song-separator\">\n");
         }
-        render_song_body(song, cli_transpose, config, &mut html);
+        render_song_body(song, cli_transpose, config, &mut html, &mut warnings);
     }
 
     html.push_str("</body>\n</html>\n");
-    html
+    RenderResult::with_warnings(html, warnings)
 }
 
 /// Parse a ChordPro source string and render it to HTML.

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -10,6 +10,7 @@
 use chordpro_core::ast::{CommentStyle, DirectiveKind, ImageAttributes, Line, LyricsLine, Song};
 use chordpro_core::config::Config;
 use chordpro_core::inline_markup::TextSpan;
+use chordpro_core::render_result::RenderResult;
 use chordpro_core::transpose::transpose_chord;
 
 use flate2::Compression;
@@ -138,11 +139,32 @@ pub fn render_song(song: &Song) -> Vec<u8> {
 ///
 /// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
 /// values, allowing the CLI `--transpose` flag to combine with in-file directives.
+///
+/// Warnings are printed to stderr via `eprintln!`. Use
+/// [`render_song_with_warnings`] to capture them programmatically.
 #[must_use]
 pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Config) -> Vec<u8> {
-    let mut doc = PdfDocument::from_config(config);
-    render_song_into_doc(song, cli_transpose, &mut doc);
-    doc.build_pdf()
+    let result = render_song_with_warnings(song, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render a [`Song`] AST to PDF bytes, returning warnings programmatically.
+///
+/// This is the structured variant of [`render_song_with_transpose`]. Instead
+/// of printing warnings to stderr, they are collected into
+/// [`RenderResult::warnings`].
+pub fn render_song_with_warnings(
+    song: &Song,
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<Vec<u8>> {
+    let mut warnings = Vec::new();
+    let mut doc = PdfDocument::from_config_with_warnings(config, &mut warnings);
+    render_song_into_doc(song, cli_transpose, &mut doc, &mut warnings);
+    RenderResult::with_warnings(doc.build_pdf(), warnings)
 }
 
 /// Render multiple [`Song`]s into a single multi-page PDF document.
@@ -158,14 +180,38 @@ pub fn render_songs(songs: &[Song]) -> Vec<u8> {
 /// Each song starts on a new page (except the first). When there are two or
 /// more songs, a Table of Contents page is prepended with song titles and
 /// page numbers.
+///
+/// Warnings are printed to stderr via `eprintln!`. Use
+/// [`render_songs_with_warnings`] to capture them programmatically.
 #[must_use]
 pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &Config) -> Vec<u8> {
+    let result = render_songs_with_warnings(songs, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render multiple [`Song`]s into a single PDF, returning warnings programmatically.
+///
+/// This is the structured variant of [`render_songs_with_transpose`]. Instead
+/// of printing warnings to stderr, they are collected into
+/// [`RenderResult::warnings`].
+pub fn render_songs_with_warnings(
+    songs: &[Song],
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<Vec<u8>> {
+    let mut warnings = Vec::new();
+
     if songs.len() == 1 {
-        return render_song_with_transpose(&songs[0], cli_transpose, config);
+        let mut doc = PdfDocument::from_config_with_warnings(config, &mut warnings);
+        render_song_into_doc(&songs[0], cli_transpose, &mut doc, &mut warnings);
+        return RenderResult::with_warnings(doc.build_pdf(), warnings);
     }
 
     // Phase 1: render all songs and record which page each starts on.
-    let mut body_doc = PdfDocument::from_config(config);
+    let mut body_doc = PdfDocument::from_config_with_warnings(config, &mut warnings);
     let mut toc_entries: Vec<(String, usize)> = Vec::new(); // (title, page_index)
 
     for (i, song) in songs.iter().enumerate() {
@@ -180,11 +226,11 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
             .unwrap_or("Untitled")
             .to_string();
         toc_entries.push((title, start_page));
-        render_song_into_doc(song, cli_transpose, &mut body_doc);
+        render_song_into_doc(song, cli_transpose, &mut body_doc, &mut warnings);
     }
 
     // Phase 2: generate ToC pages.
-    let mut toc_doc = PdfDocument::from_config(config);
+    let mut toc_doc = PdfDocument::from_config_with_warnings(config, &mut warnings);
     toc_doc.text("Table of Contents", Font::HelveticaBold, TITLE_SIZE);
     toc_doc.newline(TITLE_SIZE + LINE_GAP * 2.0);
 
@@ -202,7 +248,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
     };
 
     // Phase 3: rebuild ToC with correct page numbers (offset by toc_page_count).
-    let mut toc_doc = PdfDocument::from_config(config);
+    let mut toc_doc = PdfDocument::from_config_with_warnings(config, &mut warnings);
     toc_doc.text("Table of Contents", Font::HelveticaBold, TITLE_SIZE);
     toc_doc.newline(TITLE_SIZE + LINE_GAP * 2.0);
 
@@ -230,7 +276,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
         combined.push_page(page_ops);
     }
 
-    combined.build_pdf()
+    RenderResult::with_warnings(combined.build_pdf(), warnings)
 }
 
 /// Render a single song's content into an existing [`PdfDocument`].
@@ -238,7 +284,12 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
 /// This is the shared implementation used by both [`render_song_with_transpose`]
 /// and [`render_songs_with_transpose`]. It does not call `build_pdf`; the caller
 /// is responsible for finalising the document.
-fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
+fn render_song_into_doc(
+    song: &Song,
+    cli_transpose: i8,
+    doc: &mut PdfDocument,
+    warnings: &mut Vec<String>,
+) {
     let mut transpose_offset: i8 = cli_transpose;
     let mut fmt_state = PdfFormattingState::default();
 
@@ -280,10 +331,10 @@ fn render_song_into_doc(song: &Song, cli_transpose: i8, doc: &mut PdfDocument) {
                     let (combined, saturated) =
                         chordpro_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
-                        eprintln!(
-                            "warning: transpose offset {file_offset} + {cli_transpose} \
+                        warnings.push(format!(
+                            "transpose offset {file_offset} + {cli_transpose} \
                              exceeds i8 range, clamped to {combined}"
-                        );
+                        ));
                     }
                     transpose_offset = combined;
                     continue;
@@ -1472,9 +1523,11 @@ impl PdfDocument {
 
     /// Validate and clamp a margin value. Returns the default if the value is
     /// negative, non-finite, or exceeds `MAX_MARGIN`.
-    fn validate_margin(value: f32, default: f32, name: &str) -> f32 {
+    fn validate_margin(value: f32, default: f32, name: &str, warnings: &mut Vec<String>) -> f32 {
         if !value.is_finite() || !(0.0..=Self::MAX_MARGIN).contains(&value) {
-            eprintln!("warning: invalid pdf.margins.{name} value {value}, using default {default}");
+            warnings.push(format!(
+                "invalid pdf.margins.{name} value {value}, using default {default}"
+            ));
             default
         } else {
             value
@@ -1482,26 +1535,40 @@ impl PdfDocument {
     }
 
     /// Create a new document reading margins from config.
+    ///
+    /// Warnings are printed to stderr. Use [`from_config_with_warnings`](Self::from_config_with_warnings)
+    /// to capture them programmatically.
+    #[cfg(test)]
     fn from_config(config: &Config) -> Self {
+        let mut warnings = Vec::new();
+        let doc = Self::from_config_with_warnings(config, &mut warnings);
+        for w in &warnings {
+            eprintln!("warning: {w}");
+        }
+        doc
+    }
+
+    /// Create a new document reading margins from config, collecting warnings.
+    fn from_config_with_warnings(config: &Config, warnings: &mut Vec<String>) -> Self {
         let top = config
             .get_path("pdf.margins.top")
             .as_f64()
-            .map(|v| Self::validate_margin(v as f32, MARGIN_TOP, "top"))
+            .map(|v| Self::validate_margin(v as f32, MARGIN_TOP, "top", warnings))
             .unwrap_or(MARGIN_TOP);
         let bottom = config
             .get_path("pdf.margins.bottom")
             .as_f64()
-            .map(|v| Self::validate_margin(v as f32, MARGIN_BOTTOM, "bottom"))
+            .map(|v| Self::validate_margin(v as f32, MARGIN_BOTTOM, "bottom", warnings))
             .unwrap_or(MARGIN_BOTTOM);
         let left = config
             .get_path("pdf.margins.left")
             .as_f64()
-            .map(|v| Self::validate_margin(v as f32, MARGIN_LEFT, "left"))
+            .map(|v| Self::validate_margin(v as f32, MARGIN_LEFT, "left", warnings))
             .unwrap_or(MARGIN_LEFT);
         let right = config
             .get_path("pdf.margins.right")
             .as_f64()
-            .map(|v| Self::validate_margin(v as f32, MARGIN_RIGHT, "right"))
+            .map(|v| Self::validate_margin(v as f32, MARGIN_RIGHT, "right", warnings))
             .unwrap_or(MARGIN_RIGHT);
         Self::with_margins(top, bottom, left, right)
     }
@@ -2921,7 +2988,8 @@ mod column_tests {
     fn test_render_song_into_doc_helper() {
         let song = chordpro_core::parse("{title: Test}\n[Am]Hello").unwrap();
         let mut doc = PdfDocument::new();
-        render_song_into_doc(&song, 0, &mut doc);
+        let mut warnings = Vec::new();
+        render_song_into_doc(&song, 0, &mut doc, &mut warnings);
         // Document should have 1 page with content
         assert_eq!(doc.page_count(), 1);
         let pdf = doc.build_pdf();

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -5,6 +5,7 @@
 
 use chordpro_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordpro_core::config::Config;
+use chordpro_core::render_result::RenderResult;
 use chordpro_core::transpose::transpose_chord;
 use unicode_width::UnicodeWidthStr;
 
@@ -35,8 +36,40 @@ pub fn render_song(song: &Song) -> String {
 ///
 /// The `cli_transpose` parameter is added to any in-file `{transpose}` directive
 /// values, allowing the CLI `--transpose` flag to combine with in-file directives.
+///
+/// Warnings are printed to stderr via `eprintln!`. Use
+/// [`render_song_with_warnings`] to capture them programmatically.
 #[must_use]
 pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Config) -> String {
+    let result = render_song_with_warnings(song, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render a [`Song`] AST to plain text, returning warnings programmatically.
+///
+/// This is the structured variant of [`render_song_with_transpose`]. Instead
+/// of printing warnings to stderr, they are collected into
+/// [`RenderResult::warnings`].
+pub fn render_song_with_warnings(
+    song: &Song,
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<String> {
+    let mut warnings = Vec::new();
+    let output = render_song_impl(song, cli_transpose, config, &mut warnings);
+    RenderResult::with_warnings(output, warnings)
+}
+
+/// Internal implementation that renders a song and collects warnings.
+fn render_song_impl(
+    song: &Song,
+    cli_transpose: i8,
+    config: &Config,
+    warnings: &mut Vec<String>,
+) -> String {
     // Config is plumbed through for future use (e.g., suppress_empty_chords).
     let _ = config;
     let mut output = Vec::new();
@@ -76,10 +109,10 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                     let (combined, saturated) =
                         chordpro_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
-                        eprintln!(
-                            "warning: transpose offset {file_offset} + {cli_transpose} \
+                        warnings.push(format!(
+                            "transpose offset {file_offset} + {cli_transpose} \
                              exceeds i8 range, clamped to {combined}"
-                        );
+                        ));
                     }
                     transpose_offset = combined;
                     continue;
@@ -102,10 +135,10 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
                             render_chorus_recall(&directive.value, &chorus_lines, &mut output);
                             chorus_recall_count += 1;
                         } else if chorus_recall_count == MAX_CHORUS_RECALLS {
-                            eprintln!(
-                                "warning: chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
+                            warnings.push(format!(
+                                "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
                                  further recalls suppressed"
-                            );
+                            ));
                             chorus_recall_count += 1;
                         }
                     }
@@ -157,12 +190,33 @@ pub fn render_songs(songs: &[Song]) -> String {
 }
 
 /// Render multiple [`Song`]s to plain text with transposition.
+///
+/// Warnings are printed to stderr via `eprintln!`. Use
+/// [`render_songs_with_warnings`] to capture them programmatically.
 #[must_use]
 pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &Config) -> String {
+    let result = render_songs_with_warnings(songs, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render multiple [`Song`]s to plain text, returning warnings programmatically.
+///
+/// This is the structured variant of [`render_songs_with_transpose`]. Instead
+/// of printing warnings to stderr, they are collected into
+/// [`RenderResult::warnings`].
+pub fn render_songs_with_warnings(
+    songs: &[Song],
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<String> {
+    let mut warnings = Vec::new();
     let mut parts: Vec<String> = songs
         .iter()
         .map(|song| {
-            render_song_with_transpose(song, cli_transpose, config)
+            render_song_impl(song, cli_transpose, config, &mut warnings)
                 .trim_end()
                 .to_string()
         })
@@ -171,7 +225,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
     if let Some(last) = parts.last_mut() {
         last.push('\n');
     }
-    parts.join("\n\n")
+    RenderResult::with_warnings(parts.join("\n\n"), warnings)
 }
 
 /// Parse a ChordPro source string and render it to plain text.


### PR DESCRIPTION
## What

Add a `RenderResult<T>` type to `chordpro-core` and `_with_warnings` variants to all three renderer crates (text, HTML, PDF). This allows library consumers to access render warnings programmatically instead of having them printed to stderr.

## Why

The renderers previously used `eprintln!` to emit warnings (transpose saturation, chorus recall limits, invalid PDF margins). This is problematic for library consumers who cannot capture or suppress stderr output. A structured warning mechanism gives callers full control over how warnings are handled.

## Changes

- **`chordpro-core`**: New `render_result` module with `RenderResult<T>` struct containing `output: T` and `warnings: Vec<String>`. Re-exported from the crate root.
- **`chordpro-render-text`**: Added `render_song_with_warnings()` and `render_songs_with_warnings()`. Existing `_with_transpose` functions remain backward-compatible (print warnings to stderr).
- **`chordpro-render-html`**: Same pattern. Internal `render_song_body()` now accepts `&mut Vec<String>` for warnings.
- **`chordpro-render-pdf`**: Same pattern. `validate_margin()` and `from_config_with_warnings()` collect warnings instead of printing. `render_song_into_doc()` now accepts `&mut Vec<String>`.
- **CLI**: Updated to use `_with_warnings` variants and print warnings to stderr.

All 6 `eprintln!` calls in the renderer crates have been replaced with structured warning collection. The backward-compatible wrapper functions still print to stderr for existing API users.

## Test results

```
cargo fmt --check  # pass
cargo clippy -- -D warnings  # pass
cargo test  # all tests pass
```

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)