### PR TITLE
Fix Ruby gem platform library collision and improve loader

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,19 +36,24 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             lib: libchordsketch_ffi.so
+            platform_dir: x86_64-linux
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             lib: libchordsketch_ffi.so
+            platform_dir: aarch64-linux
             cross: true
           - os: macos-latest
             target: aarch64-apple-darwin
             lib: libchordsketch_ffi.dylib
+            platform_dir: aarch64-darwin
           - os: macos-latest
             target: x86_64-apple-darwin
             lib: libchordsketch_ffi.dylib
+            platform_dir: x86_64-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             lib: chordsketch_ffi.dll
+            platform_dir: x86_64-windows
     steps:
       - uses: actions/checkout@v6
 
@@ -96,12 +101,13 @@ jobs:
             --library target/debug/libchordsketch_ffi.so \
             --language ruby \
             --out-dir packages/ruby/lib/
+          mv packages/ruby/lib/chordsketch.rb packages/ruby/lib/chordsketch_uniffi.rb
 
       - name: Download native library (linux-x86-64)
         uses: actions/download-artifact@v4
         with:
           name: native-x86_64-unknown-linux-gnu
-          path: packages/ruby/lib/
+          path: packages/ruby/lib/x86_64-linux/
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -113,8 +119,6 @@ jobs:
 
       - name: Run tests
         working-directory: packages/ruby
-        env:
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/ruby/lib
         run: ruby -Ilib -Itest test/test_chordsketch.rb
 
   publish:
@@ -138,13 +142,24 @@ jobs:
             --library target/debug/libchordsketch_ffi.so \
             --language ruby \
             --out-dir packages/ruby/lib/
+          mv packages/ruby/lib/chordsketch.rb packages/ruby/lib/chordsketch_uniffi.rb
 
       - name: Download all native libraries
         uses: actions/download-artifact@v4
         with:
           pattern: native-*
           path: packages/ruby/lib/
-          merge-multiple: true
+
+      - name: Organize native libraries by platform
+        run: |
+          cd packages/ruby/lib
+          mkdir -p x86_64-linux aarch64-linux aarch64-darwin x86_64-darwin x86_64-windows
+          mv native-x86_64-unknown-linux-gnu/* x86_64-linux/
+          mv native-aarch64-unknown-linux-gnu/* aarch64-linux/
+          mv native-aarch64-apple-darwin/* aarch64-darwin/
+          mv native-x86_64-apple-darwin/* x86_64-darwin/
+          mv native-x86_64-pc-windows-msvc/* x86_64-windows/
+          rmdir native-*
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/packages/ruby/chordsketch.gemspec
+++ b/packages/ruby/chordsketch.gemspec
@@ -1,6 +1,9 @@
+cargo_toml = File.read(File.join(__dir__, "..", "..", "crates", "ffi", "Cargo.toml"))
+cargo_version = cargo_toml.match(/^version\s*=\s*"(.+)"$/)[1]
+
 Gem::Specification.new do |s|
   s.name        = "chordsketch"
-  s.version     = "0.1.0"
+  s.version     = cargo_version
   s.summary     = "ChordPro file format parser and renderer"
   s.description = "Parse and render ChordPro files to text, HTML, and PDF. " \
                   "Native bindings via UniFFI for high performance."

--- a/packages/ruby/lib/chordsketch.rb
+++ b/packages/ruby/lib/chordsketch.rb
@@ -11,9 +11,57 @@
 # @example Render with transposition
 #   text = Chordsketch.parse_and_render_text(input, "guitar", 2)
 
-# The actual module is defined in the UniFFI-generated chordsketch.rb.
-# For local development, generate bindings with:
-#   cargo run -p chordsketch-ffi --bin uniffi-bindgen generate \
-#     --library target/debug/libchordsketch_ffi.so \
-#     --language ruby \
-#     --out-dir packages/ruby/lib/
+require "ffi"
+require "rbconfig"
+
+# Detect the platform and pre-load the correct native library before
+# requiring the UniFFI-generated bindings.
+module Chordsketch
+  # @api private
+  module NativeLoader
+    PLATFORM_MAP = {
+      /x86_64.*linux/                 => "x86_64-linux",
+      /aarch64.*linux/                => "aarch64-linux",
+      /arm64.*darwin|aarch64.*darwin/ => "aarch64-darwin",
+      /x86_64.*darwin/                => "x86_64-darwin",
+      /x64.*mingw|x64.*mswin/        => "x86_64-windows",
+    }.freeze
+
+    # Detect the platform-specific subdirectory for native libraries.
+    def self.detect_platform_dir
+      arch = RbConfig::CONFIG["arch"]
+      PLATFORM_MAP.each do |pattern, dir|
+        return dir if arch.match?(pattern)
+      end
+      raise "Unsupported platform: #{arch}. " \
+            "ChordSketch supports x86_64/aarch64 Linux, macOS, and x86_64 Windows."
+    end
+
+    # Pre-load the native library so UniFFI-generated ffi_lib calls find it.
+    def self.load!
+      platform_dir = detect_platform_dir
+      lib_dir = File.join(File.dirname(__FILE__), platform_dir)
+      lib_name = FFI.map_library_name("chordsketch_ffi")
+      lib_path = File.join(lib_dir, lib_name)
+
+      unless File.exist?(lib_path)
+        raise "Native library not found at #{lib_path}. " \
+              "Ensure the gem was built for your platform (#{platform_dir}). " \
+              "For local development, generate bindings with:\n" \
+              "  cargo run -p chordsketch-ffi --bin uniffi-bindgen generate \\\n" \
+              "    --library target/debug/libchordsketch_ffi.so \\\n" \
+              "    --language ruby --out-dir packages/ruby/lib/"
+      end
+
+      FFI::DynamicLibrary.open(
+        lib_path,
+        FFI::DynamicLibrary::RTLD_LAZY | FFI::DynamicLibrary::RTLD_GLOBAL
+      )
+    end
+  end
+end
+
+Chordsketch::NativeLoader.load!
+
+# Load the UniFFI-generated bindings (the pre-loaded library will be found).
+require_relative "chordsketch_uniffi"


### PR DESCRIPTION
## What

- **Platform-specific library directories** (#954): Native libraries are now placed in platform-specific subdirectories (`x86_64-linux/`, `aarch64-linux/`, `aarch64-darwin/`, `x86_64-darwin/`, `x86_64-windows/`) instead of a single flat directory. This prevents the x86_64 and aarch64 Linux `.so` files from overwriting each other during gem packaging.

- **Platform-aware loader** (#951): `chordsketch.rb` now detects the current platform via `RbConfig::CONFIG["arch"]`, pre-loads the correct native library using `FFI::DynamicLibrary.open`, and then requires the UniFFI-generated bindings (`chordsketch_uniffi.rb`). If the native library is missing or the platform is unsupported, a clear error message is raised with development instructions.

- **Version from Cargo.toml** (#953): The gemspec now reads the version from `crates/ffi/Cargo.toml` at `gem build` time instead of hardcoding it, ensuring the gem and Rust crate versions stay in sync.

## Why

The publish job used `merge-multiple: true` when downloading native library artifacts, causing both Linux `.so` files (which share the same filename) to be merged into the same directory — the second one silently overwrote the first. The published gem was broken for at least one Linux architecture on every release.

## CI changes

- `build-native` matrix: Added `platform_dir` column for each target
- `generate-and-test`: UniFFI binding renamed to `chordsketch_uniffi.rb`; native library downloaded to `x86_64-linux/` subdirectory
- `publish`: Downloads artifacts to separate directories, then reorganizes them into platform-specific subdirectories under `lib/`

## Test results

CI will verify the test job works with the new directory layout (linux-x86-64 tests).

## Issues

Closes #954, closes #951, closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)