### PR TITLE
Document that FFI render functions discard parse warnings

### DIFF
--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -1,6 +1,9 @@
 namespace chordsketch {
     /// Parse ChordPro input and render as plain text.
     ///
+    /// Parse warnings are silently discarded. Call `validate()` to retrieve
+    /// diagnostics if needed.
+    ///
     /// - `input`: ChordPro source text
     /// - `config_json`: optional RRJSON configuration string or preset name
     ///   (e.g., "guitar", "ukulele")
@@ -9,15 +12,24 @@ namespace chordsketch {
     string parse_and_render_text(string input, string? config_json, i8? transpose);
 
     /// Parse ChordPro input and render as an HTML document.
+    ///
+    /// Parse warnings are silently discarded. Call `validate()` to retrieve
+    /// diagnostics if needed.
     [Throws=ChordSketchError]
     string parse_and_render_html(string input, string? config_json, i8? transpose);
 
     /// Parse ChordPro input and render as a PDF document.
+    ///
+    /// Parse warnings are silently discarded. Call `validate()` to retrieve
+    /// diagnostics if needed.
     [Throws=ChordSketchError]
     bytes parse_and_render_pdf(string input, string? config_json, i8? transpose);
 
     /// Validate ChordPro input and return any parse errors as strings.
     /// Returns an empty list if the input is valid.
+    ///
+    /// Call this before or after rendering to surface parse diagnostics
+    /// that the render functions silently discard.
     sequence<string> validate(string input);
 
     /// Return the ChordSketch library version.

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -50,6 +50,10 @@ fn parse_songs(input: &str) -> Result<Vec<chordsketch_core::ast::Song>, ChordSke
 }
 
 /// Parse ChordPro input and render as plain text.
+///
+/// Parse warnings are silently discarded — the lenient parser produces a
+/// best-effort result even when the input contains errors. To retrieve
+/// diagnostics, call [`validate()`] before or after rendering.
 pub fn parse_and_render_text(
     input: String,
     config_json: Option<String>,
@@ -65,6 +69,10 @@ pub fn parse_and_render_text(
 }
 
 /// Parse ChordPro input and render as an HTML document.
+///
+/// Parse warnings are silently discarded — the lenient parser produces a
+/// best-effort result even when the input contains errors. To retrieve
+/// diagnostics, call [`validate()`] before or after rendering.
 pub fn parse_and_render_html(
     input: String,
     config_json: Option<String>,
@@ -80,6 +88,10 @@ pub fn parse_and_render_html(
 }
 
 /// Parse ChordPro input and render as a PDF document.
+///
+/// Parse warnings are silently discarded — the lenient parser produces a
+/// best-effort result even when the input contains errors. To retrieve
+/// diagnostics, call [`validate()`] before or after rendering.
 pub fn parse_and_render_pdf(
     input: String,
     config_json: Option<String>,
@@ -204,6 +216,25 @@ mod tests {
     fn test_version() {
         let v = version();
         assert!(!v.is_empty());
+    }
+
+    #[test]
+    fn test_render_succeeds_despite_parse_warnings() {
+        // Input with an unclosed chord produces parse warnings, but the
+        // lenient parser still yields a song that can be rendered.
+        // Callers who want diagnostics should call validate() separately.
+        let input = "{title: Warn}\n[C]Hello [G\nWorld".to_string();
+        let result = parse_and_render_text(input.clone(), None, None);
+        assert!(result.is_ok(), "render should succeed despite parse errors");
+        let text = result.unwrap();
+        assert!(text.contains("Warn"), "title should be rendered");
+
+        // validate() surfaces the warnings that render silently discards.
+        let warnings = validate(input);
+        assert!(
+            !warnings.is_empty(),
+            "validate should report the unclosed chord"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

- Add doc comments to `parse_and_render_text`, `parse_and_render_html`, and `parse_and_render_pdf` in both Rust code and the UDL file, explaining that parse warnings are silently discarded and callers should use `validate()` to retrieve diagnostics.
- Add doc comment to `validate()` in the UDL clarifying its role alongside the render functions.
- Add a test (`test_render_succeeds_despite_parse_warnings`) demonstrating that render succeeds with malformed input (unclosed chord) and that `validate()` surfaces the warnings.

## Why

Callers in Python, Kotlin, Swift, and Ruby had no documentation indicating that parse warnings are silently dropped. Without calling `validate()`, they would have no way to know their input contained recoverable errors.

## Test results

```
cargo test -p chordsketch-ffi   14 passed, 0 failed
cargo fmt --check               OK
cargo clippy -- -D warnings     OK
```

## Issues

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)