### PR TITLE
Document Perl ChordPro version in known-deviations.md

### DIFF
--- a/docs/known-deviations.md
+++ b/docs/known-deviations.md
@@ -1,5 +1,7 @@
 # Known Deviations from Perl ChordPro
 
+**Compared against**: Perl ChordPro core v6.090.1 (`App::Music::ChordPro`)
+
 This document lists intentional differences between chordpro-rs and the Perl
 ChordPro reference implementation. These are not bugs — they represent design
 decisions where chordpro-rs chose a different (or simpler) text rendering format.


### PR DESCRIPTION
## What

Add the tested Perl ChordPro version (v6.090.1) to the document header.

## Why

Without the version reference, the document becomes ambiguous as Perl ChordPro evolves.

## Test results

Documentation-only change.

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)