### PR TITLE
Improve diagrams.frets test placement and structural assertion

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -2188,6 +2188,21 @@ Verse text\n\
         );
     }
 
+    #[test]
+    fn test_diagrams_frets_config_controls_svg_height() {
+        let input = "{define: Am base-fret 1 frets x 0 2 2 1 0}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("diagrams.frets=4")
+            .unwrap();
+        let html = render_song_with_transpose(&song, 0, &config);
+        // 4 frets: grid_h = 4*20 = 80, total_h = 80 + 30 + 30 = 140
+        assert!(
+            html.contains("height=\"140\""),
+            "SVG height should reflect diagrams.frets=4 (expected 140)"
+        );
+    }
+
     // -- {diagrams} directive tests -----------------------------------------------
 
     #[test]
@@ -2240,21 +2255,6 @@ Verse text\n\
         } else {
             panic!("expected a directive line, got: {:?}", &song.lines[0]);
         }
-    }
-
-    #[test]
-    fn test_diagrams_frets_config_controls_svg_height() {
-        let input = "{define: Am base-fret 1 frets x 0 2 2 1 0}";
-        let song = chordpro_core::parse(input).unwrap();
-        let config = chordpro_core::config::Config::defaults()
-            .with_define("diagrams.frets=4")
-            .unwrap();
-        let html = render_song_with_transpose(&song, 0, &config);
-        // 4 frets: grid_h = 4*20 = 80, total_h = 80 + 30 + 30 = 140
-        assert!(
-            html.contains("height=\"140\""),
-            "SVG height should reflect diagrams.frets=4 (expected 140)"
-        );
     }
 
     // -- abc2svg delegate rendering tests -----------------------------------------

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -3294,14 +3294,18 @@ mod chord_diagram_pdf_tests {
             .unwrap();
         let bytes_4 = render_song_with_transpose(&song, 0, &config_4);
         let bytes_7 = render_song_with_transpose(&song, 0, &config_7);
-        assert!(bytes_4.starts_with(b"%PDF"));
-        assert!(bytes_7.starts_with(b"%PDF"));
-        // Different fret counts produce different PDF content: more frets means
-        // more horizontal lines and a taller grid, yielding a larger output.
-        assert_ne!(
-            bytes_4.len(),
-            bytes_7.len(),
-            "diagrams.frets config should affect rendered PDF size"
+        let content_4 = String::from_utf8_lossy(&bytes_4);
+        let content_7 = String::from_utf8_lossy(&bytes_7);
+        // Each line_at() emits "m ... l S". Count line-drawing operations:
+        // frets=4 → 5 horizontal + 6 vertical + 1 nut = 12 lines
+        // frets=7 → 8 horizontal + 6 vertical + 1 nut = 15 lines
+        // The difference of 3 corresponds to the 3 extra fret lines.
+        let lines_4 = content_4.matches("l S").count();
+        let lines_7 = content_7.matches("l S").count();
+        assert_eq!(
+            lines_7 - lines_4,
+            3,
+            "frets=7 should produce exactly 3 more line-drawing ops than frets=4"
         );
     }
 }


### PR DESCRIPTION
## What

- Move `test_diagrams_frets_config_controls_svg_height` from after `{diagrams}` directive tests to the chord diagram tests section where it belongs (#640)
- Replace PDF test's byte-size comparison with a structural assertion counting PDF line-drawing operations (`l S`), verifying that `frets=7` produces exactly 3 more lines than `frets=4` (#641)

## Why

Both issues were found during review of PR #638. The HTML test was placed in the wrong section, and the PDF test relied on a weak size comparison instead of verifying structural output properties.

## Test results

```
cargo test --package chordpro-render-html diagrams_frets → 1 passed
cargo test --package chordpro-render-pdf test_diagrams_frets_config → 1 passed
cargo clippy -- -D warnings → clean
```

Closes #640
Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)