### PR TITLE
Bundle review follow-ups: dead is_empty guards (#1083) + #1094 + #1095

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -87,8 +87,9 @@ jobs:
         #
         # Cross-compiled targets (aarch64-linux from x86_64 runner) cannot
         # `require()` their `.node` file on the build host, so this step is
-        # gated to host-native targets only. The published gem still gets
-        # exercised end-to-end on every supported platform via readme-smoke.
+        # gated to host-native targets only. The published Node.js addon
+        # still gets exercised end-to-end on every supported platform via
+        # readme-smoke.
         if: |
           (matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu') ||
           (matrix.os == 'macos-latest' && matrix.target == 'aarch64-apple-darwin') ||
@@ -122,6 +123,10 @@ jobs:
             const optsHtml = m.renderHtmlWithOptions("{title:Test}\n[C]Hello", { config: "guitar" });
             if (!optsHtml.includes("Test")) throw new Error("renderHtmlWithOptions output missing title");
             console.log("renderHtmlWithOptions: OK");
+            const optsPdf = m.renderPdfWithOptions("{title:Test}\n[C]Hello", { transpose: 2 });
+            if (!Buffer.isBuffer(optsPdf)) throw new Error("renderPdfWithOptions did not return a Buffer");
+            if (!optsPdf.toString("utf8", 0, 4).startsWith("%PDF")) throw new Error("renderPdfWithOptions output missing PDF header");
+            console.log("renderPdfWithOptions: OK");
             const errs = m.validate("{title:T}\n[C]X");
             if (!Array.isArray(errs) || errs.length !== 0) throw new Error("validate(valid) returned " + JSON.stringify(errs));
             console.log("validate (valid): OK");

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -39,13 +39,23 @@ fn resolve_config(
     }
 }
 
-/// Parse input into songs, returning an error if no songs are found.
+/// Parse input into songs.
+///
+/// `parse_multi_lenient` always returns at least one `ParseResult`
+/// (`split_at_new_song` unconditionally pushes the trailing segment, even
+/// for empty input — see `chordsketch_core::parser`), so the resulting
+/// `Vec<Song>` is never empty. The previous `is_empty()` guard was dead
+/// code. See #1083.
+///
+/// The function still returns `Result` (and the [`ChordSketchError::NoSongsFound`]
+/// variant is still part of the FFI surface) for binding ABI stability —
+/// removing the variant would be a breaking change for Python / Swift /
+/// Kotlin / Ruby consumers. The variant is retained as defensive
+/// future-proofing in case the lenient parser ever changes its
+/// always-returns-one-segment behavior.
 fn parse_songs(input: &str) -> Result<Vec<chordsketch_core::ast::Song>, ChordSketchError> {
     let result = chordsketch_core::parse_multi_lenient(input);
     let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
-    if songs.is_empty() {
-        return Err(ChordSketchError::NoSongsFound);
-    }
     Ok(songs)
 }
 

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -46,7 +46,6 @@
   "scripts": {
     "build": "napi build --release --manifest-path Cargo.toml",
     "build:debug": "napi build --manifest-path Cargo.toml",
-    "prepack": "napi build --release --manifest-path Cargo.toml",
-    "prepublishOnly": "napi build --release --manifest-path Cargo.toml"
+    "prepack": "napi build --release --manifest-path Cargo.toml"
   }
 }

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -42,13 +42,18 @@ fn resolve_config(config: Option<String>) -> Result<chordsketch_core::config::Co
     }
 }
 
-/// Parse input into songs, returning an error if none found.
+/// Parse input into songs.
+///
+/// `parse_multi_lenient` always returns at least one `ParseResult`
+/// (`split_at_new_song` unconditionally pushes the trailing segment, even
+/// for empty input — see `chordsketch_core::parser`), so the resulting
+/// `Vec<Song>` is never empty. The previous `is_empty()` guard was dead
+/// code. See #1083. The function still returns `Result` because the
+/// `*_with_options` callers use the same `napi::Result` channel for
+/// their `resolve_config` failures.
 fn parse_songs(input: &str) -> Result<Vec<chordsketch_core::ast::Song>> {
     let result = chordsketch_core::parse_multi_lenient(input);
     let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
-    if songs.is_empty() {
-        return Err(Error::new(Status::InvalidArg, "no songs found in input"));
-    }
     Ok(songs)
 }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -52,7 +52,15 @@ fn resolve_config(opts: &RenderOptions) -> Result<chordsketch_core::config::Conf
     }
 }
 
-/// Parse input and render songs, returning a `String` result or an error.
+/// Parse input and render songs.
+///
+/// `parse_multi_lenient` always returns at least one `ParseResult`
+/// (`split_at_new_song` unconditionally pushes the trailing segment, even
+/// for empty input — see `chordsketch_core::parser`), so the resulting
+/// `Vec<Song>` is never empty and the previous `is_empty()` guard was
+/// dead code. See #1083. The return type stays `Result` because
+/// `render_html_with_options` and friends use the same `JsValue` error
+/// channel for their config-parse failures.
 fn do_render_string(
     input: &str,
     config: &chordsketch_core::config::Config,
@@ -61,13 +69,13 @@ fn do_render_string(
 ) -> Result<String, JsValue> {
     let result = chordsketch_core::parse_multi_lenient(input);
     let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
-    if songs.is_empty() {
-        return Err(JsValue::from_str("no songs found in input"));
-    }
     Ok(render_fn(&songs, transpose, config))
 }
 
-/// Parse input and render songs, returning a `Vec<u8>` result or an error.
+/// Parse input and render songs, returning a `Vec<u8>` result.
+///
+/// See [`do_render_string`] for the note on the lenient parser always
+/// producing at least one song.
 fn do_render_bytes(
     input: &str,
     config: &chordsketch_core::config::Config,
@@ -76,9 +84,6 @@ fn do_render_bytes(
 ) -> Result<Vec<u8>, JsValue> {
     let result = chordsketch_core::parse_multi_lenient(input);
     let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
-    if songs.is_empty() {
-        return Err(JsValue::from_str("no songs found in input"));
-    }
     Ok(render_fn(&songs, transpose, config))
 }
 


### PR DESCRIPTION
## What

Three small follow-ups from the auto-review on PR #1093:

| # | Type | File(s) | Change |
|---|------|---------|--------|
| #1083 | dead code | `crates/{wasm,ffi,napi}/src/lib.rs` | Remove `if songs.is_empty()` guards that never fire because `parse_multi_lenient` always returns at least one `ParseResult` |
| #1094 | refactor | `crates/napi/package.json` | Drop `prepublishOnly` (redundant with `prepack` — npm runs both, doubling the Rust build time on `npm publish`) |
| #1095 | ci + nit | `.github/workflows/napi.yml` | Add `renderPdfWithOptions` to the smoke test (was the only `#[napi]` function not exercised), and replace the stale "published gem" wording with "published Node.js addon" |

## Why #1083's guards are dead

`chordsketch_core::parser::split_at_new_song` (`crates/core/src/parser.rs:1058`) unconditionally pushes the trailing segment as the last operation:

```
fn split_at_new_song(input: &str) -> Vec<&str> {
    let mut segments = Vec::new();
    // ... walk through lines, push at {new_song} boundaries ...
    segments.push(&input[seg_start..]);  // <- always runs, even for empty input
    segments
}
```

So `parse_multi_lenient` always returns at least one `ParseResult`, even for `""`, even for whitespace-only input. The downstream `result.results.into_iter().map(|r| r.song).collect()` therefore always produces a `Vec<Song>` with `len >= 1`, and the `if songs.is_empty()` check is unreachable. Caught by the auto-review on PR #1081 as #1083.

## Why ChordSketchError::NoSongsFound is kept

The variant in `crates/ffi/src/lib.rs` is part of the **binding ABI**: the .udl mirrors the Rust enum, and removing a variant is a breaking change for Python / Swift / Kotlin / Ruby consumers. The variant is retained with a doc-comment explaining it's "defensive future-proofing in case the lenient parser ever changes its always-returns-one-segment behavior."

The wasm and napi crates use anonymous string errors, so they have no equivalent ABI surface to preserve.

## Test results

```
$ cargo test -p chordsketch-wasm -p chordsketch-ffi -p chordsketch-napi
... 8 wasm + 9 ffi + 10 napi tests, all pass

$ cargo clippy -p chordsketch-wasm -p chordsketch-ffi -p chordsketch-napi -- -D warnings
... clean
```

The Ruby and Python workflows are now both green on main (#1082, #1084 resolved), so the `crates/ffi/**` change here is safe to land.

Closes #1083
Closes #1094
Closes #1095