### PR TITLE
Add library usage examples for core and render crates

### DIFF
--- a/crates/core/examples/multi_song.rs
+++ b/crates/core/examples/multi_song.rs
@@ -1,0 +1,31 @@
+//! Parse a multi-song ChordPro file and list each song's title.
+//!
+//! Run with: `cargo run --example multi_song -p chordpro-core`
+
+fn main() {
+    let input = "\
+{title: Song One}
+[C]First song [G]lyrics.
+
+{new_song}
+
+{title: Song Two}
+[Am]Second song [F]lyrics.
+
+{new_song}
+
+{title: Song Three}
+[G]Third song [D]lyrics.
+";
+
+    let songs = chordpro_core::parse_multi(input).expect("parse failed");
+
+    println!("Found {} songs:", songs.len());
+    for (i, song) in songs.iter().enumerate() {
+        println!(
+            "  {}. {}",
+            i + 1,
+            song.metadata.title.as_deref().unwrap_or("(untitled)")
+        );
+    }
+}

--- a/crates/core/examples/parse_song.rs
+++ b/crates/core/examples/parse_song.rs
@@ -1,0 +1,23 @@
+//! Parse a ChordPro string and print the song metadata and line count.
+//!
+//! Run with: `cargo run --example parse_song -p chordpro-core`
+
+fn main() {
+    let input = "\
+{title: Amazing Grace}
+{subtitle: Traditional}
+{key: G}
+
+{start_of_verse}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound,
+That [G]saved a [Em]wretch like [D]me.
+{end_of_verse}
+";
+
+    let song = chordpro_core::parse(input).expect("parse failed");
+
+    println!("Title:    {:?}", song.metadata.title);
+    println!("Subtitle: {:?}", song.metadata.subtitles);
+    println!("Key:      {:?}", song.metadata.key);
+    println!("Lines:    {}", song.lines.len());
+}

--- a/crates/core/examples/transpose.rs
+++ b/crates/core/examples/transpose.rs
@@ -1,0 +1,24 @@
+//! Parse a ChordPro string and transpose all chords up by 2 semitones.
+//!
+//! Run with: `cargo run --example transpose -p chordpro-core`
+
+use chordpro_core::transpose::transpose;
+
+fn main() {
+    let input = "\
+{title: Transposition Demo}
+
+[C]Row, row, [G]row your [Am]boat,
+[F]Gently [G]down the [C]stream.
+";
+
+    let song = chordpro_core::parse(input).expect("parse failed");
+    let transposed = transpose(&song, 2);
+
+    println!("Original key directives:");
+    println!("  title = {:?}", song.metadata.title);
+    println!();
+    println!("After transposing +2 semitones:");
+    println!("  title = {:?}", transposed.metadata.title);
+    println!("  (chords shifted: C->D, G->A, Am->Bm, F->G)");
+}

--- a/crates/render-text/examples/render_text.rs
+++ b/crates/render-text/examples/render_text.rs
@@ -1,0 +1,20 @@
+//! Parse a ChordPro string and render it to plain text.
+//!
+//! Run with: `cargo run --example render_text -p chordpro-render-text`
+
+fn main() {
+    let input = "\
+{title: Amazing Grace}
+{subtitle: Traditional}
+
+{start_of_verse: Verse 1}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound,
+That [G]saved a [Em]wretch like [D]me.
+{end_of_verse}
+";
+
+    let song = chordpro_core::parse(input).expect("parse failed");
+    let text = chordpro_render_text::render_song(&song);
+
+    println!("{text}");
+}


### PR DESCRIPTION
## What

Add four runnable examples demonstrating the public API of the core and render-text crates.

## Why

Downstream users need working examples to understand how to use the library crates. Required by #799.

## Examples added

- `crates/core/examples/parse_song.rs` — parse and inspect metadata
- `crates/core/examples/transpose.rs` — parse and transpose chords
- `crates/core/examples/multi_song.rs` — parse multi-song files
- `crates/render-text/examples/render_text.rs` — parse and render to plain text

All examples compile and run correctly.

## Test results

- `cargo clippy` — no warnings
- All examples run successfully

Closes #799