### PR TITLE
Qualify Swift test calls with module name

### DIFF
--- a/packages/swift/Tests/ChordSketchTests.swift
+++ b/packages/swift/Tests/ChordSketchTests.swift
@@ -1,44 +1,44 @@
 import XCTest
-@testable import ChordSketch
+import ChordSketch
 
 final class ChordSketchTests: XCTestCase {
     let minimalInput = "{title: Test}\n[C]Hello"
 
     func testVersion() throws {
-        let v = version()
+        let v = ChordSketch.version()
         XCTAssertFalse(v.isEmpty)
     }
 
     func testRenderText() throws {
-        let text = try parseAndRenderText(input: minimalInput, configJson: nil, transpose: nil)
+        let text = try ChordSketch.parseAndRenderText(input: minimalInput, configJson: nil, transpose: nil)
         XCTAssert(text.contains("Test"))
         XCTAssert(text.contains("Hello"))
     }
 
     func testRenderHtml() throws {
-        let html = try parseAndRenderHtml(input: minimalInput, configJson: nil, transpose: nil)
+        let html = try ChordSketch.parseAndRenderHtml(input: minimalInput, configJson: nil, transpose: nil)
         XCTAssert(html.contains("Test"))
     }
 
     func testRenderPdf() throws {
-        let pdf = try parseAndRenderPdf(input: minimalInput, configJson: nil, transpose: nil)
+        let pdf = try ChordSketch.parseAndRenderPdf(input: minimalInput, configJson: nil, transpose: nil)
         XCTAssertFalse(pdf.isEmpty)
         // PDF files start with %PDF
         XCTAssertEqual(String(bytes: Array(pdf.prefix(4)), encoding: .ascii), "%PDF")
     }
 
     func testValidate() throws {
-        let errors = validate(input: minimalInput)
+        let errors = ChordSketch.validate(input: minimalInput)
         XCTAssert(errors.isEmpty)
     }
 
     func testRenderWithPreset() throws {
-        let text = try parseAndRenderText(input: minimalInput, configJson: "guitar", transpose: nil)
+        let text = try ChordSketch.parseAndRenderText(input: minimalInput, configJson: "guitar", transpose: nil)
         XCTAssert(text.contains("Test"))
     }
 
     func testRenderWithTranspose() throws {
-        let text = try parseAndRenderText(input: minimalInput, configJson: nil, transpose: 2)
+        let text = try ChordSketch.parseAndRenderText(input: minimalInput, configJson: nil, transpose: 2)
         XCTAssertFalse(text.isEmpty)
     }
 }


### PR DESCRIPTION
## What

Update `ChordSketchTests.swift` to qualify all module function calls with `ChordSketch.` prefix and use regular `import` instead of `@testable import`.

## Why

After fixing the module map in #996, Swift tests still fail with:
```
ChordSketchTests.swift:8:17: error: static member 'version' cannot be used on instance of type 'ChordSketchTests'
```

Bare calls like `version()` and `validate()` collide with members in `XCTestCase`'s type hierarchy. Qualifying with the module name (`ChordSketch.version()`) resolves the call unambiguously to the module's free function.

`@testable import` is also unnecessary since the API functions are public.

## Issues

Follow-up to #994 (Swift module map fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)