### PR TITLE
Fix python.yml: disable macos-13 wheel test to unblock CI (#1084)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,8 +90,16 @@ jobs:
           #   artifact: wheels-ubuntu-latest-aarch64
           - os: macos-latest
             artifact: wheels-macos-latest-aarch64
-          - os: macos-13
-            artifact: wheels-macos-latest-x86_64
+          # macos-13 (Intel) entry was added in #990 to test the macOS
+          # x86_64 wheel, but its job has been failing on every push to
+          # main since 2026-04-06 18:00 UTC: the runner is cancelled
+          # immediately at allocation (0 steps run) — a runner-availability
+          # rejection, not a test failure. Disabled here until either the
+          # repository's macos-13 runner allocation is restored, or this
+          # entry is replaced with a macos-latest run that exercises the
+          # x86_64 wheel via Rosetta. See #1084.
+          # - os: macos-13
+          #   artifact: wheels-macos-latest-x86_64
           - os: windows-latest
             artifact: wheels-windows-latest-x64
     steps:


### PR DESCRIPTION
## What

Comment out the `Test Python bindings (macos-13)` matrix entry in `.github/workflows/python.yml`.

## Why

Since #990 (2026-04-06 18:00 UTC) added the macos-13 entry to test the macOS x86_64 wheel, the job has been failing on every push to `main` that triggers `python.yml`. The failure is a runner-allocation rejection — the job is cancelled immediately with 0 steps actually run:

```
$ gh api 'repos/koedame/chordsketch/actions/jobs/<id>'
{
  "status": "completed",
  "conclusion": "cancelled",
  "steps": []
}
```

This is not a test failure. The runner is never reached. Possible underlying causes (per #1084):

1. Repository or org doesn't have `macos-13` runner labels enabled.
2. GitHub's `macos-13` runners have been deprecated or quota-restricted for this account.
3. Some other allocation policy is rejecting the request.

Either way, fixing it requires investigation/coordination outside this PR (settings change, runner image swap, or matrix replacement).

Disabling the entry restores `python.yml` to green and unblocks any PR that:
- touches `crates/ffi/**`, `crates/core/**`, `crates/render-*/**`, `Cargo.toml`, or `Cargo.lock` (the python.yml path filter)
- which is most non-trivial PRs in the repo

The preserved `#` comment block + the `# See #1084` link make the gap easy to track.

## Test results

`python.yml` runs on this PR — the four other test matrix entries (`ubuntu-latest`, `macos-latest`, `windows-latest`) should all succeed and the workflow should be green.

## Important: this PR does NOT close #1084

This is a workaround, not the actual fix. #1084's true resolution is to restore macOS x86_64 wheel testing — either by:
- enabling the `macos-13` runner allocation upstream, or
- replacing the entry with a `macos-latest` run that exercises the x86_64 wheel via Rosetta.

#1084 stays **open** as a tracker for the proper fix. This PR just unblocks CI in the meantime.

Refs #1084