### PR TITLE
Add version fields to inter-crate dependencies

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,10 +17,10 @@ name = "chordpro"
 path = "src/main.rs"
 
 [dependencies]
-chordpro-core = { path = "../core" }
-chordpro-render-text = { path = "../render-text" }
-chordpro-render-html = { path = "../render-html" }
-chordpro-render-pdf = { path = "../render-pdf" }
+chordpro-core = { version = "0.1.0", path = "../core" }
+chordpro-render-text = { version = "0.1.0", path = "../render-text" }
+chordpro-render-html = { version = "0.1.0", path = "../render-html" }
+chordpro-render-pdf = { version = "0.1.0", path = "../render-pdf" }
 clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/render-html/Cargo.toml
+++ b/crates/render-html/Cargo.toml
@@ -13,4 +13,4 @@ description = "HTML renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordpro-core = { path = "../core" }
+chordpro-core = { version = "0.1.0", path = "../core" }

--- a/crates/render-pdf/Cargo.toml
+++ b/crates/render-pdf/Cargo.toml
@@ -13,7 +13,7 @@ description = "PDF renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordpro-core = { path = "../core" }
+chordpro-core = { version = "0.1.0", path = "../core" }
 flate2 = { version = "1", default-features = false, features = ["zlib"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/render-text/Cargo.toml
+++ b/crates/render-text/Cargo.toml
@@ -13,5 +13,5 @@ description = "Plain text renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordpro-core = { path = "../core" }
+chordpro-core = { version = "0.1.0", path = "../core" }
 unicode-width = "0.2.2"


### PR DESCRIPTION
## What

Add `version = "0.1.0"` alongside `path` for all inter-crate dependency specifications.

## Why

`cargo publish` rejects path-only dependencies. Both `path` and `version` must be specified so that crates.io resolves the version while local development continues to use the path.

## Changes

- `crates/render-text/Cargo.toml`: `chordpro-core` dep gets `version = "0.1.0"`
- `crates/render-html/Cargo.toml`: same
- `crates/render-pdf/Cargo.toml`: same
- `crates/cli/Cargo.toml`: all 4 internal deps get `version = "0.1.0"`

## Test results

- `cargo build` — success
- `cargo test` — all 19 test suites pass

Closes #794