### PR TITLE
Pin GitHub Actions to commit SHAs in napi.yml, ffi.yml, and swift.yml

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -27,12 +27,12 @@ jobs:
     name: Build and test FFI crate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: rustup show
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ffi
 
@@ -55,12 +55,12 @@ jobs:
       matrix:
         language: [python, swift, kotlin, ruby]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: rustup show
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ffi
 
@@ -84,7 +84,7 @@ jobs:
             --out-dir bindings/${{ matrix.language }}
 
       - name: Upload bindings artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bindings-${{ matrix.language }}
           path: bindings/${{ matrix.language }}/

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -45,18 +45,18 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: |
           rustup target add ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: napi-${{ matrix.target }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -77,7 +77,7 @@ jobs:
           napi build --release --manifest-path Cargo.toml --target ${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: napi-${{ matrix.target }}
           path: crates/napi/*.node
@@ -86,12 +86,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: rustup show
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: napi-lint
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build XCFramework
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust targets
         run: |
@@ -40,7 +40,7 @@ jobs:
           rustup target add aarch64-apple-ios-sim
           rustup target add x86_64-apple-ios
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: swift
 
@@ -106,13 +106,13 @@ jobs:
           zip -r chordsketch-xcframework.zip chordsketchFFI.xcframework
 
       - name: Upload XCFramework
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: xcframework
           path: chordsketch-xcframework.zip
 
       - name: Upload Swift source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: swift-source
           path: generated/chordsketch.swift
@@ -125,7 +125,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: xcframework
 


### PR DESCRIPTION
## What

Pin all third-party GitHub Actions references in `napi.yml`, `ffi.yml`, and `swift.yml` to full commit SHAs instead of mutable version tags. Each line retains a `# vN` comment for readability.

## Why

Mutable tags (e.g. `@v6`) can be silently rewritten by the action author — a known supply chain attack vector. The `swift.yml` publish job has `contents: write` permissions, making it particularly sensitive. SHA pinning ensures that CI always runs the exact code that was audited.

## Pinned versions

| Action | SHA | Tag |
|---|---|---|
| `actions/checkout` | `de0fac2e` | v6 |
| `Swatinem/rust-cache` | `e18b4977` | v2 |
| `actions/upload-artifact` | `ea165f8d` | v4 |
| `actions/download-artifact` | `d3f86a10` | v4 |
| `actions/setup-node` | `49933ea5` | v4 |

## Test results

No code changes — CI workflows only.

## Issues

Closes #962, closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)