### PR TITLE
Add defense-in-depth guards to PDF chord diagram renderer

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -982,6 +982,11 @@ fn render_chord_diagram_pdf(
     data: &chordpro_core::chord_diagram::DiagramData,
     doc: &mut PdfDocument,
 ) {
+    // Guard: need at least 2 strings to compute grid width without underflow.
+    if data.strings < 2 {
+        return;
+    }
+
     // PDF cell dimensions in points (1 pt = 1/72 inch). Intentionally
     // smaller than the SVG renderer's 16x20 px because PDF targets printed
     // pages where diagrams sit alongside text and must be compact.
@@ -1008,13 +1013,14 @@ fn render_chord_diagram_pdf(
     if data.base_fret == 1 {
         doc.line_at(base_x, grid_top, base_x + grid_w, grid_top, 2.0);
     } else {
-        // Show fret number
+        // Show fret number, clamping x to >= 0 to prevent off-page rendering.
         let fret_label = format!("{}fr", data.base_fret);
+        let fret_label_x = (base_x - 16.0).max(0.0);
         doc.text_at(
             &fret_label,
             Font::Helvetica,
             6.0,
-            base_x - 16.0,
+            fret_label_x,
             grid_top - cell_h / 2.0,
         );
     }


### PR DESCRIPTION
## What

Adds two defense-in-depth guards to `render_chord_diagram_pdf` in `crates/render-pdf/src/lib.rs`:

1. **Early return for strings < 2** (#661) — Prevents underflow in `(num_strings - 1) as f32 * cell_w` when `num_strings` is 0 or 1 via direct construction bypassing `from_raw` validation.

2. **Clamp fret label x-position** (#656) — `(base_x - 16.0).max(0.0)` prevents the fret number label from rendering at negative x coordinates when margins are very small.

## Why

While `DiagramData::from_raw` enforces `MIN_STRINGS..=MAX_STRINGS`, the struct fields are public and direct construction can bypass validation. These guards prevent arithmetic issues in the PDF renderer.

## Test results

```
test result: ok. 162 passed; 0 failed
```

## Review summary

- All changes in `crates/render-pdf/src/lib.rs`
- Zero new dependencies

Closes #656
Closes #661