### PR TITLE
Fix delegate warning source and deduplicate delegate_perm helper

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -534,7 +534,7 @@ impl Config {
                 "reset to false (disabled)"
             };
             warnings.push(format!(
-                "delegates.abc2svg was enabled by a project-level config file and has been \
+                "delegates.abc2svg was escalated by an untrusted config and has been \
                  {explanation} for security; use --define delegates.abc2svg=true to enable"
             ));
         }
@@ -555,7 +555,7 @@ impl Config {
                 "reset to false (disabled)"
             };
             warnings.push(format!(
-                "delegates.lilypond was enabled by a project-level config file and has been \
+                "delegates.lilypond was escalated by an untrusted config and has been \
                  {explanation} for security; use --define delegates.lilypond=true to enable"
             ));
         }
@@ -884,6 +884,16 @@ static PRESET_UKULELE: &str = r#"{
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// Map a delegate config value to a permissiveness level for ordering.
+    /// Matches the `delegate_perm` function used in `Config::load()`.
+    fn delegate_perm(v: &Value) -> u8 {
+        match v.as_bool() {
+            Some(false) => 0,
+            None => 1, // Null or non-bool → auto-detect level
+            Some(true) => 2,
+        }
+    }
 
     #[test]
     fn test_defaults_load() {
@@ -1320,13 +1330,6 @@ mod tests {
         );
 
         // Verify the permissiveness ordering used by the security check.
-        fn delegate_perm(v: &Value) -> u8 {
-            match v.as_bool() {
-                Some(false) => 0,
-                None => 1,
-                Some(true) => 2,
-            }
-        }
         assert!(
             delegate_perm(&Value::Null) > delegate_perm(&Value::Bool(false)),
             "null (auto-detect) must be more permissive than false (disabled)"
@@ -1340,13 +1343,6 @@ mod tests {
     #[test]
     fn test_project_config_can_downgrade_delegates() {
         // Downgrading from null (auto) to false (disabled) is safe and allowed.
-        fn delegate_perm(v: &Value) -> u8 {
-            match v.as_bool() {
-                Some(false) => 0,
-                None => 1,
-                Some(true) => 2,
-            }
-        }
         assert!(
             delegate_perm(&Value::Bool(false)) <= delegate_perm(&Value::Null),
             "false should not be considered an escalation over null"


### PR DESCRIPTION
## What

- Replace "project-level config file" with "untrusted config" in delegate security warnings, since both project and song configs can trigger the escalation (#724)
- Extract the `delegate_perm` helper from two test functions into a shared helper in `mod tests` (#726)

## Why

The warning message incorrectly attributed escalation to "project-level config" when song configs can also cause it. The helper function was duplicated in two test functions.

## Test results

```
cargo test --package chordpro-core → 860 passed
cargo clippy -- -D warnings → clean
cargo fmt --check → clean
```

Closes #724
Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)