### PR TITLE
Reuse generated Kotlin bindings in publish job via artifact

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -118,6 +118,12 @@ jobs:
           chmod +x gradlew 2>/dev/null || true
           ./gradlew test || gradle test
 
+      - name: Upload generated Kotlin bindings
+        uses: actions/upload-artifact@v4
+        with:
+          name: kotlin-bindings
+          path: packages/kotlin/lib/src/main/kotlin/uniffi/
+
   publish:
     name: Publish to Maven Central
     needs: [generate-and-test]
@@ -126,19 +132,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Download generated Kotlin bindings
+        uses: actions/download-artifact@v4
         with:
-          shared-key: kotlin-generate
-
-      - name: Build FFI crate
-        run: cargo build -p chordsketch-ffi
-
-      - name: Generate Kotlin bindings
-        run: |
-          cargo run -p chordsketch-ffi --bin uniffi-bindgen generate \
-            --library target/debug/libchordsketch_ffi.so \
-            --language kotlin \
-            --out-dir packages/kotlin/lib/src/main/kotlin/
+          name: kotlin-bindings
+          path: packages/kotlin/lib/src/main/kotlin/uniffi/
 
       - name: Download all JNI artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## What

Upload the UniFFI-generated Kotlin bindings as a workflow artifact in the `generate-and-test` job, then download them in the `publish` job instead of rebuilding the FFI crate and regenerating bindings.

## Why

The publish job previously duplicated the `cargo build -p chordsketch-ffi` and `uniffi-bindgen generate` steps that `generate-and-test` had already completed. This wasted CI time and created a risk of the published bindings differing from the tested ones (e.g., if the Rust toolchain or dependencies changed between jobs).

## Changes

- `generate-and-test`: Added `Upload generated Kotlin bindings` step
- `publish`: Replaced `Build FFI crate` + `Generate Kotlin bindings` + `Swatinem/rust-cache` steps with a single `Download generated Kotlin bindings` step

## Test results

No Rust code changes — CI workflow only.

## Issues

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)