### PR TITLE
Add per-song limit on config override directives

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -350,8 +350,20 @@ impl Config {
         /// song-level overrides. These require exact match, not prefix.
         const ALLOWED_EXACT_KEYS: &[&str] = &["tuning"];
 
+        /// Maximum number of song-level config overrides processed per song.
+        /// Prevents CPU exhaustion from malicious inputs with thousands of
+        /// `{+config.*}` directives.
+        const MAX_SONG_OVERRIDES: usize = 1000;
+
         let mut config = self;
-        for &(key, value) in overrides {
+        if overrides.len() > MAX_SONG_OVERRIDES {
+            warnings.push(format!(
+                "too many song-level config overrides ({}, max {}); excess ignored",
+                overrides.len(),
+                MAX_SONG_OVERRIDES
+            ));
+        }
+        for &(key, value) in overrides.iter().take(MAX_SONG_OVERRIDES) {
             let allowed = ALLOWED_PREFIXES
                 .iter()
                 .any(|prefix| key.starts_with(prefix))
@@ -1560,5 +1572,16 @@ mod tests {
         assert!(warnings[0].contains("failed to apply song override"));
         // Config should remain unchanged
         assert_eq!(config.get_path("pdf.margins.top"), &Value::Number(56.0));
+    }
+
+    #[test]
+    fn test_song_overrides_excess_count_warns() {
+        let config = Config::defaults();
+        let mut warnings = Vec::new();
+        // Create 1002 overrides — first 1000 should be applied, rest ignored.
+        let overrides: Vec<(&str, &str)> = (0..1002).map(|_| ("settings.transpose", "1")).collect();
+        let _config = config.with_song_overrides(&overrides, &mut warnings);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("too many song-level config overrides"));
     }
 }


### PR DESCRIPTION
## What

Add a `MAX_SONG_OVERRIDES` limit (1000) to `with_song_overrides()` that caps the number of `{+config.*}` directives processed per song.

## Why

There was no limit on how many `{+config.*}` directives a single song could contain. Each override involves RRJSON parsing, nested object construction, and deep merge. A crafted `.cho` file with thousands of config override directives could cause significant CPU usage. The limit of 1000 is generous for legitimate use while preventing abuse.

## Test results

```
test config::tests::test_song_overrides_excess_count_warns ... ok
```

All 770+ core tests pass. `cargo clippy` and `cargo fmt` clean.

## Review summary

Adds early-exit with warning when override count exceeds the limit. Uses `overrides.iter().take(MAX_SONG_OVERRIDES)` for clean truncation.

Closes #559