### PR TITLE
Replace heredoc Package.swift with surgical Python substitution

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -106,23 +106,32 @@ jobs:
           # Copy XCFramework into the Swift package directory
           cp -R chordsketchFFI.xcframework packages/swift/
 
-          # Rewrite Package.swift to use local XCFramework path
-          cat > packages/swift/Package.swift << 'EOF'
-          // swift-tools-version: 5.9
-          import PackageDescription
-          let package = Package(
-              name: "ChordSketch",
-              platforms: [.macOS(.v12), .iOS(.v15)],
-              products: [
-                  .library(name: "ChordSketch", targets: ["ChordSketch"]),
-              ],
-              targets: [
-                  .binaryTarget(name: "chordsketchFFI", path: "chordsketchFFI.xcframework"),
-                  .target(name: "ChordSketch", dependencies: ["chordsketchFFI"], path: "Sources/ChordSketch"),
-                  .testTarget(name: "ChordSketchTests", dependencies: ["ChordSketch"], path: "Tests"),
-              ]
+          # Replace only the binaryTarget in Package.swift with a local path,
+          # preserving any other changes to the file (platforms, products, etc.).
+          python3 << 'PYTHON'
+          import re
+          path = "packages/swift/Package.swift"
+          with open(path) as f:
+              content = f.read()
+          # Match .binaryTarget(...) for chordsketchFFI, allowing multi-line content
+          pattern = re.compile(
+              r'\.binaryTarget\(\s*name:\s*"chordsketchFFI"[^)]*\)',
+              re.DOTALL,
           )
-          EOF
+          replacement = (
+              '.binaryTarget(\n'
+              '            name: "chordsketchFFI",\n'
+              '            path: "chordsketchFFI.xcframework"\n'
+              '        )'
+          )
+          new_content, count = pattern.subn(replacement, content, count=1)
+          if count != 1:
+              raise SystemExit(
+                  f"Expected to replace exactly 1 binaryTarget, replaced {count}"
+              )
+          with open(path, "w") as f:
+              f.write(new_content)
+          PYTHON
 
           cd packages/swift
           swift test


### PR DESCRIPTION
## What

Replace the in-place heredoc rewrite of `packages/swift/Package.swift` in the Swift test step with a Python script that surgically replaces only the `.binaryTarget(...)` for `chordsketchFFI` with a local-path version, preserving all other content.

## Why

The previous heredoc approach (PR #987) hardcoded the entire Package.swift contents. If the committed Package.swift gains new platforms, products, targets, or Swift tools version requirements, the CI would test against a stale configuration while the actually-distributed file diverges silently.

The Python regex approach reads the latest committed Package.swift and only swaps the binary target, so any other changes propagate to the test build automatically. The script asserts exactly 1 replacement occurred to fail loudly if the regex stops matching due to unexpected file structure changes.

## Test results

Verified the Python script produces correct output against the current committed `packages/swift/Package.swift` (only the binaryTarget block changes).

## Issues

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)