### PR TITLE
Remove duplicate frets_shown zero-clamping test

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -861,13 +861,6 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw_frets_zero_clamped_to_one() {
-        let data =
-            DiagramData::from_raw_frets("Am", "base-fret 1 frets x 0 2 2 1 0", 6, 0).unwrap();
-        assert_eq!(data.frets_shown, 1);
-    }
-
-    #[test]
     fn test_from_raw_frets_clamps_fret_values() {
         // With frets_shown=3, fret value 5 should be clamped to 3.
         let data =


### PR DESCRIPTION
## What

Remove `test_from_raw_frets_zero_clamped_to_one` which is a near-duplicate of `test_from_raw_frets_clamps_zero_frets_shown`. The retained test uses the `MIN_FRETS_SHOWN` constant instead of a literal `1`.

## Why

Both tests call `from_raw_frets("Am", ..., 6, 0)` and assert `frets_shown == 1`/`MIN_FRETS_SHOWN`. The only difference was the raw string and assertion style. Closes #705.

## Test results

```
cargo test --package chordpro-core → 855 passed
```

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)