### PR TITLE
Document English-only requirement and issue template in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,27 @@
 Thank you for your interest in contributing to ChordSketch! This document
 explains how to get started.
 
+## Language
+
+All contributions must be in **English**. This includes code, comments,
+documentation, commit messages, PR titles, PR descriptions, issue titles, and
+issue bodies.
+
 ## Filing Issues
 
 - Check [existing issues](https://github.com/koedame/chordsketch/issues)
   before opening a new one.
 - Use a clear, imperative title (e.g., "Fix chord transposition for sharps").
-- Include steps to reproduce for bugs, or a clear goal and acceptance criteria
-  for feature requests.
+- Issue bodies should include the following fields:
+
+  - **Goal** — What should be achieved.
+  - **Acceptance Criteria** — Checkboxes for done-ness.
+  - **Phase** — Which roadmap phase this belongs to (if known).
+
+- For bugs, include steps to reproduce. For features, describe the desired
+  behavior.
+- Labels: `phase:N`, `type:feature`/`type:bug`/`type:docs`/`type:refactor`,
+  `size:small`/`size:medium`/`size:large`, `priority:high`/`priority:medium`/`priority:low`.
 
 ## Development Setup
 


### PR DESCRIPTION
## What

- Add a **Language** section documenting the English-only requirement for all contributions.
- Expand the **Filing Issues** section with required issue body fields (Goal, Acceptance Criteria, Phase) and available label categories.

## Why

The English-only rule (`.claude/rules/english-only.md`) and issue body template (`.claude/rules/issue-workflow.md`) were not documented in CONTRIBUTING.md, which could confuse external contributors.

## Test results

- `cargo fmt --check` — pass
- `cargo clippy -- -D warnings` — pass
- Documentation-only change, no code affected.

## Review summary

Nit-level documentation improvements. No code changes.

Closes #857
Closes #858