### PR TITLE
Harden render_chord_diagram_pdf with full bounds guards

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -985,8 +985,12 @@ fn render_chord_diagram_pdf(
     data: &chordpro_core::chord_diagram::DiagramData,
     doc: &mut PdfDocument,
 ) {
-    // Guard: need at least 2 strings to compute grid width without underflow.
-    if data.strings < 2 {
+    // Guard: mirror render_svg bounds checks for strings and frets_shown.
+    if data.strings < chordpro_core::chord_diagram::MIN_STRINGS
+        || data.strings > chordpro_core::chord_diagram::MAX_STRINGS
+        || data.frets_shown < chordpro_core::chord_diagram::MIN_FRETS_SHOWN
+        || data.frets_shown > chordpro_core::chord_diagram::MAX_FRETS_SHOWN
+    {
         return;
     }
 


### PR DESCRIPTION
## What

Replace the literal `data.strings < 2` guard in `render_chord_diagram_pdf` with a comprehensive guard mirroring `render_svg`:
- `MIN_STRINGS` / `MAX_STRINGS` for string count (#677, #678)
- `MIN_FRETS_SHOWN` / `MAX_FRETS_SHOWN` for fret count (#684)

## Why

The PDF renderer guard was inconsistent with the SVG renderer: it used a literal `2` instead of the `MIN_STRINGS` constant, lacked an upper-bound strings check, and had no frets_shown validation at all.

## Test results

```
cargo test --package chordpro-render-pdf → 164 passed
cargo clippy -- -D warnings → clean
```

Closes #677
Closes #678
Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)