### PR TITLE
Harden ChordDefinition parser: tab delimiters, empty attribute values, and flexible whitespace

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -3159,10 +3159,7 @@ mod chord_definition_tests {
         let def = ChordDefinition::parse_value("Am base-fret 1 frets x 0 2 2 1 0 display=");
         assert_eq!(def.display, Some(String::new()));
         // display= must not appear in raw — only the fret portion remains.
-        assert_eq!(
-            def.raw,
-            Some("base-fret 1 frets x 0 2 2 1 0".to_string())
-        );
+        assert_eq!(def.raw, Some("base-fret 1 frets x 0 2 2 1 0".to_string()));
     }
 
     // --- Forward-reference {define} (#657) ---


### PR DESCRIPTION
## What

Hardens the `ChordDefinition::parse_value` and `extract_attribute` functions in `crates/core/src/ast.rs` with four improvements:

1. **Tab delimiter for copy/copyall** (#649) — `copy` and `copyall` prefix matching now handles tab delimiters, consistent with the existing `keys` keyword handling.

2. **Empty attribute value handling** (#650) — `extract_attribute` now returns `Some("")` when a key is found but no value follows (e.g., `display=`), instead of returning `None` while still mutating the input string.

3. **Flexible whitespace after keys** (#659) — The `keys` keyword now handles arbitrary whitespace (multiple spaces, tabs) instead of only single space or tab.

4. **Forward-reference {define} test** (#657) — Documents the two-pass behavior of `apply_define_displays` which correctly handles `{define}` directives appearing after chord usage.

## Why

These are spec-compliance and correctness fixes from Phase 14 review. The tab delimiter and whitespace handling align with ChordPro's general tolerance for whitespace variations. The empty attribute fix prevents a contract violation where `extract_attribute` mutated the string without returning a meaningful result.

## Test results

```
test result: ok. 841 passed; 0 failed; 6 ignored
```

All existing tests pass. 8 new tests added.

## Review summary

- All changes are in `crates/core/src/ast.rs`
- Zero new dependencies
- Backwards compatible

Closes #649
Closes #650
Closes #657
Closes #659