### PR TITLE
Document ffi.yml generate-bindings purpose and expand Python smoke tests

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Clippy
         run: cargo clippy -p chordsketch-ffi -- -D warnings
 
+  # Smoke-test that UniFFI binding generation succeeds for all languages.
+  # Each language has its own dedicated workflow (python.yml, swift.yml,
+  # kotlin.yml, ruby.yml) that generates, tests, and publishes bindings.
+  # This job catches UDL schema breakage early without running full builds.
   generate-bindings:
     name: Generate ${{ matrix.language }} bindings
     runs-on: ubuntu-latest
@@ -82,9 +86,3 @@ jobs:
             --library ${{ steps.lib-path.outputs.path }} \
             --language ${{ matrix.language }} \
             --out-dir bindings/${{ matrix.language }}
-
-      - name: Upload bindings artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: bindings-${{ matrix.language }}
-          path: bindings/${{ matrix.language }}/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -74,9 +74,19 @@ jobs:
           path: dist
 
   test:
-    name: Test Python bindings
+    name: Test Python bindings (${{ matrix.os }})
     needs: [build-wheels]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: wheels-ubuntu-latest-x86_64
+          - os: macos-latest
+            artifact: wheels-macos-latest-aarch64
+          - os: windows-latest
+            artifact: wheels-windows-latest-x64
     steps:
       - uses: actions/checkout@v6
 
@@ -86,7 +96,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: wheels-ubuntu-latest-x86_64
+          name: ${{ matrix.artifact }}
           path: dist
 
       - name: Install wheel


### PR DESCRIPTION
## What

- **ffi.yml** (#941): Remove the unused `Upload bindings artifact` step from the `generate-bindings` job and add a comment explaining its purpose — it serves as a UDL schema smoke test, while each language (Python, Swift, Kotlin, Ruby) has its own dedicated workflow for full builds/tests/publishing.
- **python.yml** (#943): Expand the test job from single-platform (Linux x86_64 only) to a matrix covering Linux x86_64, macOS aarch64, and Windows x64.

## Why

The uploaded binding artifacts were never downloaded or used by any downstream job. The Python smoke tests only ran on one platform, missing potential platform-specific issues (e.g., endianness, path separators, PDF font loading).

## Test results

No Rust code changes — CI workflows only.

## Issues

Closes #941, closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)