### PR TITLE
Fix two Phase 21 Mediums: docker :latest gating + napi/UniFFI transpose parity

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,11 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }}
-            type=raw,value=latest
+            # Only auto-tag :latest on actual release events. workflow_dispatch
+            # reruns (e.g. fixing a broken older release) MUST NOT regress the
+            # :latest tag — they only republish the immutable :X.Y.Z and :X.Y
+            # aliases. See #1064 for the regression scenario.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -9,7 +9,8 @@ use napi_derive::napi;
 /// Render options matching the WASM package API.
 #[napi(object)]
 pub struct RenderOptions {
-    /// Semitone transposition offset (-12 to +12). Defaults to 0.
+    /// Semitone transposition offset. Any integer is accepted; the renderer
+    /// reduces modulo 12. Defaults to 0.
     pub transpose: Option<i32>,
     /// Configuration preset name (e.g., "guitar", "ukulele") or inline
     /// RRJSON configuration string.
@@ -79,22 +80,24 @@ pub fn render_pdf(input: String) -> Result<Buffer> {
     Ok(bytes.into())
 }
 
-/// Parse and validate a transpose value, returning an error if out of range.
-fn parse_transpose(raw: i32) -> Result<i8> {
-    if !(-12..=12).contains(&raw) {
-        return Err(Error::new(
-            Status::InvalidArg,
-            format!("transpose must be between -12 and 12, got {raw}"),
-        ));
-    }
-    Ok(raw as i8)
+/// Coerce a JS-supplied transposition value to `i8`.
+///
+/// Matches the CLI / UniFFI / WASM behavior: any integer is accepted, and the
+/// underlying renderer reduces modulo 12 internally (`shift_semitone` uses
+/// `i16 + rem_euclid(12)` so the arithmetic is overflow-safe). Out-of-range
+/// `i32` values are clamped to `i8::MIN..=i8::MAX` rather than rejected,
+/// because rejecting them would make this binding behave differently from
+/// every other binding for the same input. See #1065 for the cross-binding
+/// inconsistency that motivated this change.
+fn parse_transpose(raw: i32) -> i8 {
+    raw.clamp(i8::MIN as i32, i8::MAX as i32) as i8
 }
 
 /// Render ChordPro input as plain text with options.
 #[napi]
 pub fn render_text_with_options(input: String, options: RenderOptions) -> Result<String> {
     let config = resolve_config(options.config)?;
-    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0));
     let songs = parse_songs(&input)?;
     Ok(chordsketch_render_text::render_songs_with_transpose(
         &songs, transpose, &config,
@@ -105,7 +108,7 @@ pub fn render_text_with_options(input: String, options: RenderOptions) -> Result
 #[napi]
 pub fn render_html_with_options(input: String, options: RenderOptions) -> Result<String> {
     let config = resolve_config(options.config)?;
-    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0));
     let songs = parse_songs(&input)?;
     Ok(chordsketch_render_html::render_songs_with_transpose(
         &songs, transpose, &config,
@@ -116,7 +119,7 @@ pub fn render_html_with_options(input: String, options: RenderOptions) -> Result
 #[napi]
 pub fn render_pdf_with_options(input: String, options: RenderOptions) -> Result<Buffer> {
     let config = resolve_config(options.config)?;
-    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0));
     let songs = parse_songs(&input)?;
     let bytes = chordsketch_render_pdf::render_songs_with_transpose(&songs, transpose, &config);
     Ok(bytes.into())
@@ -195,24 +198,24 @@ mod tests {
     }
 
     #[test]
-    fn test_transpose_range_validation() {
-        // parse_transpose returns napi::Result which requires the Node.js
-        // runtime for linking (napi::Error drops call napi_delete_reference).
-        // This test validates the range logic directly as a sanity check.
-        // The actual parse_transpose function is tested via the napi addon
-        // in the build job where Node.js is available.
-        for valid in [-12i32, -1, 0, 1, 12] {
-            assert!(
-                (-12..=12).contains(&valid),
-                "{valid} should be in valid range"
-            );
-        }
-        for invalid in [-13i32, 13, 100, -100] {
-            assert!(
-                !(-12..=12).contains(&invalid),
-                "{invalid} should be out of range"
-            );
-        }
+    fn test_transpose_clamps_to_i8_range() {
+        // After #1065, parse_transpose clamps any i32 to i8 range and never
+        // returns an error, matching the CLI / UniFFI / WASM behavior. The
+        // renderer then reduces modulo 12 internally.
+        use super::parse_transpose;
+        // In-range values pass through unchanged.
+        assert_eq!(parse_transpose(0), 0);
+        assert_eq!(parse_transpose(7), 7);
+        assert_eq!(parse_transpose(-7), -7);
+        assert_eq!(parse_transpose(12), 12);
+        assert_eq!(parse_transpose(-12), -12);
+        // Beyond i8 are clamped, not rejected.
+        assert_eq!(parse_transpose(127), 127);
+        assert_eq!(parse_transpose(128), 127);
+        assert_eq!(parse_transpose(1_000_000), 127);
+        assert_eq!(parse_transpose(-128), -128);
+        assert_eq!(parse_transpose(-129), -128);
+        assert_eq!(parse_transpose(-1_000_000), -128);
     }
 
     #[test]


### PR DESCRIPTION
## What

Two unrelated Phase 21 Medium fixes bundled into one PR. Both surfaced by the Phase 21 Completion Gate review on #917.

### #1064 — Gate Docker `:latest` on release events

`.github/workflows/docker.yml` had:
```yaml
type=raw,value=latest
```

…unconditionally. Running the workflow via `workflow_dispatch` against an *older* tag would overwrite `:latest` on both GHCR and Docker Hub with the older binary, regressing every `docker pull ghcr.io/koedame/chordsketch:latest` user until the next forward release.

Now:
```yaml
type=raw,value=latest,enable=${{ github.event_name == 'release' }}
```

`workflow_dispatch` reruns can still refresh the immutable `:X.Y.Z` and `:X.Y` aliases (e.g. fixing a broken release), but they cannot regress `:latest`. Comment in the workflow explains the regression scenario.

### #1065 — napi/UniFFI transpose parity

`crates/napi/src/lib.rs` enforced `transpose ∈ [-12, 12]` and rejected out-of-range values with `Status::InvalidArg`, while:
- `crates/ffi/src/lib.rs` (UniFFI → Python/Swift/Kotlin/Ruby) accepts the full `i8` range with no validation.
- `crates/cli` accepts the full `i8` range.

Same input behaved differently across bindings — `renderTextWithOptions(input, { transpose: 24 })` would throw in Node but run silently in Python/Swift/Kotlin/Ruby.

The renderer is overflow-safe: `shift_semitone` uses `i16 + rem_euclid(12)`, so even `i8::MIN..=i8::MAX` is safe. The napi range check was over-strict and inconsistent.

Drop the range check, clamp to `i8::MIN..=i8::MAX` instead, and make `parse_transpose` infallible. The doc-comment on `RenderOptions::transpose` is updated to remove the now-inaccurate "-12 to +12" claim. The previous unit test that validated rejection logic is rewritten to verify clamping behavior at the boundaries.

## Test results

```
$ cargo test -p chordsketch-napi
running 10 tests
test tests::test_invalid_config_fails ... ok
test tests::test_preset_config_resolves ... ok
test tests::test_render_html_returns_content ... ok
test tests::test_transpose_clamps_to_i8_range ... ok
test tests::test_render_pdf_returns_bytes ... ok
test tests::test_valid_rrjson_config_parses ... ok
test tests::test_validate_returns_empty_for_valid_input ... ok
test tests::test_render_text_returns_content ... ok
test tests::test_version_returns_nonempty_string ... ok
test tests::test_validate_returns_errors_for_bad_input ... ok
test result: ok. 10 passed; 0 failed; 0 ignored

$ cargo clippy -p chordsketch-napi -- -D warnings
... clean
```

## Notes / follow-ups

- This change converges napi with the CLI / UniFFI / WASM behavior. The remaining inconsistency is the doc claim in the WASM crate's `transpose` parameter (#1053), which is a Phase 20 follow-up that should resolve to the same policy ("any integer, renderer reduces modulo 12").
- The Docker fix is forward-only — there is no `:latest` regression to clean up because only v0.1.0 has shipped.
- This PR does NOT address the other two Phase 21 Mediums:
  - #1062 (Swift Package.swift PLACEHOLDER + missing xcframework asset) — separate PR planned
  - #1063 (Kotlin OSSRH endpoint + never-published) — separate PR; needs user action for Central Portal credentials

## Diff size

- `.github/workflows/docker.yml`: +5 / -1
- `crates/napi/src/lib.rs`: +34 / -31

Closes #1064, #1065