### PR TITLE
Fix rustdoc warnings in chordpro-core

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -1108,6 +1108,7 @@ fn split_at_new_song(input: &str) -> Vec<&str> {
 ///
 /// # Examples
 ///
+/// ```
 /// use chordpro_core::parser::parse_multi;
 ///
 /// let input = "{title: Song One}\nLyrics one\n{new_song}\n{title: Song Two}\nLyrics two";


### PR DESCRIPTION
## What

Add the missing opening code fence (` ``` `) to the `parse_multi` doc example in `crates/core/src/parser.rs`.

## Why

The doc example was missing its opening fence, which caused three rustdoc warnings:
- Two "unresolved link" warnings for `songs[0]` and `songs[1]` (brackets interpreted as link syntax)
- One "empty code block" warning at the closing fence

## Test results

- `cargo doc --workspace --no-deps 2>&1 | grep "warning:"` produces no output
- All existing tests pass (`cargo test` — 0 failures)

## Review summary

Single-line fix — added `/// ``` ` before the doc example code.

Closes #792