### PR TITLE
Paginate listComments in claude-review.yml

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,13 +40,16 @@ jobs:
               return;
             }
 
-            // Fetch existing comments to prevent duplicates and limit iterations
-            const { data: comments } = await github.rest.issues.listComments({
+            // Fetch all existing comments to prevent duplicates and limit iterations
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
               per_page: 100,
             });
+            if (comments.length > 100) {
+              console.log(`Note: PR #${prNumber} has ${comments.length} comments (paginated fetch)`);
+            }
 
             // Skip if this commit was already reviewed
             const marker = `<!-- claude-auto-review:${headSha} -->`;


### PR DESCRIPTION
## What

Replace the single `listComments` REST call with `github.paginate()` to automatically fetch all comments regardless of count. Adds a log message when more than 100 comments are encountered.

## Why

The previous `per_page: 100` parameter (added in #630) could still silently truncate comments on PRs with 100+ comments. This would cause auto-review markers to be missed, breaking deduplication and iteration counting. Closes #632.

## Test results

Workflow YAML syntax is valid. The `github.paginate()` API is the standard Octokit approach for handling GitHub API pagination and returns a flat array of all items across all pages.

## Changes

- `github.rest.issues.listComments(...)` → `github.paginate(github.rest.issues.listComments, ...)`
- Added log message for PRs exceeding 100 comments

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)