### PR TITLE
Add project: prefix to custom slash commands

### DIFF
--- a/.claude/commands/project/delta-review.md
+++ b/.claude/commands/project/delta-review.md
@@ -32,7 +32,7 @@ review. The argument is a base commit hash or PR number: `$ARGUMENTS`
 7. **Verdict**:
    - If no blocking findings: the changes are approved.
    - If blocking findings exist: report them for fixing. After fixes, run
-     `/delta-review` again with the new base commit.
+     `/project:delta-review` again with the new base commit.
 
 ## Important
 

--- a/.claude/commands/project/phase-review.md
+++ b/.claude/commands/project/phase-review.md
@@ -36,7 +36,7 @@ tracking issue number: `$ARGUMENTS`
 6. **Verdict**:
    - If there are **no blocking findings**: report that the phase is ready to close.
    - If there are **blocking findings**: report that fixes are required. After fixes
-     are merged, the user should run `/delta-review` on the fix commits.
+     are merged, the user should run `/project:delta-review` on the fix commits.
 
 ## Important
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -46,7 +46,7 @@ Before closing a phase tracking issue:
 
 0. **Prerequisite** — all sub-issues of the tracking issue must be closed.
    If any are open, complete them first.
-1. **Initial review** — run `/phase-review <tracking-issue-number>`. This
+1. **Initial review** — run `/project:phase-review <tracking-issue-number>`. This
    verifies the prerequisite, performs both code review and security review
    on the full phase diff, classifies findings by severity (see
    [Severity Definitions](pr-workflow.md#severity-definitions)), and creates
@@ -55,7 +55,7 @@ Before closing a phase tracking issue:
    via normal PR workflow, and merge to `main`.
 3. **Non-blocking findings** (Low, Nit) — issues are created but do **not**
    block phase closure.
-4. **Delta review** — run `/delta-review <base-commit>` where `<base-commit>`
+4. **Delta review** — run `/project:delta-review <base-commit>` where `<base-commit>`
    is the last commit reviewed. This reviews only the fix commits, not the
    entire phase. Only new blocking findings require further fixes.
 5. **Repeat steps 2–4** until a delta review produces no new blocking findings.


### PR DESCRIPTION
## What
Move project-specific custom commands under `.claude/commands/project/` subdirectory to namespace them with the `project:` prefix.

## Why
Organize project-specific slash commands distinctly from global/plugin commands by using a consistent `project:` prefix namespace.

## Changes
- `.claude/commands/delta-review.md` → `.claude/commands/project/delta-review.md`
- `.claude/commands/phase-review.md` → `.claude/commands/project/phase-review.md`
- Updated all documentation references in `.claude/rules/issue-workflow.md` and the command files themselves to use `/project:delta-review` and `/project:phase-review`

## Test results
- Commands are recognized as `/project:delta-review` and `/project:phase-review` in the Claude Code skill list

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)