### PR TITLE
Fix review workflow to guarantee convergence

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -44,31 +44,33 @@
 Before closing a phase tracking issue, perform the following review against
 `main`:
 
-1. **`/review`** — full code review of the phase's changes on `main`.
-2. **`/security-review`** — security review of the phase's changes on `main`.
-3. If either review finds issues, create new sub-issues under the phase tracking
-   issue for each finding. These sub-issues follow normal workflow (implement,
-   PR, CI, review, merge).
-4. Repeat steps 1–3 until a review pass produces **no new findings**.
-5. Only when both `/review` and `/security-review` pass with no new sub-issues
-   may the phase tracking issue be closed.
+1. **Initial review** — run `/review` and `/security-review` on the full phase
+   diff (may run in parallel).
+2. **Classify findings** by severity (see
+   [Severity Definitions](pr-workflow.md#severity-definitions)).
+3. **Blocking findings** (High, Medium) — create sub-issues, implement fixes
+   via normal PR workflow, and merge to `main`.
+4. **Non-blocking findings** (Low, Nit) — create issues for future work. These
+   do **not** block phase closure.
+5. **Delta review** — run `/review` and `/security-review` on only the fix
+   commits merged since the initial review. Do **not** re-review the entire
+   phase. Only new blocking findings in the fix code require further fixes.
+6. **Repeat steps 3–5** until a delta review produces no new blocking findings.
+7. **Close** the phase tracking issue when all blocking findings are resolved
+   and all non-blocking findings are tracked as issues.
 
 ### Review Finding Accountability
 
-All review findings — regardless of severity (Major, Minor, Nit, Low,
-Informational) — must be:
+All review findings must be:
 
 1. **Individually documented** in the review comment on the tracking issue or PR,
-   with a clear description of each finding.
+   with a clear description and severity classification.
 2. **Resolved or tracked** before the phase or PR is closed:
-   - **Fixed** in the current cycle, or
-   - **Issue created** for deferred items (with a link in the review comment).
+   - **Blocking** (High, Medium) — fixed in the current cycle.
+   - **Non-blocking** (Low, Nit) — GitHub Issue created for future work.
 3. **Never silently dropped.** Aggregate counts like "14 Low findings" without
    enumeration are not acceptable. Every finding must be enumerable and
    traceable.
-
-Non-blocking findings (Nit, Low) may be deferred to future work, but a GitHub
-Issue must exist for each deferred finding so it is not lost.
 
 ### Creating Sub-Issue Relationships
 

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -3,16 +3,41 @@
 1. All changes enter `main` via pull request — no direct pushes.
 2. **Implement + test** — open a PR with code and tests.
 3. **CI must pass** (cargo fmt --check, cargo clippy -- -D warnings, cargo test).
-4. **`/review`** — request code review. Fix any issues raised, then return to step 3.
-5. **`/security-review`** — request security review. Fix any issues raised, then return
-   to step 3.
-6. **CI must pass on the final commit** — after all review-driven fixes, CI must be
+4. **`/review` + `/security-review`** — run both reviews (may run in parallel).
+5. **Classify findings** by severity (see [Severity Definitions](#severity-definitions)).
+6. **Blocking findings** (High, Medium) — fix in the same PR, then return to step 3.
+   The subsequent review is a **delta review**: it covers only the fix commits, not the
+   entire PR from scratch.
+7. **Non-blocking findings** (Low, Nit) — create a GitHub Issue for each finding. These
+   do **not** block the PR from merging.
+8. **CI must pass on the final commit** — after all review-driven fixes, CI must be
    green again on the HEAD commit.
-7. **Merge** — only when CI is green on the latest commit and both reviews approve.
+9. **Merge** — when CI is green on the latest commit, all blocking findings are resolved,
+   and non-blocking findings are tracked as issues.
 
 Branch protection enforces that status checks pass on the HEAD commit before merging.
 No merge is possible unless CI is green on the latest commit. All PRs are
 **squash-merged** (merge commits and rebase merging are disabled).
+
+### Severity Definitions
+
+| Severity | Blocks PR/Phase | Definition |
+|----------|-----------------|------------|
+| High | Yes | Security vulnerabilities, data corruption, crashes |
+| Medium | Yes | Spec violations, logic bugs, incorrect output |
+| Low | No | Defense-in-depth gaps, minor inconsistencies, portability |
+| Nit | No | Style, naming, test coverage suggestions |
+
+### Delta Review
+
+When a review produces blocking findings and fixes are applied, the subsequent review
+must only examine the new commits (the fix diff), not re-review the entire PR. This
+ensures convergence: fix diffs are small and produce fewer findings, trending toward
+zero.
+
+Previously-reviewed code that was not flagged is considered accepted. If a reviewer
+later discovers a blocking issue in previously-accepted code, it should be filed as a
+separate issue — not raised in the delta review.
 
 ### PR Formatting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,10 +75,11 @@ Pull requests follow this workflow before merging to `main`:
 
 1. **Implement + test** — author opens PR with code and tests
 2. **CI passes** — fmt, clippy, test must all be green
-3. **`/review`** — code review; fix any issues raised (go back to step 2)
-4. **`/security-review`** — security review; fix any issues raised (go back to step 2)
-5. **CI passes on the final commit** — after all fixes, CI must be green again
-6. **Merge** — only when CI is green on the latest commit and both reviews approve
+3. **`/review` + `/security-review`** — run both reviews (may run in parallel)
+4. **Fix blocking findings** (High/Medium) — delta review on fixes only
+5. **Track non-blocking findings** (Low/Nit) — create issues, do not block merge
+6. **CI passes on the final commit** — after all fixes, CI must be green again
+7. **Merge** — only when CI is green and all blocking findings are resolved
 
 Branch protection requires status checks to pass on the HEAD commit before merging.
 No merge is possible unless CI is green on the latest commit, regardless of how many


### PR DESCRIPTION
## What

Redesign the review workflow (PR-level and Phase Completion Gate) to guarantee convergence by introducing severity-based blocking and delta reviews.

## Why

The previous workflow could loop indefinitely:
1. Every review re-examined the entire codebase, re-flagging previously-accepted code
2. All severity levels (including Nit/Low) blocked PR merge and phase closure
3. Subjective findings (test coverage, naming) are effectively infinite

## Changes

### pr-workflow.md
- `/review` and `/security-review` may run in parallel (previously sequential)
- Added **Severity Definitions** table (High/Medium = blocking, Low/Nit = non-blocking)
- Added **Delta Review** section: subsequent reviews cover only fix commits
- Non-blocking findings create issues but do not block merge

### issue-workflow.md
- Phase Completion Gate: initial review is full-phase, subsequent reviews are delta-only
- Non-blocking findings do not block phase closure
- Review Finding Accountability updated to use severity classification

### CLAUDE.md
- Merge Policy section updated to match new workflow

## Test plan

- [x] No code changes — documentation/process only
- [ ] Verify the workflow converges in practice on next phase completion review

🤖 Generated with [Claude Code](https://claude.com/claude-code)