### PR TITLE
Tighten inline markup clip-count assertion to exact value

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -3511,26 +3511,17 @@ mod column_tests {
 
     #[test]
     fn test_multi_column_inline_markup_single_clip_per_line() {
-        // A lyrics line with inline markup in 2-column mode should produce
-        // a single clip rect from render_lyrics_spans, not one per span.
+        // A lyrics line with inline markup (no chords) in 2-column mode
+        // should produce exactly 1 clip rect from render_lyrics_spans,
+        // not one per markup segment.
         let input = "{columns: 2}\nHello <b>bold</b> and <i>italic</i> text";
         let song = chordpro_core::parse(input).unwrap();
         let bytes = render_song(&song);
         let content = String::from_utf8_lossy(&bytes);
-        // Count "re W n" occurrences from the lyrics line.
-        // The chord row may also contribute clips, so we check that
-        // the lyrics line with 3 markup segments produces at most 2 clips
-        // (one from chord row text_at, one from lyrics render_lyrics_spans).
         let clip_count = content.matches("re W n").count();
-        // Without the per-line optimization, 3 segments would produce 3+ clips.
-        // With it, the lyrics line produces exactly 1 clip.
-        assert!(
-            clip_count <= 3,
-            "inline markup should not produce excessive clips (got {clip_count})"
-        );
-        assert!(
-            clip_count >= 1,
-            "multi-column with markup should have at least 1 clip"
+        assert_eq!(
+            clip_count, 1,
+            "inline markup line should produce exactly 1 clip rect (got {clip_count})"
         );
     }
 


### PR DESCRIPTION
## What

Replace the loose `clip_count >= 1 && <= 3` assertion with `assert_eq!(clip_count, 1)` and fix the misleading comment.

## Why

The input has no chords, so only the lyrics line contributes a clip. The comment said "at most 2" but the assertion allowed 3. Closes #789.

## Test results

```
cargo test --package chordpro-render-pdf inline_markup_single → 1 passed
```

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)