### PR TITLE
Defer external tool availability checks to first use

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -95,22 +95,6 @@ fn main() -> ExitCode {
         }
     }
 
-    // Auto-detect external delegate tools and enable them in config.
-    // This runs after user configs but before --define, so explicit
-    // --define delegates.abc2svg=false can still override.
-    if chordpro_core::external_tool::has_abc2svg() {
-        // Hardcoded key=value — unwrap is safe.
-        config = config
-            .with_define("delegates.abc2svg=true")
-            .expect("hardcoded define is valid");
-    }
-    if chordpro_core::external_tool::has_lilypond() {
-        // Hardcoded key=value — unwrap is safe.
-        config = config
-            .with_define("delegates.lilypond=true")
-            .expect("hardcoded define is valid");
-    }
-
     // Apply --define overrides (highest precedence)
     for define in &cli.defines {
         match config.with_define(define) {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -466,16 +466,10 @@ impl Config {
 
         // Snapshot delegate settings from trusted sources (system + user config).
         // Project-level and song-specific configs must not silently enable
-        // delegate execution — only CLI flags, auto-detection, or explicit
-        // user config (~/.config/chordpro/) may enable delegates.
-        let trusted_abc2svg = config
-            .get_path("delegates.abc2svg")
-            .as_bool()
-            .unwrap_or(false);
-        let trusted_lilypond = config
-            .get_path("delegates.lilypond")
-            .as_bool()
-            .unwrap_or(false);
+        // delegate execution — only CLI flags or explicit user config
+        // (~/.config/chordpro/) may enable delegates.
+        let trusted_abc2svg = config.get_path("delegates.abc2svg").clone();
+        let trusted_lilypond = config.get_path("delegates.lilypond").clone();
 
         // Project config (untrusted — reduced size limit)
         if let Some(dir) = project_dir {
@@ -509,19 +503,18 @@ impl Config {
 
         // Restore delegate settings to trusted values. If a project or song
         // config attempted to enable a delegate, override it back and warn.
-        let project_abc2svg = config
-            .get_path("delegates.abc2svg")
-            .as_bool()
-            .unwrap_or(false);
-        let project_lilypond = config
-            .get_path("delegates.lilypond")
-            .as_bool()
-            .unwrap_or(false);
+        let current_abc2svg = config.get_path("delegates.abc2svg").as_bool();
+        let current_lilypond = config.get_path("delegates.lilypond").as_bool();
 
-        if project_abc2svg && !trusted_abc2svg {
-            // Hardcoded key=value — unwrap is safe.
+        if current_abc2svg == Some(true) && trusted_abc2svg.as_bool() != Some(true) {
+            // Reset to trusted value (null=auto or false=disabled).
+            let reset = if trusted_abc2svg.is_null() {
+                "null"
+            } else {
+                "false"
+            };
             config = config
-                .with_define("delegates.abc2svg=false")
+                .with_define(&format!("delegates.abc2svg={reset}"))
                 .expect("hardcoded define is valid");
             warnings.push(
                 "delegates.abc2svg was enabled by a project-level config file and has been \
@@ -529,10 +522,15 @@ impl Config {
                     .to_string(),
             );
         }
-        if project_lilypond && !trusted_lilypond {
-            // Hardcoded key=value — unwrap is safe.
+        if current_lilypond == Some(true) && trusted_lilypond.as_bool() != Some(true) {
+            // Reset to trusted value (null=auto or false=disabled).
+            let reset = if trusted_lilypond.is_null() {
+                "null"
+            } else {
+                "false"
+            };
             config = config
-                .with_define("delegates.lilypond=false")
+                .with_define(&format!("delegates.lilypond={reset}"))
                 .expect("hardcoded define is valid");
             warnings.push(
                 "delegates.lilypond was enabled by a project-level config file and has been \
@@ -819,10 +817,11 @@ const DEFAULT_CONFIG: &str = r#"{
         separator: "; "
     },
 
-    // Delegate environments (external tool integration)
+    // Delegate environments (external tool integration).
+    // null = auto-detect on first use; true = force enable; false = force disable.
     delegates: {
-        abc2svg: false,
-        lilypond: false
+        abc2svg: null,
+        lilypond: null
     }
 }"#;
 
@@ -1260,15 +1259,9 @@ mod tests {
         .unwrap();
 
         let result = Config::load(Some(dir.path().to_str().unwrap()), None);
-        // Delegates should be reset to false
-        assert_eq!(
-            result.config.get_path("delegates.abc2svg"),
-            &Value::Bool(false)
-        );
-        assert_eq!(
-            result.config.get_path("delegates.lilypond"),
-            &Value::Bool(false)
-        );
+        // Delegates should be reset to null (auto-detect default)
+        assert_eq!(result.config.get_path("delegates.abc2svg"), &Value::Null);
+        assert_eq!(result.config.get_path("delegates.lilypond"), &Value::Null);
         // Warnings should be emitted
         assert!(
             result
@@ -1534,9 +1527,9 @@ mod tests {
             ("delegates.lilypond", "true"),
         ];
         let config = config.with_song_overrides(&overrides, &mut warnings);
-        // Delegate keys should remain at their default (false)
-        assert_eq!(config.get_path("delegates.abc2svg"), &Value::Bool(false));
-        assert_eq!(config.get_path("delegates.lilypond"), &Value::Bool(false));
+        // Delegate keys should remain at their default (null = auto-detect)
+        assert_eq!(config.get_path("delegates.abc2svg"), &Value::Null);
+        assert_eq!(config.get_path("delegates.lilypond"), &Value::Null);
         assert_eq!(warnings.len(), 2);
         assert!(warnings[0].contains("delegates.abc2svg"));
         assert!(warnings[1].contains("delegates.lilypond"));

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -210,18 +210,14 @@ fn render_song_body(
     let mut columns_open = false;
     // Tracks whether we are inside an SVG delegate section.
     let mut in_svg_section = false;
-    // Buffer for collecting ABC notation content when abc2svg rendering is enabled.
-    let abc2svg_enabled = config
-        .get_path("delegates.abc2svg")
-        .as_bool()
-        .unwrap_or(false);
+    // Delegate tool availability: Some(true) = force enable, Some(false) = force
+    // disable, None = auto-detect on first encounter. The auto-detect value is
+    // lazily resolved (via `get_or_insert_with`) so that subprocess checks only
+    // run when a delegate section is actually present in the input.
+    let mut abc2svg_resolved: Option<bool> = config.get_path("delegates.abc2svg").as_bool();
+    let mut lilypond_resolved: Option<bool> = config.get_path("delegates.lilypond").as_bool();
     let mut abc_buf: Option<String> = None;
     let mut abc_label: Option<String> = None;
-    // Buffer for collecting Lilypond notation content when lilypond rendering is enabled.
-    let lilypond_enabled = config
-        .get_path("delegates.lilypond")
-        .as_bool()
-        .unwrap_or(false);
     let mut ly_buf: Option<String> = None;
     let mut ly_label: Option<String> = None;
 
@@ -377,9 +373,25 @@ fn render_song_body(
                         // in duplex printing.
                         html.push_str("<div style=\"break-before: recto;\"></div>\n");
                     }
-                    DirectiveKind::StartOfAbc if abc2svg_enabled => {
-                        abc_buf = Some(String::new());
-                        abc_label = directive.value.clone();
+                    DirectiveKind::StartOfAbc => {
+                        let enabled = *abc2svg_resolved
+                            .get_or_insert_with(chordpro_core::external_tool::has_abc2svg);
+                        if enabled {
+                            abc_buf = Some(String::new());
+                            abc_label = directive.value.clone();
+                        } else {
+                            let mut target = String::new();
+                            render_directive_inner(
+                                directive,
+                                show_diagrams,
+                                diagram_frets,
+                                &mut target,
+                            );
+                            if let Some(buf) = chorus_buf.as_mut() {
+                                buf.push_str(&target);
+                            }
+                            html.push_str(&target);
+                        }
                     }
                     DirectiveKind::EndOfAbc if abc_buf.is_some() => {
                         if let Some(abc_content) = abc_buf.take() {
@@ -387,9 +399,25 @@ fn render_song_body(
                             abc_label = None;
                         }
                     }
-                    DirectiveKind::StartOfLy if lilypond_enabled => {
-                        ly_buf = Some(String::new());
-                        ly_label = directive.value.clone();
+                    DirectiveKind::StartOfLy => {
+                        let enabled = *lilypond_resolved
+                            .get_or_insert_with(chordpro_core::external_tool::has_lilypond);
+                        if enabled {
+                            ly_buf = Some(String::new());
+                            ly_label = directive.value.clone();
+                        } else {
+                            let mut target = String::new();
+                            render_directive_inner(
+                                directive,
+                                show_diagrams,
+                                diagram_frets,
+                                &mut target,
+                            );
+                            if let Some(buf) = chorus_buf.as_mut() {
+                                buf.push_str(&target);
+                            }
+                            html.push_str(&target);
+                        }
                     }
                     DirectiveKind::EndOfLy if ly_buf.is_some() => {
                         if let Some(ly_content) = ly_buf.take() {
@@ -2386,9 +2414,14 @@ Verse text\n\
     // -- abc2svg delegate rendering tests -----------------------------------------
 
     #[test]
-    fn test_abc_section_without_delegate_config() {
-        // Default config has delegates.abc2svg=false, so ABC renders as text
-        let html = render("{start_of_abc}\nX:1\n{end_of_abc}");
+    fn test_abc_section_disabled_by_config() {
+        // With delegates.abc2svg explicitly disabled, ABC renders as text
+        let input = "{start_of_abc}\nX:1\n{end_of_abc}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("delegates.abc2svg=false")
+            .unwrap();
+        let html = render_song_with_transpose(&song, 0, &config);
         assert!(html.contains("<section class=\"abc\">"));
         assert!(html.contains("ABC"));
         assert!(html.contains("</section>"));
@@ -2448,9 +2481,14 @@ Verse text\n\
     // -- lilypond delegate rendering tests ----------------------------------------
 
     #[test]
-    fn test_ly_section_without_delegate_config() {
-        // Default config has delegates.lilypond=false, so Ly renders as text
-        let html = render("{start_of_ly}\n\\relative c' { c4 }\n{end_of_ly}");
+    fn test_ly_section_disabled_by_config() {
+        // With delegates.lilypond explicitly disabled, Ly renders as text
+        let input = "{start_of_ly}\n\\relative c' { c4 }\n{end_of_ly}";
+        let song = chordpro_core::parse(input).unwrap();
+        let config = chordpro_core::config::Config::defaults()
+            .with_define("delegates.lilypond=false")
+            .unwrap();
+        let html = render_song_with_transpose(&song, 0, &config);
         assert!(html.contains("<section class=\"ly\">"));
         assert!(html.contains("Lilypond"));
         assert!(html.contains("</section>"));


### PR DESCRIPTION
## What

Move `has_abc2svg()` and `has_lilypond()` availability checks from CLI startup to the first encounter of a delegate section during HTML rendering. Change the config default for `delegates.abc2svg` and `delegates.lilypond` from `false` to `null` (auto-detect).

## Why

Every CLI invocation spawned two subprocesses (`abc2svg --version`, `lilypond --version`) even when no ABC or Lilypond sections existed in the input. This added unnecessary startup latency. By deferring detection to first use, the subprocess cost is only paid when a delegate section is actually present.

## Changes

- **`crates/cli/src/main.rs`**: Removed eager `has_abc2svg()` / `has_lilypond()` detection at startup.
- **`crates/core/src/config.rs`**: Changed delegate defaults from `false` to `null`. Updated project-level config security checks to restore the trusted value (which may be `null`). Updated tests.
- **`crates/render-html/src/lib.rs`**: Added lazy auto-detection via `Option<bool>` with `get_or_insert_with`. When config is `null`, tool availability is checked on first delegate section encounter and cached. `true`/`false` explicit config values still work as before.

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all tests pass)
```

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)