### PR TITLE
Strengthen selector filtering test with negative assertion

### DIFF
--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -1084,9 +1084,16 @@ mod delegate_tests {
         let song = chordpro_core::parse(input).unwrap();
         let ctx = chordpro_core::selector::SelectorContext::new(Some("guitar"), None);
         let filtered = ctx.filter_song(&song);
+        // The piano textfont directive should be absent from the filtered song.
+        let has_textfont = filtered.lines.iter().any(|l| {
+            matches!(l, chordpro_core::ast::Line::Directive(d) if d.kind == chordpro_core::ast::DirectiveKind::TextFont)
+        });
+        assert!(
+            !has_textfont,
+            "piano textfont directive should be removed for guitar context"
+        );
         let output = render_song(&filtered);
-        // Piano directive should not produce any textfont effect in output
-        assert!(output.contains("Hello"));
+        assert!(output.contains("Hello"), "lyrics should survive filtering");
     }
 
     #[test]


### PR DESCRIPTION
## What

Add negative assertion to verify the piano textfont directive is absent from the filtered AST, not just that lyrics survive rendering.

## Why

The test only checked `output.contains("Hello")` which passes even if filtering is broken — lyrics would be present regardless.

## Test results

```
cargo test -p chordpro-render-text  ✅ (68 passed)
```

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)