### PR TITLE
Quote --language and --out-dir arguments in ffi.yml

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -85,5 +85,5 @@ jobs:
         run: |
           cargo run -p chordsketch-ffi --bin uniffi-bindgen generate \
             --library "${{ steps.lib-path.outputs.path }}" \
-            --language ${{ matrix.language }} \
-            --out-dir bindings/${{ matrix.language }}
+            --language "${{ matrix.language }}" \
+            --out-dir "bindings/${{ matrix.language }}"


### PR DESCRIPTION
## What

Quote `--language` and `--out-dir` arguments in the `Generate bindings` step of `ffi.yml` for consistency with the already-quoted `--library` argument.

## Why

Defensive shell quoting best practice. The matrix values (python, swift, kotlin, ruby) are controlled strings and pose no real risk today, but quoting all arguments is consistent and prevents future issues.

## Issues

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)