### PR TITLE
Clamp frets_shown in constructor and add copyall mixed whitespace test

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -3179,6 +3179,12 @@ mod chord_definition_tests {
         assert_eq!(def.copy, Some("Amin".to_string()));
     }
 
+    #[test]
+    fn test_parse_copyall_mixed_whitespace() {
+        let def = ChordDefinition::parse_value("Am copyall \t Amin");
+        assert_eq!(def.copyall, Some("Amin".to_string()));
+    }
+
     // --- extract_attribute empty value (#650) ---
 
     #[test]

--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -197,8 +197,8 @@ impl DiagramData {
             return None;
         }
 
-        // Ensure frets_shown is at least 1 to avoid nonsensical diagrams.
-        let frets_shown = frets_shown.max(1);
+        // Clamp frets_shown to the valid range, mirroring base_fret clamping.
+        let frets_shown = frets_shown.clamp(MIN_FRETS_SHOWN, MAX_FRETS_SHOWN);
 
         // Clamp positive fret values to the visible range to prevent
         // rendering dots outside the fret grid.
@@ -949,6 +949,15 @@ mod tests {
             fingers: vec![],
         };
         assert!(!render_svg(&data).is_empty());
+    }
+
+    // --- from_raw_frets clamps frets_shown (#691) ---
+
+    #[test]
+    fn test_from_raw_frets_clamps_excessive_frets_shown() {
+        // frets_shown > MAX_FRETS_SHOWN should be clamped, not rejected.
+        let data = DiagramData::from_raw_frets("Am", "frets x 0 2 2 1 0", 6, 100).unwrap();
+        assert_eq!(data.frets_shown, MAX_FRETS_SHOWN);
     }
 
     // --- "fingers" self-referencing stop-word (#647) ---


### PR DESCRIPTION
## What

- Replace `frets_shown.max(1)` with `frets_shown.clamp(MIN_FRETS_SHOWN, MAX_FRETS_SHOWN)` in `from_raw_frets`, mirroring how `base_fret` is clamped (#691)
- Add `test_parse_copyall_mixed_whitespace` to match existing `test_parse_copy_mixed_whitespace` coverage (#698)

## Why

`frets_shown` only had a lower-bound clamp at construction time but `render_svg`/`render_chord_diagram_pdf` guard at the upper bound — an asymmetry. The copyall keyword lacked a mixed-whitespace test that the copy keyword already had.

## Test results

```
cargo test --package chordpro-core → 855 passed
```

Closes #691
Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)