### PR TITLE
Add golden test coverage for keys+display and copy+display define variants

### DIFF
--- a/crates/core/tests/fixtures/define-copy-display/expected.txt
+++ b/crates/core/tests/fixtures/define-copy-display/expected.txt
@@ -1,0 +1,114 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Define Copy Display Test",
+        ),
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Define Copy Display Test",
+                ),
+                kind: Title,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "Am base-fret 1 frets x 0 2 2 1 0",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "Am7 copy Am display=\"Alt\"",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "Bm copy Amin extra stuff",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am7",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: Some(
+                                            "7",
+                                        ),
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: Some(
+                                    "Alt",
+                                ),
+                            },
+                        ),
+                        text: "Hello ",
+                        spans: [],
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Bm",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: B,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "world",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/define-copy-display/input.cho
+++ b/crates/core/tests/fixtures/define-copy-display/input.cho
@@ -1,0 +1,5 @@
+{title: Define Copy Display Test}
+{define: Am base-fret 1 frets x 0 2 2 1 0}
+{define: Am7 copy Am display="Alt"}
+{define: Bm copy Amin extra stuff}
+[Am7]Hello [Bm]world

--- a/crates/core/tests/fixtures/define-display-keys/expected.txt
+++ b/crates/core/tests/fixtures/define-display-keys/expected.txt
@@ -1,0 +1,104 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Define Display Keys Test",
+        ),
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Define Display Keys Test",
+                ),
+                kind: Title,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "Am keys 0 3 7 display=\"A minor\"",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "Dm keys 2 5 9 format=\"minor\"",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: Some(
+                                    "A minor",
+                                ),
+                            },
+                        ),
+                        text: "Hello ",
+                        spans: [],
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Dm",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: D,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: Some(
+                                    "minor",
+                                ),
+                            },
+                        ),
+                        text: "world",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/define-display-keys/input.cho
+++ b/crates/core/tests/fixtures/define-display-keys/input.cho
@@ -1,0 +1,4 @@
+{title: Define Display Keys Test}
+{define: Am keys 0 3 7 display="A minor"}
+{define: Dm keys 2 5 9 format="minor"}
+[Am]Hello [Dm]world


### PR DESCRIPTION
## What

Add two golden test fixture sets for `ChordDefinition::parse_value` behaviors that were missing golden test coverage:

- `define-display-keys/`: Tests `display=` and `format=` attributes on `keys` definitions
- `define-copy-display/`: Tests `display=` on `copy` definitions and first-token-only parsing for copy source (trailing tokens ignored)

## Why

PR #612 added unit tests for these behaviors, but the project golden test rule requires `.cho`/`expected.txt` fixture coverage for all parser behaviors.

## Test results

```
cargo test    — all tests pass
cargo clippy  — no warnings
cargo fmt     — formatted
```

## Review summary

Test-only change adding golden test fixtures. No production code modified.

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)