### PR TITLE
Strengthen RRJSON duplicate-key test and remove duplicate config test

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1715,18 +1715,6 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_song_per_song_config_overrides() {
-        // Verify that config overrides in one song do not leak to the next.
-        let input = "{title: Song A}\n{+config.settings.transpose: 2}\n[C]Hello\n{new_song}\n{title: Song B}\n[C]World";
-        let songs = crate::parse_multi(input).unwrap();
-        assert_eq!(songs.len(), 2);
-        // Song A has the transpose override.
-        assert!(!songs[0].config_overrides().is_empty());
-        // Song B should have no overrides.
-        assert!(songs[1].config_overrides().is_empty());
-    }
-
-    #[test]
     fn test_song_config_plus_delegate_blocking() {
         // Song-level config cannot enable delegates.
         let config = Config::defaults();

--- a/crates/core/src/rrjson.rs
+++ b/crates/core/src/rrjson.rs
@@ -1888,13 +1888,14 @@ mod tests {
     fn test_duplicate_keys_last_wins() {
         let result = parse_rrjson(r#"{"a": 1, "a": 2}"#).unwrap();
         if let Value::Object(entries) = result {
-            // Last value should win for the key.
+            // Duplicate key should be deduplicated to exactly one entry.
             let vals: Vec<_> = entries
                 .iter()
                 .filter(|(k, _)| k == "a")
                 .map(|(_, v)| v)
                 .collect();
-            assert_eq!(vals.last(), Some(&&Value::Number(2.0)));
+            assert_eq!(vals.len(), 1);
+            assert_eq!(vals[0], &Value::Number(2.0));
         } else {
             panic!("expected object");
         }


### PR DESCRIPTION
## What

- Strengthen `test_duplicate_keys_last_wins` assertion in `rrjson.rs` to verify exactly one entry exists for duplicate keys
- Remove `test_multi_song_per_song_config_overrides` from `config.rs` (duplicates `config_overrides_not_in_multi_song_leak` in `parser.rs`)

## Why

- The `.last()` check passed but did not assert deduplication produced exactly one entry
- The config.rs test duplicated parser.rs coverage and was misplaced (tests parser behavior, not config module logic)

## Test results

```
cargo test    — all tests pass
cargo clippy  — no warnings
```

## Review summary

Test-only changes: one assertion strengthened, one duplicate test removed.

Closes #600
Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)