### PR TITLE
Bundle 3 Phase 20/21 Lows: wasm doc cleanup (#1097) + Dockerfile pins (#1070) + ABI deps pin (#1078)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ COPY . .
 RUN cargo build --release --locked -p chordsketch && \
     cp target/release/chordsketch /usr/local/bin/chordsketch
 
-FROM debian:bookworm-slim
+# Pinned to a specific date-stamped Debian point release (was floating
+# `debian:bookworm-slim`) so a future bookworm patch cannot silently break
+# the source-build path. Bump intentionally via Dependabot. See #1070.
+FROM debian:bookworm-20260406-slim
 
 RUN useradd --no-create-home --uid 1000 chordsketch
 COPY --from=builder /usr/local/bin/chordsketch /usr/local/bin/chordsketch

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,7 +2,10 @@
 # Expects a pre-built musl binary at ./chordsketch-${TARGETARCH}.
 # Used by .github/workflows/docker.yml.
 
-FROM alpine:3
+# Pinned to a specific Alpine point release (was floating `alpine:3`) so a
+# future Alpine 3.x change to `adduser` flags or musl ABI cannot silently
+# break the docker pipeline. Bump intentionally via Dependabot. See #1070.
+FROM alpine:3.23.3
 
 RUN adduser -D -u 1000 chordsketch
 

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -19,8 +19,14 @@ chordsketch-core = { version = "0.1.0", path = "../core" }
 chordsketch-render-text = { version = "0.1.0", path = "../render-text" }
 chordsketch-render-html = { version = "0.1.0", path = "../render-html" }
 chordsketch-render-pdf = { version = "0.1.0", path = "../render-pdf" }
-uniffi = { version = "0.31", features = ["cli"] }
+# `uniffi` is pinned to an exact patch version because the .udl + scaffolding
+# generated layout is part of the FFI surface — Python/Swift/Kotlin/Ruby
+# bindings depend on the binary being byte-compatible with the bindgen output.
+# Caret ranges (`"0.31"`) would let a patch with a layout change land via a
+# casual `cargo update` and silently break consumers. Bump intentionally via
+# Dependabot or a tracked PR. See #1078.
+uniffi = { version = "=0.31.0", features = ["cli"] }
 thiserror = "2"
 
 [build-dependencies]
-uniffi = { version = "0.31", features = ["build"] }
+uniffi = { version = "=0.31.0", features = ["build"] }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -19,8 +19,13 @@ chordsketch-core = { version = "0.1.0", path = "../core" }
 chordsketch-render-text = { version = "0.1.0", path = "../render-text" }
 chordsketch-render-html = { version = "0.1.0", path = "../render-html" }
 chordsketch-render-pdf = { version = "0.1.0", path = "../render-pdf" }
-napi = { version = "3", features = ["napi9"] }
-napi-derive = "3"
+# `napi` and `napi-derive` are pinned to exact patch versions because the
+# `#[napi]` macro emits ABI-sensitive C glue against the Node-API ABI.
+# Caret ranges (`"3"`) would let a 3.5 release land via a casual `cargo
+# update` with potentially incompatible glue. Bump intentionally via
+# Dependabot or a tracked PR. See #1078.
+napi = { version = "=3.4.0", features = ["napi9"] }
+napi-derive = "=3.3.0"
 
 [build-dependencies]
-napi-build = "2"
+napi-build = "=2.2.4"

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -87,13 +87,15 @@ fn do_render_bytes(
     Ok(render_fn(&songs, transpose, config))
 }
 
-/// Render ChordPro input as HTML.
+/// Render ChordPro input as HTML using default configuration.
 ///
-/// Returns the rendered HTML string.
+/// Returns the rendered HTML string. Use [`render_html_with_options`]
+/// to pass a config preset or transposition.
 ///
-/// # Errors
-///
-/// Returns a `JsValue` error string if the input contains no songs.
+/// The return type is `Result<String, JsValue>` for consistency with
+/// the `*_with_options` variants — this function itself never errors
+/// because the lenient parser always produces at least one song
+/// (see [`do_render_string`]).
 #[wasm_bindgen]
 pub fn render_html(input: &str) -> Result<String, JsValue> {
     do_render_string(
@@ -104,13 +106,15 @@ pub fn render_html(input: &str) -> Result<String, JsValue> {
     )
 }
 
-/// Render ChordPro input as plain text.
+/// Render ChordPro input as plain text using default configuration.
 ///
-/// Returns the rendered text string.
+/// Returns the rendered text string. Use [`render_text_with_options`]
+/// to pass a config preset or transposition.
 ///
-/// # Errors
-///
-/// Returns a `JsValue` error string if the input contains no songs.
+/// The return type is `Result<String, JsValue>` for consistency with
+/// the `*_with_options` variants — this function itself never errors
+/// because the lenient parser always produces at least one song
+/// (see [`do_render_string`]).
 #[wasm_bindgen]
 pub fn render_text(input: &str) -> Result<String, JsValue> {
     do_render_string(
@@ -121,13 +125,15 @@ pub fn render_text(input: &str) -> Result<String, JsValue> {
     )
 }
 
-/// Render ChordPro input as a PDF document.
+/// Render ChordPro input as a PDF document using default configuration.
 ///
-/// Returns the PDF as a `Uint8Array`.
+/// Returns the PDF as a `Uint8Array`. Use [`render_pdf_with_options`]
+/// to pass a config preset or transposition.
 ///
-/// # Errors
-///
-/// Returns a `JsValue` error string if the input contains no songs.
+/// The return type is `Result<Vec<u8>, JsValue>` for consistency with
+/// the `*_with_options` variants — this function itself never errors
+/// because the lenient parser always produces at least one song
+/// (see [`do_render_bytes`]).
 #[wasm_bindgen]
 pub fn render_pdf(input: &str) -> Result<Vec<u8>, JsValue> {
     do_render_bytes(


### PR DESCRIPTION
## What

Three small Phase 20/21 Low-priority follow-ups bundled into one PR.

## Issues addressed

| # | Type | File(s) | Change |
|---|------|---------|--------|
| #1097 | docs | `crates/wasm/src/lib.rs` | Replace stale `# Errors` doc sections on `render_html` / `render_text` / `render_pdf`. After #1083 removed the `is_empty()` guards, these functions never error — keep the `Result` return type for API consistency with the `*_with_options` variants but document the actual behavior. |
| #1070 | bug | `Dockerfile`, `Dockerfile.release` | Pin Docker base images to specific point releases: `alpine:3` → `alpine:3.23.3` and `debian:bookworm-slim` → `debian:bookworm-20260406-slim`. |
| #1078 | refactor | `crates/ffi/Cargo.toml`, `crates/napi/Cargo.toml` | Pin ABI-sensitive deps to exact patch versions: `uniffi = "=0.31.0"`, `napi = "=3.4.0"`, `napi-derive = "=3.3.0"`, `napi-build = "=2.2.4"`. |

## Why each pin

### #1070 — Docker base images

`alpine:3` is a floating major tag. A future Alpine 3.x change to `adduser` flags or musl ABI would silently break the docker pipeline that ships to users. Same for `debian:bookworm-slim` (floating point release).

`Dockerfile`'s `rust:1.85-bookworm` was already pinned to a Rust minor and is left as-is.

Dependabot continues to bump these via PRs intentionally rather than via casual `docker pull`.

### #1078 — ABI-sensitive Rust deps

`uniffi`'s scaffolding generator emits binary glue for the Python/Swift/Kotlin/Ruby bindings. The .udl + scaffolding layout is part of the FFI ABI surface — a casual `cargo update` picking up a 0.31.x patch with a layout change would silently break consumers.

`napi`'s `#[napi]` macro emits ABI-sensitive C glue against the Node-API ABI. A 3.5 release picked up via `cargo update` could land incompatible glue.

All exact pins match what's currently in `Cargo.lock`, so this PR is a **no-op for the lock file** but a hard wall against accidental updates. Bumps still come via Dependabot intentionally.

## Test results

```
$ cargo build -p chordsketch-ffi --lib
... pass with =0.31.0 pin

$ cargo build -p chordsketch-napi --lib
... pass with =3.4.0 / =3.3.0 / =2.2.4 pins

$ cargo test -p chordsketch-wasm
... 8/8 pass

$ cargo clippy -p chordsketch-wasm -p chordsketch-ffi -p chordsketch-napi -- -D warnings
... clean
```

The ruby/python/kotlin/swift workflows on this PR exercise the new pinned deps end-to-end on every supported binding platform.

Closes #1097
Closes #1070
Closes #1078