### PR TITLE
Add HTML renderer golden test for SVG section output

### DIFF
--- a/crates/render-html/tests/fixtures/svg-section/expected.html
+++ b/crates/render-html/tests/fixtures/svg-section/expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>SVG Section Test</title>
+<style>
+body { font-family: serif; max-width: 800px; margin: 2em auto; padding: 0 1em; }
+h1 { margin-bottom: 0.2em; }
+h2 { margin-top: 0; font-weight: normal; color: #555; }
+.line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
+.chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
+.chord { font-weight: bold; color: #b00; font-size: 0.9em; min-height: 1.2em; }
+.lyrics { white-space: pre; }
+.empty-line { height: 1em; }
+section { margin: 1em 0; }
+section > .section-label { font-weight: bold; font-style: italic; margin-bottom: 0.3em; }
+.comment { font-style: italic; color: #666; margin: 0.3em 0; }
+.comment-box { border: 1px solid #999; padding: 0.2em 0.5em; display: inline-block; margin: 0.3em 0; }
+.chorus-recall { margin: 1em 0; }
+.chorus-recall > .section-label { font-weight: bold; font-style: italic; margin-bottom: 0.3em; }
+img { max-width: 100%; height: auto; }
+.chord-diagram-container { display: inline-block; margin: 0.5em 0.5em 0.5em 0; vertical-align: top; }
+.chord-diagram { display: block; }
+</style>
+</head>
+<body>
+<div class="song">
+<h1>SVG Section Test</h1>
+<div class="svg-section">
+<svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="blue"/></svg>
+
+</div>
+<div class="svg-section">
+<svg><rect width="10" height="10"/></svg>
+
+</div>
+</div>
+</body>
+</html>

--- a/crates/render-html/tests/fixtures/svg-section/input.cho
+++ b/crates/render-html/tests/fixtures/svg-section/input.cho
@@ -1,0 +1,7 @@
+{title: SVG Section Test}
+{start_of_svg}
+<svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="blue"/></svg>
+{end_of_svg}
+{start_of_svg}
+<svg><script>alert('xss')</script><rect width="10" height="10"/></svg>
+{end_of_svg}

--- a/crates/render-html/tests/golden_svg_section.rs
+++ b/crates/render-html/tests/golden_svg_section.rs
@@ -1,0 +1,22 @@
+/// Golden test for SVG section rendering in the HTML renderer.
+///
+/// Verifies that `{start_of_svg}`/`{end_of_svg}` sections produce the
+/// expected HTML output, including safe SVG passthrough and dangerous
+/// content stripping (e.g., `<script>` tags are removed).
+#[test]
+fn svg_section_html_golden() {
+    let input = std::fs::read_to_string("tests/fixtures/svg-section/input.cho")
+        .expect("read input.cho")
+        .replace("\r\n", "\n");
+    let expected = std::fs::read_to_string("tests/fixtures/svg-section/expected.html")
+        .expect("read expected.html")
+        .replace("\r\n", "\n");
+
+    let actual = chordpro_render_html::render(&input);
+
+    assert_eq!(
+        actual, expected,
+        "HTML output for SVG section does not match golden snapshot.\n\
+         If the change is intentional, update tests/fixtures/svg-section/expected.html"
+    );
+}


### PR DESCRIPTION
## What

Add a golden test for the HTML renderer's SVG section rendering:
- Input `.cho` file with two SVG sections: one with safe content, one with a `<script>` tag
- Expected `.html` output verifies safe SVG is passed through and `<script>` is stripped

## Why

SVG section behavior was only verified via boolean assertions in unit tests. Per `.claude/rules/golden-tests.md`, renderer behaviors should have golden test coverage to catch subtle output regressions. Closes #720.

## Test results

```
cargo test --package chordpro-render-html svg_section_html_golden → 1 passed
```

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)