### PR TITLE
Fix PDF chorus fmt leak, harden HTML test, restore comment

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1923,7 +1923,10 @@ mod transpose_tests {
             .expect("should have post-chorus text");
         // Look backward from "Normal text" for the nearest <div class="line">
         let line_start = html[..after_chorus].rfind("<div class=\"line\"").unwrap();
-        let post_chorus_line = &html[line_start..after_chorus + 20];
+        let line_end = html[line_start..]
+            .find("</div>")
+            .map_or(html.len(), |i| line_start + i + 6);
+        let post_chorus_line = &html[line_start..line_end];
         assert!(
             !post_chorus_line.contains("font-size"),
             "in-chorus {{textsize}} should not leak to post-chorus content: {post_chorus_line}"

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -485,6 +485,7 @@ fn render_song_into_doc(
     let mut chorus_body: Vec<Line> = Vec::new();
     // Temporary buffer for collecting chorus content while inside a chorus section.
     let mut chorus_buf: Option<Vec<Line>> = None;
+    let mut saved_fmt_state: Option<PdfFormattingState> = None;
     let mut chorus_recall_count: usize = 0;
 
     for line in &song.lines {
@@ -525,10 +526,14 @@ fn render_song_into_doc(
                     DirectiveKind::StartOfChorus => {
                         render_section_label(d, doc);
                         chorus_buf = Some(Vec::new());
+                        saved_fmt_state = Some(fmt_state.clone());
                     }
                     DirectiveKind::EndOfChorus => {
                         if let Some(buf) = chorus_buf.take() {
                             chorus_body = buf;
+                        }
+                        if let Some(saved) = saved_fmt_state.take() {
+                            fmt_state = saved;
                         }
                     }
                     DirectiveKind::Chorus => {
@@ -1237,6 +1242,7 @@ fn render_comment(style: CommentStyle, text: &str, doc: &mut PdfDocument) {
         doc.ensure_space(box_h + LINE_GAP);
         let x = doc.margin_left();
         let text_y = doc.y();
+        // PDF rect y is bottom-left; text_y is the baseline top.
         let rect_y = text_y - COMMENT_SIZE - padding;
         let text_w = text_width(text, COMMENT_SIZE);
         let box_w = text_w + padding * 2.0;


### PR DESCRIPTION
## What

- Save/restore `PdfFormattingState` around chorus blocks so in-chorus formatting does not leak (#776)
- Replace fragile `after_chorus + 20` slice with `find("</div>")` search in HTML test (#777)
- Restore the coordinate-system comment removed in #778 refactor (#779)

## Why

The PDF renderer had the same chorus formatting leak fixed for HTML in #775. The test slice was fragile. The explanatory comment was accidentally dropped. All three are low-priority follow-ups from recent PRs.

## Test results

```
cargo test → all passed
cargo clippy -- -D warnings → clean
cargo fmt --check → clean
```

Closes #776
Closes #777
Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)