### PR TITLE
Honor diagrams.frets config value in chord diagram rendering

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -29,6 +29,9 @@ const MIN_STRINGS: usize = 2;
 /// Maximum number of strings for a valid chord diagram (covers 12-string guitar).
 const MAX_STRINGS: usize = 12;
 
+/// Default number of frets shown in a chord diagram.
+pub const DEFAULT_FRETS_SHOWN: usize = 5;
+
 /// Data needed to render a chord diagram.
 #[derive(Debug, Clone)]
 pub struct DiagramData {
@@ -77,6 +80,13 @@ impl DiagramData {
         Self::from_raw(name, raw, 0)
     }
 
+    /// Like [`from_raw_infer`](Self::from_raw_infer) but uses a custom
+    /// `frets_shown` value instead of the default (5).
+    #[must_use]
+    pub fn from_raw_infer_frets(name: &str, raw: &str, frets_shown: usize) -> Option<Self> {
+        Self::from_raw_frets(name, raw, 0, frets_shown)
+    }
+
     /// Parse fretted chord data from a `ChordDefinition` raw string.
     ///
     /// Expected format: `base-fret N frets f1 f2 ... [fingers g1 g2 ...]`
@@ -89,10 +99,23 @@ impl DiagramData {
     /// - No fret values are provided
     /// - The resulting string count is outside the valid range (2–12)
     ///
-    /// Positive fret values exceeding `frets_shown` (5) are clamped to
-    /// prevent rendering outside the visible grid.
+    /// Positive fret values exceeding `frets_shown` are clamped to
+    /// prevent rendering outside the visible grid. Uses the default
+    /// frets shown value ([`DEFAULT_FRETS_SHOWN`]).
     #[must_use]
     pub fn from_raw(name: &str, raw: &str, num_strings: usize) -> Option<Self> {
+        Self::from_raw_frets(name, raw, num_strings, DEFAULT_FRETS_SHOWN)
+    }
+
+    /// Like [`from_raw`](Self::from_raw) but uses a custom `frets_shown`
+    /// value instead of the default.
+    #[must_use]
+    pub fn from_raw_frets(
+        name: &str,
+        raw: &str,
+        num_strings: usize,
+        frets_shown: usize,
+    ) -> Option<Self> {
         let mut base_fret: u32 = 1;
         let mut frets: Vec<i32> = Vec::new();
         let mut fingers: Vec<u8> = Vec::new();
@@ -148,7 +171,8 @@ impl DiagramData {
             return None;
         }
 
-        let frets_shown: usize = 5;
+        // Ensure frets_shown is at least 1 to avoid nonsensical diagrams.
+        let frets_shown = frets_shown.max(1);
 
         // Clamp positive fret values to the visible range to prevent
         // rendering dots outside the fret grid.

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -228,6 +228,14 @@ fn render_song_body(
     // Controls whether chord diagrams are rendered. Set by {diagrams: off/on}.
     let mut show_diagrams = true;
 
+    // Read configurable frets_shown for chord diagrams.
+    let diagram_frets = config
+        .get_path("diagrams.frets")
+        .as_f64()
+        .map_or(chordpro_core::chord_diagram::DEFAULT_FRETS_SHOWN, |n| {
+            (n as usize).max(1)
+        });
+
     // Stores the rendered HTML of the most recently defined chorus body
     // (everything between StartOfChorus and EndOfChorus, excluding the
     // section open/close tags). Used by `{chorus}` recall.
@@ -392,7 +400,12 @@ fn render_song_body(
                     }
                     _ => {
                         let mut target = String::new();
-                        render_directive_inner(directive, show_diagrams, &mut target);
+                        render_directive_inner(
+                            directive,
+                            show_diagrams,
+                            diagram_frets,
+                            &mut target,
+                        );
                         if let Some(buf) = chorus_buf.as_mut() {
                             buf.push_str(&target);
                         }
@@ -1077,6 +1090,7 @@ fn sanitize_tag_attrs(tag: &str) -> String {
 fn render_directive_inner(
     directive: &chordpro_core::ast::Directive,
     show_diagrams: bool,
+    diagram_frets: usize,
     html: &mut String,
 ) {
     match &directive.kind {
@@ -1132,8 +1146,10 @@ fn render_directive_inner(
                     let def = chordpro_core::ast::ChordDefinition::parse_value(value);
                     if let Some(ref raw) = def.raw {
                         if let Some(mut diagram) =
-                            chordpro_core::chord_diagram::DiagramData::from_raw_infer(
-                                &def.name, raw,
+                            chordpro_core::chord_diagram::DiagramData::from_raw_infer_frets(
+                                &def.name,
+                                raw,
+                                diagram_frets,
                             )
                         {
                             diagram.display_name = def.display.clone();

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -177,7 +177,13 @@ pub fn render_song_with_warnings(
         &song_config
     };
     let mut doc = PdfDocument::from_config_with_warnings(effective_config, &mut warnings);
-    render_song_into_doc(song, cli_transpose, &mut doc, &mut warnings);
+    render_song_into_doc(
+        song,
+        cli_transpose,
+        effective_config,
+        &mut doc,
+        &mut warnings,
+    );
     RenderResult::with_warnings(doc.build_pdf(), warnings)
 }
 
@@ -231,7 +237,13 @@ pub fn render_songs_with_warnings(
             &song_config
         };
         let mut doc = PdfDocument::from_config_with_warnings(effective_config, &mut warnings);
-        render_song_into_doc(&songs[0], cli_transpose, &mut doc, &mut warnings);
+        render_song_into_doc(
+            &songs[0],
+            cli_transpose,
+            effective_config,
+            &mut doc,
+            &mut warnings,
+        );
         return RenderResult::with_warnings(doc.build_pdf(), warnings);
     }
 
@@ -265,7 +277,13 @@ pub fn render_songs_with_warnings(
             .unwrap_or("Untitled")
             .to_string();
         toc_entries.push((title, start_page));
-        render_song_into_doc(song, cli_transpose, &mut body_doc, &mut warnings);
+        render_song_into_doc(
+            song,
+            cli_transpose,
+            effective_config,
+            &mut body_doc,
+            &mut warnings,
+        );
     }
 
     // Phase 2: generate ToC pages.
@@ -326,6 +344,7 @@ pub fn render_songs_with_warnings(
 fn render_song_into_doc(
     song: &Song,
     cli_transpose: i8,
+    config: &Config,
     doc: &mut PdfDocument,
     warnings: &mut Vec<String>,
 ) {
@@ -337,6 +356,14 @@ fn render_song_into_doc(
         chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);
     let mut transpose_offset: i8 = combined_transpose;
     let mut fmt_state = PdfFormattingState::default();
+
+    // Read configurable frets_shown for chord diagrams.
+    let diagram_frets = config
+        .get_path("diagrams.frets")
+        .as_f64()
+        .map_or(chordpro_core::chord_diagram::DEFAULT_FRETS_SHOWN, |n| {
+            (n as usize).max(1)
+        });
 
     // Title
     if let Some(title) = &song.metadata.title {
@@ -407,6 +434,7 @@ fn render_song_into_doc(
                                 transpose_offset,
                                 &fmt_state,
                                 show_diagrams,
+                                diagram_frets,
                                 doc,
                             );
                             chorus_recall_count += 1;
@@ -451,7 +479,7 @@ fn render_song_into_doc(
                         if let Some(buf) = chorus_buf.as_mut() {
                             buf.push(line.clone());
                         }
-                        render_directive(d, show_diagrams, doc);
+                        render_directive(d, show_diagrams, diagram_frets, doc);
                     }
                 }
             }
@@ -648,6 +676,7 @@ fn render_section_label(directive: &chordpro_core::ast::Directive, doc: &mut Pdf
 fn render_directive(
     directive: &chordpro_core::ast::Directive,
     show_diagrams: bool,
+    diagram_frets: usize,
     doc: &mut PdfDocument,
 ) {
     if directive.kind == DirectiveKind::Define && show_diagrams {
@@ -655,7 +684,11 @@ fn render_directive(
             let def = chordpro_core::ast::ChordDefinition::parse_value(value);
             if let Some(ref raw) = def.raw {
                 if let Some(mut diagram) =
-                    chordpro_core::chord_diagram::DiagramData::from_raw_infer(&def.name, raw)
+                    chordpro_core::chord_diagram::DiagramData::from_raw_infer_frets(
+                        &def.name,
+                        raw,
+                        diagram_frets,
+                    )
                 {
                     diagram.display_name = def.display.clone();
                     render_chord_diagram_pdf(&diagram, doc);
@@ -1057,6 +1090,7 @@ fn render_chorus_recall(
     transpose_offset: i8,
     fmt_state: &PdfFormattingState,
     show_diagrams: bool,
+    diagram_frets: usize,
     doc: &mut PdfDocument,
 ) {
     let text = match value {
@@ -1074,7 +1108,7 @@ fn render_chorus_recall(
             Line::Comment(style, text) => render_comment(*style, text, doc),
             Line::Empty => doc.newline(LINE_GAP * 2.0),
             Line::Directive(d) if !d.kind.is_metadata() => {
-                render_directive(d, show_diagrams, doc);
+                render_directive(d, show_diagrams, diagram_frets, doc);
             }
             _ => {}
         }
@@ -3113,7 +3147,7 @@ mod column_tests {
         let song = chordpro_core::parse("{title: Test}\n[Am]Hello").unwrap();
         let mut doc = PdfDocument::new();
         let mut warnings = Vec::new();
-        render_song_into_doc(&song, 0, &mut doc, &mut warnings);
+        render_song_into_doc(&song, 0, &Config::defaults(), &mut doc, &mut warnings);
         // Document should have 1 page with content
         assert_eq!(doc.page_count(), 1);
         let pdf = doc.build_pdf();


### PR DESCRIPTION
## What

Add configurable `frets_shown` support to `DiagramData` parsing and update both PDF and HTML renderers to read `diagrams.frets` from config.

## Why

`DiagramData::from_raw` hardcoded `frets_shown = 5`. The config system defines `diagrams.frets` which can be overridden per-song, but the value was never read.

## Test results

```
cargo test   — all pass
cargo clippy — no warnings
cargo fmt    — clean
```

## Review summary

- Added `from_raw_frets` and `from_raw_infer_frets` methods to `DiagramData`
- Existing `from_raw` and `from_raw_infer` delegate with `DEFAULT_FRETS_SHOWN = 5`
- PDF renderer: added `config` parameter to `render_song_into_doc`, reads `diagrams.frets`
- HTML renderer: reads `diagrams.frets` in `render_song_body`
- Both renderers pass the value through to `render_directive`/`render_directive_inner`

Closes #605