### PR TITLE
Fix napi test docs, ffi.yml default case, and CLAUDE.md crate count

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -78,11 +78,12 @@ jobs:
             Linux)  echo "path=target/debug/libchordsketch_ffi.so" >> "$GITHUB_OUTPUT" ;;
             macOS)  echo "path=target/debug/libchordsketch_ffi.dylib" >> "$GITHUB_OUTPUT" ;;
             Windows) echo "path=target/debug/chordsketch_ffi.dll" >> "$GITHUB_OUTPUT" ;;
+            *) echo "Unsupported RUNNER_OS: $RUNNER_OS" && exit 1 ;;
           esac
 
       - name: Generate bindings
         run: |
           cargo run -p chordsketch-ffi --bin uniffi-bindgen generate \
-            --library ${{ steps.lib-path.outputs.path }} \
+            --library "${{ steps.lib-path.outputs.path }}" \
             --language ${{ matrix.language }} \
             --out-dir bindings/${{ matrix.language }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ cargo fmt            # Auto-format code
 
 ## Architecture
 
-This is a Cargo workspace with six crates:
+This is a Cargo workspace with the following crates:
 
 | Crate | Path | Kind | Dependencies |
 |---|---|---|---|

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -196,14 +196,18 @@ mod tests {
 
     #[test]
     fn test_transpose_range_validation() {
-        // Mirrors the parse_transpose logic: valid range is -12..=12.
-        for valid in [-12, -1, 0, 1, 12] {
+        // parse_transpose returns napi::Result which requires the Node.js
+        // runtime for linking (napi::Error drops call napi_delete_reference).
+        // This test validates the range logic directly as a sanity check.
+        // The actual parse_transpose function is tested via the napi addon
+        // in the build job where Node.js is available.
+        for valid in [-12i32, -1, 0, 1, 12] {
             assert!(
                 (-12..=12).contains(&valid),
                 "{valid} should be in valid range"
             );
         }
-        for invalid in [-13, 13, 100, -100] {
+        for invalid in [-13i32, 13, 100, -100] {
             assert!(
                 !(-12..=12).contains(&invalid),
                 "{invalid} should be out of range"


### PR DESCRIPTION
## What

- **napi test** (#975): Document that `parse_transpose` cannot be called in unit tests without the Node.js runtime due to `napi::Error` linking requirements (`napi_delete_reference`). The range validation test remains as a sanity check on the logic.
- **ffi.yml** (#965): Add a `*) exit 1` default case to the `Determine library path` step so unsupported runner OS produces a clear error instead of silently generating an empty path. Also quote the library path argument as a defensive measure.
- **CLAUDE.md** (#966): Replace "six crates" with generic "the following crates" since the count changes as new crates are added.

## Test results

```
cargo test -p chordsketch-napi   10 passed, 0 failed
cargo fmt --check                OK
cargo clippy -- -D warnings      OK
```

## Issues

Closes #975, closes #965, closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)