### PR TITLE
Fix upstream-watch.yml workflow file error

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
 
       - name: Get upstream latest release
         id: upstream


### PR DESCRIPTION
## What

Replace pinned SHA (`de0fac2e...`) for `actions/checkout` with `@v6` tag reference, consistent with all other CI workflows. The SHA pin was likely invalid or mismatched, causing GitHub Actions to report "workflow file issue" on every push.

## Why

The upstream-watch workflow has been failing on every push to main with "This run likely failed because of a workflow file issue."

## Test results

YAML syntax validated. No code changes beyond the checkout action reference.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)