### PR TITLE
Create GitHub Actions release workflow for binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g., v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} -p chordpro-rs
+          else
+            cargo build --release --target ${{ matrix.target }} -p chordpro-rs
+          fi
+        shell: bash
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          ARCHIVE_NAME="chordpro-${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz"
+          STAGING="chordpro-${{ steps.version.outputs.version }}-${{ matrix.target }}"
+          mkdir "$STAGING"
+          cp "target/${{ matrix.target }}/release/chordpro" "$STAGING/"
+          cp LICENSE README.md "$STAGING/"
+          tar czf "$ARCHIVE_NAME" "$STAGING"
+          echo "ARCHIVE=$ARCHIVE_NAME" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $Version = "${{ steps.version.outputs.version }}"
+          $Target = "${{ matrix.target }}"
+          $ArchiveName = "chordpro-$Version-$Target.zip"
+          $Staging = "chordpro-$Version-$Target"
+          New-Item -ItemType Directory -Path $Staging
+          Copy-Item "target/$Target/release/chordpro.exe" "$Staging/"
+          Copy-Item LICENSE, README.md "$Staging/"
+          Compress-Archive -Path "$Staging/*" -DestinationPath $ArchiveName
+          echo "ARCHIVE=$ArchiveName" >> $env:GITHUB_ENV
+        shell: pwsh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "See [CHANGELOG.md](https://github.com/koedame/chordpro-rs/blob/main/CHANGELOG.md) for details." \
+            artifacts/*/* \
+            --draft=false


### PR DESCRIPTION
## What

Add `.github/workflows/release.yml` for automated binary releases.

## Why

Users need pre-built binaries for easy installation without a Rust toolchain.

## Changes

Builds binaries for 5 targets on tag push:
- `x86_64-unknown-linux-gnu` (ubuntu)
- `aarch64-unknown-linux-gnu` (ubuntu + cross)
- `x86_64-apple-darwin` (macos)
- `aarch64-apple-darwin` (macos)
- `x86_64-pc-windows-msvc` (windows)

Archives include the binary, LICENSE, and README. Creates a GitHub Release with all archives as assets.

Also supports `workflow_dispatch` for manual testing.

## Test results

Workflow file only, no code changes. Will be validated on first tag push.

Closes #802