### PR TITLE
Fix FFI crate no-op test, add fmt check, and fix hardcoded .so path

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Test
         run: cargo test -p chordsketch-ffi
 
+      - name: Format
+        run: cargo fmt -p chordsketch-ffi --check
+
       - name: Clippy
         run: cargo clippy -p chordsketch-ffi -- -D warnings
 
@@ -64,10 +67,19 @@ jobs:
       - name: Build FFI crate
         run: cargo build -p chordsketch-ffi
 
+      - name: Determine library path
+        id: lib-path
+        run: |
+          case "$RUNNER_OS" in
+            Linux)  echo "path=target/debug/libchordsketch_ffi.so" >> "$GITHUB_OUTPUT" ;;
+            macOS)  echo "path=target/debug/libchordsketch_ffi.dylib" >> "$GITHUB_OUTPUT" ;;
+            Windows) echo "path=target/debug/chordsketch_ffi.dll" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Generate bindings
         run: |
           cargo run -p chordsketch-ffi --bin uniffi-bindgen generate \
-            --library target/debug/libchordsketch_ffi.so \
+            --library ${{ steps.lib-path.outputs.path }} \
             --language ${{ matrix.language }} \
             --out-dir bindings/${{ matrix.language }}
 

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -187,12 +187,17 @@ mod tests {
 
     #[test]
     fn test_validate_returns_errors_for_bad_input() {
-        // Strict parsing of unclosed directive would produce an error
-        // but lenient parsing may accept it. Use a structurally invalid directive.
-        let errors = validate("{title: Test}\n{invalid_directive}".to_string());
-        // The lenient parser may or may not produce errors here depending
-        // on how unknown directives are handled, so just check the return type.
-        let _ = errors;
+        // An unclosed chord bracket is always a parse error, even in lenient mode.
+        let errors = validate("{title: Test}\n[G".to_string());
+        assert!(
+            !errors.is_empty(),
+            "unclosed chord should produce a parse error"
+        );
+        assert!(
+            errors[0].contains("unclosed"),
+            "error message should mention 'unclosed', got: {}",
+            errors[0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

- **Fix no-op test** (`test_validate_returns_errors_for_bad_input`): The test previously called `validate()` and discarded the result with `let _ = errors`. Now uses an unclosed chord bracket (`[G`) as input, which reliably produces a parse error in lenient mode, and asserts both that errors are non-empty and that the message contains "unclosed".
- **Add `cargo fmt --check`** to `ffi.yml`: The `build-and-test` job was missing a format check step, unlike the main CI workflow.
- **Fix hardcoded `.so` extension** in `ffi.yml`: The `generate-bindings` job hardcoded `libchordsketch_ffi.so`, which only works on Linux. Now uses an OS-aware step that resolves the correct library extension (`.so`, `.dylib`, or `.dll`) based on `RUNNER_OS`.

## Why

The no-op test provided zero regression protection. The missing fmt check meant FFI-specific formatting issues could slip through. The hardcoded `.so` path would break if the generate-bindings job ever ran on non-Linux runners.

## Test results

```
cargo test -p chordsketch-ffi -- test_validate
  2 passed, 0 failed

cargo fmt -p chordsketch-ffi --check
  OK

cargo clippy -p chordsketch-ffi -- -D warnings
  OK
```

## Issues

Closes #958, closes #929, closes #940
Closes #949, closes #945, closes #931, closes #947 (duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)