### PR TITLE
Update CLAUDE.md architecture table and fix napi crate minor issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,20 @@ This is a Cargo workspace with six crates:
 | `chordsketch-render-pdf` | `crates/render-pdf` | lib | `chordsketch-core` |
 | `chordsketch` (CLI) | `crates/cli` | bin | `chordsketch-core`, `chordsketch-render-text`, `chordsketch-render-html`, `chordsketch-render-pdf` |
 | `chordsketch-wasm` | `crates/wasm` | cdylib | `chordsketch-core`, all renderers, `wasm-bindgen`, `serde` |
+| `chordsketch-ffi` | `crates/ffi` | cdylib/staticlib/lib | `chordsketch-core`, all renderers, `uniffi`, `thiserror` |
+| `chordsketch-napi` | `crates/napi` | cdylib | `chordsketch-core`, all renderers, `napi`, `napi-derive` |
 
 Additionally, these non-Rust packages exist:
 
 | Package | Path | Description |
 |---|---|---|
 | `@chordsketch/wasm` | `packages/npm` | npm package with TypeScript types |
+| `@chordsketch/node` | `crates/napi` | Native Node.js addon via napi-rs |
 | Playground | `packages/playground` | Vite-based browser playground (Vanilla TS) |
+| Python (`chordsketch`) | `crates/ffi` | Python package via UniFFI + maturin |
+| Swift (`ChordSketch`) | `packages/swift` | Swift package with XCFramework |
+| Kotlin (`chordsketch`) | `packages/kotlin` | Kotlin/JVM package via JNI |
+| Ruby (`chordsketch`) | `packages/ruby` | Ruby gem via UniFFI |
 
 ### Dependency Policy
 
@@ -83,6 +90,7 @@ High-level phases:
 18. **Phase 18** — Perl reference implementation compatibility testing ✅
 19. **Phase 19** — Production readiness and publishing ✅
 20. **Phase 20** — WASM build & web playground
+21. **Phase 21** — Multi-language bindings & expanded distribution
 
 ## Merge Policy
 

--- a/crates/napi/build.rs
+++ b/crates/napi/build.rs
@@ -1,5 +1,3 @@
-extern crate napi_build;
-
 fn main() {
     napi_build::setup();
 }

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -9,6 +9,9 @@
     "directory": "crates/napi"
   },
   "homepage": "https://github.com/koedame/chordsketch",
+  "engines": {
+    "node": ">=15.12.0"
+  },
   "keywords": [
     "chordpro",
     "music",


### PR DESCRIPTION
## What

- **CLAUDE.md architecture table**: Add `chordsketch-ffi` and `chordsketch-napi` to the Rust crate table, and add all language binding packages (Python, Swift, Kotlin, Ruby, Node) to the non-Rust packages table. Add Phase 21 to the roadmap.
- **napi build.rs**: Remove unnecessary `extern crate napi_build;` declaration (not needed in Rust 2018+ edition).
- **napi package.json**: Add `engines` field requiring Node.js >= 15.12.0 (needed for napi9 feature).

## Why

The architecture table was out of date after Phase 21 PRs added the FFI and napi crates plus five language binding packages. The `extern crate` is a Rust 2015 idiom. The `engines` field communicates the minimum Node.js version required by the napi9 feature.

## Test results

```
cargo fmt --check        OK
cargo clippy -p chordsketch-napi -- -D warnings   OK
```

## Issues

Closes #950, closes #946, closes #932 (CLAUDE.md update — duplicates)
Closes #935 (napi build.rs extern crate)
Closes #934 (napi package.json engines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)