### PR TITLE
Rename CLI crate package to chordpro-rs for crates.io

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "chordpro"
+name = "chordpro-rs"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## What

Rename the CLI crate package from `chordpro` to `chordpro-rs` in `crates/cli/Cargo.toml`.

## Why

The name `chordpro` is already taken on crates.io by a different project. The binary name `chordpro` is preserved via the `[[bin]]` section so users still run `chordpro` after `cargo install chordpro-rs`.

## Test results

- `cargo build` — success
- `cargo test` — all 19 test suites pass (binary name unchanged, `cargo_bin("chordpro")` still works)

Closes #795