### PR TITLE
Add /phase-review and /delta-review commands

### DIFF
--- a/.claude/commands/delta-review.md
+++ b/.claude/commands/delta-review.md
@@ -1,0 +1,42 @@
+# Delta Review
+
+You are performing a **delta review** — reviewing only new changes since a previous
+review. The argument is a base commit hash or PR number: `$ARGUMENTS`
+
+## Steps
+
+1. **Determine the diff scope**:
+   - If the argument is a commit hash: `git log --oneline <hash>..HEAD` and
+     `git diff <hash>..HEAD`.
+   - If the argument is a PR number: `gh pr diff <number>`.
+   - If the argument is empty: ask the user for a base commit or PR number.
+
+2. **Review only the diff** — do NOT review code outside the diff. Previously-reviewed
+   code that was not flagged is considered accepted.
+
+3. **Perform both code review and security review** on the diff.
+
+4. **Classify every finding by severity**:
+
+   | Severity | Blocks | Definition |
+   |----------|--------|------------|
+   | High     | Yes    | Security vulnerabilities, data corruption, crashes |
+   | Medium   | Yes    | Spec violations, logic bugs, incorrect output |
+   | Low      | No     | Defense-in-depth gaps, minor inconsistencies, portability |
+   | Nit      | No     | Style, naming, test coverage suggestions |
+
+5. **Output a structured report** with findings grouped by severity.
+
+6. **Create GitHub issues** for non-blocking findings (Low, Nit).
+
+7. **Verdict**:
+   - If no blocking findings: the changes are approved.
+   - If blocking findings exist: report them for fixing. After fixes, run
+     `/delta-review` again with the new base commit.
+
+## Important
+
+- This is a delta review. Do NOT flag issues in code that was not changed in this diff.
+- If a previously-accepted pattern is reused in new code, do not flag the pattern
+  itself — only flag if the new usage introduces a new bug.
+- Classify findings strictly. When in doubt between Medium and Low, prefer Low.

--- a/.claude/commands/phase-review.md
+++ b/.claude/commands/phase-review.md
@@ -1,0 +1,45 @@
+# Phase Completion Review
+
+You are performing a **Phase Completion Gate** review. The argument is the phase
+tracking issue number: `$ARGUMENTS`
+
+## Steps
+
+1. **Verify prerequisites**:
+   - Run `gh issue view $ARGUMENTS` to get the tracking issue details.
+   - List all sub-issues and verify they are all closed. If any are open, report
+     them and stop — the phase is not ready for review.
+
+2. **Run code review and security review in parallel**:
+   - Identify all code files related to this phase (from sub-issue PRs and commit
+     history).
+   - Perform a thorough code review: correctness, quality, consistency, test coverage.
+   - Perform a security review: input validation, injection, trust boundaries,
+     data exposure.
+
+3. **Classify every finding by severity**:
+
+   | Severity | Blocks phase closure | Definition |
+   |----------|---------------------|------------|
+   | High     | Yes                 | Security vulnerabilities, data corruption, crashes |
+   | Medium   | Yes                 | Spec violations, logic bugs, incorrect output |
+   | Low      | No                  | Defense-in-depth gaps, minor inconsistencies, portability |
+   | Nit      | No                  | Style, naming, test coverage suggestions |
+
+4. **Output a structured report** with findings grouped by severity. For each finding
+   include: file path, line number, severity, description, and recommended fix.
+
+5. **Create GitHub issues** for all findings:
+   - Blocking (High, Medium): create as sub-issues of the tracking issue.
+   - Non-blocking (Low, Nit): create as standalone issues with the phase label.
+
+6. **Verdict**:
+   - If there are **no blocking findings**: report that the phase is ready to close.
+   - If there are **blocking findings**: report that fixes are required. After fixes
+     are merged, the user should run `/delta-review` on the fix commits.
+
+## Important
+
+- Classify findings strictly. When in doubt between Medium and Low, prefer Low.
+- Do not re-report findings that already have open issues.
+- Security findings require confidence >= 80% of real exploitability.

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -25,7 +25,7 @@
 2. Create worktree + branch from latest `main`.
 3. Implement (commits reference issue: `Part of #N` or `Closes #N`).
 4. Open PR (title references issue, body has `Closes #N`).
-5. CI -> `/review` -> `/security-review` -> merge.
+5. CI -> `/review` + `/security-review` -> fix blocking -> merge.
 6. Cleanup worktree.
 
 ## Tracking Issues & Sub-Issues
@@ -41,23 +41,24 @@
 
 ### Phase Completion Gate
 
-Before closing a phase tracking issue, perform the following review against
-`main`:
+Before closing a phase tracking issue:
 
-1. **Initial review** — run `/review` and `/security-review` on the full phase
-   diff (may run in parallel).
-2. **Classify findings** by severity (see
-   [Severity Definitions](pr-workflow.md#severity-definitions)).
-3. **Blocking findings** (High, Medium) — create sub-issues, implement fixes
+0. **Prerequisite** — all sub-issues of the tracking issue must be closed.
+   If any are open, complete them first.
+1. **Initial review** — run `/phase-review <tracking-issue-number>`. This
+   verifies the prerequisite, performs both code review and security review
+   on the full phase diff, classifies findings by severity (see
+   [Severity Definitions](pr-workflow.md#severity-definitions)), and creates
+   issues for all findings.
+2. **Blocking findings** (High, Medium) — create sub-issues, implement fixes
    via normal PR workflow, and merge to `main`.
-4. **Non-blocking findings** (Low, Nit) — create issues for future work. These
-   do **not** block phase closure.
-5. **Delta review** — run `/review` and `/security-review` on only the fix
-   commits merged since the initial review. Do **not** re-review the entire
-   phase. Only new blocking findings in the fix code require further fixes.
-6. **Repeat steps 3–5** until a delta review produces no new blocking findings.
-7. **Close** the phase tracking issue when all blocking findings are resolved
-   and all non-blocking findings are tracked as issues.
+3. **Non-blocking findings** (Low, Nit) — issues are created but do **not**
+   block phase closure.
+4. **Delta review** — run `/delta-review <base-commit>` where `<base-commit>`
+   is the last commit reviewed. This reviews only the fix commits, not the
+   entire phase. Only new blocking findings require further fixes.
+5. **Repeat steps 2–4** until a delta review produces no new blocking findings.
+6. **Close** the phase tracking issue.
 
 ### Review Finding Accountability
 


### PR DESCRIPTION
## What

Add custom Claude Code commands for the review workflow and update the Phase Completion Gate to reference them.

Follow-up to #582 — the command files were not included in the squash merge due to a timing issue.

## Why

Without dedicated commands, users must manually instruct reviewers about severity classification and delta scope. The commands encode the review rules so that `/phase-review 98` and `/delta-review abc1234` work out of the box.

## Changes

- `.claude/commands/phase-review.md`: Verifies sub-issues closed, runs code + security review, classifies by severity, creates issues
- `.claude/commands/delta-review.md`: Reviews only the diff since a base commit
- `.claude/rules/issue-workflow.md`: Phase Completion Gate now references `/phase-review` and `/delta-review`, adds prerequisite step (all sub-issues closed)

## Test plan

- [ ] `/phase-review 98` invokes phase completion review with severity classification
- [ ] `/delta-review <commit>` reviews only the delta diff
- [ ] Phase Completion Gate documentation is accurate

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)