### PR TITLE
Clarify delegate security warnings and add null auto-detect test

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -527,11 +527,15 @@ impl Config {
             config = config
                 .with_define(&format!("delegates.abc2svg={reset}"))
                 .expect("hardcoded define is valid");
-            warnings.push(
-                "delegates.abc2svg was escalated by a project-level config file and has been \
-                 restored for security; use --define delegates.abc2svg=true to enable"
-                    .to_string(),
-            );
+            let explanation = if reset == "null" {
+                "reset to null (auto-detect: enabled only if abc2svg is installed)"
+            } else {
+                "reset to false (disabled)"
+            };
+            warnings.push(format!(
+                "delegates.abc2svg was enabled by a project-level config file and has been \
+                 {explanation} for security; use --define delegates.abc2svg=true to enable"
+            ));
         }
         if delegate_perm(&current_lilypond) > delegate_perm(&trusted_lilypond) {
             let reset = if trusted_lilypond.is_null() {
@@ -544,11 +548,15 @@ impl Config {
             config = config
                 .with_define(&format!("delegates.lilypond={reset}"))
                 .expect("hardcoded define is valid");
-            warnings.push(
-                "delegates.lilypond was escalated by a project-level config file and has been \
-                 restored for security; use --define delegates.lilypond=true to enable"
-                    .to_string(),
-            );
+            let explanation = if reset == "null" {
+                "reset to null (auto-detect: enabled only if lilypond is installed)"
+            } else {
+                "reset to false (disabled)"
+            };
+            warnings.push(format!(
+                "delegates.lilypond was enabled by a project-level config file and has been \
+                 {explanation} for security; use --define delegates.lilypond=true to enable"
+            ));
         }
 
         ConfigLoadResult { config, warnings }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -2432,6 +2432,28 @@ Verse text\n\
     }
 
     #[test]
+    fn test_abc_section_null_config_auto_detect_disabled() {
+        // Default config has delegates.abc2svg=null (auto-detect).
+        // When abc2svg is not installed, sections render as plain text.
+        if chordpro_core::external_tool::has_abc2svg() {
+            return; // Skip on machines with abc2svg installed
+        }
+        let input = "{start_of_abc}\nX:1\n{end_of_abc}";
+        let song = chordpro_core::parse(input).unwrap();
+        // Use defaults — delegates.abc2svg is null (auto-detect)
+        let config = chordpro_core::config::Config::defaults();
+        assert!(
+            config.get_path("delegates.abc2svg").is_null(),
+            "default config should have null delegates.abc2svg"
+        );
+        let html = render_song_with_transpose(&song, 0, &config);
+        assert!(
+            html.contains("<section class=\"abc\">"),
+            "null auto-detect with no abc2svg should render as text section"
+        );
+    }
+
+    #[test]
     fn test_abc_section_fallback_preformatted() {
         // With delegate enabled but abc2svg not available, falls back to <pre>
         if chordpro_core::external_tool::has_abc2svg() {


### PR DESCRIPTION
## What

- Update security warning messages for blocked delegate config to explain that `null` means auto-detect (enabled only if the tool is installed) (#709)
- Add `test_abc_section_null_config_auto_detect_disabled` exercising the null config path when `has_abc2svg()` returns false (#710)

## Why

Warning messages said "disabled for security" without clarifying that the reset value (`null`) means auto-detect, not hard-disabled. The null auto-detect path had no renderer-level test coverage.

## Test results

```
cargo test → all passed
cargo clippy -- -D warnings → clean
cargo fmt --check → clean
```

Closes #709
Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)