### PR TITLE
Add Docker Hub push to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,11 +68,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            docker.io/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## What

Update `docker.yml` to push images to both GHCR and Docker Hub, making ChordSketch available via `docker pull koedame/chordsketch`.

## Why

Docker Hub is where most users search for images. Currently we only push to GHCR.

## Changes

- Add Docker Hub login step using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
- Update metadata action to generate tags for both `ghcr.io/koedame/chordsketch` and `docker.io/koedame/chordsketch`

## Prerequisites

Before this workflow can run successfully:
1. Create `koedame/chordsketch` repository on Docker Hub
2. Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the repo settings

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] After secrets are configured, trigger workflow manually with `v0.1.0` tag
- [ ] Verify `docker pull koedame/chordsketch` works

Closes #915