### PR TITLE
Fix deploy-playground.yml broken since #1026 dual-package layout

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -38,16 +38,20 @@ jobs:
         with:
           tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
-      - name: Build WASM
-        run: wasm-pack build crates/wasm --release --target web
-
-      - name: Copy WASM artifacts to npm package
-        run: cp crates/wasm/pkg/chordsketch_wasm* packages/npm/
-
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
+
+      - name: Build @chordsketch/wasm (dual-package layout)
+        # Use the canonical build script (`packages/npm/scripts/build.mjs`,
+        # invoked via `npm run build`). It produces the dual-package layout
+        # (web/ ESM + node/ CommonJS, each with its own `package.json`) that
+        # the playground imports from at `packages/playground/src/main.ts`.
+        # This is the same script that local development uses, and its
+        # output is mirrored byte-for-byte by `npm-publish.yml`.
+        run: npm run build
+        working-directory: packages/npm
 
       - name: Install playground dependencies
         run: npm ci


### PR DESCRIPTION
## What

Replace the broken `Build WASM` + `Copy WASM artifacts` steps in `.github/workflows/deploy-playground.yml` with a single call to the canonical build script (`packages/npm/scripts/build.mjs`, invoked via `npm run build` from `packages/npm/`).

`Setup Node.js` is moved earlier so node is on PATH before the build script runs.

## Why

PR #1026 introduced a dual-package layout (`packages/npm/web/` + `packages/npm/node/`, each with its own `package.json` declaring `type: module` vs `commonjs`). It updated `packages/npm/scripts/build.mjs` and `.github/workflows/npm-publish.yml`, but missed `deploy-playground.yml`.

The result: `deploy-playground.yml` kept writing WASM artifacts to `packages/npm/` (root), while `packages/playground/src/main.ts:8` imports from `'../../npm/web/chordsketch_wasm.js'`. `tsc` then failed:

```
src/main.ts(8,8): error TS2307: Cannot find module '../../npm/web/chordsketch_wasm.js' or its corresponding type declarations.
```

GitHub Pages has been silently serving a stale build of the playground since 2026-04-07 06:07Z. Three consecutive failing runs:
- [24067060204](https://github.com/koedame/chordsketch/actions/runs/24067060204) (commit 0991ae9)
- [24092616984](https://github.com/koedame/chordsketch/actions/runs/24092616984) (commit b8c74db)
- [24093720848](https://github.com/koedame/chordsketch/actions/runs/24093720848) (commit 40dbfb3)

Surfaced by the Phase 20 Completion Gate review on #862 as the only High-severity finding.

## Test results

Verified locally with the same wasm-pack pin (`0.14.0`) the workflow uses:

```
$ cd packages/npm && npm run build
... wasm-pack build ... --target web --out-dir .../packages/npm/web ...
... wasm-pack build ... --target nodejs --out-dir .../packages/npm/node ...
wrote .../packages/npm/web/package.json
wrote .../packages/npm/node/package.json
@chordsketch/wasm build complete.

$ cd packages/playground && npm ci && npm run build
> tsc && vite build
vite v6.4.1 building for production...
✓ 6 modules transformed.
dist/index.html                                  1.39 kB │ gzip:   0.65 kB
dist/assets/chordsketch_wasm_bg-2iYkgSV8.wasm  360.32 kB │ gzip: 146.94 kB
dist/assets/index-DCB2R0SB.css                   2.45 kB │ gzip:   0.97 kB
dist/assets/index-D0UIMPIX.js                   10.32 kB │ gzip:   4.19 kB
✓ built in 211ms
```

## Why use `npm run build` instead of inlining the wasm-pack steps?

Single source of truth. After this PR:

- `packages/npm/scripts/build.mjs` — canonical local + deploy build
- `.github/workflows/npm-publish.yml` — keeps its own copy because it interleaves `npm version` between build and publish

So future layout changes only need to touch one or two files instead of three. The `npm-publish.yml` mirror is still required because of the version-stamping interleave, and its existing comment already documents the byte-for-byte coupling with `build.mjs`.

## Review summary

- Diff is 4 lines added, 0 lines removed (net +10/-6 with reordering); all existing pinned action SHAs preserved.
- No change to `npm-publish.yml`, `build.mjs`, or any application code.
- Local verification covered the exact failing path (TS2307).

Closes #1050