### PR TITLE
Harden readme-smoke workflow: pin action, clone tag, verify WASM render

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -52,10 +52,27 @@ jobs:
           npm init -y
           npm install @chordsketch/wasm
 
-      - name: Smoke test require
+      - name: Smoke test render
         run: |
           cd /tmp/wasm-smoke
-          node -e "const cs = require('@chordsketch/wasm'); console.log(typeof cs);"
+          # Use ESM since the package ships ES modules. The script
+          # initializes the WASM module, renders a small ChordPro snippet,
+          # and asserts the output contains the expected content. This
+          # confirms the WASM binary is loaded and exports execute correctly,
+          # not just that the JS wrapper resolves.
+          cat > smoke.mjs << 'EOF'
+          import init, { render_text, version } from '@chordsketch/wasm';
+          await init();
+          const v = version();
+          if (!v) throw new Error('version() returned empty');
+          console.log('version:', v);
+          const out = render_text('{title: Smoke}\n[C]Hello');
+          if (!out.includes('Smoke') || !out.includes('Hello')) {
+            throw new Error('render_text output missing expected content: ' + out);
+          }
+          console.log('render_text OK');
+          EOF
+          node smoke.mjs
 
   cargo-install:
     name: cargo install chordsketch
@@ -82,7 +99,15 @@ jobs:
           CARGO_HOME: /tmp/cargo-source
         run: |
           mkdir -p "$CARGO_HOME"
-          git clone https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
+          # On a release trigger, clone the exact released tag.
+          # Otherwise (schedule, dispatch) use the default branch.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            git clone --branch "${{ github.ref_name }}" --depth 1 \
+              https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
+          else
+            git clone --depth 1 \
+              https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
+          fi
           cd /tmp/chordsketch-src
           cargo install --path crates/cli
           "$CARGO_HOME/bin/chordsketch" --version
@@ -92,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@fc695c54c2032716dd4cedd007489c8e32fc8a5d # master
 
       - name: Tap and install
         run: |


### PR DESCRIPTION
## What

Three follow-ups to #1001 (README install smoke tests):

- **#1006**: Pin `Homebrew/actions/setup-homebrew@master` to commit SHA `fc695c54` for supply chain consistency with other pinned actions
- **#1007**: On `release: published` trigger, `source-build` job clones the released tag (`--branch ${{ github.ref_name }}`) instead of HEAD of main
- **#1008**: Replace the npm-wasm `require()` smoke test with an actual `render_text()` call that asserts the output contains expected content — catches broken WASM binaries that load-only tests miss

## Why

- **#1006**: Mutable tag refs are a supply chain risk
- **#1007**: A release-triggered run should test the exact released commit, not whatever happens to be on main at that moment
- **#1008**: A `require()` test passes even if the WASM binary is missing or stub — we need to actually execute an exported function

## Issues

Closes #1006, closes #1007, closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)