### PR TITLE
Pin GitHub Actions to commit SHAs in all remaining workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
 
@@ -32,14 +32,14 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Clippy lints
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -52,14 +52,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, "1.85.0"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run tests
         run: cargo test --workspace

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -24,17 +24,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@94cb46f8d6e437890146ffbd78a778b78e623fb2 # v2
         with:
           tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
@@ -45,7 +45,7 @@ jobs:
         run: cp crates/wasm/pkg/chordsketch_wasm* packages/npm/
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
@@ -58,7 +58,7 @@ jobs:
         working-directory: packages/playground
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: packages/playground/dist
 
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -50,7 +50,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             jni-dir: win32-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
@@ -61,7 +61,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: kotlin-${{ matrix.target }}
 
@@ -71,7 +71,7 @@ jobs:
         run: cargo build -p chordsketch-ffi --release --target ${{ matrix.target }}
 
       - name: Upload JNI library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jni-${{ matrix.jni-dir }}
           path: |
@@ -84,9 +84,9 @@ jobs:
     needs: [build-jni]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: kotlin-generate
 
@@ -101,13 +101,13 @@ jobs:
             --out-dir packages/kotlin/lib/src/main/kotlin/
 
       - name: Download JNI library (linux-x86-64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: jni-linux-x86-64
           path: packages/kotlin/lib/src/main/resources/linux-x86-64/
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: "17"
           distribution: "temurin"
@@ -119,7 +119,7 @@ jobs:
           ./gradlew test || gradle test
 
       - name: Upload generated Kotlin bindings
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: kotlin-bindings
           path: packages/kotlin/lib/src/main/kotlin/uniffi/
@@ -130,23 +130,23 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download generated Kotlin bindings
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: kotlin-bindings
           path: packages/kotlin/lib/src/main/kotlin/uniffi/
 
       - name: Download all JNI artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: jni-*
           path: packages/kotlin/lib/src/main/resources/
           merge-multiple: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,17 +20,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@94cb46f8d6e437890146ffbd78a778b78e623fb2 # v2
         with:
           tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
@@ -41,7 +41,7 @@ jobs:
         run: cp crates/wasm/pkg/chordsketch_wasm* packages/npm/
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,14 +28,14 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         with:
           command: sdist
           args: --manifest-path crates/ffi/Cargo.toml --out dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-sdist
           path: dist
@@ -58,9 +58,9 @@ jobs:
           - os: windows-latest
             target: x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         with:
           command: build
           args: --release --manifest-path crates/ffi/Cargo.toml --out dist
@@ -68,7 +68,7 @@ jobs:
           manylinux: manylinux2014
           sccache: "true"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: dist
@@ -88,13 +88,13 @@ jobs:
           - os: windows-latest
             artifact: wheels-windows-latest-x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ matrix.artifact }}
           path: dist
@@ -157,13 +157,13 @@ jobs:
       name: pypi
       url: https://pypi.org/p/chordsketch
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: wheels-*
           merge-multiple: true
           path: dist
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         with:
           command: upload
           args: --non-interactive --skip-existing dist/*

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,7 +55,7 @@ jobs:
             lib: chordsketch_ffi.dll
             platform_dir: x86_64-windows
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
@@ -66,7 +66,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ruby-${{ matrix.target }}
 
@@ -76,7 +76,7 @@ jobs:
         run: cargo build -p chordsketch-ffi --release --target ${{ matrix.target }}
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: native-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.lib }}
@@ -86,9 +86,9 @@ jobs:
     needs: [build-native]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ruby-generate
 
@@ -104,13 +104,13 @@ jobs:
           mv packages/ruby/lib/chordsketch.rb packages/ruby/lib/chordsketch_uniffi.rb
 
       - name: Download native library (linux-x86-64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: native-x86_64-unknown-linux-gnu
           path: packages/ruby/lib/x86_64-linux/
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
         with:
           ruby-version: "3.3"
 
@@ -127,9 +127,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ruby-generate
 
@@ -145,7 +145,7 @@ jobs:
           mv packages/ruby/lib/chordsketch.rb packages/ruby/lib/chordsketch_uniffi.rb
 
       - name: Download all native libraries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: native-*
           path: packages/ruby/lib/
@@ -162,7 +162,7 @@ jobs:
           rmdir native-*
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
         with:
           ruby-version: "3.3"
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -19,17 +19,17 @@ jobs:
     name: WASM Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@94cb46f8d6e437890146ffbd78a778b78e623fb2 # v2
         with:
           tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 


### PR DESCRIPTION
## What

Pin all third-party GitHub Actions references to full commit SHAs in 7 remaining workflow files, completing the supply chain security hardening started in #968.

## Files modified

| File | Elevated permissions |
|---|---|
| `ci.yml` | none |
| `wasm.yml` | none |
| `kotlin.yml` | none |
| `ruby.yml` | none |
| `npm-publish.yml` | none |
| `python.yml` | `id-token: write` (PyPI publish) |
| `deploy-playground.yml` | `pages: write`, `id-token: write` |

## Pinned actions

| Action | SHA | Tag |
|---|---|---|
| `actions/checkout` | `de0fac2e` | v6 |
| `Swatinem/rust-cache` | `e18b4977` | v2 |
| `actions/upload-artifact` | `ea165f8d` | v4 |
| `actions/download-artifact` | `d3f86a10` | v4 |
| `actions/setup-node` | `49933ea5` | v4 |
| `dtolnay/rust-toolchain` | `29eef336` | stable |
| `taiki-e/install-action` | `94cb46f8` | v2 |
| `actions/setup-python` | `a26af69b` | v5 |
| `PyO3/maturin-action` | `04ac600d` | v1 |
| `actions/setup-java` | `c1e32368` | v4 |
| `actions/upload-pages-artifact` | `56afc609` | v3 |
| `actions/deploy-pages` | `d6db9016` | v4 |
| `ruby/setup-ruby` | `3ff19f5e` | v1 |

## Intentionally unpinned

`dtolnay/rust-toolchain@master` in ci.yml — used with dynamic `${{ matrix.rust }}` toolchain selection.

## Test results

No code changes — CI workflows only.

## Issues

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)