### PR TITLE
ci: bundle 2 readme-sync follow-ups (#1043, #1044)

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -13,12 +13,17 @@ on:
       - "scripts/extract-readme-commands.py"
       - "scripts/test_extract_readme_commands.py"
       - ".github/workflows/readme-sync.yml"
-      # Also fire when the smoke workflow itself changes. Without this,
-      # adding a new install path to readme-smoke.yml without a matching
-      # README update would slip past the sync gate, since the snapshot
-      # is unchanged. The signal-to-noise ratio is acceptable: this
-      # workflow is fast (single python script) and readme-smoke.yml
-      # changes are infrequent.
+      # Defense-in-depth: also re-run the sync check when the smoke
+      # workflow (the CI coverage layer this gate is meant to protect)
+      # changes. The README.md path filter above already catches the
+      # common case (smoke + README touched in the same PR), so this
+      # extra trigger is mostly belt-and-suspenders: it guarantees the
+      # extractor and snapshot are re-validated whenever the coverage
+      # layer is rewritten, even in the unlikely case that a future
+      # snapshot bug only surfaces under a smoke.yml change. The
+      # signal-to-noise ratio is acceptable: this workflow is fast
+      # (single python script) and readme-smoke.yml changes are
+      # infrequent.
       - ".github/workflows/readme-smoke.yml"
   push:
     branches: [main]

--- a/scripts/test_extract_readme_commands.py
+++ b/scripts/test_extract_readme_commands.py
@@ -20,7 +20,12 @@ SCRIPT = REPO_ROOT / "scripts" / "extract-readme-commands.py"
 # The script's filename has hyphens, which prevents `import` directly.
 # Load it via importlib.util so we can call `extract()` from tests.
 _spec = importlib.util.spec_from_file_location("extract_readme_commands", SCRIPT)
-assert _spec is not None and _spec.loader is not None
+# Use an explicit RuntimeError instead of `assert` so the guard survives
+# `python3 -O` (which strips assert statements). Without this, running
+# the suite under `-O` would silently skip the check and crash later
+# inside `exec_module` with an unhelpful AttributeError.
+if _spec is None or _spec.loader is None:
+    raise RuntimeError(f"Could not load module spec from {SCRIPT}")
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 extract = _mod.extract


### PR DESCRIPTION
## What

Bundle two small readme-sync infrastructure follow-ups from the review of #1042:

- **#1043** — replace the bare `assert _spec is not None and _spec.loader is not None` in `scripts/test_extract_readme_commands.py` with an explicit `RuntimeError`. `python3 -O` strips assert statements; without this guard, running the suite under `-O` would silently skip the check and crash later inside `exec_module` with an unhelpful `AttributeError`.
- **#1044** — rewrite the `readme-smoke.yml` trigger comment in `.github/workflows/readme-sync.yml`. The previous comment claimed the trigger catches "adding a new install path to readme-smoke.yml without a matching README update", but that scenario is *not* actually caught — the sync gate compares extracted README commands against the snapshot, and a smoke-only change leaves both unchanged. The real value of the trigger is defense-in-depth: it guarantees the extractor and snapshot are re-validated whenever the coverage layer is rewritten.

## Why

Both findings were filed as Low-severity follow-ups during PR review. Bundling them keeps churn on the readme-sync infrastructure to a single commit.

## Test plan

- [x] `python3 scripts/test_extract_readme_commands.py` — 6/6 pass
- [x] `python3 -O scripts/test_extract_readme_commands.py` — 6/6 pass (the new `RuntimeError` guard survives `-O`)
- [x] `.github/workflows/readme-sync.yml` is YAML-valid; no functional workflow changes (only the comment under the `paths:` list changed).

Closes #1043
Closes #1044