### PR TITLE
Self-correction bundle: fix #1086 comment, #1087 redundant branch, #1090 .gitignore

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -75,10 +75,18 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          # Use the URL-form token rather than the base64 extraheader
-          # variant: it never writes credentials to a persistent file
-          # under tap/.git/config, so an accidental upload-artifact of the
-          # working directory cannot leak the token. See #1071.
+          # Note on credential persistence: both this URL-form approach
+          # AND the previous `git config http.<url>.extraheader "..."`
+          # approach persist the token to `tap/.git/config` — the URL
+          # form embeds it in `[remote "origin"].url`, the extraheader
+          # form embeds it in `[http "https://github.com/"].extraheader`.
+          # Neither approach avoids on-disk credential persistence; the
+          # working directory itself is the trust boundary. Do NOT
+          # `actions/upload-artifact` the `tap/` directory — that is the
+          # only way the token would leak from this step. See #1086 for
+          # the prior comment that overstated the URL-form's security.
+          # Use a credential helper or SSH deploy key if true zero-disk
+          # credential persistence is required.
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/koedame/homebrew-tap.git" tap
           cd tap
           git config user.name "github-actions[bot]"
@@ -138,8 +146,9 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          # See note on the same step in `update-homebrew` above. URL-form
-          # token avoids persisting credentials in bucket/.git/config. #1071.
+          # See the credential-persistence note on `update-homebrew` above.
+          # The token IS written to `bucket/.git/config`; do not artifact
+          # this directory. #1086.
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/koedame/scoop-bucket.git" bucket
           cd bucket
           git config user.name "github-actions[bot]"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@ crates/wasm/pkg/
 packages/npm/web/
 packages/npm/node/
 
+# UniFFI binding generation scratch dir
+# Created by `ruby.yml` (and any local invocation of the same generate
+# step) when generating Ruby bindings. Files are immediately moved out
+# and the directory removed; this entry only catches a stray dir from
+# a failed mid-step run. See #1090.
+.uniffi-tmp/
+
 # Node.js
 node_modules/
 packages/playground/dist/

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -38,10 +38,13 @@ function hideError(): void {
  * structured errors (e.g. JsError objects with line/col info) to "[object
  * Object]"; preferring `e.message` when available preserves the underlying
  * Rust error string. See #1060.
+ *
+ * `String(s)` is the identity function for strings, so a separate
+ * `typeof e === 'string'` branch is unnecessary — `String(e)` already
+ * returns it unchanged. See #1087.
  */
 function formatError(e: unknown): string {
   if (e instanceof Error) return e.message;
-  if (typeof e === 'string') return e;
   return String(e);
 }
 


### PR DESCRIPTION
## What

Three small follow-up corrections from review feedback on prior PRs (#1085 and #1089). Each one uses a separate \`Closes\` keyword so GitHub auto-closes them all (lesson learned from PR #1081 / #1085 where comma-separated lists left issues stuck open).

## Issues addressed

### #1086 — `post-release.yml` misleading comment

The URL-form clone token approach added in #1071 (PR #1085) had an inline comment claiming it "never writes credentials to a persistent file under tap/.git/config". This is **wrong**: `git clone https://x-access-token:${TOKEN}@github.com/...` writes the full URL — including the embedded token — to `[remote "origin"].url` in `tap/.git/config`. The previous `extraheader` form was equivalent: it wrote the base64-encoded token to `[http "https://github.com/"].extraheader`. Neither approach avoids on-disk persistence.

Replace the inaccurate rationale with an honest note: the working directory is the trust boundary (do NOT `actions/upload-artifact` the directory), and true zero-disk persistence requires a credential helper or SSH deploy key.

### #1087 — `formatError` redundant branch

The `formatError` helper introduced in #1060 (PR #1085) had an unnecessary `if (typeof e === 'string') return e` branch. `String(s)` returns `s` unchanged when `s` is already a string, so the trailing `String(e)` already handles this case. Remove the dead branch and document the simplification in the doc comment.

### #1090 — Add `.uniffi-tmp/` to `.gitignore`

`ruby.yml`'s binding-generation step (added in PR #1089 for #1082) creates `.uniffi-tmp/` as a scratch directory, immediately moves the generated file out, and then `rm -rf`s the directory. But if a developer runs the same `cargo run -p chordsketch-ffi --bin uniffi-bindgen generate ... --out-dir .uniffi-tmp/` locally — or if CI fails mid-step — the directory stays as untracked in `git status`. Add it to `.gitignore` to prevent that.

## Test results

- `.gitignore` change: trivial (no executable code)
- `formatError` change: TypeScript still type-checks (`if (e instanceof Error)` narrows to `Error`, the fall-through `String(e)` handles all remaining `unknown` types including `string`, `number`, `null`, `undefined`, objects)
- `post-release.yml` change: comment-only, no semantic difference

## Why bundle

All three are sub-1-line-of-real-code corrections to mistakes I made in the previous PRs. Bundling them avoids three separate PRs each spinning up the full CI matrix.

Closes #1086
Closes #1087
Closes #1090