### PR TITLE
Fix metadata population and section content filtering for selectors

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -187,9 +187,13 @@ impl Parser {
         while !self.is_at_end() {
             let line = self.parse_line()?;
 
-            // If this is a metadata directive, populate the Song's metadata.
+            // If this is a metadata directive without a selector, populate
+            // the Song's metadata. Selector-bearing directives are deferred
+            // to filter_song(), which re-derives metadata after filtering.
             if let Line::Directive(ref directive) = line {
-                Self::populate_metadata(&mut song.metadata, directive);
+                if directive.selector.is_none() {
+                    Self::populate_metadata(&mut song.metadata, directive);
+                }
             }
 
             song.lines.push(line);
@@ -220,7 +224,9 @@ impl Parser {
             match self.parse_line() {
                 Ok(line) => {
                     if let Line::Directive(ref directive) = line {
-                        Self::populate_metadata(&mut song.metadata, directive);
+                        if directive.selector.is_none() {
+                            Self::populate_metadata(&mut song.metadata, directive);
+                        }
                     }
                     song.lines.push(line);
                 }
@@ -254,7 +260,12 @@ impl Parser {
 
     /// Populates metadata fields from a directive, if it is a known metadata
     /// directive with a value.
-    fn populate_metadata(metadata: &mut crate::ast::Metadata, directive: &Directive) {
+    /// Populate metadata fields from a directive's kind and value.
+    ///
+    /// This is called during parsing for unselectored directives, and again
+    /// by [`SelectorContext::filter_song`](crate::selector::SelectorContext::filter_song)
+    /// after filtering to re-derive metadata from matching selector-bearing directives.
+    pub fn populate_metadata(metadata: &mut crate::ast::Metadata, directive: &Directive) {
         let value = match directive.value.as_deref() {
             Some(v) => v.to_string(),
             None => return, // Metadata directives without values are no-ops.

--- a/crates/core/src/selector.rs
+++ b/crates/core/src/selector.rs
@@ -93,26 +93,71 @@ impl SelectorContext {
         self.matches(directive.selector.as_deref())
     }
 
-    /// Filter a song's lines, removing directives whose selectors don't match.
+    /// Filter a song's lines based on the active selector context.
     ///
-    /// Non-directive lines (lyrics, comments, empty) are always kept.
-    /// Directives without selectors are always kept.
-    /// Directives with non-matching selectors are removed.
+    /// - Directives without selectors are always kept.
+    /// - Directives with matching selectors are kept.
+    /// - Directives with non-matching selectors are removed.
+    /// - When a non-matching section-start directive is removed, all lines
+    ///   until (and including) its corresponding section-end are also removed.
     ///
-    /// Returns a new [`Song`](crate::ast::Song) with filtered lines.
+    /// After filtering, metadata is re-derived: the base metadata (from
+    /// unselectored directives) is augmented with metadata from any
+    /// selector-bearing directives that survived filtering.
     #[must_use]
     pub fn filter_song(&self, song: &crate::ast::Song) -> crate::ast::Song {
-        let filtered_lines = song
-            .lines
-            .iter()
-            .filter(|line| match line {
-                crate::ast::Line::Directive(d) => self.matches_directive(d),
-                _ => true,
-            })
-            .cloned()
-            .collect();
+        let mut filtered_lines = Vec::new();
+        // Depth counter for non-matching sections. When > 0, all lines are suppressed.
+        let mut suppress_depth: usize = 0;
+
+        for line in &song.lines {
+            match line {
+                crate::ast::Line::Directive(d) => {
+                    if suppress_depth > 0 {
+                        // Inside a suppressed section — track nested section boundaries.
+                        if d.kind.is_section_start() {
+                            suppress_depth += 1;
+                        } else if d.kind.is_section_end() {
+                            suppress_depth -= 1;
+                        }
+                        // All lines inside the suppressed section are dropped.
+                        continue;
+                    }
+
+                    if !self.matches_directive(d) {
+                        // Non-matching directive.
+                        if d.kind.is_section_start() {
+                            // Begin suppressing all content until the matching end.
+                            suppress_depth = 1;
+                        }
+                        // Either way, this directive is removed.
+                        continue;
+                    }
+
+                    filtered_lines.push(line.clone());
+                }
+                _ => {
+                    if suppress_depth == 0 {
+                        filtered_lines.push(line.clone());
+                    }
+                }
+            }
+        }
+
+        // Re-derive metadata: start from the base metadata (unselectored directives
+        // were already populated during parsing) and add metadata from any
+        // selector-bearing directives that survived filtering.
+        let mut metadata = song.metadata.clone();
+        for line in &filtered_lines {
+            if let crate::ast::Line::Directive(d) = line {
+                if d.selector.is_some() {
+                    crate::parser::Parser::populate_metadata(&mut metadata, d);
+                }
+            }
+        }
+
         crate::ast::Song {
-            metadata: song.metadata.clone(),
+            metadata,
             lines: filtered_lines,
         }
     }
@@ -323,5 +368,91 @@ mod tests {
             .filter(|l| matches!(l, crate::ast::Line::Directive(_)))
             .count();
         assert_eq!(directive_count, 1);
+    }
+
+    // -- Section content filtering (#319) ------------------------------------
+
+    #[test]
+    fn test_filter_song_removes_section_contents() {
+        let input =
+            "{start_of_chorus-piano}\n[C]La la la\n{end_of_chorus-piano}\n[Am]Regular lyrics";
+        let song = crate::parse(input).unwrap();
+        let ctx = SelectorContext::new(Some("guitar"), None);
+        let filtered = ctx.filter_song(&song);
+        // The piano chorus and its lyrics should be removed.
+        let texts: Vec<_> = filtered
+            .lines
+            .iter()
+            .filter_map(|l| match l {
+                crate::ast::Line::Lyrics(ly) => Some(ly.text()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !texts.iter().any(|t| t.contains("La la")),
+            "piano chorus lyrics should be removed"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("Regular")),
+            "unselectored lyrics should remain"
+        );
+    }
+
+    #[test]
+    fn test_filter_song_keeps_matching_section_contents() {
+        let input = "{start_of_chorus-guitar}\n[C]Guitar chorus\n{end_of_chorus-guitar}";
+        let song = crate::parse(input).unwrap();
+        let ctx = SelectorContext::new(Some("guitar"), None);
+        let filtered = ctx.filter_song(&song);
+        let has_chorus_lyrics = filtered.lines.iter().any(|l| match l {
+            crate::ast::Line::Lyrics(ly) => ly.text().contains("Guitar chorus"),
+            _ => false,
+        });
+        assert!(
+            has_chorus_lyrics,
+            "matching section contents should be kept"
+        );
+    }
+
+    // -- Metadata re-derivation (#318) ---------------------------------------
+
+    #[test]
+    fn test_metadata_skips_selector_directives_during_parse() {
+        let input = "{title: Main Title}\n{title-band: Band Title}";
+        let song = crate::parse(input).unwrap();
+        // During parsing, only the unselectored title should populate metadata.
+        assert_eq!(
+            song.metadata.title.as_deref(),
+            Some("Main Title"),
+            "selector-bearing title should not overwrite metadata during parsing"
+        );
+    }
+
+    #[test]
+    fn test_filter_song_rederives_metadata_from_matching_selector() {
+        let input = "{title: Main Title}\n{title-band: Band Title}";
+        let song = crate::parse(input).unwrap();
+        // When filtering for "band", the band title should be applied.
+        let ctx = SelectorContext::new(None, Some("band"));
+        let filtered = ctx.filter_song(&song);
+        assert_eq!(
+            filtered.metadata.title.as_deref(),
+            Some("Band Title"),
+            "matching selector title should override metadata after filtering"
+        );
+    }
+
+    #[test]
+    fn test_filter_song_keeps_base_metadata_when_no_selector_match() {
+        let input = "{title: Main Title}\n{title-band: Band Title}";
+        let song = crate::parse(input).unwrap();
+        // When filtering for "guitar" (no match for "band"), only the base title remains.
+        let ctx = SelectorContext::new(Some("guitar"), None);
+        let filtered = ctx.filter_song(&song);
+        assert_eq!(
+            filtered.metadata.title.as_deref(),
+            Some("Main Title"),
+            "base metadata should remain when selector doesn't match"
+        );
     }
 }

--- a/crates/core/tests/fixtures/selector-suffix/expected.txt
+++ b/crates/core/tests/fixtures/selector-suffix/expected.txt
@@ -1,7 +1,7 @@
 Song {
     metadata: Metadata {
         title: Some(
-            "Override Title",
+            "Selector Test",
         ),
         subtitles: [],
         artists: [],
@@ -9,16 +9,10 @@ Song {
         lyricists: [],
         album: None,
         year: None,
-        key: Some(
-            "E",
-        ),
-        tempo: Some(
-            "120",
-        ),
+        key: None,
+        tempo: None,
         time: None,
-        capo: Some(
-            "3",
-        ),
+        capo: None,
         sort_title: None,
         sort_artist: None,
         arrangers: [],


### PR DESCRIPTION
## What

Fix two bugs in selector filtering: metadata pollution from selector-bearing directives and orphaned section contents when section boundaries are filtered out.

## Why

**Metadata (#318)**: `populate_metadata()` was called unconditionally during parsing, so `{title-band: Override}` would overwrite `metadata.title` even when the rendering context was not "band". Now selector-bearing directives are skipped during parsing, and `filter_song()` re-derives metadata from surviving directives after filtering.

**Section contents (#319)**: `filter_song()` only removed individual directive lines. When `{start_of_chorus-piano}` was removed for a guitar context, the lyrics inside remained orphaned. Now `filter_song()` uses a stateful pass that tracks non-matching section depth and suppresses all enclosed lines.

## Changes

- **`parser.rs`**: Skip `populate_metadata()` for `directive.selector.is_some()`; make `populate_metadata` public for reuse
- **`selector.rs`**: Rewrite `filter_song()` with section-depth tracking and metadata re-derivation
- **Golden test**: Update `selector-suffix/expected.txt` (metadata no longer includes selector-only values)
- **Tests**: 5 new tests covering section filtering and metadata behavior

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (all tests pass, 870 core tests)
```

Closes #318
Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)