### PR TITLE
Drop path filter from readme-smoke pull_request trigger

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -16,23 +16,16 @@ on:
     - cron: "0 6 * * *"
   release:
     types: [published]
+  # Run on every PR, no path filter. End-user installability is a
+  # global property of the repo: it either works or it doesn't, and
+  # the validity of that guarantee should not depend on which file
+  # the current PR happens to edit. A path-filter list also has to be
+  # re-audited every time the workspace shape changes (new crate,
+  # build.rs, rust-toolchain.toml, .cargo/config.toml, etc.) and a
+  # missed entry produces a false sense of safety. The daily cron
+  # already runs the same matrix; running it on each PR adds bounded
+  # cost in exchange for catching every regression at PR time.
   pull_request:
-    # Run on PRs that touch anything affecting installability or
-    # rendering. The path filter keeps the heavy Windows/Docker jobs
-    # off pure-docs PRs that cannot break end-user state.
-    paths:
-      - "README.md"
-      - ".github/workflows/readme-smoke.yml"
-      - ".github/actions/cli-render-smoke/**"
-      - ".github/fixtures/**"
-      - "scripts/extract-readme-commands.py"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/cli/**"
-      - "crates/core/**"
-      - "crates/render-text/**"
-      - "crates/render-html/**"
-      - "crates/render-pdf/**"
 
 # Cancel previous runs on the same PR when new commits land. Daily cron
 # and release runs use a unique run_id and are never cancelled.


### PR DESCRIPTION
## Summary

Removes the `paths:` filter from the `pull_request:` trigger in `.github/workflows/readme-smoke.yml` so every PR runs the install smoke tests, regardless of which files it touches.

## What

```diff
-  pull_request:
-    paths:
-      - "README.md"
-      - ".github/workflows/readme-smoke.yml"
-      - ".github/actions/cli-render-smoke/**"
-      - ".github/fixtures/**"
-      - "scripts/extract-readme-commands.py"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/cli/**"
-      - "crates/core/**"
-      - "crates/render-text/**"
-      - "crates/render-html/**"
-      - "crates/render-pdf/**"
+  pull_request:
```

All other behavior in #1018 is preserved unchanged: the `concurrency:` group still cancels in-flight PR runs on force-push, `source-build` still resolves to PR HEAD on PR events, `library-smoke` still switches to workspace path deps on PR events, and `report-failure` still skips on PR events.

## Why

The path filter was the wrong trade-off for the guarantee this workflow exists to provide:

1. **Path filters are silently incomplete.** Any source path not listed (a new crate, a `build.rs`, `rust-toolchain.toml`, `.cargo/config.toml`, a workspace-level dependency tweak) bypasses the gate. The list has to be re-audited every time the workspace shape changes, and a missed entry produces a false sense of safety.
2. **End-user installability is a global property of the repo.** A README install method either works for end users or it doesn't. The validity of that guarantee should not depend on which file the current PR happens to edit.
3. **The cost saving is small.** Pure-docs PRs are infrequent on this repo, and the daily cron already runs the same matrix every day; the marginal cost of also running it on each PR is bounded.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/readme-smoke.yml'))"` passes.
- [ ] On this PR's first CI run: `readme-smoke` triggers via the bare `pull_request:` (this PR only changes the trigger block, no source paths).

## Issues

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)