### PR TITLE
Fix readme-smoke report-failure: pass GH_REPO so gh works without checkout

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -458,8 +458,16 @@ jobs:
       - name: Open or update tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # GH_REPO is honored by every `gh` invocation below, so we
+          # don't need an actions/checkout to read remote.origin.url
+          # from a local .git/. Without this, every previous run of
+          # this job has died with:
+          #   failed to run git: fatal: not a git repository
+          # …meaning the auto-managed tracking issue was never
+          # actually created. See koedame/chordsketch#1030.
           TITLE="README install smoke tests are failing"
           # Find existing open tracking issue (if any).
           EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')


### PR DESCRIPTION
## Summary

Fix `.github/workflows/readme-smoke.yml` `report-failure` job so it can actually create or update its tracking issue when smoke fails. Sets `GH_REPO=${{ github.repository }}` at job env level so `gh` does not need a local git remote.

## Bug

The `report-failure` job has no `actions/checkout` step, so it runs in an empty `$GITHUB_WORKSPACE`. Every previous failing run has died at the first `gh` invocation with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The net effect: the auto-managed tracking issue this job is supposed to maintain has **never actually been created** since the job was added in #1004, even though smoke has failed many times. Verified against the latest failing run #24083658264 — same error in the log.

The flip side is that the broken job has been silently providing spam suppression: every run that should have created a duplicate tracking issue instead crashed harmlessly. With this fix, the spam suppression returns to its intended form (find-existing-by-title, comment on it instead of creating new).

## Fix

```diff
       - name: Open or update tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ ... }}
```

`GH_REPO` is the documented environment override that every `gh` subcommand honors instead of trying to derive the repo from a local git remote. No `actions/checkout` is added because this job needs zero repo files — only API calls.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/readme-smoke.yml'))"` passes.
- [ ] On the next run that produces a failing smoke job, an open issue titled "README install smoke tests are failing" actually appears (or an existing one is commented on). The currently-red `Docker Hub` and `winget (Windows)` jobs guarantee this PR's own readme-smoke run will exercise the fixed path.

## Out of Scope

- Closing the docker-hub and winget gaps themselves. Those are tracked separately (Docker Hub publishing and winget-pkgs manifest submission).

## Issues

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)