### PR TITLE
Use UniFFI-generated module map for XCFramework

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -75,15 +75,13 @@ jobs:
             target/x86_64-apple-ios/release/libchordsketch_ffi.a \
             -output universal/ios-sim/libchordsketch_ffi.a
 
-      - name: Create module map
+      - name: Set up module map for XCFramework
         run: |
           mkdir -p generated/include
-          cat > generated/include/module.modulemap << 'MODULEMAP'
-          framework module chordsketchFFI {
-            header "chordsketchFFI.h"
-            export *
-          }
-          MODULEMAP
+          # Use the UniFFI-generated modulemap which correctly declares
+          # `module` (not `framework module`) for the static library and
+          # includes the necessary `use` declarations for the C standard library.
+          cp generated/chordsketchFFI.modulemap generated/include/module.modulemap
           cp generated/chordsketchFFI.h generated/include/
 
       - name: Create XCFramework


### PR DESCRIPTION
## What

Replace the hand-written module map in swift.yml with the one UniFFI already generates (`chordsketchFFI.modulemap`), which correctly declares `module chordsketchFFI` (not `framework module`) and includes necessary `use` clauses for the C standard library.

## Why

The previous hand-written module map declared `framework module chordsketchFFI`. This is incorrect for an XCFramework containing **static libraries** (created with `xcodebuild -create-xcframework -library`) — `framework module` is meant for Cocoa-style framework bundles with the Headers/Modules layout.

This caused `swift test` to fail with errors like:
```
ChordSketch.swift:14:23: error: cannot find type 'RustBuffer' in scope
```

…because the generated UniFFI Swift code uses `#if canImport(chordsketchFFI)` which evaluates to false when the module map declaration doesn't match the actual layout.

The Swift tests have been silently failing on every PR since they were added in #985, because the Build XCFramework job is non-required.

## Test results

CI will verify the fix by running swift test. If this PR's Build XCFramework job passes, the underlying issue is resolved.

## Issues

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)