### PR TITLE
Validate empty segments in Config::with_define() dotted keys

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -75,6 +75,8 @@ pub enum DefineError {
     MissingEquals,
     /// The key (before `=`) is empty or whitespace-only.
     EmptyKey,
+    /// The dotted key contains an empty segment (e.g., `"a..b"`, `".a"`, `"a."`).
+    EmptySegment,
     /// The dotted key exceeds the maximum nesting depth.
     ExcessiveDepth,
 }
@@ -84,6 +86,7 @@ impl fmt::Display for DefineError {
         match self {
             Self::MissingEquals => write!(f, "invalid --define syntax (expected key=value)"),
             Self::EmptyKey => write!(f, "key must not be empty"),
+            Self::EmptySegment => write!(f, "key contains empty segment"),
             Self::ExcessiveDepth => write!(f, "key exceeds maximum nesting depth"),
         }
     }
@@ -294,6 +297,9 @@ impl Config {
         let raw_value = define[eq_pos + 1..].trim();
         if key.is_empty() {
             return Err(DefineError::EmptyKey);
+        }
+        if key.split('.').any(|s| s.is_empty()) {
+            return Err(DefineError::EmptySegment);
         }
 
         // Try to parse the value as a JSON value; fall back to string.
@@ -971,6 +977,24 @@ mod tests {
         let deep_key = segments.join(".");
         let result = Config::empty().with_define(&format!("{deep_key}=1"));
         assert_eq!(result.unwrap_err(), DefineError::ExcessiveDepth);
+    }
+
+    #[test]
+    fn test_define_double_dot_rejected() {
+        let result = Config::empty().with_define("a..b=1");
+        assert_eq!(result.unwrap_err(), DefineError::EmptySegment);
+    }
+
+    #[test]
+    fn test_define_leading_dot_rejected() {
+        let result = Config::empty().with_define(".a=1");
+        assert_eq!(result.unwrap_err(), DefineError::EmptySegment);
+    }
+
+    #[test]
+    fn test_define_trailing_dot_rejected() {
+        let result = Config::empty().with_define("a.=1");
+        assert_eq!(result.unwrap_err(), DefineError::EmptySegment);
     }
 
     #[test]


### PR DESCRIPTION
## What

Add `EmptySegment` variant to `DefineError` and reject dotted keys with empty segments (e.g., `"a..b"`, `".a"`, `"a."`) in `Config::with_define()`.

## Why

The RRJSON parser validates that dotted keys have no empty segments, but `Config::with_define()` did not perform this validation. This inconsistency allowed `with_define("a..b=1")` to create objects with empty-string keys (`{"a": {"": {"b": 1}}}`), which could cause subtle bugs in config lookups.

## Test results

```
test config::tests::test_define_double_dot_rejected ... ok
test config::tests::test_define_leading_dot_rejected ... ok
test config::tests::test_define_trailing_dot_rejected ... ok
```

All 770+ core tests pass. `cargo clippy` and `cargo fmt` clean.

## Review summary

Root-cause fix in `with_define()` adds the same empty-segment check that the RRJSON parser already enforces, maintaining consistency between the two config input paths.

Closes #555