### PR TITLE
Cache has_perl_chordpro with OnceLock and add Lilypond raw content assertion

### DIFF
--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -326,9 +326,13 @@ pub fn invoke_lilypond(ly_content: &str) -> Result<String, String> {
 }
 
 /// Returns `true` if the Perl `chordpro` reference implementation is available.
+///
+/// The result is cached at the process level via `OnceLock`, so the
+/// subprocess check runs at most once.
 #[must_use]
 pub fn has_perl_chordpro() -> bool {
-    is_available("chordpro")
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| is_available("chordpro"))
 }
 
 #[cfg(test)]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -2556,6 +2556,10 @@ Verse text\n\
         );
         if !chordpro_core::external_tool::has_lilypond() {
             assert!(
+                html.contains("\\relative"),
+                "raw Lilypond content should be present without tool"
+            );
+            assert!(
                 !html.contains("<svg"),
                 "no SVG should be generated without lilypond"
             );


### PR DESCRIPTION
## What

- Apply `OnceLock` caching to `has_perl_chordpro()` matching the pattern used by `has_abc2svg()` and `has_lilypond()` (#721)
- Add `html.contains("\\relative")` assertion to `test_ly_section_auto_detect_default_config` mirroring the ABC test's raw content check (#731)

## Why

`has_perl_chordpro()` was the only availability function without process-level caching. The Lilypond auto-detect test only checked for absence of SVG but not presence of raw content, unlike its ABC counterpart.

## Test results

```
cargo test → all passed
cargo clippy -- -D warnings → clean
cargo fmt --check → clean
```

Closes #721
Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)