### PR TITLE
Add Swift unit tests to CI workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -101,6 +101,23 @@ jobs:
         run: |
           cp generated/chordsketch.swift packages/swift/Sources/ChordSketch/
 
+      - name: Run Swift tests
+        run: |
+          # Copy XCFramework into the Swift package directory
+          cp -R chordsketchFFI.xcframework packages/swift/
+
+          # Rewrite Package.swift to use local path instead of remote URL
+          sed -i '' \
+            -e '/.binaryTarget(/,/)/c\
+            .binaryTarget(\
+                name: "chordsketchFFI",\
+                path: "chordsketchFFI.xcframework"\
+            ),' \
+            packages/swift/Package.swift
+
+          cd packages/swift
+          swift test
+
       - name: Package XCFramework
         run: |
           zip -r chordsketch-xcframework.zip chordsketchFFI.xcframework


### PR DESCRIPTION
## What

Add a `Run Swift tests` step to the `build-xcframework` job in `swift.yml` that:
1. Copies the built XCFramework into `packages/swift/`
2. Rewrites `Package.swift` to use a local `path:` reference instead of the remote `url:`/`checksum:` reference
3. Runs `swift test` to execute the 7 tests in `ChordSketchTests.swift`

## Why

The Swift test file (`packages/swift/Tests/ChordSketchTests.swift`) was committed in PR #937 but never executed in CI. The test plan listed "Swift tests pass" as a requirement but this was never verified automatically.

## Test results

CI will verify the Swift tests run on the macOS runner (the `build-xcframework` job already uses `macos-latest`).

## Issues

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)