### PR TITLE
Add distributionSha256Sum to Gradle wrapper for supply chain hardening

### DIFF
--- a/packages/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
## What

Add `distributionSha256Sum=7a00d51f...e08bef03` to `packages/kotlin/gradle/wrapper/gradle-wrapper.properties`. This is the official SHA-256 checksum of `gradle-8.12-bin.zip` published at https://services.gradle.org/distributions/gradle-8.12-bin.zip.sha256.

## Why

PR #989 committed the Gradle wrapper with `validateDistributionUrl=true` (URL tampering protection), but without `distributionSha256Sum` a compromised or MITM'd Gradle distribution download would not be detected. Adding the checksum closes this supply chain gap — the wrapper will refuse to execute if the downloaded zip doesn't match.

## Issues

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)