### PR TITLE
Move song_transpose_delta() to Config in chordpro-core

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -372,6 +372,25 @@ impl Config {
         config
     }
 
+    /// Extract the `settings.transpose` value from song-level config overrides.
+    ///
+    /// Scans the override list in reverse order (last wins) for
+    /// `settings.transpose` and parses it as an `i8` semitone delta.
+    /// Returns `0` if the key is absent or the value is not a valid number.
+    #[must_use]
+    pub fn song_transpose_delta(overrides: &[(&str, &str)]) -> i8 {
+        for &(key, value) in overrides.iter().rev() {
+            if key == "settings.transpose" {
+                return value
+                    .trim()
+                    .parse::<f64>()
+                    .unwrap_or(0.0)
+                    .clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
+            }
+        }
+        0
+    }
+
     /// Build a configuration by loading and merging from all sources.
     ///
     /// Loads: defaults → system → user → project → song-specific.

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -28,23 +28,6 @@ use chordpro_core::transpose::transpose_chord;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
-/// Extract the transpose delta from song-level config overrides.
-///
-/// Parses `settings.transpose` from the override list. Returns `0` if the
-/// key is absent or the value is not a valid number.
-fn song_transpose_delta(overrides: &[(&str, &str)]) -> i8 {
-    for &(key, value) in overrides.iter().rev() {
-        if key == "settings.transpose" {
-            return value
-                .trim()
-                .parse::<f64>()
-                .unwrap_or(0.0)
-                .clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
-        }
-    }
-    0
-}
-
 /// Maximum number of CSS columns allowed.
 /// Matches `MAX_COLUMNS` in the PDF renderer.
 const MAX_COLUMNS: u32 = 32;
@@ -214,7 +197,7 @@ fn render_song_body(
     };
     // Extract song-level transpose delta from {+config.settings.transpose}.
     // The base config transpose is already folded into cli_transpose by the caller.
-    let song_transpose_delta = song_transpose_delta(&song_overrides);
+    let song_transpose_delta = Config::song_transpose_delta(&song_overrides);
     let (combined_transpose, _) =
         chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);
     let mut transpose_offset: i8 = combined_transpose;

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -63,23 +63,6 @@ impl PdfFormattingState {
     }
 }
 
-/// Extract the transpose delta from song-level config overrides.
-///
-/// Parses `settings.transpose` from the override list. Returns `0` if the
-/// key is absent or the value is not a valid number.
-fn song_transpose_delta(overrides: &[(&str, &str)]) -> i8 {
-    for &(key, value) in overrides.iter().rev() {
-        if key == "settings.transpose" {
-            return value
-                .trim()
-                .parse::<f64>()
-                .unwrap_or(0.0)
-                .clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
-        }
-    }
-    0
-}
-
 // ---------------------------------------------------------------------------
 // Layout constants (units: PDF points, 1 pt = 1/72 inch)
 // ---------------------------------------------------------------------------
@@ -324,7 +307,7 @@ fn render_song_into_doc(
     // Extract song-level transpose delta from {+config.settings.transpose}.
     // The base config transpose is already folded into cli_transpose by the caller.
     let song_overrides = song.config_overrides();
-    let song_transpose_delta = song_transpose_delta(&song_overrides);
+    let song_transpose_delta = Config::song_transpose_delta(&song_overrides);
     let (combined_transpose, _) =
         chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);
     let mut transpose_offset: i8 = combined_transpose;

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -13,23 +13,6 @@ use unicode_width::UnicodeWidthStr;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
-/// Extract the transpose delta from song-level config overrides.
-///
-/// Parses `settings.transpose` from the override list. Returns `0` if the
-/// key is absent or the value is not a valid number.
-fn song_transpose_delta(overrides: &[(&str, &str)]) -> i8 {
-    for &(key, value) in overrides.iter().rev() {
-        if key == "settings.transpose" {
-            return value
-                .trim()
-                .parse::<f64>()
-                .unwrap_or(0.0)
-                .clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
-        }
-    }
-    0
-}
-
 /// Render a [`Song`] AST to plain text.
 ///
 /// The output format:
@@ -100,7 +83,7 @@ fn render_song_impl(
     };
     // Extract song-level transpose delta from {+config.settings.transpose}.
     // The base config transpose is already folded into cli_transpose by the caller.
-    let song_transpose_delta = song_transpose_delta(&song_overrides);
+    let song_transpose_delta = Config::song_transpose_delta(&song_overrides);
     let mut output = Vec::new();
     let (combined_transpose, _) =
         chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);


### PR DESCRIPTION
## What

Move `song_transpose_delta()` from the three renderer crates to `Config::song_transpose_delta()` in `chordpro-core`.

## Why

The identical function was copy-pasted in `render-text`, `render-html`, and `render-pdf`. Any bug fix or behavior change had to be applied in three places. Moving it to core eliminates this DRY violation.

## Test results

All tests pass across all crates. `cargo clippy` and `cargo fmt` clean. Net reduction of 32 lines.

## Review summary

Pure refactor — no behavior change. The function signature and implementation are identical to the originals. All three renderers now call `Config::song_transpose_delta()` instead of their local copies.

Closes #557