### PR TITLE
Add resolve_config tests, fix stale pdf-pane, add focus-visible style

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -239,4 +239,33 @@ mod tests {
         let v = version();
         assert!(!v.is_empty());
     }
+
+    // resolve_config delegates to Config::preset and Config::parse.
+    // We test the underlying logic here since JsValue is not available
+    // on native targets.
+
+    #[test]
+    fn test_invalid_rrjson_config_parse_fails() {
+        let result = chordsketch_core::config::Config::parse("{ invalid rrjson !!!");
+        assert!(result.is_err(), "invalid RRJSON should fail to parse");
+    }
+
+    #[test]
+    fn test_preset_config_resolves() {
+        assert!(
+            chordsketch_core::config::Config::preset("guitar").is_some(),
+            "guitar preset should exist"
+        );
+        assert!(
+            chordsketch_core::config::Config::preset("nonexistent").is_none(),
+            "unknown preset should return None"
+        );
+    }
+
+    #[test]
+    fn test_valid_inline_rrjson_config_parses() {
+        let result =
+            chordsketch_core::config::Config::parse(r#"{ "settings": { "transpose": 2 } }"#);
+        assert!(result.is_ok(), "valid RRJSON should parse successfully");
+    }
 }

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -37,8 +37,11 @@ function render(): void {
   const input = editor.value;
   if (!input.trim()) {
     hideError();
+    preview.hidden = false;
     preview.srcdoc = '';
+    textOutput.hidden = true;
     textOutput.textContent = '';
+    pdfPane.hidden = true;
     return;
   }
 

--- a/packages/playground/src/style.css
+++ b/packages/playground/src/style.css
@@ -152,6 +152,11 @@ main {
   background: var(--accent-dim);
 }
 
+#pdf-pane button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .error {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## What

- Add unit tests for config resolution error/success paths in chordsketch-wasm (#904)
- Fix stale pdf-pane visibility when editor is cleared by resetting all pane hidden states in the early-return path (#905)
- Add `:focus-visible` outline to PDF download button for keyboard accessibility (#906)

## Test results

- `cargo test -p chordsketch-wasm` (8 tests) ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅

Closes #904, #905, #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)