### PR TITLE
Add unit tests for empty/whitespace user.name in from_config

### DIFF
--- a/crates/core/src/selector.rs
+++ b/crates/core/src/selector.rs
@@ -263,6 +263,23 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_empty_user_treated_as_none() {
+        let config = crate::config::Config::parse(r#"{"user": {"name": ""}}"#).unwrap();
+        let ctx = SelectorContext::from_config(&config);
+        assert!(ctx.user.is_none(), "empty user.name should be None");
+    }
+
+    #[test]
+    fn test_from_config_whitespace_user_treated_as_none() {
+        let config = crate::config::Config::parse(r#"{"user": {"name": "  "}}"#).unwrap();
+        let ctx = SelectorContext::from_config(&config);
+        assert!(
+            ctx.user.is_none(),
+            "whitespace-only user.name should be None"
+        );
+    }
+
+    #[test]
     fn test_matches_directive() {
         let ctx = SelectorContext::new(Some("guitar"), None);
         let directive = crate::ast::Directive {


### PR DESCRIPTION
## What

Add two tests mirroring the existing instrument coverage:
- `test_from_config_empty_user_treated_as_none`: `user.name = ""` → `ctx.user.is_none()`
- `test_from_config_whitespace_user_treated_as_none`: `user.name = "  "` → `ctx.user.is_none()`

## Why

PR #749 added `.filter()` to both `instrument.type` and `user.name` paths but only tested the instrument case. Closes #750.

## Test results

```
cargo test --package chordpro-core from_config → 6 passed
```

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)