### PR TITLE
Expose MIN_STRINGS/MAX_STRINGS as pub and add strings assertion

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -24,10 +24,10 @@
 //! ```
 
 /// Minimum number of strings for a valid chord diagram.
-const MIN_STRINGS: usize = 2;
+pub const MIN_STRINGS: usize = 2;
 
 /// Maximum number of strings for a valid chord diagram (covers 12-string guitar).
-const MAX_STRINGS: usize = 12;
+pub const MAX_STRINGS: usize = 12;
 
 /// Default number of frets shown in a chord diagram.
 pub const DEFAULT_FRETS_SHOWN: usize = 5;
@@ -808,6 +808,8 @@ mod tests {
         assert_eq!(data.fingers, vec![0, 0, 2]);
         // Both frets batches (6 + 6) are accumulated by the outer loop.
         assert_eq!(data.frets.len(), 12);
+        // strings is max(num_strings, frets.len()) = max(6, 12) = 12.
+        assert_eq!(data.strings, 12);
     }
 
     #[test]


### PR DESCRIPTION
## What

- Change `MIN_STRINGS` and `MAX_STRINGS` from private to `pub const` so API consumers can validate string counts without trial-and-error (#642)
- Add `assert_eq!(data.strings, 12)` to `test_frets_stops_finger_parsing` to verify the strings field is correctly computed as `max(num_strings, frets.len())` (#643)

## Why

Both constants (`MIN_FRETS_SHOWN`, `MAX_BASE_FRET`, `DEFAULT_FRETS_SHOWN`) are already public — `MIN_STRINGS` and `MAX_STRINGS` should be consistent. The missing assertion in the test left the `strings` field unchecked. Found during review of #639.

## Test results

```
cargo test --package chordpro-core → 824 passed (including frets_stops_finger_parsing)
cargo clippy --package chordpro-core -- -D warnings → clean
```

Closes #642
Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)