### PR TITLE
Add shell completion generation to CLI

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,7 @@ chordpro-render-text = { version = "0.1.0", path = "../render-text" }
 chordpro-render-html = { version = "0.1.0", path = "../render-html" }
 chordpro-render-pdf = { version = "0.1.0", path = "../render-pdf" }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,15 +7,20 @@ use std::io::{self, Write};
 use std::path::Path;
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::Shell;
 
 /// ChordPro file processor — parse and render ChordPro songs.
 #[derive(Parser)]
 #[command(name = "chordpro", version, about)]
 struct Cli {
     /// Input ChordPro file(s) to process.
-    #[arg(required = true)]
+    #[arg(required_unless_present = "completions")]
     files: Vec<String>,
+
+    /// Generate shell completions and print to stdout.
+    #[arg(long, value_name = "SHELL")]
+    completions: Option<Shell>,
 
     /// Write output to a file instead of stdout.
     #[arg(short, long)]
@@ -67,6 +72,12 @@ enum Format {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+
+    if let Some(shell) = cli.completions {
+        let mut cmd = Cli::command();
+        clap_complete::generate(shell, &mut cmd, "chordpro", &mut io::stdout());
+        return ExitCode::SUCCESS;
+    }
 
     // Derive project directory from the first input file for project-level config.
     let project_dir = cli

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -523,3 +523,43 @@ fn test_song_config_override_combined_with_cli_transpose() {
         .stdout(predicate::str::contains("A#"))
         .stdout(predicate::str::contains("Hello world"));
 }
+
+#[test]
+fn test_completions_bash() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_chordpro"));
+}
+
+#[test]
+fn test_completions_zsh() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#compdef chordpro"));
+}
+
+#[test]
+fn test_completions_fish() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete -c chordpro"));
+}
+
+#[test]
+fn test_completions_powershell() {
+    Command::cargo_bin("chordpro")
+        .unwrap()
+        .args(["--completions", "powershell"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}


### PR DESCRIPTION
## What

Add `--completions <SHELL>` flag to the CLI that generates shell completions for bash, zsh, fish, and PowerShell.

## Why

Shell completions improve the user experience by providing tab completion for all CLI flags and options.

## Changes

- `crates/cli/Cargo.toml`: add `clap_complete` dependency
- `crates/cli/src/main.rs`: add `--completions` flag, generate completions early-return
- `crates/cli/tests/cli.rs`: add 4 tests verifying non-empty output for each shell

New dependency justification: `clap_complete` is the official companion to `clap` for completion generation.

## Test results

- `cargo test -p chordpro-rs` — all 39 tests pass
- `cargo clippy` — no warnings
- Manually verified output for all 4 shells

Closes #806