### PR TITLE
Handle empty song slice in PDF multi-song renderer

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -224,8 +224,11 @@ pub fn render_songs_with_warnings(
 ) -> RenderResult<Vec<u8>> {
     let mut warnings = Vec::new();
 
-    if songs.len() == 1 {
-        return render_song_with_warnings(&songs[0], cli_transpose, config);
+    if songs.len() <= 1 {
+        return songs
+            .first()
+            .map(|s| render_song_with_warnings(s, cli_transpose, config))
+            .unwrap_or_else(|| RenderResult::with_warnings(Vec::new(), warnings));
     }
 
     // Phase 1: render all songs and record which page each starts on.
@@ -4617,5 +4620,13 @@ mod png_tests {
         assert_eq!(paeth_predictor(10, 20, 15), 15);
         // a=10, b=10, c=10: p=10, pa=0, pb=0, pc=0 → a (pa<=pb and pa<=pc)
         assert_eq!(paeth_predictor(10, 10, 10), 10);
+    }
+
+    #[test]
+    fn test_render_songs_with_warnings_empty_slice() {
+        let songs: Vec<chordpro_core::ast::Song> = Vec::new();
+        let result = render_songs_with_warnings(&songs, 0, &Config::defaults());
+        // Should not panic and should return empty output.
+        assert!(result.output.is_empty());
     }
 }


### PR DESCRIPTION
## What

Fix the PDF multi-song renderer to gracefully handle an empty song slice instead of panicking on index `[0]`.

## Why

The HTML renderer uses `songs.len() <= 1` with `unwrap_or_default()`, but the PDF renderer used `songs.len() == 1` with direct `songs[0]` access, which would panic on an empty slice.

## Changes

- **`render-pdf/lib.rs`**: Change guard from `== 1` to `<= 1` with safe `.first()` + `unwrap_or_else`
- **Test**: Add `test_render_songs_with_warnings_empty_slice` verifying no panic

## Test results

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test -p chordpro-render-pdf  ✅ (170 passed)
```

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)