### PR TITLE
Redesign auto-review with severity classification and delta review

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -25,7 +25,8 @@
 2. Create worktree + branch from latest `main`.
 3. Implement (commits reference issue: `Part of #N` or `Closes #N`).
 4. Open PR (title references issue, body has `Closes #N`).
-5. CI -> `/review` + `/security-review` -> fix blocking -> merge.
+5. CI -> auto-review (severity classification) -> auto-merge.
+   See [Pull Request Workflow](pr-workflow.md) for details.
 6. Cleanup worktree.
 
 ## Tracking Issues & Sub-Issues

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -1,23 +1,35 @@
 # Pull Request Workflow
 
-1. All changes enter `main` via pull request — no direct pushes.
-2. **Implement + test** — open a PR with code and tests.
-3. **CI must pass** (cargo fmt --check, cargo clippy -- -D warnings, cargo test).
-4. **`/review` + `/security-review`** — run both reviews (may run in parallel).
-5. **Classify findings** by severity (see [Severity Definitions](#severity-definitions)).
-6. **Blocking findings** (High, Medium) — fix in the same PR, then return to step 3.
-   The subsequent review is a **delta review**: it covers only the fix commits, not the
-   entire PR from scratch.
-7. **Non-blocking findings** (Low, Nit) — create a GitHub Issue for each finding. These
-   do **not** block the PR from merging.
-8. **CI must pass on the final commit** — after all review-driven fixes, CI must be
-   green again on the HEAD commit.
-9. **Merge** — when CI is green on the latest commit, all blocking findings are resolved,
-   and non-blocking findings are tracked as issues.
+## Automated Flow (default)
 
-Branch protection enforces that status checks pass on the HEAD commit before merging.
-No merge is possible unless CI is green on the latest commit. All PRs are
-**squash-merged** (merge commits and rebase merging are disabled).
+PRs are reviewed and merged automatically via CI:
+
+1. **PR created** — author opens PR with code and tests.
+2. **CI runs** (cargo fmt --check, cargo clippy -- -D warnings, cargo test).
+3. **Auto-review** — on CI success, `claude-review.yml` requests a Claude review
+   with severity classification. Claude performs both code review and security review.
+4. **Blocking findings** (High, Medium) — Claude pushes fix commits directly.
+   CI re-runs, then a **delta review** examines only the fix commits.
+5. **Non-blocking findings** (Low, Nit) — Claude creates GitHub Issues. These do
+   **not** block the PR from merging.
+6. **Auto-merge** — when there are no blocking findings, Claude enables auto-merge
+   (`gh pr merge --squash --auto`). The PR merges once CI passes on the final commit.
+7. **Safety cap** — after 3 auto-review iterations, the process stops and waits for
+   human intervention.
+
+## Manual Flow (optional)
+
+For local review before pushing, or when the automated flow is not desired:
+
+1. Run `/review` and/or `/security-review` locally.
+2. Fix any blocking findings, then push.
+3. The automated flow takes over from step 2 above.
+
+## Rules
+
+- All changes enter `main` via pull request — no direct pushes.
+- All PRs are **squash-merged** (merge commits and rebase merging are disabled).
+- Branch protection enforces that status checks pass on the HEAD commit before merging.
 
 ### Severity Definitions
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,20 +29,6 @@ jobs:
             const prNumber = prs[0].number;
             const headSha = context.payload.workflow_run.head_sha;
 
-            // Skip if head commit was authored by claude[bot] to prevent
-            // review loops (Claude pushes fix → CI → auto-review → Claude
-            // reviews again). Manual @claude requests still work.
-            const { data: commit } = await github.rest.repos.getCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: headSha,
-            });
-            const commitAuthor = commit.author?.login || '';
-            if (commitAuthor === 'claude[bot]') {
-              console.log(`Skipping auto-review: head commit ${headSha.substring(0, 7)} authored by claude[bot]`);
-              return;
-            }
-
             // Skip Dependabot PRs (handled by claude-dependabot.yml)
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -68,7 +54,9 @@ jobs:
               return;
             }
 
-            // Limit auto-review iterations to prevent infinite loops
+            // Limit auto-review iterations to prevent infinite loops.
+            // claude[bot] fix commits are NOT skipped — they get delta-reviewed.
+            // MAX_ITERATIONS is the safety cap.
             const MAX_ITERATIONS = 3;
             const autoReviewCount = comments.filter(c =>
               c.body.startsWith('<!-- claude-auto-review:')
@@ -78,6 +66,24 @@ jobs:
               return;
             }
 
+            // Find the SHA from the previous auto-review (if any) for delta review
+            const previousMarkers = comments
+              .filter(c => c.body.startsWith('<!-- claude-auto-review:'))
+              .map(c => {
+                const match = c.body.match(/<!-- claude-auto-review:([a-f0-9]+) -->/);
+                return match ? match[1] : null;
+              })
+              .filter(Boolean);
+            const previousSha = previousMarkers.length > 0
+              ? previousMarkers[previousMarkers.length - 1]
+              : null;
+
+            const isFirstReview = previousSha === null;
+            const reviewType = isFirstReview ? 'Full review' : 'Delta review';
+            const deltaInstruction = isFirstReview
+              ? 'Review the entire PR diff (`gh pr diff`).'
+              : `This is a **delta review**. Only review changes since commit \`${previousSha.substring(0, 7)}\`. Use \`git diff ${previousSha.substring(0, 7)}..${headSha.substring(0, 7)}\` to see only the new changes. Do NOT re-review previously-accepted code.`;
+
             // Post review request comment (triggers claude.yml via @claude mention)
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -86,22 +92,27 @@ jobs:
               body: [
                 marker,
                 '',
-                `@claude CI passed for commit \`${headSha.substring(0, 7)}\`. Please review this PR:`,
+                `@claude ${reviewType} requested for commit \`${headSha.substring(0, 7)}\`.`,
                 '',
-                '**Code Review:**',
-                '- Code quality and adherence to project conventions (see CLAUDE.md)',
-                '- Logic correctness and edge case handling',
-                '- Test coverage and quality',
+                deltaInstruction,
                 '',
-                '**Security Review:**',
-                '- No unsafe code without justification',
-                '- Input validation at system boundaries',
-                '- Dependency safety (no unnecessary external deps, especially in chordpro-core)',
+                '## Review Instructions',
                 '',
-                'If you find fixable issues, push fix commits directly. For design issues requiring author input, leave review comments.',
+                'Perform both **code review** and **security review**. Classify every finding by severity:',
                 '',
-                'If both code review and security review pass with no issues, enable auto-merge with `gh pr merge --squash --auto`.',
+                '| Severity | Blocks merge | Definition |',
+                '|----------|-------------|------------|',
+                '| High | Yes | Security vulnerabilities, data corruption, crashes |',
+                '| Medium | Yes | Spec violations, logic bugs, incorrect output |',
+                '| Low | No | Defense-in-depth gaps, minor inconsistencies |',
+                '| Nit | No | Style, naming, test coverage suggestions |',
+                '',
+                '## Actions',
+                '',
+                '- **Blocking findings (High/Medium):** Push fix commits directly to the PR branch. Do NOT enable auto-merge.',
+                '- **Non-blocking findings (Low/Nit):** Create a GitHub issue for each finding. These do NOT block merge.',
+                '- **No blocking findings:** Enable auto-merge with `gh pr merge --squash --auto`.',
               ].join('\n'),
             });
 
-            console.log(`Review requested for PR #${prNumber} at ${headSha.substring(0, 7)}`);
+            console.log(`${reviewType} requested for PR #${prNumber} at ${headSha.substring(0, 7)}`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,20 +71,16 @@ High-level phases:
 
 ## Merge Policy
 
-Pull requests follow this workflow before merging to `main`:
+PRs are automatically reviewed and merged:
 
-1. **Implement + test** — author opens PR with code and tests
-2. **CI passes** — fmt, clippy, test must all be green
-3. **`/review` + `/security-review`** — run both reviews (may run in parallel)
-4. **Fix blocking findings** (High/Medium) — delta review on fixes only
-5. **Track non-blocking findings** (Low/Nit) — create issues, do not block merge
-6. **CI passes on the final commit** — after all fixes, CI must be green again
-7. **Merge** — only when CI is green and all blocking findings are resolved
+1. **PR created** — CI runs (fmt, clippy, test)
+2. **Auto-review** — Claude reviews with severity classification on CI success
+3. **Blocking findings** (High/Medium) — Claude pushes fix commits, delta review follows
+4. **Non-blocking findings** (Low/Nit) — issues created, merge not blocked
+5. **Auto-merge** — enabled when no blocking findings remain
 
-Branch protection requires status checks to pass on the HEAD commit before merging.
-No merge is possible unless CI is green on the latest commit, regardless of how many
-fix iterations occurred. All PRs are **squash-merged** (merge commits and rebase
-merging are disabled).
+All PRs are **squash-merged**. Branch protection requires CI to pass on HEAD.
+See `.claude/rules/pr-workflow.md` for full details.
 
 ## Parallel Development with tmux
 


### PR DESCRIPTION
## What

Redesign `claude-review.yml` for the fully automated issue-to-merge pipeline with severity-based classification and delta reviews.

## Why

The previous auto-review prompt had no severity classification, skipped claude[bot] fix commits (preventing delta review), and auto-merged based on a vague "no issues" criteria. This caused PRs to merge before all changes were reviewed (#582 incident).

## Changes

### claude-review.yml
- Remove `claude[bot]` author skip → fix commits get delta-reviewed
- Rewrite prompt with severity classification table (High/Medium block, Low/Nit don't)
- Track previous review SHA for delta review scoping
- Auto-merge only when no blocking findings

### Documentation
- `pr-workflow.md`: Document automated flow as default, manual `/review` as optional
- `issue-workflow.md`: Update lifecycle step 5 to reference auto-review
- `CLAUDE.md`: Update Merge Policy to match automated flow

## Test plan

- [x] Workflow YAML is syntactically valid
- [ ] Next PR will exercise the new auto-review flow automatically
- [ ] Verify delta review uses previous SHA correctly (iteration 2+)

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)