### PR TITLE
Add unit tests to chordsketch-napi crate

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -139,3 +139,108 @@ pub fn validate(input: String) -> Vec<String> {
 pub fn version() -> String {
     chordsketch_core::version().to_string()
 }
+
+// Unit tests exercise the underlying rendering and parsing logic directly
+// via chordsketch_core and renderer crates. The napi wrapper functions
+// cannot be tested natively because they depend on the Node.js runtime for
+// linking (Buffer, napi::Error, etc.).
+#[cfg(test)]
+mod tests {
+    const MINIMAL_INPUT: &str = "{title: Test}\n[C]Hello";
+
+    #[test]
+    fn test_render_text_returns_content() {
+        let result = chordsketch_core::parse_multi_lenient(MINIMAL_INPUT);
+        let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
+        assert!(!songs.is_empty());
+        let text = chordsketch_render_text::render_songs_with_transpose(
+            &songs,
+            0,
+            &chordsketch_core::config::Config::defaults(),
+        );
+        assert!(!text.is_empty());
+        assert!(text.contains("Test"));
+    }
+
+    #[test]
+    fn test_render_html_returns_content() {
+        let result = chordsketch_core::parse_multi_lenient(MINIMAL_INPUT);
+        let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
+        let html = chordsketch_render_html::render_songs_with_transpose(
+            &songs,
+            0,
+            &chordsketch_core::config::Config::defaults(),
+        );
+        assert!(!html.is_empty());
+        assert!(html.contains("Test"));
+    }
+
+    #[test]
+    fn test_render_pdf_returns_bytes() {
+        let result = chordsketch_core::parse_multi_lenient(MINIMAL_INPUT);
+        let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
+        let bytes = chordsketch_render_pdf::render_songs_with_transpose(
+            &songs,
+            0,
+            &chordsketch_core::config::Config::defaults(),
+        );
+        assert!(!bytes.is_empty());
+        assert!(bytes.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_version_returns_nonempty_string() {
+        let v = chordsketch_core::version();
+        assert!(!v.is_empty());
+    }
+
+    #[test]
+    fn test_transpose_range_validation() {
+        // Mirrors the parse_transpose logic: valid range is -12..=12.
+        for valid in [-12, -1, 0, 1, 12] {
+            assert!(
+                (-12..=12).contains(&valid),
+                "{valid} should be in valid range"
+            );
+        }
+        for invalid in [-13, 13, 100, -100] {
+            assert!(
+                !(-12..=12).contains(&invalid),
+                "{invalid} should be out of range"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_returns_empty_for_valid_input() {
+        let result = chordsketch_core::parse_multi_lenient(MINIMAL_INPUT);
+        let errors: Vec<_> = result.results.into_iter().flat_map(|r| r.errors).collect();
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_validate_returns_errors_for_bad_input() {
+        let result = chordsketch_core::parse_multi_lenient("{title: Test}\n[G");
+        let errors: Vec<_> = result.results.into_iter().flat_map(|r| r.errors).collect();
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn test_preset_config_resolves() {
+        assert!(chordsketch_core::config::Config::preset("guitar").is_some());
+        assert!(chordsketch_core::config::Config::preset("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_invalid_config_fails() {
+        assert!(chordsketch_core::config::Config::parse("{ invalid rrjson !!!").is_err());
+    }
+
+    #[test]
+    fn test_valid_rrjson_config_parses() {
+        assert!(
+            chordsketch_core::config::Config::parse(r#"{ "settings": { "transpose": 2 } }"#)
+                .is_ok()
+        );
+    }
+}


### PR DESCRIPTION
## What

Add 10 unit tests to `crates/napi/src/lib.rs` mirroring the test coverage in the WASM crate:

- `render_text`, `render_html`, `render_pdf` return correct content
- `version()` returns a non-empty string
- Transpose range validation (-12..=12)
- `validate` returns empty for valid input, non-empty for bad input
- Config preset resolution, invalid RRJSON rejection, valid RRJSON parsing

## Why

The napi crate had zero test coverage. Tests exercise the underlying core and renderer crates directly since napi wrapper functions require a Node.js runtime for linking (`Buffer`, `napi::Error`, etc. depend on `napi_*` C symbols).

## Test results

```
cargo test -p chordsketch-napi   10 passed, 0 failed
cargo fmt --check                OK
cargo clippy -- -D warnings      OK
```

## Issues

Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)