### PR TITLE
Add golden and renderer-level tests for chord diagram directives

### DIFF
--- a/crates/core/tests/fixtures/define-copyall-fingers/expected.txt
+++ b/crates/core/tests/fixtures/define-copyall-fingers/expected.txt
@@ -1,0 +1,102 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Define Copyall Fingers Test",
+        ),
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Define Copyall Fingers Test",
+                ),
+                kind: Title,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "Am base-fret 1 frets x 0 2 2 1 0 fingers 0 0 2 3 1 0",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "Am7 copyall Am",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "Hello ",
+                        spans: [],
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am7",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: Some(
+                                            "7",
+                                        ),
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "world",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/define-copyall-fingers/input.cho
+++ b/crates/core/tests/fixtures/define-copyall-fingers/input.cho
@@ -1,0 +1,4 @@
+{title: Define Copyall Fingers Test}
+{define: Am base-fret 1 frets x 0 2 2 1 0 fingers 0 0 2 3 1 0}
+{define: Am7 copyall Am}
+[Am]Hello [Am7]world

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1617,6 +1617,15 @@ mod tests {
         // Label still uses HTML escaping for display
         assert!(html.contains("&amp;"));
     }
+
+    #[test]
+    fn test_define_display_name_in_html_output() {
+        let html = render("{define: Am base-fret 1 frets x 0 2 2 1 0 display=\"A minor\"}");
+        assert!(
+            html.contains("A minor"),
+            "display name should appear in rendered HTML output"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -2563,6 +2563,31 @@ Sing along
         let content = String::from_utf8_lossy(&bytes);
         assert!(content.contains("Grid: Intro"));
     }
+
+    #[test]
+    fn test_define_display_name_in_pdf_output() {
+        let input = "{define: Am base-fret 1 frets x 0 2 2 1 0 display=\"A minor\"}";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        let content = String::from_utf8_lossy(&bytes);
+        assert!(
+            content.contains("A minor"),
+            "display name should appear in rendered PDF output"
+        );
+    }
+
+    #[test]
+    fn test_define_with_fingers_in_pdf_output() {
+        let input = "{define: C base-fret 1 frets x 3 2 0 1 0 fingers 0 3 2 0 1 0}";
+        let song = chordpro_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        let content = String::from_utf8_lossy(&bytes);
+        // PDF text streams should contain finger numbers
+        assert!(
+            content.contains("(3)") || content.contains("fret_marker"),
+            "finger numbers should appear in rendered PDF output"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

1. Add golden test fixture for `{define}` with `copyall` and `fingers` parsing
2. Add renderer-level tests verifying `display_name` override in HTML/PDF output
3. Add renderer-level test verifying finger number rendering in PDF output

## Why

Issue #610: Golden tests were missing for `copyall` variant and `fingers` attribute.
Issue #611: No end-to-end renderer tests existed for display_name override flow or finger number rendering.

## Test results

```
cargo test   — all pass
cargo clippy — no warnings
cargo fmt    — clean
```

## Review summary

Test-only changes — no production code modified.

Closes #610
Closes #611