### PR TITLE
Use pre-built wasm-pack binary via taiki-e/install-action

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -34,7 +34,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --version "=$WASM_PACK_VERSION" --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
       - name: Build WASM
         run: wasm-pack build crates/wasm --release --target web

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --version "=$WASM_PACK_VERSION" --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
       - name: Build WASM
         run: wasm-pack build crates/wasm --release --target web

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -29,7 +29,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --version "=$WASM_PACK_VERSION" --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
       - name: Build with wasm-pack
         run: wasm-pack build crates/wasm --target web


### PR DESCRIPTION
## What

Replace `cargo install wasm-pack --version --locked` (compiles from source, ~5-10 min) with `taiki-e/install-action` (downloads pre-built binary, ~5 sec) in all three CI workflows:

- `wasm.yml`
- `deploy-playground.yml`
- `npm-publish.yml`

Version pinning to 0.14.0 is preserved via the `tool: wasm-pack@0.14.0` syntax.

## Why

PR #907 switched from the unpinned curl installer to `cargo install` for version pinning, but this regressed CI wall-clock time by compiling wasm-pack from source on every run. `taiki-e/install-action` provides both version pinning and fast pre-built binary installation.

## Test results

Workflow YAML syntax validated. No code changes.

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)