### PR TITLE
Fix misleading comments in matches() and populate_metadata

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -258,8 +258,6 @@ impl Parser {
 
     // -- Metadata population ------------------------------------------------
 
-    /// Populates metadata fields from a directive, if it is a known metadata
-    /// directive with a value.
     /// Populate metadata fields from a directive's kind and value.
     ///
     /// This is called during parsing for unselectored directives, and again

--- a/crates/core/src/selector.rs
+++ b/crates/core/src/selector.rs
@@ -69,9 +69,10 @@ impl SelectorContext {
             return true; // No selector = unconditional
         };
 
-        // Both context values and selectors are normalized to lowercase at
-        // construction time, so `eq_ignore_ascii_case` handles any residual
-        // mixed-case input without allocating.
+        // Context values are normalized to lowercase at construction, but
+        // selectors may bypass normalization via direct Directive struct
+        // construction. `eq_ignore_ascii_case` is used defensively to handle
+        // both paths without allocating.
         if let Some(ref instrument) = self.instrument {
             if instrument.eq_ignore_ascii_case(sel) {
                 return true;


### PR DESCRIPTION
## What

- Clarify `matches()` comment in `selector.rs`: `eq_ignore_ascii_case` is defensive because direct `Directive` struct construction can bypass selector normalization (#742)
- Remove duplicate opening sentence in `populate_metadata` doc comment in `parser.rs` (#744)

## Why

The original `matches()` comment implied both sides are always lowercase, which could mislead someone into "simplifying" to `==`. The `populate_metadata` doc had two sentences saying the same thing.

## Test results

```
cargo clippy -- -D warnings → clean
cargo fmt --check → clean
```

Closes #742
Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)