### PR TITLE
Add macOS x86_64 smoke test and document aarch64 gap in python.yml

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -83,8 +83,15 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: wheels-ubuntu-latest-x86_64
+          # ubuntu-aarch64 wheel requires an arm64 runner to test natively.
+          # GitHub's ubuntu-24.04-arm runner is available but may need to be
+          # enabled for the repository. Uncomment when arm64 runners are confirmed.
+          # - os: ubuntu-24.04-arm
+          #   artifact: wheels-ubuntu-latest-aarch64
           - os: macos-latest
             artifact: wheels-macos-latest-aarch64
+          - os: macos-13
+            artifact: wheels-macos-latest-x86_64
           - os: windows-latest
             artifact: wheels-windows-latest-x64
     steps:


### PR DESCRIPTION
## What

- Add `macos-13` (Intel) test matrix entry for the `wheels-macos-latest-x86_64` artifact
- Add a commented-out `ubuntu-24.04-arm` entry for the aarch64 Linux wheel with documentation explaining the arm64 runner requirement

## Why

4 of 5 built wheels are now tested (up from 3):

| Platform | Built | Tested |
|----------|-------|--------|
| ubuntu x86_64 | ✅ | ✅ |
| ubuntu aarch64 | ✅ | ❌ (needs arm64 runner) |
| macOS aarch64 | ✅ | ✅ |
| macOS x86_64 | ✅ | ✅ (new) |
| Windows x64 | ✅ | ✅ |

The aarch64 Linux wheel requires a native arm64 runner to test. GitHub's `ubuntu-24.04-arm` is available but may need to be enabled for the repository. The commented-out entry is ready to uncomment once confirmed.

## Issues

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)