### PR TITLE
ci: bundle 8 readme-smoke/readme-sync/extractor fixes

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -69,6 +69,12 @@ jobs:
             cat "$DOCKER_CONFIG/config.json" >&2
             exit 1
           fi
+          # Idempotent: if a previous attempt left a stale named container
+          # behind (e.g., the runner re-runs after `docker create` succeeded
+          # but before `docker rm` ran), remove it so the next
+          # `docker create --name extract-ghcr` below doesn't fail with
+          # "Conflict. The container name already in use".
+          docker rm -f extract-ghcr 2>/dev/null || true
 
       - name: Verify GHCR manifest is anonymously pullable at HTTP layer
         run: |
@@ -129,6 +135,9 @@ jobs:
             cat "$DOCKER_CONFIG/config.json" >&2
             exit 1
           fi
+          # See docker-ghcr for the rationale: stale named container from a
+          # previous attempt would block the docker create below.
+          docker rm -f extract-hub 2>/dev/null || true
 
       - name: Verify Docker Hub manifest is anonymously pullable at HTTP layer
         run: |
@@ -177,12 +186,22 @@ jobs:
           mkdir -p /tmp/wasm-smoke
           cd /tmp/wasm-smoke
           npm init -y
-          # Pin to >=0.1.1 because 0.1.0 is published-but-broken on
-          # Node.js (the --target web init tries to fetch via file://
-          # which Node's undici does not implement). 0.1.1 ships the
-          # dual-package layout where Node resolves to a wasm-pack
-          # --target nodejs build that auto-loads synchronously.
-          npm install '@chordsketch/wasm@>=0.1.1'
+          # Pin to the exact released version so the smoke test verifies
+          # the *specific* artifact it was written against, rather than
+          # silently following whatever the latest published version
+          # happens to be. 0.1.0 is published-but-broken on Node.js (the
+          # --target web init tries to fetch via file:// which Node's
+          # undici does not implement); 0.1.1 ships the dual-package
+          # layout where Node resolves to a wasm-pack --target nodejs
+          # build that auto-loads synchronously.
+          #
+          # Bump policy: every time `@chordsketch/wasm` is published to
+          # npm, update this pin in the same PR that bumps the workspace
+          # version (or, for npm-only patch releases like the dual-package
+          # 0.1.0 → 0.1.1 fix, in the publish PR itself). The README sync
+          # check (.github/workflows/readme-sync.yml) does not catch this
+          # automatically because the version string lives only here.
+          npm install '@chordsketch/wasm@0.1.1'
 
       - name: Smoke test text + HTML + PDF render
         run: |
@@ -262,28 +281,42 @@ jobs:
       - name: Clone, install, and run
         env:
           CARGO_HOME: /tmp/cargo-source
+          # Route attacker-controllable GitHub context values through env
+          # vars instead of inline `${{ }}` interpolation in the shell
+          # script — see GitHub Actions security hardening guide. Even
+          # though `release: published` requires write access (limiting
+          # the practical attack surface for REF_NAME), the env-var
+          # pattern is the established defense-in-depth convention used
+          # elsewhere in this workflow.
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          ORIG_DIR="$PWD"
           mkdir -p "$CARGO_HOME"
           # The literal `git clone` ritual from README ## Installation
           # ## From source must work end-to-end. We resolve the ref the
           # clone should land on based on event:
           #   - release:      the exact tag being released
-          #   - pull_request: the PR's HEAD commit (so a PR that breaks
-          #                   the from-source build fails the PR check
-          #                   instead of slipping through to schedule)
+          #   - pull_request: the PR's HEAD commit, fetched via the
+          #                   `refs/pull/<N>/head` ref so the SHA is
+          #                   reachable for *both* same-repo and fork
+          #                   PRs (a raw `origin <sha>` fetch would only
+          #                   resolve same-repo branches because forks
+          #                   live in a different remote).
           #   - schedule/dispatch: default branch
-          if [ "${{ github.event_name }}" = "release" ]; then
-            git clone --branch "${{ github.ref_name }}" --depth 1 \
+          if [ "$EVENT_NAME" = "release" ]; then
+            git clone --branch "$REF_NAME" --depth 1 \
               https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
             git clone --depth 1 \
               https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
             cd /tmp/chordsketch-src
-            git fetch --depth 1 origin "$PR_HEAD_SHA"
+            git fetch --depth 1 origin "refs/pull/${PR_NUMBER}/head"
             git checkout "$PR_HEAD_SHA"
-            cd -
+            cd "$ORIG_DIR"
           else
             git clone --depth 1 \
               https://github.com/koedame/chordsketch.git /tmp/chordsketch-src
@@ -381,8 +414,13 @@ jobs:
             RENDER_DEP="chordsketch-render-text = { path = \"$GITHUB_WORKSPACE/crates/render-text\" }"
             MODE="workspace path deps (PR)"
           else
-            CORE_DEP='chordsketch-core = ">=0.1, <0.2"'
-            RENDER_DEP='chordsketch-render-text = ">=0.1, <0.2"'
+            # Cargo `^0.1` means `>=0.1.0, <0.2.0` (the caret rules treat
+            # the leftmost non-zero as the breaking-change boundary).
+            # Bump policy: when the workspace bumps to 0.2.x, update both
+            # constraints below to `^0.2` in the same release PR.
+            # Otherwise, daily smoke tests will silently stop resolving.
+            CORE_DEP='chordsketch-core = "^0.1"'
+            RENDER_DEP='chordsketch-render-text = "^0.1"'
             MODE="crates.io published"
           fi
           echo "library-smoke mode: $MODE"

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -11,14 +11,24 @@ on:
       - "README.md"
       - ".github/snapshots/readme-commands.txt"
       - "scripts/extract-readme-commands.py"
+      - "scripts/test_extract_readme_commands.py"
       - ".github/workflows/readme-sync.yml"
+      # Also fire when the smoke workflow itself changes. Without this,
+      # adding a new install path to readme-smoke.yml without a matching
+      # README update would slip past the sync gate, since the snapshot
+      # is unchanged. The signal-to-noise ratio is acceptable: this
+      # workflow is fast (single python script) and readme-smoke.yml
+      # changes are infrequent.
+      - ".github/workflows/readme-smoke.yml"
   push:
     branches: [main]
     paths:
       - "README.md"
       - ".github/snapshots/readme-commands.txt"
       - "scripts/extract-readme-commands.py"
+      - "scripts/test_extract_readme_commands.py"
       - ".github/workflows/readme-sync.yml"
+      - ".github/workflows/readme-smoke.yml"
 
 permissions:
   contents: read
@@ -29,6 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run extractor self-tests
+        run: python3 scripts/test_extract_readme_commands.py
 
       - name: Diff README install/usage snapshot
         run: python3 scripts/extract-readme-commands.py --check

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ packages/playground/dist/
 
 # Tools
 .serena/
+
+# Python (used by scripts/ and CI helpers, not a runtime dep)
+__pycache__/
+*.pyc

--- a/scripts/extract-readme-commands.py
+++ b/scripts/extract-readme-commands.py
@@ -51,7 +51,16 @@ def extract(readme_text: str) -> list[str]:
             block_lang = None
             continue
 
-        fence = re.match(r"^```(\w*)\s*$", raw)
+        # Match opening/closing fences. The language identifier may
+        # contain hyphens (e.g., ```pwsh-script), and an opening fence
+        # may carry a trailing annotation (e.g., ```bash some-tag) which
+        # CommonMark allows after the info string. Both must be tracked
+        # without breaking parsing. The pattern below recognises:
+        #   ```
+        #   ```bash
+        #   ```pwsh-script
+        #   ```bash some annotation
+        fence = re.match(r"^```([\w-]*)(?:\s.*)?$", raw)
         if fence:
             if in_block:
                 in_block = False

--- a/scripts/test_extract_readme_commands.py
+++ b/scripts/test_extract_readme_commands.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Self-tests for extract-readme-commands.py.
+
+Run with: python3 scripts/test_extract_readme_commands.py
+
+Kept stdlib-only and import-by-path so we don't need a Python test
+runner or packaging setup. Wired into .github/workflows/readme-sync.yml.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "extract-readme-commands.py"
+
+# The script's filename has hyphens, which prevents `import` directly.
+# Load it via importlib.util so we can call `extract()` from tests.
+_spec = importlib.util.spec_from_file_location("extract_readme_commands", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+extract = _mod.extract
+
+
+class ExtractTests(unittest.TestCase):
+    def test_plain_bash_block_in_installation(self) -> None:
+        readme = "\n".join(
+            [
+                "## Installation",
+                "",
+                "```bash",
+                "cargo install chordsketch",
+                "```",
+                "",
+            ]
+        )
+        self.assertEqual(
+            extract(readme),
+            ["[Installation] cargo install chordsketch"],
+        )
+
+    def test_annotated_bash_fence_is_recognised(self) -> None:
+        # CommonMark allows arbitrary annotation text after the info
+        # string. The previous regex required `\w*\s*$` and would skip
+        # annotated fences entirely, silently dropping the contained
+        # commands from the snapshot. Regression test for #1016.
+        readme = "\n".join(
+            [
+                "## Installation",
+                "",
+                "```bash some-annotation here",
+                "brew install chordsketch",
+                "```",
+                "",
+            ]
+        )
+        self.assertEqual(
+            extract(readme),
+            ["[Installation] brew install chordsketch"],
+        )
+
+    def test_hyphenated_language_is_recognised(self) -> None:
+        # Some renderers use compound language identifiers like
+        # `pwsh-script`. Even though we only extract bash blocks, the
+        # parser must still toggle in_block correctly so the closing
+        # fence does not bleed into a subsequent bash block.
+        readme = "\n".join(
+            [
+                "## Installation",
+                "",
+                "```pwsh-script",
+                "Install-Package chordsketch",
+                "```",
+                "",
+                "```bash",
+                "cargo install chordsketch",
+                "```",
+                "",
+            ]
+        )
+        self.assertEqual(
+            extract(readme),
+            ["[Installation] cargo install chordsketch"],
+        )
+
+    def test_only_tracked_sections_are_walked(self) -> None:
+        readme = "\n".join(
+            [
+                "## Some Other Section",
+                "",
+                "```bash",
+                "echo 'should be ignored'",
+                "```",
+                "",
+                "## Usage",
+                "",
+                "```bash",
+                "chordsketch input.cho",
+                "```",
+                "",
+            ]
+        )
+        self.assertEqual(
+            extract(readme),
+            ["[Usage] chordsketch input.cho"],
+        )
+
+    def test_comments_and_blank_lines_are_dropped(self) -> None:
+        readme = "\n".join(
+            [
+                "## Installation",
+                "",
+                "```bash",
+                "# this is a comment",
+                "",
+                "cargo install chordsketch",
+                "```",
+                "",
+            ]
+        )
+        self.assertEqual(
+            extract(readme),
+            ["[Installation] cargo install chordsketch"],
+        )
+
+    def test_section_heading_resets_block_state(self) -> None:
+        # An unterminated fence in one section must not bleed lines from
+        # the next section into the snapshot.
+        readme = "\n".join(
+            [
+                "## Installation",
+                "",
+                "```bash",
+                "cargo install chordsketch",
+                "## Usage",  # heading inside an unterminated block
+                "",
+                "```bash",
+                "chordsketch input.cho",
+                "```",
+                "",
+            ]
+        )
+        self.assertEqual(
+            extract(readme),
+            [
+                "[Installation] cargo install chordsketch",
+                "[Usage] chordsketch input.cho",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)


### PR DESCRIPTION
## Summary

Bundles eight low-priority CI hygiene issues that all touch the README
install/usage smoke pipeline (`readme-smoke.yml`, `readme-sync.yml`,
`extract-readme-commands.py`).

### #1027 — pin `@chordsketch/wasm` version
Replace `>=0.1.1` with the exact `0.1.1` so the smoke test verifies the
specific artifact it was written against, not whichever version the
registry happens to serve. Adds an explicit bump policy: every npm
publish requires a matching update to this pin.

### #1020 — explicit `ORIG_DIR` over `cd -` in source-build smoke
Replace the fragile `cd -` (which depends on `$OLDPWD` being set) with
an explicit `ORIG_DIR="$PWD"` save and restore.

### #1019 — source-build smoke supports fork PRs
Switch the per-PR clone to fetch `refs/pull/<N>/head` instead of
`origin <sha>`. The `refs/pull/N/head` ref is exposed by GitHub for
*all* PRs (same-repo and fork), while a raw-SHA fetch only resolves
same-repo branches.

### #1016 — annotated and hyphenated fences in `extract-readme-commands.py`
Update the fence regex from `^```(\w*)\s*$` to
`^```([\w-]*)(?:\s.*)?$` so it handles compound language identifiers
like `pwsh-script` and CommonMark-style annotated info strings like
```` ```bash some-annotation ````. Adds
`scripts/test_extract_readme_commands.py` with six unit tests covering:
- plain bash blocks
- annotated fences (regression test for the bug)
- hyphenated language identifiers
- untracked sections
- comments and blank lines
- section-heading state reset

Wired into `readme-sync.yml` as a new "Run extractor self-tests" step
that runs before the snapshot diff.

### #1015 — `readme-sync.yml` triggers on `readme-smoke.yml` changes
Add `.github/workflows/readme-smoke.yml` to the `paths:` filter so a PR
that adds an install path to the smoke matrix without a matching README
update is caught at PR time. Also added the new
`test_extract_readme_commands.py` to the trigger list.

### #1014 — `library-smoke` version constraint uses idiomatic `^0.1`
Replace `>=0.1, <0.2` with `^0.1` (semantically identical for `0.x.y`
series) and document the bump policy in a code comment: when the
workspace bumps to `0.2`, both constraints must be updated to `^0.2`
in the same release PR or daily smoke will silently stop resolving.

### #1013 — Docker smoke jobs idempotent on retry
Add `docker rm -f extract-{ghcr,hub} 2>/dev/null || true` before each
`docker create --name` so a runner re-run after a partial failure
doesn't hit "Conflict. The container name already in use".

### #1010 — route `github.ref_name` through `env:` in source-build
Pass `REF_NAME`, `EVENT_NAME`, `PR_NUMBER`, and `PR_HEAD_SHA` through
`env:` instead of inline `${{ github.* }}` interpolation in the shell
script, per the GitHub Actions security hardening guide. Defense in
depth — `release: published` requires write access so the practical
attack surface is small, but the env-var pattern matches what the rest
of the workflow already does.

### Bonus: `.gitignore` for Python pycache
Adds `__pycache__/` and `*.pyc` now that `scripts/` contains a Python
test file.

## Test plan

- [x] `python3 scripts/test_extract_readme_commands.py` → all 6 tests pass locally
- [x] `python3 scripts/extract-readme-commands.py --check` → no snapshot drift
- [x] Visual review of YAML diffs for `readme-smoke.yml` and `readme-sync.yml`
- [x] `set -euo pipefail` preserved in source-build run block
- [x] `ORIG_DIR` set before any `cd`, used to restore current directory
- [x] `refs/pull/N/head` fetch only happens inside the `pull_request` branch (`PR_NUMBER` is undefined for other events but never read there)
- [x] CI will exercise the changed jobs (smoke, sync) on this PR

Closes #1027
Closes #1020
Closes #1019
Closes #1016
Closes #1015
Closes #1014
Closes #1013
Closes #1010