### PR TITLE
Fix Swift test step to use heredoc for Package.swift

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -106,14 +106,23 @@ jobs:
           # Copy XCFramework into the Swift package directory
           cp -R chordsketchFFI.xcframework packages/swift/
 
-          # Rewrite Package.swift to use local path instead of remote URL
-          sed -i '' \
-            -e '/.binaryTarget(/,/)/c\
-            .binaryTarget(\
-                name: "chordsketchFFI",\
-                path: "chordsketchFFI.xcframework"\
-            ),' \
-            packages/swift/Package.swift
+          # Rewrite Package.swift to use local XCFramework path
+          cat > packages/swift/Package.swift << 'EOF'
+          // swift-tools-version: 5.9
+          import PackageDescription
+          let package = Package(
+              name: "ChordSketch",
+              platforms: [.macOS(.v12), .iOS(.v15)],
+              products: [
+                  .library(name: "ChordSketch", targets: ["ChordSketch"]),
+              ],
+              targets: [
+                  .binaryTarget(name: "chordsketchFFI", path: "chordsketchFFI.xcframework"),
+                  .target(name: "ChordSketch", dependencies: ["chordsketchFFI"], path: "Sources/ChordSketch"),
+                  .testTarget(name: "ChordSketchTests", dependencies: ["ChordSketch"], path: "Tests"),
+              ]
+          )
+          EOF
 
           cd packages/swift
           swift test


### PR DESCRIPTION
## What

Replace the broken sed-based Package.swift rewrite in the Swift test step with a heredoc that writes the entire file, using a local path for the XCFramework binary target.

## Why

The sed range pattern \`.binaryTarget(/,/)\` in PR #985 didn't match correctly on the macOS CI runner, leaving the remote URL reference intact and causing \`swift test\` to fail with "cannot find 'RustBuffer' in scope" and similar errors.

## Test results

CI will verify Swift tests pass with the heredoc approach.

## Issues

Closes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)