### PR TITLE
Bundle #1052 (WASM panic hook) + #1068 (python OIDC docs) — both unblocked

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -165,6 +165,15 @@ jobs:
     needs: [build-sdist, build-wheels, test]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    # Uses PyPI Trusted Publishing via OIDC — no API token needed.
+    # `id-token: write` exposes ACTIONS_ID_TOKEN_REQUEST_* env vars to the
+    # job, which `maturin upload` automatically picks up to obtain a short-
+    # lived OIDC token from PyPI. Do NOT add a `MATURIN_PYPI_TOKEN` secret
+    # here — that would silently downgrade us back to long-lived credentials.
+    # The trusted publisher must be pre-registered on
+    #   https://pypi.org/manage/project/chordsketch/settings/publishing/
+    # for this repo + workflow + environment, otherwise the very first
+    # publish fails with 403 Forbidden. See #1068.
     permissions:
       contents: read
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "chordsketch-render-html",
  "chordsketch-render-pdf",
  "chordsketch-render-text",
+ "console_error_panic_hook",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
@@ -360,6 +361,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "convert_case"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -23,3 +23,4 @@ chordsketch-render-pdf = { version = "0.1.0", path = "../render-pdf" }
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
+console_error_panic_hook = "0.1"

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -6,6 +6,14 @@
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
+/// Set up the panic hook on module instantiation so any unexpected panic
+/// in the renderer surfaces in the JavaScript console with a Rust
+/// backtrace instead of an opaque `unreachable executed`. See #1052.
+#[wasm_bindgen(start)]
+pub fn start() {
+    console_error_panic_hook::set_once();
+}
+
 /// Render options passed from JavaScript.
 #[derive(Deserialize, Default)]
 struct RenderOptions {


### PR DESCRIPTION
## What

Two small fixes that were previously dropped from earlier bundles to avoid triggering broken-on-main workflows. Both are now safe to land.

## Issues

| # | File(s) | Change |
|---|---------|--------|
| #1052 | `crates/wasm/{Cargo.toml, src/lib.rs}` (and `Cargo.lock`) | Wire up `console_error_panic_hook` via `#[wasm_bindgen(start)]`. Any unexpected panic in the renderer now surfaces in the JS console with a Rust backtrace instead of an opaque "unreachable executed". |
| #1068 | `.github/workflows/python.yml` | Inline doc comment explaining that the publish job uses PyPI Trusted Publishing via OIDC and warning future contributors not to add a long-lived `MATURIN_PYPI_TOKEN`. |

## Why these were previously blocked

Both touch files that are in the `paths:` filter of one or more broken workflows on main:

- #1052 forces a `Cargo.lock` update, which triggered `ruby.yml` (broken — UniFFI overwriting loader + RTLD_GLOBAL not propagating to ffi_lib).
- #1068 touches `python.yml`, which triggered the workflow itself, and `python.yml` had a broken `Test Python bindings (macos-13)` job (runner cancelled at allocation, 0 steps run).

Both blockers were resolved earlier in this session:

- #1082 (Ruby pipeline) was fixed by PR #1089 — generate UniFFI bindings to a temp dir AND rewrite the `ffi_lib` line via a Python regex to use the absolute path resolved by the loader.
- #1084 (Python macos-13) was worked around by PR #1088 — disabled the broken matrix entry, leaving an open issue tracker for the proper restoration.

`ruby.yml` and `python.yml` are now both green on `main`, so this bundle is safe to land.

## Test results

```
$ cargo test -p chordsketch-wasm
... 8/8 pass

$ cargo clippy -p chordsketch-wasm -- -D warnings
... clean
```

## Why bundle these two?

They are both unblocked by the same prior work (PR #1088 + PR #1089) and are unrelated otherwise. Bundling avoids a second round of CI for what would have been two trivial-size PRs. The bundle pattern matches the project's recent practice (#1042, #1043+#1044, #1048, etc.).

Closes #1052
Closes #1068