### PR TITLE
Improve Config API: collect warnings in resolve() and return errors from with_define()

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -82,7 +82,12 @@ fn main() -> ExitCode {
     // Apply --config files/presets in order (preset names resolved first)
     for config_name in &cli.configs {
         match chordpro_core::config::Config::resolve(config_name) {
-            Ok(overlay) => config = config.merge(overlay),
+            Ok(result) => {
+                for warning in &result.warnings {
+                    eprintln!("warning: {config_name}: {warning}");
+                }
+                config = config.merge(result.config);
+            }
             Err(e) => {
                 eprintln!("error: {e}");
                 return ExitCode::FAILURE;
@@ -94,25 +99,25 @@ fn main() -> ExitCode {
     // This runs after user configs but before --define, so explicit
     // --define delegates.abc2svg=false can still override.
     if chordpro_core::external_tool::has_abc2svg() {
-        config = config.with_define("delegates.abc2svg=true");
+        // Hardcoded key=value — unwrap is safe.
+        config = config
+            .with_define("delegates.abc2svg=true")
+            .expect("hardcoded define is valid");
     }
     if chordpro_core::external_tool::has_lilypond() {
-        config = config.with_define("delegates.lilypond=true");
+        // Hardcoded key=value — unwrap is safe.
+        config = config
+            .with_define("delegates.lilypond=true")
+            .expect("hardcoded define is valid");
     }
 
     // Apply --define overrides (highest precedence)
     for define in &cli.defines {
-        match define.split_once('=') {
-            None => {
-                eprintln!("error: invalid --define syntax: {define} (expected key=value)");
+        match config.with_define(define) {
+            Ok(updated) => config = updated,
+            Err(e) => {
+                eprintln!("error: invalid --define: {define} ({e})");
                 return ExitCode::FAILURE;
-            }
-            Some((key, _)) if key.trim().is_empty() => {
-                eprintln!("error: invalid --define syntax: {define} (key must not be empty)");
-                return ExitCode::FAILURE;
-            }
-            Some(_) => {
-                config = config.with_define(define);
             }
         }
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -68,6 +68,29 @@ impl std::error::Error for ConfigError {
     }
 }
 
+/// An error from applying a `--define key=value` override.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefineError {
+    /// The input does not contain an `=` separator.
+    MissingEquals,
+    /// The key (before `=`) is empty or whitespace-only.
+    EmptyKey,
+    /// The dotted key exceeds the maximum nesting depth.
+    ExcessiveDepth,
+}
+
+impl fmt::Display for DefineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingEquals => write!(f, "invalid --define syntax (expected key=value)"),
+            Self::EmptyKey => write!(f, "key must not be empty"),
+            Self::ExcessiveDepth => write!(f, "key exceeds maximum nesting depth"),
+        }
+    }
+}
+
+impl std::error::Error for DefineError {}
+
 // ---------------------------------------------------------------------------
 // Deep merge
 // ---------------------------------------------------------------------------
@@ -100,6 +123,16 @@ pub(crate) fn deep_merge(base: Value, overlay: Value) -> Value {
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
+
+/// Result of resolving a configuration name (preset or file path),
+/// including any non-fatal warnings from RRJSON parsing.
+#[derive(Debug)]
+pub struct ConfigResolveResult {
+    /// The resolved configuration.
+    pub config: Config,
+    /// Non-fatal warnings (e.g., unsupported RRJSON include directives).
+    pub warnings: Vec<String>,
+}
 
 /// Result of loading configuration, including any non-fatal warnings.
 #[derive(Debug)]
@@ -220,19 +253,26 @@ impl Config {
     ///
     /// Returns [`ConfigError::Io`] if the file cannot be read, or
     /// [`ConfigError::Parse`] if the content is malformed.
-    pub fn resolve(name: &str) -> Result<Self, ConfigError> {
+    pub fn resolve(name: &str) -> Result<ConfigResolveResult, ConfigError> {
         // Try preset first
         if let Some(preset) = Self::preset(name) {
-            return Ok(preset);
+            return Ok(ConfigResolveResult {
+                config: preset,
+                warnings: Vec::new(),
+            });
         }
         // Try as a file path — apply the same security checks as hierarchical config
         let text = read_config_file(Path::new(name)).map_err(|e| ConfigError::Io {
             path: name.to_string(),
             source: e,
         })?;
-        Self::parse(&text).map_err(|e| ConfigError::Parse {
+        let result = rrjson::parse_rrjson_with_warnings(&text).map_err(|e| ConfigError::Parse {
             path: name.to_string(),
             source: e,
+        })?;
+        Ok(ConfigResolveResult {
+            config: Self { root: result.value },
+            warnings: result.warnings,
         })
     }
 
@@ -242,15 +282,19 @@ impl Config {
     /// The value is parsed as RRJSON (so `20` becomes a number, `"hello"`
     /// becomes a string, etc.). If the value cannot be parsed, it is
     /// treated as a plain string.
-    #[must_use]
-    pub fn with_define(self, define: &str) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DefineError`] if the input has no `=`, the key is empty,
+    /// or the dotted key exceeds the maximum nesting depth.
+    pub fn with_define(self, define: &str) -> Result<Self, DefineError> {
         let Some(eq_pos) = define.find('=') else {
-            return self;
+            return Err(DefineError::MissingEquals);
         };
         let key = define[..eq_pos].trim();
         let raw_value = define[eq_pos + 1..].trim();
         if key.is_empty() {
-            return self;
+            return Err(DefineError::EmptyKey);
         }
 
         // Try to parse the value as a JSON value; fall back to string.
@@ -263,13 +307,12 @@ impl Config {
             .unwrap_or_else(|| Value::String(raw_value.to_string()));
 
         // Build a nested object from the dot-separated key.
-        // If the key exceeds the nesting depth limit, ignore the define.
         let Some(overlay) = build_nested_value(key, value) else {
-            return self;
+            return Err(DefineError::ExcessiveDepth);
         };
-        Config {
+        Ok(Config {
             root: deep_merge(self.root, overlay),
-        }
+        })
     }
 
     /// Apply song-level config overrides from `{+config.KEY: VALUE}` directives.
@@ -297,7 +340,10 @@ impl Config {
                 ));
                 continue;
             }
-            config = config.with_define(&format!("{key}={value}"));
+            // Song overrides always have well-formed key=value; unwrap is safe.
+            config = config
+                .with_define(&format!("{key}={value}"))
+                .expect("song override has valid key=value");
         }
         config
     }
@@ -390,7 +436,10 @@ impl Config {
             .unwrap_or(false);
 
         if project_abc2svg && !trusted_abc2svg {
-            config = config.with_define("delegates.abc2svg=false");
+            // Hardcoded key=value — unwrap is safe.
+            config = config
+                .with_define("delegates.abc2svg=false")
+                .expect("hardcoded define is valid");
             warnings.push(
                 "delegates.abc2svg was enabled by a project-level config file and has been \
                  disabled for security; use --define delegates.abc2svg=true to enable"
@@ -398,7 +447,10 @@ impl Config {
             );
         }
         if project_lilypond && !trusted_lilypond {
-            config = config.with_define("delegates.lilypond=false");
+            // Hardcoded key=value — unwrap is safe.
+            config = config
+                .with_define("delegates.lilypond=false")
+                .expect("hardcoded define is valid");
             warnings.push(
                 "delegates.lilypond was enabled by a project-level config file and has been \
                  disabled for security; use --define delegates.lilypond=true to enable"
@@ -810,25 +862,27 @@ mod tests {
 
     #[test]
     fn test_define_simple_number() {
-        let config = Config::empty().with_define("key=42");
+        let config = Config::empty().with_define("key=42").unwrap();
         assert_eq!(config.get("key"), &Value::Number(42.0));
     }
 
     #[test]
     fn test_define_string() {
-        let config = Config::empty().with_define(r#"key="hello""#);
+        let config = Config::empty().with_define(r#"key="hello""#).unwrap();
         assert_eq!(config.get("key"), &Value::String("hello".to_string()));
     }
 
     #[test]
     fn test_define_dotted_key() {
-        let config = Config::empty().with_define("pdf.chorus.indent=20");
+        let config = Config::empty().with_define("pdf.chorus.indent=20").unwrap();
         assert_eq!(config.get_path("pdf.chorus.indent"), &Value::Number(20.0));
     }
 
     #[test]
     fn test_define_overrides_existing() {
-        let config = Config::defaults().with_define("pdf.margins.top=100");
+        let config = Config::defaults()
+            .with_define("pdf.margins.top=100")
+            .unwrap();
         assert_eq!(config.get_path("pdf.margins.top"), &Value::Number(100.0));
         // Other margins should be unchanged
         assert_eq!(config.get_path("pdf.margins.left"), &Value::Number(56.0));
@@ -836,41 +890,55 @@ mod tests {
 
     #[test]
     fn test_define_bool() {
-        let config = Config::empty().with_define("flag=true");
+        let config = Config::empty().with_define("flag=true").unwrap();
         assert_eq!(config.get("flag"), &Value::Bool(true));
     }
 
     #[test]
     fn test_define_unquoted_string_fallback() {
         // Values that aren't valid JSON fall back to string
-        let config = Config::empty().with_define("key=hello world");
+        let config = Config::empty().with_define("key=hello world").unwrap();
         assert_eq!(config.get("key"), &Value::String("hello world".to_string()));
     }
 
     #[test]
-    fn test_define_no_equals_ignored() {
-        let config = Config::empty().with_define("noequalssign");
-        assert!(config.get("noequalssign").is_null());
+    fn test_define_no_equals_returns_error() {
+        let result = Config::empty().with_define("noequalssign");
+        assert_eq!(result.unwrap_err(), DefineError::MissingEquals);
+    }
+
+    #[test]
+    fn test_define_empty_key_returns_error() {
+        let result = Config::empty().with_define("=value");
+        assert_eq!(result.unwrap_err(), DefineError::EmptyKey);
+    }
+
+    #[test]
+    fn test_define_whitespace_key_returns_error() {
+        let result = Config::empty().with_define("  =value");
+        assert_eq!(result.unwrap_err(), DefineError::EmptyKey);
     }
 
     #[test]
     fn test_multiple_defines() {
         let config = Config::empty()
             .with_define("a=1")
+            .unwrap()
             .with_define("b=2")
-            .with_define("a=3");
+            .unwrap()
+            .with_define("a=3")
+            .unwrap();
         assert_eq!(config.get("a"), &Value::Number(3.0));
         assert_eq!(config.get("b"), &Value::Number(2.0));
     }
 
     #[test]
     fn test_define_excessive_depth_rejected() {
-        // A dotted key with more than MAX_DEFINE_DEPTH segments should be ignored.
+        // A dotted key with more than MAX_DEFINE_DEPTH segments should be rejected.
         let segments: Vec<String> = (0..=MAX_DEFINE_DEPTH).map(|i| format!("k{i}")).collect();
         let deep_key = segments.join(".");
-        let config = Config::empty().with_define(&format!("{deep_key}=1"));
-        // The define should have been silently ignored
-        assert!(config.get("k0").is_null());
+        let result = Config::empty().with_define(&format!("{deep_key}=1"));
+        assert_eq!(result.unwrap_err(), DefineError::ExcessiveDepth);
     }
 
     #[test]
@@ -878,7 +946,7 @@ mod tests {
         // Exactly MAX_DEFINE_DEPTH segments should be accepted.
         let segments: Vec<String> = (0..MAX_DEFINE_DEPTH).map(|i| format!("k{i}")).collect();
         let key = segments.join(".");
-        let config = Config::empty().with_define(&format!("{key}=42"));
+        let config = Config::empty().with_define(&format!("{key}=42")).unwrap();
         assert!(!config.get("k0").is_null());
     }
 
@@ -928,9 +996,10 @@ mod tests {
 
     #[test]
     fn test_resolve_preset() {
-        let config = Config::resolve("guitar").expect("guitar should resolve");
+        let result = Config::resolve("guitar").expect("guitar should resolve");
+        assert!(result.warnings.is_empty());
         assert_eq!(
-            config.get_path("instrument.type"),
+            result.config.get_path("instrument.type"),
             &Value::String("guitar".to_string())
         );
     }
@@ -961,7 +1030,7 @@ mod tests {
 
     #[test]
     fn test_define_empty_value() {
-        let config = Config::empty().with_define("key=");
+        let config = Config::empty().with_define("key=").unwrap();
         assert_eq!(config.get("key"), &Value::String(String::new()));
     }
 
@@ -1096,8 +1165,8 @@ mod tests {
         let file_path = dir.path().join("custom.json");
         std::fs::write(&file_path, r#"{ "custom": true }"#).unwrap();
 
-        let config = Config::resolve(file_path.to_str().unwrap()).unwrap();
-        assert_eq!(config.get("custom"), &Value::Bool(true));
+        let result = Config::resolve(file_path.to_str().unwrap()).unwrap();
+        assert_eq!(result.config.get("custom"), &Value::Bool(true));
     }
 
     // -- File size / symlink guard tests --------------------------------------

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -2173,8 +2173,9 @@ Verse text\n\
         }
         let input = "{start_of_abc}\nX:1\nT:Test\nK:C\n{end_of_abc}";
         let song = chordpro_core::parse(input).unwrap();
-        let config =
-            chordpro_core::config::Config::defaults().with_define("delegates.abc2svg=true");
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("delegates.abc2svg=true")
+            .unwrap();
         let html = render_song_with_transpose(&song, 0, &config);
         assert!(html.contains("<section class=\"abc\">"));
         assert!(html.contains("<pre>"));
@@ -2189,8 +2190,9 @@ Verse text\n\
         }
         let input = "{start_of_abc: Melody}\nX:1\n{end_of_abc}";
         let song = chordpro_core::parse(input).unwrap();
-        let config =
-            chordpro_core::config::Config::defaults().with_define("delegates.abc2svg=true");
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("delegates.abc2svg=true")
+            .unwrap();
         let html = render_song_with_transpose(&song, 0, &config);
         assert!(html.contains("ABC: Melody"));
         assert!(html.contains("<pre>"));
@@ -2202,8 +2204,9 @@ Verse text\n\
         // Requires abc2svg installed. Run with: cargo test -- --ignored
         let input = "{start_of_abc}\nX:1\nT:Test\nM:4/4\nK:C\nCDEF|GABc|\n{end_of_abc}";
         let song = chordpro_core::parse(input).unwrap();
-        let config =
-            chordpro_core::config::Config::defaults().with_define("delegates.abc2svg=true");
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("delegates.abc2svg=true")
+            .unwrap();
         let html = render_song_with_transpose(&song, 0, &config);
         assert!(html.contains("<section class=\"abc\">"));
         assert!(
@@ -2231,8 +2234,9 @@ Verse text\n\
         }
         let input = "{start_of_ly}\n\\relative c' { c4 }\n{end_of_ly}";
         let song = chordpro_core::parse(input).unwrap();
-        let config =
-            chordpro_core::config::Config::defaults().with_define("delegates.lilypond=true");
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("delegates.lilypond=true")
+            .unwrap();
         let html = render_song_with_transpose(&song, 0, &config);
         assert!(html.contains("<section class=\"ly\">"));
         assert!(html.contains("<pre>"));
@@ -2245,8 +2249,9 @@ Verse text\n\
         // Requires lilypond installed. Run with: cargo test -- --ignored
         let input = "{start_of_ly}\n\\relative c' { c4 d e f | g2 g | }\n{end_of_ly}";
         let song = chordpro_core::parse(input).unwrap();
-        let config =
-            chordpro_core::config::Config::defaults().with_define("delegates.lilypond=true");
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("delegates.lilypond=true")
+            .unwrap();
         let html = render_song_with_transpose(&song, 0, &config);
         assert!(html.contains("<section class=\"ly\">"));
         assert!(

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -3956,7 +3956,9 @@ mod jpeg_tests {
 
     #[test]
     fn test_custom_margins_from_config() {
-        let config = Config::defaults().with_define("pdf.margins.top=100");
+        let config = Config::defaults()
+            .with_define("pdf.margins.top=100")
+            .unwrap();
         let doc = PdfDocument::from_config(&config);
         assert!((doc.margin_top - 100.0).abs() < 0.01);
         // Other margins should keep defaults.
@@ -3967,21 +3969,25 @@ mod jpeg_tests {
 
     #[test]
     fn test_negative_margin_falls_back_to_default() {
-        let config = Config::defaults().with_define("pdf.margins.top=-100");
+        let config = Config::defaults()
+            .with_define("pdf.margins.top=-100")
+            .unwrap();
         let doc = PdfDocument::from_config(&config);
         assert!((doc.margin_top - MARGIN_TOP).abs() < 0.01);
     }
 
     #[test]
     fn test_zero_margin_is_valid() {
-        let config = Config::defaults().with_define("pdf.margins.top=0");
+        let config = Config::defaults().with_define("pdf.margins.top=0").unwrap();
         let doc = PdfDocument::from_config(&config);
         assert!(doc.margin_top.abs() < 0.01);
     }
 
     #[test]
     fn test_excessive_margin_falls_back_to_default() {
-        let config = Config::defaults().with_define("pdf.margins.left=1000");
+        let config = Config::defaults()
+            .with_define("pdf.margins.left=1000")
+            .unwrap();
         let doc = PdfDocument::from_config(&config);
         assert!((doc.margin_left - MARGIN_LEFT).abs() < 0.01);
     }
@@ -3990,7 +3996,9 @@ mod jpeg_tests {
     fn test_custom_margins_affect_output() {
         let song = chordpro_core::parse("{title: Test}\nHello").unwrap();
         let default_pdf = render_song(&song);
-        let config = Config::defaults().with_define("pdf.margins.top=200");
+        let config = Config::defaults()
+            .with_define("pdf.margins.top=200")
+            .unwrap();
         let custom_pdf = render_song_with_transpose(&song, 0, &config);
         // Different margins produce different PDF output.
         assert_ne!(default_pdf, custom_pdf);


### PR DESCRIPTION
## What

Two Config API improvements in one PR:

### 1. Collect warnings in `Config::resolve()` (#539)

- `Config::resolve()` now returns `ConfigResolveResult` (containing both config and warnings) instead of plain `Config`
- Previously, `resolve()` used `parse_rrjson()` (discards warnings); now uses `parse_rrjson_with_warnings()`
- CLI surfaces these warnings via `eprintln!("warning: ...")` for `--config` files
- Presets return empty warnings (no file parsing involved)

### 2. Return errors from `Config::with_define()` (#540)

- `with_define()` now returns `Result<Self, DefineError>` instead of silently returning `self`
- New `DefineError` enum with `MissingEquals`, `EmptyKey`, `ExcessiveDepth` variants
- CLI `--define` validation now uses `with_define()` directly, eliminating the redundant `split_once('=')` pre-check
- Internal callers with hardcoded valid inputs use `.expect("hardcoded define is valid")`

## Why

- **#539**: `--config` files with RRJSON include directives silently lost the "include directives are not supported" warning, while the same warning appeared for system/user/project config files
- **#540**: Library callers of `with_define()` couldn't distinguish between a successfully applied define and one silently dropped due to missing `=` or empty key

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all 1188 tests pass)
```

### Updated/new tests

- `test_define_no_equals_returns_error` — verifies `DefineError::MissingEquals`
- `test_define_empty_key_returns_error` — verifies `DefineError::EmptyKey`
- `test_define_whitespace_key_returns_error` — verifies `DefineError::EmptyKey`
- `test_define_excessive_depth_rejected` — updated to verify `DefineError::ExcessiveDepth`
- `test_resolve_preset` — updated to verify empty warnings

## Review summary

Second PR for Phase 13 completion gate (koedame/chordpro-rs#98).

Closes #539
Closes #540