### PR TITLE
Use full SHAs in delta review and paginate listComments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,6 +45,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
+              per_page: 100,
             });
 
             // Skip if this commit was already reviewed
@@ -82,7 +83,7 @@ jobs:
             const reviewType = isFirstReview ? 'Full review' : 'Delta review';
             const deltaInstruction = isFirstReview
               ? 'Review the entire PR diff (`gh pr diff`).'
-              : `This is a **delta review**. Only review changes since commit \`${previousSha.substring(0, 7)}\`. Use \`git diff ${previousSha.substring(0, 7)}..${headSha.substring(0, 7)}\` to see only the new changes. Do NOT re-review previously-accepted code.`;
+              : `This is a **delta review**. Only review changes since commit \`${previousSha.substring(0, 7)}\`. Use \`git diff ${previousSha}..${headSha}\` to see only the new changes. Do NOT re-review previously-accepted code.`;
 
             // Post review request comment (triggers claude.yml via @claude mention)
             await github.rest.issues.createComment({


### PR DESCRIPTION
## What

Two fixes to `.github/workflows/claude-review.yml`:

1. Use full SHAs in the `git diff` instruction for delta reviews (abbreviated SHAs still used in log/display messages)
2. Add `per_page: 100` to `listComments` API call to avoid missing auto-review markers on PRs with 30+ comments

## Why

- 7-char abbreviated SHAs could theoretically collide in larger repos; full SHAs are the robust default for git operations
- The default 30-comment page size could cause missed markers, leading to incorrect iteration counts or stale delta base SHAs

## Test results

Workflow YAML change only — no Rust code modified.

## Review summary

CI workflow hardening, no functional changes to the codebase.

Closes #588
Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)