### PR TITLE
Fix misleading test assertions in HTML and PDF renderers

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -2143,7 +2143,7 @@ Verse text\n\
             "CSS should include .chord-diagram-container rule"
         );
         assert!(
-            html.contains(".chord-diagram"),
+            html.contains(".chord-diagram {"),
             "CSS should include .chord-diagram rule"
         );
     }

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -2584,7 +2584,7 @@ Sing along
         let content = String::from_utf8_lossy(&bytes);
         // PDF text streams should contain finger numbers
         assert!(
-            content.contains("(3)") || content.contains("fret_marker"),
+            content.contains("(3)"),
             "finger numbers should appear in rendered PDF output"
         );
     }


### PR DESCRIPTION
## What

- Remove dead `|| content.contains("fret_marker")` fallback from the PDF test `test_define_with_fingers_in_pdf_output` — the string `"fret_marker"` is never emitted by the PDF renderer, making this branch unreachable dead code.
- Strengthen the CSS assertion in `test_chord_diagram_css_rules_present` to check for `.chord-diagram {` instead of `.chord-diagram`, which previously could match `.chord-diagram-container` and give a false positive.

## Why

Both assertions were misleading and could mask real failures. Fixes #627 and #631.

## Test results

```
cargo test --package chordpro-render-pdf  → 161 passed
cargo test --package chordpro-render-html test_chord_diagram_css → 1 passed
```

Closes #627
Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)