### PR TITLE
Fix chorus recall to re-apply current transpose offset

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -233,12 +233,11 @@ fn render_song_body(
             (n as usize).max(1)
         });
 
-    // Stores the rendered HTML of the most recently defined chorus body
-    // (everything between StartOfChorus and EndOfChorus, excluding the
-    // section open/close tags). Used by `{chorus}` recall.
-    let mut chorus_html = String::new();
-    // Temporary buffer for collecting chorus content while inside a chorus section.
-    let mut chorus_buf: Option<String> = None;
+    // Stores the AST lines of the most recently defined chorus body.
+    // Re-rendered at recall time so the current transpose offset is applied.
+    let mut chorus_body: Vec<Line> = Vec::new();
+    // Temporary buffer for collecting chorus AST lines.
+    let mut chorus_buf: Option<Vec<Line>> = None;
     let mut chorus_recall_count: usize = 0;
 
     for line in &song.lines {
@@ -262,12 +261,10 @@ fn render_song_body(
                     buf.push_str(&raw);
                     buf.push('\n');
                 } else {
-                    let mut target = String::new();
-                    render_lyrics(lyrics_line, transpose_offset, &fmt_state, &mut target);
                     if let Some(buf) = chorus_buf.as_mut() {
-                        buf.push_str(&target);
+                        buf.push(line.clone());
                     }
-                    html.push_str(&target);
+                    render_lyrics(lyrics_line, transpose_offset, &fmt_state, html);
                 }
             }
             Line::Directive(directive) => {
@@ -305,27 +302,25 @@ fn render_song_body(
                 match &directive.kind {
                     DirectiveKind::StartOfChorus => {
                         render_section_open("chorus", "Chorus", &directive.value, html);
-                        // Begin collecting chorus content.
-                        chorus_buf = Some(String::new());
+                        chorus_buf = Some(Vec::new());
                     }
                     DirectiveKind::EndOfChorus => {
                         html.push_str("</section>\n");
-                        // Finish collecting: store the buffered HTML as the
-                        // most recent chorus for future recall.
-                        //
-                        // NOTE: This captures the diagram state at definition time.
-                        // If {diagrams: off} appears between {end_of_chorus} and
-                        // {chorus}, the recall still uses the captured HTML (with
-                        // diagrams). The PDF renderer re-renders at recall time
-                        // with current state, which is arguably more correct but
-                        // would require an architecture change here.
                         if let Some(buf) = chorus_buf.take() {
-                            chorus_html = buf;
+                            chorus_body = buf;
                         }
                     }
                     DirectiveKind::Chorus => {
                         if chorus_recall_count < MAX_CHORUS_RECALLS {
-                            render_chorus_recall(&directive.value, &chorus_html, html);
+                            render_chorus_recall(
+                                &directive.value,
+                                &chorus_body,
+                                transpose_offset,
+                                &fmt_state,
+                                show_diagrams,
+                                diagram_frets,
+                                html,
+                            );
                             chorus_recall_count += 1;
                         } else if chorus_recall_count == MAX_CHORUS_RECALLS {
                             warnings.push(format!(
@@ -381,17 +376,10 @@ fn render_song_body(
                             abc_buf = Some(String::new());
                             abc_label = directive.value.clone();
                         } else {
-                            let mut target = String::new();
-                            render_directive_inner(
-                                directive,
-                                show_diagrams,
-                                diagram_frets,
-                                &mut target,
-                            );
                             if let Some(buf) = chorus_buf.as_mut() {
-                                buf.push_str(&target);
+                                buf.push(line.clone());
                             }
-                            html.push_str(&target);
+                            render_directive_inner(directive, show_diagrams, diagram_frets, html);
                         }
                     }
                     DirectiveKind::EndOfAbc if abc_buf.is_some() => {
@@ -407,17 +395,10 @@ fn render_song_body(
                             ly_buf = Some(String::new());
                             ly_label = directive.value.clone();
                         } else {
-                            let mut target = String::new();
-                            render_directive_inner(
-                                directive,
-                                show_diagrams,
-                                diagram_frets,
-                                &mut target,
-                            );
                             if let Some(buf) = chorus_buf.as_mut() {
-                                buf.push_str(&target);
+                                buf.push(line.clone());
                             }
-                            html.push_str(&target);
+                            render_directive_inner(directive, show_diagrams, diagram_frets, html);
                         }
                     }
                     DirectiveKind::EndOfLy if ly_buf.is_some() => {
@@ -438,34 +419,24 @@ fn render_song_body(
                         }
                     }
                     _ => {
-                        let mut target = String::new();
-                        render_directive_inner(
-                            directive,
-                            show_diagrams,
-                            diagram_frets,
-                            &mut target,
-                        );
                         if let Some(buf) = chorus_buf.as_mut() {
-                            buf.push_str(&target);
+                            buf.push(line.clone());
                         }
-                        html.push_str(&target);
+                        render_directive_inner(directive, show_diagrams, diagram_frets, html);
                     }
                 }
             }
             Line::Comment(style, text) => {
-                let mut target = String::new();
-                render_comment(*style, text, &mut target);
                 if let Some(buf) = chorus_buf.as_mut() {
-                    buf.push_str(&target);
+                    buf.push(line.clone());
                 }
-                html.push_str(&target);
+                render_comment(*style, text, html);
             }
             Line::Empty => {
-                let empty = "<div class=\"empty-line\"></div>\n";
                 if let Some(buf) = chorus_buf.as_mut() {
-                    buf.push_str(empty);
+                    buf.push(line.clone());
                 }
-                html.push_str(empty);
+                html.push_str("<div class=\"empty-line\"></div>\n");
             }
         }
     }
@@ -1449,16 +1420,35 @@ fn render_section_open(class: &str, label: &str, value: &Option<String>, html: &
 
 /// Render a `{chorus}` recall directive as HTML.
 ///
-/// Wraps the recalled chorus content in a `<div class="chorus-recall">` with
-/// a section label. If no chorus has been defined yet, only the label is emitted.
-fn render_chorus_recall(value: &Option<String>, chorus_html: &str, html: &mut String) {
+/// Re-renders the stored chorus AST lines with the current transpose offset,
+/// so chords are transposed correctly even if `{transpose}` changed after
+/// the chorus was defined.
+fn render_chorus_recall(
+    value: &Option<String>,
+    chorus_body: &[Line],
+    transpose_offset: i8,
+    fmt_state: &FormattingState,
+    show_diagrams: bool,
+    diagram_frets: usize,
+    html: &mut String,
+) {
     html.push_str("<div class=\"chorus-recall\">\n");
     let display_label = match value {
         Some(v) if !v.is_empty() => format!("Chorus: {}", escape(v)),
         _ => "Chorus".to_string(),
     };
     let _ = writeln!(html, "<div class=\"section-label\">{display_label}</div>");
-    html.push_str(chorus_html);
+    for line in chorus_body {
+        match line {
+            Line::Lyrics(lyrics) => render_lyrics(lyrics, transpose_offset, fmt_state, html),
+            Line::Comment(style, text) => render_comment(*style, text, html),
+            Line::Empty => html.push_str("<div class=\"empty-line\"></div>\n"),
+            Line::Directive(d) if !d.kind.is_metadata() => {
+                render_directive_inner(d, show_diagrams, diagram_frets, html);
+            }
+            _ => {}
+        }
+    }
     html.push_str("</div>\n");
 }
 
@@ -1869,6 +1859,23 @@ mod transpose_tests {
         // "Chorus text" should appear twice: once in original, once in recall
         let count = html.matches("Chorus text").count();
         assert_eq!(count, 2, "chorus content should appear twice");
+    }
+
+    #[test]
+    fn test_chorus_recall_applies_current_transpose() {
+        // Chorus defined with no transpose, recalled after {transpose: 2}.
+        // G should become A in the recalled chorus.
+        let html = render("{start_of_chorus}\n[G]La la\n{end_of_chorus}\n{transpose: 2}\n{chorus}");
+        // Original chorus has chord "G"
+        assert!(
+            html.contains("<span class=\"chord\">G</span>"),
+            "original chorus should have G"
+        );
+        // Recalled chorus should have transposed chord "A"
+        assert!(
+            html.contains("<span class=\"chord\">A</span>"),
+            "recalled chorus should have transposed chord A, got:\n{html}"
+        );
     }
 
     // -- inline markup rendering tests ----------------------------------------

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -91,11 +91,11 @@ fn render_song_impl(
     let (combined_transpose, _) =
         chordpro_core::transpose::combine_transpose(cli_transpose, song_transpose_delta);
     let mut transpose_offset: i8 = combined_transpose;
-    // Stores the rendered text lines of the most recently defined chorus,
-    // excluding the "[Chorus]" header itself. Used by `{chorus}` recall.
-    let mut chorus_lines: Vec<String> = Vec::new();
-    // Temporary buffer for collecting chorus content while inside a chorus section.
-    let mut chorus_buf: Option<Vec<String>> = None;
+    // Stores the AST lines of the most recently defined chorus body.
+    // Re-rendered at recall time so the current transpose offset is applied.
+    let mut chorus_body: Vec<Line> = Vec::new();
+    // Temporary buffer for collecting chorus AST lines.
+    let mut chorus_buf: Option<Vec<Line>> = None;
     let mut chorus_recall_count: usize = 0;
 
     render_metadata(&song.metadata, &mut output);
@@ -103,12 +103,10 @@ fn render_song_impl(
     for line in &song.lines {
         match line {
             Line::Lyrics(lyrics_line) => {
-                let mut target = Vec::new();
-                render_lyrics(lyrics_line, transpose_offset, &mut target);
                 if let Some(buf) = chorus_buf.as_mut() {
-                    buf.extend(target.iter().cloned());
+                    buf.push(line.clone());
                 }
-                output.extend(target);
+                render_lyrics(lyrics_line, transpose_offset, &mut output);
             }
             Line::Directive(directive) => {
                 // Metadata directives are already rendered via song.metadata;
@@ -141,15 +139,18 @@ fn render_song_impl(
                         chorus_buf = Some(Vec::new());
                     }
                     DirectiveKind::EndOfChorus => {
-                        // Finish collecting: store the buffered lines as the
-                        // most recent chorus for future recall.
                         if let Some(buf) = chorus_buf.take() {
-                            chorus_lines = buf;
+                            chorus_body = buf;
                         }
                     }
                     DirectiveKind::Chorus => {
                         if chorus_recall_count < MAX_CHORUS_RECALLS {
-                            render_chorus_recall(&directive.value, &chorus_lines, &mut output);
+                            render_chorus_recall(
+                                &directive.value,
+                                &chorus_body,
+                                transpose_offset,
+                                &mut output,
+                            );
                             chorus_recall_count += 1;
                         } else if chorus_recall_count == MAX_CHORUS_RECALLS {
                             warnings.push(format!(
@@ -160,26 +161,24 @@ fn render_song_impl(
                         }
                     }
                     _ => {
+                        if let Some(buf) = chorus_buf.as_mut() {
+                            buf.push(line.clone());
+                        }
                         let mut target = Vec::new();
                         render_directive(directive, &mut target);
-                        if let Some(buf) = chorus_buf.as_mut() {
-                            buf.extend(target.iter().cloned());
-                        }
                         output.extend(target);
                     }
                 }
             }
             Line::Comment(style, text) => {
-                let mut target = Vec::new();
-                render_comment(*style, text, &mut target);
                 if let Some(buf) = chorus_buf.as_mut() {
-                    buf.extend(target.iter().cloned());
+                    buf.push(line.clone());
                 }
-                output.extend(target);
+                render_comment(*style, text, &mut output);
             }
             Line::Empty => {
                 if let Some(buf) = chorus_buf.as_mut() {
-                    buf.push(String::new());
+                    buf.push(line.clone());
                 }
                 output.push(String::new());
             }
@@ -419,12 +418,25 @@ fn render_directive(directive: &chordpro_core::ast::Directive, output: &mut Vec<
 
 /// Render a `{chorus}` recall directive.
 ///
-/// If a chorus has been previously defined (via `{start_of_chorus}`...`{end_of_chorus}`),
-/// its content is replayed with a `[Chorus]` (or custom label) header. If no chorus
-/// has been defined, only the header marker is emitted.
-fn render_chorus_recall(value: &Option<String>, chorus_lines: &[String], output: &mut Vec<String>) {
+/// Re-renders the stored chorus AST lines with the current transpose offset,
+/// so chords are transposed correctly even if `{transpose}` changed after
+/// the chorus was defined.
+fn render_chorus_recall(
+    value: &Option<String>,
+    chorus_body: &[Line],
+    transpose_offset: i8,
+    output: &mut Vec<String>,
+) {
     render_section_header("Chorus", value, output);
-    output.extend(chorus_lines.iter().cloned());
+    for line in chorus_body {
+        match line {
+            Line::Lyrics(lyrics) => render_lyrics(lyrics, transpose_offset, output),
+            Line::Comment(style, text) => render_comment(*style, text, output),
+            Line::Empty => output.push(String::new()),
+            Line::Directive(d) if !d.kind.is_metadata() => render_directive(d, output),
+            _ => {}
+        }
+    }
 }
 
 /// Render a section header like "Chorus" or "Verse 1".
@@ -933,6 +945,28 @@ Second chorus
         let output = render(input);
         // The recall should use "Second chorus", not "First chorus"
         assert!(output.ends_with("[Chorus]\nSecond chorus\n"));
+    }
+
+    #[test]
+    fn test_chorus_recall_applies_current_transpose() {
+        // Chorus defined with no transpose, recalled after {transpose: 2}.
+        // G should become A in the recalled chorus.
+        let input = "\
+{start_of_chorus}
+[G]La la
+{end_of_chorus}
+{transpose: 2}
+{chorus}";
+        let output = render(input);
+        // Original chorus has [G], recalled chorus should have [A].
+        // The recalled chorus should show "A" (G+2) not "G".
+        // The output has chord on one line and lyrics on next.
+        let recall_idx = output.rfind("[Chorus]").expect("should have recall");
+        let recall_section = &output[recall_idx..];
+        assert!(
+            recall_section.contains('A') && !recall_section.contains('G'),
+            "recalled chorus should have transposed chord A (not G), got:\n{recall_section}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Change the text and HTML renderers to store AST `Line` nodes in the chorus buffer instead of pre-rendered strings. On `{chorus}` recall, the lines are re-rendered with the current transpose offset, matching the PDF renderer's existing behavior.

## Why

Previously, text and HTML renderers captured pre-rendered output at chorus definition time. If `{transpose}` changed between the chorus definition and the `{chorus}` recall, the recalled chorus used stale transposition. Closes #418.

## Test results

```
cargo test → all passed (1347 total across all crates)
cargo clippy -- -D warnings → clean
cargo fmt --check → clean
```

## Tests added

- `test_chorus_recall_applies_current_transpose` in both text and HTML renderers: chorus defined with `[G]`, recalled after `{transpose: 2}` — verifies the recalled chord is `A`

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)