### PR TITLE
Derive Python and Kotlin package versions from Cargo.toml

### DIFF
--- a/crates/ffi/pyproject.toml
+++ b/crates/ffi/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "chordsketch"
-version = "0.1.0"
+# Version is derived from Cargo.toml automatically by maturin.
+dynamic = ["version"]
 description = "ChordPro file format parser and renderer"
 readme = {text = "ChordPro file format parser and renderer for Python. See https://github.com/koedame/chordsketch for documentation.", content-type = "text/plain"}
 license = { text = "MIT" }

--- a/packages/kotlin/lib/build.gradle.kts
+++ b/packages/kotlin/lib/build.gradle.kts
@@ -6,7 +6,12 @@ plugins {
 }
 
 group = "com.koedame"
-version = "0.1.0"
+// Read version from crates/ffi/Cargo.toml to keep in sync with Rust crate.
+version = file("${rootDir}/../../crates/ffi/Cargo.toml").readText()
+    .lineSequence()
+    .first { it.startsWith("version") }
+    .substringAfter('"')
+    .substringBefore('"')
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## What

- **Python** (#942): Replace hardcoded `version = "0.1.0"` in `pyproject.toml` with `dynamic = ["version"]`. Maturin natively reads the version from `Cargo.toml` when the version field is listed in `dynamic`.
- **Kotlin** (#956): Replace hardcoded `version = "0.1.0"` in `build.gradle.kts` with a script that parses the version from `crates/ffi/Cargo.toml` at build time.

## Why

Both packages had independently hardcoded version strings that would drift from the Rust crate version when bumped for a release. This makes the Cargo.toml version the single source of truth.

## Test results

No Rust code changes — only build configuration files.

## Issues

Closes #942, closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)