### PR TITLE
Implement song-level {+config.KEY: VALUE} runtime directive

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -398,3 +398,30 @@ fn test_no_default_configs() {
         .success()
         .stdout(predicate::str::contains("Hello world"));
 }
+
+// --- Song-level config overrides ---
+
+#[test]
+fn test_song_config_override_transpose() {
+    // {+config.settings.transpose: 2} should transpose G→A and C→D
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .arg(fixture("config-override.cho"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("A     D"))
+        .stdout(predicate::str::contains("Hello world"));
+}
+
+#[test]
+fn test_song_config_override_combined_with_cli_transpose() {
+    // Song has {+config.settings.transpose: 2}, CLI adds --transpose 1
+    // Total = 3 semitones: G→A# and C→D#
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args([&fixture("config-override.cho"), "--transpose", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("A#"))
+        .stdout(predicate::str::contains("Hello world"));
+}

--- a/crates/cli/tests/fixtures/config-override.cho
+++ b/crates/cli/tests/fixtures/config-override.cho
@@ -1,0 +1,4 @@
+{title: Config Override Song}
+{+config.settings.transpose: 2}
+
+[G]Hello [C]world

--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -62,6 +62,29 @@ impl Song {
         }
     }
 
+    /// Extracts `{+config.KEY: VALUE}` overrides from this song's directives.
+    ///
+    /// Returns a list of `(key, value)` pairs in directive order. The key is
+    /// the dot-separated config path (e.g., `"pdf.chorus.indent"`), and the
+    /// value is the raw string from the directive.
+    ///
+    /// These overrides are scoped to this song and should not leak to other
+    /// songs in a multi-song file.
+    #[must_use]
+    pub fn config_overrides(&self) -> Vec<(&str, &str)> {
+        let mut overrides = Vec::new();
+        for line in &self.lines {
+            if let Line::Directive(directive) = line {
+                if let DirectiveKind::ConfigOverride(ref key) = directive.kind {
+                    if let Some(ref value) = directive.value {
+                        overrides.push((key.as_str(), value.as_str()));
+                    }
+                }
+            }
+        }
+        overrides
+    }
+
     /// Resolves `{define}` display and format attributes to matching chords.
     ///
     /// Scans all `{define}` directives in the song, collecting `display` and
@@ -955,6 +978,14 @@ pub enum DirectiveKind {
     /// `{image: src=filename}` — embeds an image with optional attributes.
     Image(ImageAttributes),
 
+    // -- Config override directives -----------------------------------------
+    /// `{+config.KEY: VALUE}` — overrides a configuration value for this song.
+    ///
+    /// The contained `String` is the dot-separated config key path
+    /// (e.g., `"pdf.chorus.indent"`). The directive value holds the new
+    /// setting (e.g., `"20"`).
+    ConfigOverride(String),
+
     // -- Unknown ------------------------------------------------------------
     /// A directive not recognized as a standard ChordPro directive.
     /// The original directive name (lowercased) is preserved.
@@ -1078,6 +1109,12 @@ impl DirectiveKind {
 
             // Custom sections (start_of_X / end_of_X)
             other => {
+                // Config override: {+config.KEY: VALUE}
+                if let Some(key) = other.strip_prefix("+config.") {
+                    if !key.is_empty() {
+                        return Self::ConfigOverride(key.to_string());
+                    }
+                }
                 if let Some(section) = other.strip_prefix("start_of_") {
                     if !section.is_empty() {
                         return Self::StartOfSection(section.to_string());
@@ -1234,6 +1271,7 @@ impl DirectiveKind {
             Self::Meta(_) => "meta",
 
             Self::Image(_) => "image",
+            Self::ConfigOverride(key) => key.as_str(),
             Self::StartOfSection(name) | Self::EndOfSection(name) | Self::Unknown(name) => {
                 name.as_str()
             }
@@ -1250,6 +1288,7 @@ impl DirectiveKind {
         match self {
             Self::StartOfSection(name) => format!("start_of_{name}"),
             Self::EndOfSection(name) => format!("end_of_{name}"),
+            Self::ConfigOverride(key) => format!("+config.{key}"),
             _ => self.canonical_name().to_string(),
         }
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -272,6 +272,36 @@ impl Config {
         }
     }
 
+    /// Apply song-level config overrides from `{+config.KEY: VALUE}` directives.
+    ///
+    /// Returns a new `Config` with the overrides applied, plus any warnings
+    /// (e.g., blocked delegate keys). Security-sensitive keys under
+    /// `delegates.*` are blocked and produce a warning.
+    #[must_use]
+    pub fn with_song_overrides(
+        self,
+        overrides: &[(&str, &str)],
+        warnings: &mut Vec<String>,
+    ) -> Self {
+        /// Keys that cannot be set from song-level config directives.
+        const BLOCKED_PREFIXES: &[&str] = &["delegates."];
+
+        let mut config = self;
+        for &(key, value) in overrides {
+            if BLOCKED_PREFIXES
+                .iter()
+                .any(|prefix| key.starts_with(prefix))
+            {
+                warnings.push(format!(
+                    "{key} cannot be overridden from a song-level config directive"
+                ));
+                continue;
+            }
+            config = config.with_define(&format!("{key}={value}"));
+        }
+        config
+    }
+
     /// Build a configuration by loading and merging from all sources.
     ///
     /// Loads: defaults → system → user → project → song-specific.
@@ -1208,5 +1238,77 @@ mod tests {
 
         // A relative path should be ignored; result should be the fallback.
         assert_ne!(result, Some(PathBuf::from("relative/path")));
+    }
+
+    // -- with_song_overrides tests --------------------------------------------
+
+    #[test]
+    fn test_song_overrides_apply() {
+        let config = Config::defaults();
+        let mut warnings = Vec::new();
+        let overrides = vec![("pdf.margins.top", "100")];
+        let config = config.with_song_overrides(&overrides, &mut warnings);
+        assert_eq!(config.get_path("pdf.margins.top"), &Value::Number(100.0));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_song_overrides_multiple() {
+        let config = Config::defaults();
+        let mut warnings = Vec::new();
+        let overrides = vec![("pdf.margins.top", "100"), ("settings.transpose", "3")];
+        let config = config.with_song_overrides(&overrides, &mut warnings);
+        assert_eq!(config.get_path("pdf.margins.top"), &Value::Number(100.0));
+        assert_eq!(config.get_path("settings.transpose"), &Value::Number(3.0));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_song_overrides_block_delegates() {
+        let config = Config::defaults();
+        let mut warnings = Vec::new();
+        let overrides = vec![
+            ("delegates.abc2svg", "true"),
+            ("delegates.lilypond", "true"),
+        ];
+        let config = config.with_song_overrides(&overrides, &mut warnings);
+        // Delegate keys should remain at their default (false)
+        assert_eq!(config.get_path("delegates.abc2svg"), &Value::Bool(false));
+        assert_eq!(config.get_path("delegates.lilypond"), &Value::Bool(false));
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings[0].contains("delegates.abc2svg"));
+        assert!(warnings[1].contains("delegates.lilypond"));
+    }
+
+    #[test]
+    fn test_song_overrides_empty_is_noop() {
+        let config = Config::defaults();
+        let original_top = config.get_path("pdf.margins.top").clone();
+        let mut warnings = Vec::new();
+        let config = config.with_song_overrides(&[], &mut warnings);
+        assert_eq!(config.get_path("pdf.margins.top"), &original_top);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_song_overrides_do_not_persist_across_songs() {
+        let base = Config::defaults();
+        let mut warnings = Vec::new();
+
+        // Song 1 overrides margins
+        let song1_config = base
+            .clone()
+            .with_song_overrides(&[("pdf.margins.top", "100")], &mut warnings);
+        assert_eq!(
+            song1_config.get_path("pdf.margins.top"),
+            &Value::Number(100.0)
+        );
+
+        // Song 2 uses the same base config — should NOT see song 1's override
+        let song2_config = base.clone().with_song_overrides(&[], &mut warnings);
+        assert_eq!(
+            song2_config.get_path("pdf.margins.top"),
+            &Value::Number(56.0)
+        );
     }
 }

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -3791,4 +3791,102 @@ mod delegate_tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 2);
     }
+
+    // -- Config override directives -------------------------------------------
+
+    #[test]
+    fn config_override_basic() {
+        let result = lines("{+config.pdf.margins.top: 100}");
+        if let Line::Directive(ref d) = result[0] {
+            assert_eq!(
+                d.kind,
+                DirectiveKind::ConfigOverride("pdf.margins.top".to_string())
+            );
+            assert_eq!(d.value.as_deref(), Some("100"));
+            assert_eq!(d.name, "+config.pdf.margins.top");
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    #[test]
+    fn config_override_string_value() {
+        let result = lines("{+config.pdf.theme.foreground: blue}");
+        if let Line::Directive(ref d) = result[0] {
+            assert_eq!(
+                d.kind,
+                DirectiveKind::ConfigOverride("pdf.theme.foreground".to_string())
+            );
+            assert_eq!(d.value.as_deref(), Some("blue"));
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    #[test]
+    fn config_override_no_value() {
+        let result = lines("{+config.settings.lyrics_only}");
+        if let Line::Directive(ref d) = result[0] {
+            assert_eq!(
+                d.kind,
+                DirectiveKind::ConfigOverride("settings.lyrics_only".to_string())
+            );
+            assert_eq!(d.value, None);
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    #[test]
+    fn config_override_case_insensitive() {
+        let result = lines("{+Config.PDF.Margins.Top: 50}");
+        if let Line::Directive(ref d) = result[0] {
+            assert_eq!(
+                d.kind,
+                DirectiveKind::ConfigOverride("pdf.margins.top".to_string())
+            );
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    #[test]
+    fn bare_plus_config_is_unknown() {
+        // {+config} without a dot-separated key is Unknown
+        let result = lines("{+config: something}");
+        if let Line::Directive(ref d) = result[0] {
+            assert!(matches!(d.kind, DirectiveKind::Unknown(_)));
+        } else {
+            panic!("expected directive");
+        }
+    }
+
+    #[test]
+    fn config_overrides_extracted_from_song() {
+        let song = crate::parse(
+            "{title: Test}\n{+config.pdf.margins.top: 100}\n{+config.settings.transpose: 2}\n",
+        )
+        .unwrap();
+        let overrides = song.config_overrides();
+        assert_eq!(overrides.len(), 2);
+        assert_eq!(overrides[0], ("pdf.margins.top", "100"));
+        assert_eq!(overrides[1], ("settings.transpose", "2"));
+    }
+
+    #[test]
+    fn config_overrides_empty_when_none() {
+        let song = crate::parse("{title: Test}\n[G]Hello\n").unwrap();
+        assert!(song.config_overrides().is_empty());
+    }
+
+    #[test]
+    fn config_overrides_not_in_multi_song_leak() {
+        let songs = crate::parse_multi(
+            "{title: A}\n{+config.settings.transpose: 5}\n{new_song}\n{title: B}\n",
+        )
+        .unwrap();
+        assert_eq!(songs.len(), 2);
+        assert_eq!(songs[0].config_overrides().len(), 1);
+        assert!(songs[1].config_overrides().is_empty());
+    }
 }

--- a/crates/core/tests/fixtures/config-override/expected.txt
+++ b/crates/core/tests/fixtures/config-override/expected.txt
@@ -1,0 +1,104 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Config Override Test",
+        ),
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Config Override Test",
+                ),
+                kind: Title,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "+config.pdf.margins.top",
+                value: Some(
+                    "100",
+                ),
+                kind: ConfigOverride(
+                    "pdf.margins.top",
+                ),
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "+config.settings.transpose",
+                value: Some(
+                    "2",
+                ),
+                kind: ConfigOverride(
+                    "settings.transpose",
+                ),
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "G",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: G,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "Hello ",
+                        spans: [],
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "C",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: C,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "world",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/config-override/input.cho
+++ b/crates/core/tests/fixtures/config-override/input.cho
@@ -1,0 +1,4 @@
+{title: Config Override Test}
+{+config.pdf.margins.top: 100}
+{+config.settings.transpose: 2}
+[G]Hello [C]world

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -28,6 +28,23 @@ use chordpro_core::transpose::transpose_chord;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
+/// Extract the transpose delta from song-level config overrides.
+///
+/// Parses `settings.transpose` from the override list. Returns `0` if the
+/// key is absent or the value is not a valid number.
+fn song_transpose_delta(overrides: &[(&str, &str)]) -> i8 {
+    for &(key, value) in overrides.iter().rev() {
+        if key == "settings.transpose" {
+            return value
+                .trim()
+                .parse::<f64>()
+                .unwrap_or(0.0)
+                .clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
+        }
+    }
+    0
+}
+
 /// Maximum number of CSS columns allowed.
 /// Matches `MAX_COLUMNS` in the PDF renderer.
 const MAX_COLUMNS: u32 = 32;
@@ -184,8 +201,23 @@ fn render_song_body(
     html: &mut String,
     warnings: &mut Vec<String>,
 ) {
-    let _ = config;
-    let mut transpose_offset: i8 = cli_transpose;
+    // Apply song-level config overrides ({+config.KEY: VALUE} directives).
+    let song_overrides = song.config_overrides();
+    let song_config;
+    let config = if song_overrides.is_empty() {
+        config
+    } else {
+        song_config = config
+            .clone()
+            .with_song_overrides(&song_overrides, warnings);
+        &song_config
+    };
+    // Extract song-level transpose delta from {+config.settings.transpose}.
+    // The base config transpose is already folded into cli_transpose by the caller.
+    let song_transpose_delta = song_transpose_delta(&song_overrides);
+    let (combined_transpose, _) =
+        chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);
+    let mut transpose_offset: i8 = combined_transpose;
     let mut fmt_state = FormattingState::default();
     html.push_str("<div class=\"song\">\n");
 

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -63,6 +63,23 @@ impl PdfFormattingState {
     }
 }
 
+/// Extract the transpose delta from song-level config overrides.
+///
+/// Parses `settings.transpose` from the override list. Returns `0` if the
+/// key is absent or the value is not a valid number.
+fn song_transpose_delta(overrides: &[(&str, &str)]) -> i8 {
+    for &(key, value) in overrides.iter().rev() {
+        if key == "settings.transpose" {
+            return value
+                .trim()
+                .parse::<f64>()
+                .unwrap_or(0.0)
+                .clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
+        }
+    }
+    0
+}
+
 // ---------------------------------------------------------------------------
 // Layout constants (units: PDF points, 1 pt = 1/72 inch)
 // ---------------------------------------------------------------------------
@@ -205,7 +222,18 @@ pub fn render_songs_with_warnings(
     let mut warnings = Vec::new();
 
     if songs.len() == 1 {
-        let mut doc = PdfDocument::from_config_with_warnings(config, &mut warnings);
+        // Apply song-level config overrides before creating the document.
+        let song_overrides = songs[0].config_overrides();
+        let song_config;
+        let effective_config = if song_overrides.is_empty() {
+            config
+        } else {
+            song_config = config
+                .clone()
+                .with_song_overrides(&song_overrides, &mut warnings);
+            &song_config
+        };
+        let mut doc = PdfDocument::from_config_with_warnings(effective_config, &mut warnings);
         render_song_into_doc(&songs[0], cli_transpose, &mut doc, &mut warnings);
         return RenderResult::with_warnings(doc.build_pdf(), warnings);
     }
@@ -290,7 +318,13 @@ fn render_song_into_doc(
     doc: &mut PdfDocument,
     warnings: &mut Vec<String>,
 ) {
-    let mut transpose_offset: i8 = cli_transpose;
+    // Extract song-level transpose delta from {+config.settings.transpose}.
+    // The base config transpose is already folded into cli_transpose by the caller.
+    let song_overrides = song.config_overrides();
+    let song_transpose_delta = song_transpose_delta(&song_overrides);
+    let (combined_transpose, _) =
+        chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);
+    let mut transpose_offset: i8 = combined_transpose;
     let mut fmt_state = PdfFormattingState::default();
 
     // Title

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -13,6 +13,23 @@ use unicode_width::UnicodeWidthStr;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
+/// Extract the transpose delta from song-level config overrides.
+///
+/// Parses `settings.transpose` from the override list. Returns `0` if the
+/// key is absent or the value is not a valid number.
+fn song_transpose_delta(overrides: &[(&str, &str)]) -> i8 {
+    for &(key, value) in overrides.iter().rev() {
+        if key == "settings.transpose" {
+            return value
+                .trim()
+                .parse::<f64>()
+                .unwrap_or(0.0)
+                .clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
+        }
+    }
+    0
+}
+
 /// Render a [`Song`] AST to plain text.
 ///
 /// The output format:
@@ -70,10 +87,24 @@ fn render_song_impl(
     config: &Config,
     warnings: &mut Vec<String>,
 ) -> String {
-    // Config is plumbed through for future use (e.g., suppress_empty_chords).
-    let _ = config;
+    // Apply song-level config overrides ({+config.KEY: VALUE} directives).
+    let song_overrides = song.config_overrides();
+    let song_config;
+    let _config = if song_overrides.is_empty() {
+        config
+    } else {
+        song_config = config
+            .clone()
+            .with_song_overrides(&song_overrides, warnings);
+        &song_config
+    };
+    // Extract song-level transpose delta from {+config.settings.transpose}.
+    // The base config transpose is already folded into cli_transpose by the caller.
+    let song_transpose_delta = song_transpose_delta(&song_overrides);
     let mut output = Vec::new();
-    let mut transpose_offset: i8 = cli_transpose;
+    let (combined_transpose, _) =
+        chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);
+    let mut transpose_offset: i8 = combined_transpose;
     // Stores the rendered text lines of the most recently defined chorus,
     // excluding the "[Chorus]" header itself. Used by `{chorus}` recall.
     let mut chorus_lines: Vec<String> = Vec::new();


### PR DESCRIPTION
## What

Add support for the `{+config.KEY: VALUE}` directive, allowing songs to override
configuration values inline. This was the last missing acceptance criterion for
Phase 13 (Configuration File System).

### Changes

- **AST**: New `DirectiveKind::ConfigOverride(String)` variant
- **Parser**: Recognizes `{+config.KEY: VALUE}` syntax (case-insensitive)
- **Song**: `config_overrides()` method extracts key-value pairs
- **Config**: `with_song_overrides()` applies overrides with delegate security blocking
- **Renderers**: Text, HTML, and PDF renderers apply song-level config transpose
- **Security**: `delegates.*` keys are blocked from song-level overrides

### Design

- Overrides are scoped per-song and do not leak to other songs in multi-song files
- Song-level `settings.transpose` is additive with CLI `--transpose` and config transpose
- For single-song PDF, margin overrides are applied before document creation
- Delegate keys (`delegates.abc2svg`, `delegates.lilypond`) cannot be enabled from songs

## Why

Completes Phase 13 acceptance criteria: "Song-level `{+config.key:value}` runtime directives".

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all 1182 tests pass)
```

### New tests

- Parser: 8 tests (basic parsing, string values, no-value, case-insensitive, bare +config, extraction, empty, multi-song isolation)
- Config: 5 tests (apply, multiple, blocked delegates, empty noop, cross-song isolation)
- Golden: 1 test (config-override fixture)
- CLI integration: 2 tests (song transpose, combined with CLI transpose)

## Review summary

First PR for Phase 13 completion gate (koedame/chordpro-rs#98).

Closes #538