### PR TITLE
Pin dtolnay/rust-toolchain@master to commit SHA in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
 


### PR DESCRIPTION
## What

Pin `dtolnay/rust-toolchain@master` to its current commit SHA (`3c5f7ea2`) in the ci.yml test matrix job.

## Why

The action ref (`@master`) and the toolchain parameter (`toolchain: ${{ matrix.rust }}`) are independent concerns. The `master` branch of dtolnay/rust-toolchain could be force-pushed with malicious code. Pinning to a SHA eliminates this supply chain attack surface while the dynamic toolchain selection continues to work.

## Issues

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)