### PR TITLE
Add meta directive cap test and document shared custom cap

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -208,6 +208,10 @@ pub struct Metadata {
     pub tags: Vec<String>,
     /// Custom metadata directives not covered by the standard fields.
     /// Each entry is a `(name, value)` pair.
+    ///
+    /// All custom entries (from both unknown directives and unrecognized
+    /// `{meta}` keys) share a single size cap. Filling the vec with one
+    /// key prevents other keys from being stored.
     pub custom: Vec<(String, String)>,
 }
 

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -3965,4 +3965,20 @@ mod metadata_cap_tests {
         assert_eq!(song.metadata.subtitles.len(), Parser::MAX_METADATA_ENTRIES);
         assert_eq!(song.metadata.artists.len(), 1);
     }
+
+    #[test]
+    fn test_metadata_cap_via_meta_directive() {
+        // The {meta: subtitle ...} path should also enforce the cap.
+        let count = Parser::MAX_METADATA_ENTRIES + 50;
+        let mut input = String::new();
+        for i in 0..count {
+            input.push_str(&format!("{{meta: subtitle s{i}}}\n"));
+        }
+        let song = parse(&input).unwrap();
+        assert_eq!(
+            song.metadata.subtitles.len(),
+            Parser::MAX_METADATA_ENTRIES,
+            "meta directive path should also cap subtitles"
+        );
+    }
 }


### PR DESCRIPTION
## What

- Add `test_metadata_cap_via_meta_directive` verifying the cap is enforced through the `{meta: subtitle ...}` path (#759)
- Document on `Metadata::custom` that all custom entries share a single size cap (#760)

## Why

The metadata cap added in #758 was only tested via the named-directive path (`{subtitle: ...}`). The `{meta: ...}` path also calls `push_if_under_cap` but had no test. The shared-cap semantics for `custom` were undocumented.

## Test results

```
cargo test --package chordpro-core metadata_cap → 4 passed
```

Closes #759
Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)