### PR TITLE
Run README install smoke tests on pull requests

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -16,6 +16,29 @@ on:
     - cron: "0 6 * * *"
   release:
     types: [published]
+  pull_request:
+    # Run on PRs that touch anything affecting installability or
+    # rendering. The path filter keeps the heavy Windows/Docker jobs
+    # off pure-docs PRs that cannot break end-user state.
+    paths:
+      - "README.md"
+      - ".github/workflows/readme-smoke.yml"
+      - ".github/actions/cli-render-smoke/**"
+      - ".github/fixtures/**"
+      - "scripts/extract-readme-commands.py"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/cli/**"
+      - "crates/core/**"
+      - "crates/render-text/**"
+      - "crates/render-html/**"
+      - "crates/render-pdf/**"
+
+# Cancel previous runs on the same PR when new commits land. Daily cron
+# and release runs use a unique run_id and are never cancelled.
+concurrency:
+  group: readme-smoke-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -240,14 +263,28 @@ jobs:
       - name: Clone, install, and run
         env:
           CARGO_HOME: /tmp/cargo-source
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           mkdir -p "$CARGO_HOME"
-          # On a release trigger, clone the exact released tag.
-          # Otherwise (schedule, dispatch) use the default branch.
+          # The literal `git clone` ritual from README ## Installation
+          # ## From source must work end-to-end. We resolve the ref the
+          # clone should land on based on event:
+          #   - release:      the exact tag being released
+          #   - pull_request: the PR's HEAD commit (so a PR that breaks
+          #                   the from-source build fails the PR check
+          #                   instead of slipping through to schedule)
+          #   - schedule/dispatch: default branch
           if [ "${{ github.event_name }}" = "release" ]; then
             git clone --branch "${{ github.ref_name }}" --depth 1 \
               https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            git clone --depth 1 \
+              https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
+            cd /tmp/chordsketch-src
+            git fetch --depth 1 origin "$PR_HEAD_SHA"
+            git checkout "$PR_HEAD_SHA"
+            cd -
           else
             git clone --depth 1 \
               https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
@@ -318,23 +355,39 @@ jobs:
         uses: ./.github/actions/cli-render-smoke
 
   library-smoke:
-    name: Library Usage (crates.io)
+    name: Library Usage
     runs-on: ubuntu-latest
     steps:
+      # Checkout is needed even on non-PR runs because the PR branch
+      # variant uses workspace path-deps. Cheap on shallow clone.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Build and run README Library Usage snippet against published crates
+      - name: Build and run README Library Usage snippet
         run: |
           set -euo pipefail
-          # Build a scratch crate in a tmp directory that depends on the
-          # published chordsketch-core and chordsketch-render-text on
-          # crates.io. The main.rs body is the EXACT snippet from
-          # README.md ## Library Usage, plus an assertion. If the
-          # published API drifts away from what the README documents,
-          # this job fails before users do.
+          # On PR events, we test the README snippet against the PR's
+          # *workspace* crates via path deps so that a PR which changes
+          # the public library API surface is caught immediately. On
+          # all other events (schedule, release, dispatch), we test
+          # against the *published* crates.io versions so that
+          # post-release API drift between README and published crates
+          # is caught daily. Both are necessary; one alone leaves a
+          # window where README and reality can disagree.
           SCRATCH=/tmp/library-smoke
           mkdir -p "$SCRATCH/src"
-          cat > "$SCRATCH/Cargo.toml" << 'EOF'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CORE_DEP="chordsketch-core = { path = \"$GITHUB_WORKSPACE/crates/core\" }"
+            RENDER_DEP="chordsketch-render-text = { path = \"$GITHUB_WORKSPACE/crates/render-text\" }"
+            MODE="workspace path deps (PR)"
+          else
+            CORE_DEP='chordsketch-core = ">=0.1, <0.2"'
+            RENDER_DEP='chordsketch-render-text = ">=0.1, <0.2"'
+            MODE="crates.io published"
+          fi
+          echo "library-smoke mode: $MODE"
+          cat > "$SCRATCH/Cargo.toml" << EOF
           [package]
           name = "library-smoke"
           version = "0.0.0"
@@ -342,8 +395,8 @@ jobs:
           publish = false
 
           [dependencies]
-          chordsketch-core = ">=0.1, <0.2"
-          chordsketch-render-text = ">=0.1, <0.2"
+          $CORE_DEP
+          $RENDER_DEP
           EOF
           cat > "$SCRATCH/src/main.rs" << 'EOF'
           use chordsketch_core::parser::parse;
@@ -369,7 +422,6 @@ jobs:
 
   usage-smoke:
     name: README Usage examples (source build)
-    needs: [source-build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Adds a `pull_request:` trigger to `readme-smoke.yml` so PR-introduced regressions in installability or rendering are caught **before merge**, with PR-aware source resolution and a concurrency group.

## What

### Trigger surface
- New `pull_request:` trigger with a `paths:` filter so the heavy Windows/Docker jobs only run on PRs that touch installability-relevant files (README, fixtures, workflow, composite action, extractor script, Cargo manifests, `crates/cli/**`, `crates/core/**`, `crates/render-*/**`).
- New `concurrency:` block. PR runs on the same `head_ref` cancel each other when a force-push lands. Daily cron and release runs use the unique `run_id` and are never cancelled.

### PR-aware source resolution
- `source-build` clones the README's literal `git clone` URL on every event but, on PR events, additionally `git fetch`/`checkout`s `${{ github.event.pull_request.head.sha }}` so the from-source path tests the PR's actual commit. Tag handling for `release` events is preserved.
- `library-smoke` switches between workspace path deps (PR) and crates.io published deps (schedule/release/dispatch). PR mode catches PR-introduced library API breakage; published mode catches post-release drift between the README snippet and the published crates. Both windows must close.

### Wiring
- `usage-smoke` no longer has `needs: [source-build]`. They were not sharing artifacts; the `needs` only added latency and made `usage-smoke` skip whenever `source-build` was conditionally skipped.
- The `report-failure` job's existing `if: failure() && github.event_name != 'pull_request'` exclusion is preserved so PR failures do NOT spam the auto-managed tracking issue — the failing PR check is the signal.

## Why

#1011 / #1012 closed the install-smoke and library-smoke gaps but kept the workflow gated to `workflow_dispatch + schedule + release`. That left a window where a PR could break the CLI, library, fixtures, or composite action and the breakage would only surface up to 24 hours later when the daily cron fires. PR-time enforcement is the missing piece for "信頼できるOSS" guarantees.

## Test plan

- [x] All YAML files parse with `python3 -c "import yaml; yaml.safe_load(open(f))"`.
- [x] The PR-mode `library-smoke` Cargo.toml shape (workspace path deps) compiles and runs with all three README snippet assertions passing locally.
- [ ] On this PR's first CI run: `readme-smoke` triggers via the path filter, source-controlled jobs (`source-build`, `library-smoke`, `usage-smoke`) test the PR HEAD, and external-state jobs (`docker-ghcr`, `docker-hub`, etc.) test current published state. The `docker-ghcr` job is **expected to fail** because the GHCR package is currently private — which is the user-visible bug this whole workflow exists to surface.

## Note on the chicken-and-egg

This PR will appear with a failing `docker-ghcr` check. That is the intended demonstration that the new PR-time gate would catch the original bug. Whether the failure blocks merge depends on branch protection, not on this workflow. After merge, the GHCR (and Docker Hub) package needs to be made public out-of-band; once that happens the next scheduled (or PR) run goes green and stays green.

## Issues

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)