### PR TITLE
Finalize v0.1.0 release date in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2026-04-04
 
 Initial release of chordpro-rs.
 


### PR DESCRIPTION
## What

Set the v0.1.0 release date in CHANGELOG.md to 2026-04-04.

## Why

All Phase 19 feature issues have been merged. This PR finalizes the changelog for the v0.1.0 release. After this PR merges, the v0.1.0 tag can be created and pushed to trigger the release workflow.

## Changes

- `CHANGELOG.md`: `## [0.1.0] - Unreleased` → `## [0.1.0] - 2026-04-04`

## Test results

Documentation-only change, no code modified.

Closes #804
Closes #817
Closes #818