### PR TITLE
Harden Kotlin version parsing with regex match

### DIFF
--- a/packages/kotlin/lib/build.gradle.kts
+++ b/packages/kotlin/lib/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 group = "com.koedame"
 // Read version from crates/ffi/Cargo.toml to keep in sync with Rust crate.
-version = file("${rootDir}/../../crates/ffi/Cargo.toml").readText()
-    .lineSequence()
-    .first { it.startsWith("version") }
-    .substringAfter('"')
-    .substringBefore('"')
+version = Regex("""^version\s*=\s*"([^"]+)"""", RegexOption.MULTILINE)
+    .find(file("${rootDir}/../../crates/ffi/Cargo.toml").readText())
+    ?.groupValues?.get(1)
+    ?: error("Failed to parse version from crates/ffi/Cargo.toml — expected a line matching: version = \"...\"")
+
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## What

Replace the brittle `.first { it.startsWith("version") }` Cargo.toml version parsing in `build.gradle.kts` with a regex `^version\s*=\s*"([^"]+)"` that only matches the exact `version = "..."` pattern.

## Why

The previous parsing had two fragility points:
1. If `Cargo.toml` ever used `version.workspace = true`, the line still starts with `version` but contains no quoted string — silently producing a broken version.
2. Any comment or field starting with `version` before the actual version line would match first.

The regex approach only matches the exact pattern and provides a clear error message when parsing fails instead of a generic `NoSuchElementException`.

## Test results

No Rust code changes — Gradle build configuration only.

## Issues

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)