### PR TITLE
Guard usize subtraction in PDF frets test to prevent overflow panic

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -3302,10 +3302,15 @@ mod chord_diagram_pdf_tests {
         // The difference of 3 corresponds to the 3 extra fret lines.
         let lines_4 = content_4.matches("l S").count();
         let lines_7 = content_7.matches("l S").count();
+        assert!(
+            lines_7 >= lines_4,
+            "frets=7 ({lines_7}) should have at least as many line ops as frets=4 ({lines_4})"
+        );
         assert_eq!(
             lines_7 - lines_4,
             3,
-            "frets=7 should produce exactly 3 more line-drawing ops than frets=4"
+            "frets=7 should produce exactly 3 more line-drawing ops than frets=4 \
+             (got {lines_7} vs {lines_4})"
         );
     }
 }


### PR DESCRIPTION
## What

Add a guard assertion (`lines_7 >= lines_4`) before the usize subtraction in `test_diagrams_frets_config_affects_pdf_output` so that if a bug causes fewer line ops for frets=7, the test fails with a meaningful message instead of panicking with "attempt to subtract with overflow".

## Why

The bare `lines_7 - lines_4` expression panics in debug mode if the invariant is violated, hiding the actual values. Closes #666.

## Test results

```
cargo test --package chordpro-render-pdf test_diagrams_frets_config → 1 passed
```

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)