### PR TITLE
Link system zlib in Swift package for flate2 dependency

### DIFF
--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -23,7 +23,12 @@ let package = Package(
         .target(
             name: "ChordSketch",
             dependencies: ["chordsketchFFI"],
-            path: "Sources/ChordSketch"
+            path: "Sources/ChordSketch",
+            linkerSettings: [
+                // chordsketch-render-pdf depends on flate2 which uses
+                // the system zlib for compression on Apple platforms.
+                .linkedLibrary("z"),
+            ]
         ),
         .testTarget(
             name: "ChordSketchTests",


### PR DESCRIPTION
## What

Add `.linkedLibrary("z")` to the `ChordSketch` target's `linkerSettings` in `Package.swift` so the system zlib is linked when building against the static library XCFramework.

## Why

After fixing the module map (#994) and test name shadowing (#997), Swift tests now compile but fail at link time:

```
Undefined symbols for architecture arm64:
  "_deflate", "_inflate", "_zlibVersion", ...
```

`chordsketch-render-pdf` depends on `flate2` which uses the system zlib for PDF stream compression on Apple platforms. Static libraries don't propagate their system dependencies, so the consumer must link `-lz` explicitly.

This affects all users of the Swift package, not just CI tests, so the linker setting belongs in the committed Package.swift.

## Issues

Follow-up to #994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)