### PR TITLE
Fix upstream-watch.yml YAML parse error

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -51,23 +51,28 @@ jobs:
           RELEASE_URL="https://github.com/ChordPro/chordpro/releases/tag/${UPSTREAM_TAG}"
           COMPARE_URL="https://github.com/ChordPro/chordpro/compare/${TRACKED_VERSION}...${UPSTREAM_TAG}"
 
+          BODY=$(cat <<BODY_EOF
+          ## New upstream ChordPro release detected
+
+          **Version**: [${UPSTREAM_TAG}](${RELEASE_URL})
+          **Previously tracked**: ${TRACKED_VERSION}
+          **Diff**: [${TRACKED_VERSION}...${UPSTREAM_TAG}](${COMPARE_URL})
+
+          ### TODO
+          - [ ] Review release notes
+          - [ ] Identify new directives or spec changes
+          - [ ] Assess impact on chordsketch
+          - [ ] Implement required changes
+          - [ ] Update compatibility tests
+          - [ ] Update \`.github/upstream-version\` to \`${UPSTREAM_TAG}\`
+
+          > Auto-created by upstream-watch workflow.
+          BODY_EOF
+          )
+
           gh issue create \
             --title "Upstream: ChordPro ${UPSTREAM_TAG} released" \
-            --body "## New upstream ChordPro release detected
-
-**Version**: [${UPSTREAM_TAG}](${RELEASE_URL})
-**Previously tracked**: ${TRACKED_VERSION}
-**Diff**: [${TRACKED_VERSION}...${UPSTREAM_TAG}](${COMPARE_URL})
-
-### TODO
-- [ ] Review release notes
-- [ ] Identify new directives or spec changes
-- [ ] Assess impact on chordsketch
-- [ ] Implement required changes
-- [ ] Update compatibility tests
-- [ ] Update \`.github/upstream-version\` to \`${UPSTREAM_TAG}\`
-
-> Auto-created by upstream-watch workflow." \
+            --body "$BODY" \
             --label "upstream" \
             --label "type:tracking" \
             --label "size:medium" \


### PR DESCRIPTION
## What

Fix the YAML parse error in `upstream-watch.yml` that caused "workflow file issue" on every push to main.

## Root cause

The `gh issue create --body "..."` argument contained multi-line Markdown with `**Version**` at column 1. This ended the YAML `run: |` block scalar prematurely, and the YAML parser interpreted `*` as an alias reference.

Confirmed via: `python3 -c "import yaml; yaml.safe_load(open(...))"` → `ScannerError: while scanning an alias... expected alphabetic or numeric character, but found '*'` at line 58.

## Fix

Store the issue body in a shell heredoc variable (`BODY=$(cat <<BODY_EOF ... BODY_EOF)`), keeping all content indented within the YAML block scalar.

## Test results

- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML valid ✅

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)