### PR TITLE
Add lower-bound clamp test for frets_shown in from_raw_frets

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -960,6 +960,13 @@ mod tests {
         assert_eq!(data.frets_shown, MAX_FRETS_SHOWN);
     }
 
+    #[test]
+    fn test_from_raw_frets_clamps_zero_frets_shown() {
+        // frets_shown = 0 should be clamped to MIN_FRETS_SHOWN, not rejected.
+        let data = DiagramData::from_raw_frets("Am", "frets x 0 2 2 1 0", 6, 0).unwrap();
+        assert_eq!(data.frets_shown, MIN_FRETS_SHOWN);
+    }
+
     // --- "fingers" self-referencing stop-word (#647) ---
 
     #[test]


### PR DESCRIPTION
## What

Add `test_from_raw_frets_clamps_zero_frets_shown` verifying that `frets_shown=0` is clamped to `MIN_FRETS_SHOWN` rather than rejected.

## Why

PR #702 added the upper-bound test but the lower-bound path (0 → 1) was untested. Closes #703.

## Test results

```
cargo test --package chordpro-core → 856 passed
```

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)