### PR TITLE
npm-publish.yml: emit pretty sub-package.json to match local build (#1046)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,10 +47,16 @@ jobs:
         #   - node/ is wasm-pack --target nodejs → CommonJS
         # The root package.json declares "type": "module" (for the web
         # entry), so the node subdir must override it back to commonjs.
+        #
+        # Output must be byte-for-byte identical to what
+        # `packages/npm/scripts/build.mjs` produces locally
+        # (`JSON.stringify({ type }, null, 2) + "\n"`), i.e.
+        # 2-space-indented pretty JSON with a trailing newline.
+        # See #1046 for the divergence that motivated this.
         run: |
           set -euo pipefail
-          printf '%s\n' '{"type":"module"}' > packages/npm/web/package.json
-          printf '%s\n' '{"type":"commonjs"}' > packages/npm/node/package.json
+          printf '%s\n' '{' '  "type": "module"' '}' > packages/npm/web/package.json
+          printf '%s\n' '{' '  "type": "commonjs"' '}' > packages/npm/node/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/packages/npm/scripts/build.mjs
+++ b/packages/npm/scripts/build.mjs
@@ -12,8 +12,10 @@
 // Run with: `npm run build` (from packages/npm/).
 //
 // Mirrors the steps in .github/workflows/npm-publish.yml so local
-// builds and CI builds produce identical artifacts. If you change
-// either, change both.
+// builds and CI builds produce **byte-for-byte identical** artifacts
+// (verified for the sub-package.json files: pretty-printed JSON with
+// 2-space indent and a trailing newline). If you change either, change
+// both.
 
 import { spawnSync } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";


### PR DESCRIPTION
## What

Make `.github/workflows/npm-publish.yml` produce **byte-for-byte identical** sub-`package.json` files to what `packages/npm/scripts/build.mjs` writes locally.

Before:

| Source | Output |
|---|---|
| `build.mjs` (local) | `{\n  "type": "module"\n}\n` (pretty, 2-space) |
| `npm-publish.yml` (CI) | `{"type":"module"}\n` (compact) |

After: both emit the pretty 2-space form.

## Why

The build script comment claimed CI and local builds produce identical artifacts, but they didn't. Functionally both forms parse the same and the published package was unaffected, but a developer diffing local vs. CI artifacts saw spurious noise. #1046 filed this as a low-severity bug.

The fix is in CI rather than the script because the rest of the npm package (`packages/npm/package.json`) is pretty-printed, so converging on pretty is more consistent with the surrounding conventions than collapsing to compact.

## Test plan

- [x] Verified locally that
  ```js
  JSON.stringify({type:"module"}, null, 2) + "\n"
  ```
  and
  ```sh
  printf '%s\n' '{' '  "type": "module"' '}'
  ```
  produce byte-identical output (`{0a 20 20 22 74 79 70 65 22 3a 20 22 6d 6f 64 75 6c 65 22 0a 7d 0a}`).
- [x] Same for `commonjs`.
- [x] CI workflow remains valid YAML (only the `run:` block under the existing step changed).

## Related

Closes #1046