### PR TITLE
npm package: extract build script and add module field

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./node/chordsketch_wasm.js",
   "browser": "./web/chordsketch_wasm.js",
+  "module": "./web/chordsketch_wasm.js",
   "types": "./web/chordsketch_wasm.d.ts",
   "exports": {
     ".": {
@@ -51,7 +52,7 @@
     "web/chordsketch_wasm_bg.wasm.d.ts"
   ],
   "scripts": {
-    "build": "wasm-pack build ../../crates/wasm --release --target web --out-dir ../../packages/npm/web && wasm-pack build ../../crates/wasm --release --target nodejs --out-dir ../../packages/npm/node && node -e \"require('fs').writeFileSync('web/package.json', JSON.stringify({type:'module'}, null, 2)+'\\n'); require('fs').writeFileSync('node/package.json', JSON.stringify({type:'commonjs'}, null, 2)+'\\n')\""
+    "build": "node scripts/build.mjs"
   },
   "sideEffects": [
     "./node/chordsketch_wasm.js",

--- a/packages/npm/scripts/build.mjs
+++ b/packages/npm/scripts/build.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Build script for @chordsketch/wasm.
+//
+// Produces the dual-package layout consumed by package.json `exports`:
+//   - web/  : wasm-pack --target web    → ESM (with await init())
+//   - node/ : wasm-pack --target nodejs → CommonJS (auto-loads sync)
+//
+// Each sub-directory carries its own package.json declaring the
+// module type so Node resolves them correctly even though the root
+// package.json declares "type": "module".
+//
+// Run with: `npm run build` (from packages/npm/).
+//
+// Mirrors the steps in .github/workflows/npm-publish.yml so local
+// builds and CI builds produce identical artifacts. If you change
+// either, change both.
+
+import { spawnSync } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = resolve(__dirname, "..");
+const CRATE_DIR = resolve(PKG_DIR, "../../crates/wasm");
+
+function run(cmd, args) {
+  console.log(`$ ${cmd} ${args.join(" ")}`);
+  const result = spawnSync(cmd, args, { stdio: "inherit" });
+  if (result.status !== 0) {
+    console.error(`Command failed with exit code ${result.status}: ${cmd}`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+function buildTarget(target, outDir) {
+  run("wasm-pack", [
+    "build",
+    CRATE_DIR,
+    "--release",
+    "--target",
+    target,
+    "--out-dir",
+    outDir,
+  ]);
+}
+
+function writeSubPackageJson(subDir, type) {
+  mkdirSync(subDir, { recursive: true });
+  const path = resolve(subDir, "package.json");
+  writeFileSync(path, JSON.stringify({ type }, null, 2) + "\n");
+  console.log(`wrote ${path}`);
+}
+
+const webDir = resolve(PKG_DIR, "web");
+const nodeDir = resolve(PKG_DIR, "node");
+
+buildTarget("web", webDir);
+buildTarget("nodejs", nodeDir);
+
+writeSubPackageJson(webDir, "module");
+writeSubPackageJson(nodeDir, "commonjs");
+
+console.log("@chordsketch/wasm build complete.");


### PR DESCRIPTION
## Summary

Bundles the two `packages/npm/` follow-ups.

### #1029 — extract `scripts.build` into a dedicated build script
Replace the 250-character one-liner with `packages/npm/scripts/build.mjs`,
called via `node scripts/build.mjs`. The new script:

- Uses `node:child_process` to run `wasm-pack build` for both
  `--target web` and `--target nodejs`, with absolute `--out-dir`
  paths so it works regardless of caller cwd.
- Writes the dual-package layout sub-`package.json` files
  (`web/{type:module}` and `node/{type:commonjs}`) explicitly via `fs`.
- Inherits stdio so build output streams live to the terminal,
  matching the previous one-liner's behavior.
- Mirrors the steps in `.github/workflows/npm-publish.yml` so local
  and CI builds produce identical artifacts. The workflow keeps its
  own per-step layout for CI annotation; deduplicating it would mean
  reordering `setup-node` against the build, which is more risk than
  reward for a comment-level improvement. Issue #1029 explicitly
  permits this ("either way is fine").

### #1028 — add `"module"` field for legacy bundlers
Add `"module": "./web/chordsketch_wasm.js"` between `"browser"` and
`"types"`. Modern bundlers (webpack 5, Vite, Rollup, Node ≥ 12.17)
read `exports` and are unaffected. Older bundlers — notably
**webpack 4** and parcel 1 — fall through to `"main"` which points at
the Node CJS build, breaking browser bundles. The `"module"` field is
the established convention for routing those older bundlers to the
ESM web build.

## Test plan

- [x] `npm run build` → both `web/` and `node/` artifacts produced
- [x] `web/package.json` and `node/package.json` written with correct `type`
- [x] `npm pack --dry-run` → 12 files, identical layout to before
- [x] Node smoke: `node -e "require('./node/chordsketch_wasm.js').version()"` → `"0.1.0"`
- [x] `node --check packages/npm/scripts/build.mjs` → syntax OK
- [x] `python3 -c "import json; json.load(open('packages/npm/package.json'))"` → JSON valid
- [x] CI's `npm-publish.yml` is untouched; its existing build steps continue to work

Closes #1029
Closes #1028