### PR TITLE
Add exports field and snippets support to npm package

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -6,6 +6,12 @@
   "type": "module",
   "main": "chordsketch_wasm.js",
   "types": "chordsketch_wasm.d.ts",
+  "exports": {
+    ".": {
+      "import": "./chordsketch_wasm.js",
+      "types": "./chordsketch_wasm.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/koedame/chordsketch.git",
@@ -25,10 +31,11 @@
     "chordsketch_wasm.js",
     "chordsketch_wasm.d.ts",
     "chordsketch_wasm_bg.wasm",
-    "chordsketch_wasm_bg.wasm.d.ts"
+    "chordsketch_wasm_bg.wasm.d.ts",
+    "snippets/"
   ],
   "scripts": {
-    "build": "wasm-pack build ../../crates/wasm --target web && cp ../../crates/wasm/pkg/chordsketch_wasm* ."
+    "build": "wasm-pack build ../../crates/wasm --target web && cp ../../crates/wasm/pkg/chordsketch_wasm* . && cp -r ../../crates/wasm/pkg/snippets . 2>/dev/null || true"
   },
   "sideEffects": [
     "./chordsketch_wasm.js"


### PR DESCRIPTION
## What

- Add `exports` field for proper ESM resolution with modern bundlers (#883)
- Add `snippets/` directory to `files` array and build script to handle wasm-pack inline JS snippets (#882)
- Keep `main` field for backwards compatibility

## Test results

No code changes — package.json only.

Closes #882, #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)