### PR TITLE
Clarify song override delegate test: blocking is allowlist-based

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1337,9 +1337,11 @@ mod tests {
     }
 
     #[test]
-    fn test_song_override_cannot_escalate_false_to_null() {
-        // Simulate a user-level false baseline (via with_define), then verify
-        // that a song override setting null is blocked as an escalation.
+    fn test_song_override_blocks_delegate_key() {
+        // Song overrides block all `delegates.*` keys because they are not
+        // on the allowlist (ALLOWED_PREFIXES / ALLOWED_EXACT_KEYS). This is
+        // not escalation-based — any song override of a delegate key is
+        // rejected regardless of the current or target value.
         let config = Config::defaults()
             .with_define("delegates.abc2svg=false")
             .expect("hardcoded");
@@ -1349,7 +1351,7 @@ mod tests {
         assert_eq!(
             config.get_path("delegates.abc2svg"),
             &Value::Bool(false),
-            "false→null escalation via song override should be blocked"
+            "delegate key should remain unchanged — not on song-override allowlist"
         );
         assert!(
             warnings


### PR DESCRIPTION
## What

Rename `test_song_override_cannot_escalate_false_to_null` to `test_song_override_blocks_delegate_key` and update comments to accurately describe that song override blocking is allowlist-based, not escalation-based.

## Why

The original comment implied escalation-detection logic in `with_song_overrides`, but the actual mechanism is that `delegates.*` keys are simply not on the allowlist. Closes #738.

## Test results

```
cargo test --package chordpro-core → 862 passed
```

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)