### PR TITLE
Skip Swift string literals in binaryTarget paren counter

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -124,17 +124,31 @@ jobs:
               raise SystemExit("Could not find .binaryTarget for chordsketchFFI")
 
           # Walk forward, counting parens, to find the matching close paren.
+          # Skip parens that appear inside Swift "..." string literals so
+          # URLs like "https://example.com/v1.0).zip" don't fool the counter.
+          # Also handles \" escape sequences inside strings.
           start = match.start()
           # The opening `(` is part of `.binaryTarget(`
           paren_pos = content.index('(', start)
           depth = 1
           i = paren_pos + 1
+          in_string = False
           while i < len(content) and depth > 0:
               ch = content[i]
-              if ch == '(':
-                  depth += 1
-              elif ch == ')':
-                  depth -= 1
+              if in_string:
+                  if ch == '\\' and i + 1 < len(content):
+                      # Skip the escaped character.
+                      i += 2
+                      continue
+                  if ch == '"':
+                      in_string = False
+              else:
+                  if ch == '"':
+                      in_string = True
+                  elif ch == '(':
+                      depth += 1
+                  elif ch == ')':
+                      depth -= 1
               i += 1
           if depth != 0:
               raise SystemExit("Unbalanced parentheses in .binaryTarget block")


### PR DESCRIPTION
## What

Track whether the cursor is inside a Swift `"..."` string literal and skip parens that appear there in the binaryTarget paren-counting walker.

## Why

The paren counter from #1002 traverses raw characters without distinguishing between structural parens and parens inside string literals. For URLs/checksums with unbalanced parens like `"https://example.com/v1.0).zip"`, the counter would stop at the wrong position.

## Edge cases handled

- Balanced parens inside strings (already worked coincidentally)
- Unbalanced `)` inside string: `url: "https://example.com/v1.0).zip"`
- Unbalanced `(` inside string: `url: "https://example.com/v1(.zip"`
- Escape sequences inside strings: `url: "...\\"foo\\"..."`

## Test results

Verified locally with synthetic test cases (normal, unbalanced `)`, unbalanced `(`) and the real `Package.swift` — all produce correct output.

## Issues

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)