### PR TITLE
Make @chordsketch/wasm a dual package (browser + Node.js)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,11 +34,23 @@ jobs:
         with:
           tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
-      - name: Build WASM
-        run: wasm-pack build crates/wasm --release --target web
+      - name: Build WASM (web target)
+        run: wasm-pack build crates/wasm --release --target web --out-dir ../../packages/npm/web
 
-      - name: Copy WASM artifacts to npm package
-        run: cp crates/wasm/pkg/chordsketch_wasm* packages/npm/
+      - name: Build WASM (nodejs target)
+        run: wasm-pack build crates/wasm --release --target nodejs --out-dir ../../packages/npm/node
+
+      - name: Write sub-package.json files to scope module type
+        # The dual-package layout requires each subdirectory to declare
+        # its own module type so Node resolves them correctly:
+        #   - web/  is wasm-pack --target web   → ESM
+        #   - node/ is wasm-pack --target nodejs → CommonJS
+        # The root package.json declares "type": "module" (for the web
+        # entry), so the node subdir must override it back to commonjs.
+        run: |
+          set -euo pipefail
+          printf '%s\n' '{"type":"module"}' > packages/npm/web/package.json
+          printf '%s\n' '{"type":"commonjs"}' > packages/npm/node/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -177,22 +177,28 @@ jobs:
           mkdir -p /tmp/wasm-smoke
           cd /tmp/wasm-smoke
           npm init -y
-          npm install @chordsketch/wasm
+          # Pin to >=0.1.1 because 0.1.0 is published-but-broken on
+          # Node.js (the --target web init tries to fetch via file://
+          # which Node's undici does not implement). 0.1.1 ships the
+          # dual-package layout where Node resolves to a wasm-pack
+          # --target nodejs build that auto-loads synchronously.
+          npm install '@chordsketch/wasm@>=0.1.1'
 
       - name: Smoke test text + HTML + PDF render
         run: |
           set -euo pipefail
           cd /tmp/wasm-smoke
-          # Use ESM since the package ships ES modules. The script
-          # initializes the WASM module, exercises every renderer the
-          # package exposes, and asserts the output for each. This
-          # mirrors the CLI smoke step shape so all distribution channels
-          # are validated to the same depth — a binary that loads but
-          # whose PDF or HTML renderer is broken would slip past a
-          # text-only check.
+          # Node.js consumes the package via the "node" condition in
+          # the package.json `exports` field. That entry resolves to a
+          # wasm-pack --target nodejs build (CommonJS) which auto-loads
+          # the .wasm file synchronously on require. There is therefore
+          # no `init()` to await on the Node side — direct named
+          # imports work. The browser-side `await init()` flow is
+          # exercised by the playground manually; CI focuses on Node
+          # correctness because that is where automated testing lives.
           cat > smoke.mjs << 'EOF'
-          import init, { render_text, render_html, render_pdf, version } from '@chordsketch/wasm';
-          await init();
+          import { render_text, render_html, render_pdf, version } from '@chordsketch/wasm';
+
           const v = version();
           if (!v) throw new Error('version() returned empty');
           console.log('version:', v);

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ Thumbs.db
 
 # WASM build output
 crates/wasm/pkg/
-packages/npm/chordsketch_wasm*
-packages/npm/snippets/
+packages/npm/web/
+packages/npm/node/
 
 # Node.js
 node_modules/

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -2,17 +2,30 @@
 
 [ChordSketch](https://github.com/koedame/chordsketch) compiled to
 WebAssembly — parse and render [ChordPro](https://www.chordpro.org/) files
-in the browser or any JavaScript runtime with WASM support.
+in the browser **or** in Node.js with the same package.
+
+> Requires `>=0.1.1`. Version `0.1.0` is published but does not work in
+> Node.js (it tries to `fetch()` the wasm file via `file://`, which Node's
+> undici does not support). `0.1.1` introduced a dual-package layout that
+> resolves to a Node-compatible build automatically.
 
 ## Installation
 
 ```bash
-npm install @chordsketch/wasm
+npm install '@chordsketch/wasm@>=0.1.1'
 ```
 
 ## Usage
 
-### Browser (ES module)
+The package ships **two builds** under one name and uses Node's
+conditional `exports` to pick the right one for the runtime:
+
+| Runtime | Build | Init required? |
+|---|---|---|
+| Browser (Vite, webpack, native ESM) | `wasm-pack --target web` | Yes — `await init()` |
+| Node.js (≥ 20) | `wasm-pack --target nodejs` | No — auto-loaded synchronously |
+
+### Browser
 
 ```js
 import init, {
@@ -22,7 +35,7 @@ import init, {
   version,
 } from '@chordsketch/wasm';
 
-// Initialize the WASM module first
+// Browsers must initialize the WASM module first.
 await init();
 
 const chordpro = `{title: Amazing Grace}
@@ -30,25 +43,44 @@ const chordpro = `{title: Amazing Grace}
 
 [G]Amazing [G7]grace, how [C]sweet the [G]sound`;
 
-// Render to HTML
 const html = render_html(chordpro);
-
-// Render to plain text
 const text = render_text(chordpro);
-
-// Render to PDF (returns Uint8Array)
-const pdfBytes = render_pdf(chordpro);
-
-// Check version
-console.log(version()); // "0.1.0"
+const pdfBytes = render_pdf(chordpro); // Uint8Array
+console.log(version());
 ```
 
-### Rendering with options
+### Node.js
 
 ```js
-import init, { render_html_with_options } from '@chordsketch/wasm';
+// No init() — the wasm-pack nodejs build auto-loads the .wasm file
+// synchronously when the module is imported.
+import {
+  render_html,
+  render_text,
+  render_pdf,
+  version,
+} from '@chordsketch/wasm';
 
+const chordpro = `{title: Amazing Grace}
+{key: G}
+
+[G]Amazing [G7]grace, how [C]sweet the [G]sound`;
+
+const html = render_html(chordpro);
+const text = render_text(chordpro);
+const pdfBytes = render_pdf(chordpro); // Uint8Array
+console.log(version());
+```
+
+### Rendering with options (both runtimes)
+
+```js
+// Browser
+import init, { render_html_with_options } from '@chordsketch/wasm';
 await init();
+
+// Node.js
+import { render_html_with_options } from '@chordsketch/wasm';
 
 const html = render_html_with_options(input, {
   transpose: 2,        // semitone offset (-12 to +12)

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,15 +1,26 @@
 {
   "name": "@chordsketch/wasm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ChordPro parser and renderer compiled to WebAssembly",
   "license": "MIT",
   "type": "module",
-  "main": "chordsketch_wasm.js",
-  "types": "chordsketch_wasm.d.ts",
+  "main": "./node/chordsketch_wasm.js",
+  "browser": "./web/chordsketch_wasm.js",
+  "types": "./web/chordsketch_wasm.d.ts",
   "exports": {
     ".": {
-      "import": "./chordsketch_wasm.js",
-      "types": "./chordsketch_wasm.d.ts"
+      "node": {
+        "types": "./node/chordsketch_wasm.d.ts",
+        "default": "./node/chordsketch_wasm.js"
+      },
+      "browser": {
+        "types": "./web/chordsketch_wasm.d.ts",
+        "default": "./web/chordsketch_wasm.js"
+      },
+      "default": {
+        "types": "./web/chordsketch_wasm.d.ts",
+        "default": "./web/chordsketch_wasm.js"
+      }
     }
   },
   "repository": {
@@ -28,17 +39,23 @@
     "webassembly"
   ],
   "files": [
-    "chordsketch_wasm.js",
-    "chordsketch_wasm.d.ts",
-    "chordsketch_wasm_bg.wasm",
-    "chordsketch_wasm_bg.wasm.d.ts",
-    "snippets/"
+    "node/package.json",
+    "node/chordsketch_wasm.js",
+    "node/chordsketch_wasm.d.ts",
+    "node/chordsketch_wasm_bg.wasm",
+    "node/chordsketch_wasm_bg.wasm.d.ts",
+    "web/package.json",
+    "web/chordsketch_wasm.js",
+    "web/chordsketch_wasm.d.ts",
+    "web/chordsketch_wasm_bg.wasm",
+    "web/chordsketch_wasm_bg.wasm.d.ts"
   ],
   "scripts": {
-    "build": "wasm-pack build ../../crates/wasm --target web && cp ../../crates/wasm/pkg/chordsketch_wasm* . && cp -r ../../crates/wasm/pkg/snippets . 2>/dev/null || true"
+    "build": "wasm-pack build ../../crates/wasm --release --target web --out-dir ../../packages/npm/web && wasm-pack build ../../crates/wasm --release --target nodejs --out-dir ../../packages/npm/node && node -e \"require('fs').writeFileSync('web/package.json', JSON.stringify({type:'module'}, null, 2)+'\\n'); require('fs').writeFileSync('node/package.json', JSON.stringify({type:'commonjs'}, null, 2)+'\\n')\""
   },
   "sideEffects": [
-    "./chordsketch_wasm.js"
+    "./node/chordsketch_wasm.js",
+    "./web/chordsketch_wasm.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -5,7 +5,7 @@ import init, {
   render_html_with_options,
   render_text_with_options,
   render_pdf_with_options,
-} from '../../npm/chordsketch_wasm.js';
+} from '../../npm/web/chordsketch_wasm.js';
 import { SAMPLE_CHORDPRO } from './sample';
 
 const editor = document.getElementById('editor') as HTMLTextAreaElement;

--- a/packages/playground/src/wasm.d.ts
+++ b/packages/playground/src/wasm.d.ts
@@ -1,4 +1,4 @@
-declare module '../../npm/chordsketch_wasm.js' {
+declare module '../../npm/web/chordsketch_wasm.js' {
   export function render_html(input: string): string;
   export function render_text(input: string): string;
   export function render_pdf(input: string): Uint8Array;


### PR DESCRIPTION
## Summary

Ships `@chordsketch/wasm` as a **dual package** that works in both browsers and Node.js out of the box, with no manual wasm-byte loading required from end users. Replaces the broken-on-Node `0.1.0` with a `0.1.1` that conditionally resolves to the right build per runtime.

## Why

`@chordsketch/wasm@0.1.0` was published successfully but its CI smoke test fails on Node.js with:

```
[cause]: Error: not implemented... yet...
  at schemeFetch (undici/undici:10891)
  at __wbg_init (chordsketch_wasm.js:575)
```

Root cause: the package was built with `wasm-pack build --target web`, whose init function calls `fetch(new URL('chordsketch_wasm_bg.wasm', import.meta.url))`. Node's undici does not implement `file://` fetch, so `await init()` fails on Node. The package is effectively browser-only despite being installable from npm.

## Layout

```
packages/npm/
├── package.json     # conditional exports + version 0.1.1
├── README.md        # documents both browser and Node usage
├── web/             # gitignored, wasm-pack --target web (ESM)
│   ├── chordsketch_wasm.js
│   ├── chordsketch_wasm.d.ts
│   ├── chordsketch_wasm_bg.wasm
│   ├── chordsketch_wasm_bg.wasm.d.ts
│   └── package.json # {"type": "module"}
└── node/            # gitignored, wasm-pack --target nodejs (CJS)
    ├── chordsketch_wasm.js
    ├── chordsketch_wasm.d.ts
    ├── chordsketch_wasm_bg.wasm
    ├── chordsketch_wasm_bg.wasm.d.ts
    └── package.json # {"type": "commonjs"}
```

The sub-`package.json` files are necessary because the root declares `"type": "module"` (for the web entry); without the override, Node would try to load the nodejs target's CJS file as ESM and fail.

## API

### Browser
```js
import init, { render_text } from '@chordsketch/wasm';
await init();
render_text(...);
```

### Node.js
```js
import { render_text } from '@chordsketch/wasm';
// No init() — the wasm-pack --target nodejs build auto-loads the .wasm
// file synchronously when the module is required. Named imports work
// because the CJS output uses `exports.foo = foo` which Node's
// cjs-module-lexer can statically analyze.
render_text(...);
```

## Files changed (7)

| File | Change |
|---|---|
| `.github/workflows/npm-publish.yml` | Builds both targets into `packages/npm/{web,node}` and writes minimal sub-package.json files |
| `packages/npm/package.json` | Version 0.1.1; conditional `exports`; `files` lists both subdirs; `main`/`browser`/`types` fallbacks; `scripts.build` mirrors workflow |
| `packages/npm/README.md` | Rewritten side-by-side for both runtimes, with `>=0.1.1` requirement banner |
| `.gitignore` | Replaces `packages/npm/chordsketch_wasm*` and `snippets/` with `packages/npm/web/` and `packages/npm/node/` |
| `packages/playground/src/main.ts` | Import path `../../npm/chordsketch_wasm.js` → `../../npm/web/chordsketch_wasm.js` |
| `packages/playground/src/wasm.d.ts` | Declared module path updated to match |
| `.github/workflows/readme-smoke.yml` | npm-wasm job switches to Node-style imports (no `init()`); pins to `>=0.1.1`; documents why browser-side `init()` flow is not exercised in CI |

## Test plan

Validated locally end-to-end:

- [x] Both targets build successfully via the new `scripts.build` and the workflow steps. Output structure matches expected layout.
- [x] `npm pack --dry-run` shows a 12-file, 301 KB tarball containing both subdirs and their sub-package.json files (key entries: `node/package.json` 20B, `web/package.json` 18B, root `package.json` 1.9 KB).
- [x] `npm pack` + `npm install ./tarball` into a scratch dir succeeds.
- [x] **The exact CI smoke script** (Node ESM with `import { render_text, render_html, render_pdf, version } from '@chordsketch/wasm'`) runs against the installed tarball with all assertions passing:
  ```
  version: 0.1.0
  render_text OK
  render_html OK
  render_pdf OK (1188 bytes)
  ```
- [x] Playground builds via `tsc && vite build` (vite v6.4.1) without errors. Wasm asset emitted: `dist/assets/chordsketch_wasm_bg-*.wasm` 360 KB. Vite resolved the `../../npm/web/chordsketch_wasm.js` import path correctly.
- [x] All YAML files parse with `yaml.safe_load`.
- [x] `cargo fmt --check` and `cargo clippy --workspace -- -D warnings` clean (no Rust changes).

Validated on CI (will appear after push):

- [ ] `readme-smoke` workflow (PR trigger) runs. The `npm-wasm` job is **expected to fail** on this PR because the smoke pins `@chordsketch/wasm@>=0.1.1` but `0.1.1` has not yet been published. After this PR merges and the post-merge publish step runs (see below), the next workflow run will have the published package available and the job will go green.

## Version skew note

This bumps ONLY the npm package version (`0.1.0` → `0.1.1`). The Rust crates and CLI stay at `0.1.0` because the WASM library code itself is unchanged — only the packaging is fixed. `version()` exposed by the WASM module still returns `"0.1.0"` (the Rust crate version), distinct from `@chordsketch/wasm@0.1.1` (the npm wrapper version). A future workspace-wide release will re-sync.

## Known limitation

`@chordsketch/wasm@0.1.0` cannot be unpublished from npm (24 h+ since publish, npm policy). It will remain on the registry as a known-broken version. The README banner instructs users to install `>=0.1.1`.

## Post-merge step

After this PR merges, the maintainer must trigger the publish workflow:

```bash
gh workflow run npm-publish.yml -f version=0.1.1 -R koedame/chordsketch
```

Once the `0.1.1` tarball lands on npm, the next `readme-smoke` run will turn the `npm-wasm` job green.

## Issues

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)