### PR TITLE
Fix rustdoc warning for private MAX_CONFIG_FILE_SIZE link

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -248,7 +248,7 @@ impl Config {
     /// invoking this programmatically with partially untrusted input should
     /// validate the path first.
     ///
-    /// Symlinks and files exceeding [`MAX_CONFIG_FILE_SIZE`] are rejected,
+    /// Symlinks and files exceeding the 10 MB file size limit are rejected,
     /// matching the behavior of hierarchical config loading.
     ///
     /// # Errors


### PR DESCRIPTION
## What

Replace the intra-doc link `[`MAX_CONFIG_FILE_SIZE`]` with plain text "the 10 MB file size limit" in the `Config::resolve()` doc comment.

## Why

`MAX_CONFIG_FILE_SIZE` is a private constant. The backtick link notation (`[`..`]`) generates a rustdoc broken-link warning because rustdoc cannot resolve links to private items from public documentation.

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅
```

## Review summary

One-line doc comment fix. No behavior change.

Closes #566