### PR TITLE
Scope in-chorus formatting directives to chorus block

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1915,9 +1915,8 @@ mod transpose_tests {
     #[test]
     fn test_chorus_formatting_does_not_leak_to_outer_scope() {
         // {textsize: 20} inside chorus must not affect text after the chorus.
-        let html = render(
-            "{start_of_chorus}\n{textsize: 20}\n[Am]Big\n{end_of_chorus}\n[G]Normal text",
-        );
+        let html =
+            render("{start_of_chorus}\n{textsize: 20}\n[Am]Big\n{end_of_chorus}\n[G]Normal text");
         // Find content after </section> (end of chorus)
         let after_chorus = html
             .rfind("Normal text")


### PR DESCRIPTION
## What

Save `fmt_state` on `StartOfChorus` and restore it on `EndOfChorus`, preventing in-chorus formatting directives (e.g., `{textsize: 20}`) from leaking into sections after the chorus.

## Why

When a font/size/color directive appeared inside a chorus block, it was applied to the outer `fmt_state` during initial rendering and persisted after the chorus ended. This was asymmetric with chorus recall (fixed in #768), where a local clone correctly scoped the formatting. Closes #769.

## Test results

```
cargo test → all passed
cargo clippy -- -D warnings → clean
cargo fmt --check → clean
```

## Test added

- `test_chorus_formatting_does_not_leak_to_outer_scope` — verifies `{textsize: 20}` inside chorus does not produce `font-size` in post-chorus content

Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)