### PR TITLE
Bundle 2 wasm crate refactors: dedup no-options entry points (#1059) + fix intra-doc links (#1099)

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -87,21 +87,61 @@ fn do_render_bytes(
     Ok(render_fn(&songs, transpose, config))
 }
 
+/// Decode a JS-supplied `options` value into a `RenderOptions` struct.
+///
+/// Treats `undefined` and `null` as the default options object so the
+/// `*_with_options` entry points can be called without an explicit
+/// options argument from JS callers.
+fn deserialize_options(options: JsValue) -> Result<RenderOptions, JsValue> {
+    if options.is_undefined() || options.is_null() {
+        Ok(RenderOptions::default())
+    } else {
+        serde_wasm_bindgen::from_value(options).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+}
+
+/// Resolve config and dispatch a string-returning render call.
+///
+/// Single source of truth shared by `render_html` / `render_text` and
+/// their `*_with_options` counterparts. Avoids the boilerplate duplication
+/// flagged in #1059. Takes `RenderOptions` directly (not `JsValue`) so
+/// the no-options entry points can call this on native test targets
+/// without touching wasm-bindgen-imported types.
+fn render_string_inner(
+    input: &str,
+    opts: RenderOptions,
+    render_fn: fn(&[chordsketch_core::ast::Song], i8, &chordsketch_core::config::Config) -> String,
+) -> Result<String, JsValue> {
+    let config = resolve_config(&opts)?;
+    do_render_string(input, &config, opts.transpose, render_fn)
+}
+
+/// Resolve config and dispatch a bytes-returning render call.
+///
+/// See [`render_string_inner`].
+fn render_bytes_inner(
+    input: &str,
+    opts: RenderOptions,
+    render_fn: fn(&[chordsketch_core::ast::Song], i8, &chordsketch_core::config::Config) -> Vec<u8>,
+) -> Result<Vec<u8>, JsValue> {
+    let config = resolve_config(&opts)?;
+    do_render_bytes(input, &config, opts.transpose, render_fn)
+}
+
 /// Render ChordPro input as HTML using default configuration.
 ///
 /// Returns the rendered HTML string. Use [`render_html_with_options`]
 /// to pass a config preset or transposition.
 ///
 /// The return type is `Result<String, JsValue>` for consistency with
-/// the `*_with_options` variants — this function itself never errors
-/// because the lenient parser always produces at least one song
-/// (see [`do_render_string`]).
+/// the `*_with_options` variant — this function itself never errors
+/// because the lenient parser always produces at least one song and
+/// the default config never fails to resolve.
 #[wasm_bindgen]
 pub fn render_html(input: &str) -> Result<String, JsValue> {
-    do_render_string(
+    render_string_inner(
         input,
-        &chordsketch_core::config::Config::defaults(),
-        0,
+        RenderOptions::default(),
         chordsketch_render_html::render_songs_with_transpose,
     )
 }
@@ -112,15 +152,14 @@ pub fn render_html(input: &str) -> Result<String, JsValue> {
 /// to pass a config preset or transposition.
 ///
 /// The return type is `Result<String, JsValue>` for consistency with
-/// the `*_with_options` variants — this function itself never errors
-/// because the lenient parser always produces at least one song
-/// (see [`do_render_string`]).
+/// the `*_with_options` variant — this function itself never errors
+/// because the lenient parser always produces at least one song and
+/// the default config never fails to resolve.
 #[wasm_bindgen]
 pub fn render_text(input: &str) -> Result<String, JsValue> {
-    do_render_string(
+    render_string_inner(
         input,
-        &chordsketch_core::config::Config::defaults(),
-        0,
+        RenderOptions::default(),
         chordsketch_render_text::render_songs_with_transpose,
     )
 }
@@ -131,15 +170,14 @@ pub fn render_text(input: &str) -> Result<String, JsValue> {
 /// to pass a config preset or transposition.
 ///
 /// The return type is `Result<Vec<u8>, JsValue>` for consistency with
-/// the `*_with_options` variants — this function itself never errors
-/// because the lenient parser always produces at least one song
-/// (see [`do_render_bytes`]).
+/// the `*_with_options` variant — this function itself never errors
+/// because the lenient parser always produces at least one song and
+/// the default config never fails to resolve.
 #[wasm_bindgen]
 pub fn render_pdf(input: &str) -> Result<Vec<u8>, JsValue> {
-    do_render_bytes(
+    render_bytes_inner(
         input,
-        &chordsketch_core::config::Config::defaults(),
-        0,
+        RenderOptions::default(),
         chordsketch_render_pdf::render_songs_with_transpose,
     )
 }
@@ -151,18 +189,17 @@ pub fn render_pdf(input: &str) -> Result<Vec<u8>, JsValue> {
 ///   reduces modulo 12 internally)
 /// - `config`: preset name ("guitar", "ukulele") or inline RRJSON string
 ///
+/// `undefined` or `null` is accepted and treated as the default options
+/// object.
+///
 /// # Errors
 ///
 /// Returns a `JsValue` error string on parse failure or invalid options.
 #[wasm_bindgen]
 pub fn render_html_with_options(input: &str, options: JsValue) -> Result<String, JsValue> {
-    let opts: RenderOptions =
-        serde_wasm_bindgen::from_value(options).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    let config = resolve_config(&opts)?;
-    do_render_string(
+    render_string_inner(
         input,
-        &config,
-        opts.transpose,
+        deserialize_options(options)?,
         chordsketch_render_html::render_songs_with_transpose,
     )
 }
@@ -176,13 +213,9 @@ pub fn render_html_with_options(input: &str, options: JsValue) -> Result<String,
 /// Returns a `JsValue` error string on parse failure or invalid options.
 #[wasm_bindgen]
 pub fn render_text_with_options(input: &str, options: JsValue) -> Result<String, JsValue> {
-    let opts: RenderOptions =
-        serde_wasm_bindgen::from_value(options).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    let config = resolve_config(&opts)?;
-    do_render_string(
+    render_string_inner(
         input,
-        &config,
-        opts.transpose,
+        deserialize_options(options)?,
         chordsketch_render_text::render_songs_with_transpose,
     )
 }
@@ -198,13 +231,9 @@ pub fn render_text_with_options(input: &str, options: JsValue) -> Result<String,
 /// Returns a `JsValue` error string on parse failure or invalid options.
 #[wasm_bindgen]
 pub fn render_pdf_with_options(input: &str, options: JsValue) -> Result<Vec<u8>, JsValue> {
-    let opts: RenderOptions =
-        serde_wasm_bindgen::from_value(options).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    let config = resolve_config(&opts)?;
-    do_render_bytes(
+    render_bytes_inner(
         input,
-        &config,
-        opts.transpose,
+        deserialize_options(options)?,
         chordsketch_render_pdf::render_songs_with_transpose,
     )
 }


### PR DESCRIPTION
## What

Two coordinated wasm crate cleanups:

1. **#1059** — Extract two private inner helpers (`render_string_inner`, `render_bytes_inner`) that take `RenderOptions` directly. Both no-options (`render_html`/`render_text`/`render_pdf`) and `*_with_options` entry points delegate to them, sharing the resolve_config + dispatch boilerplate.

2. **#1099** — Replace intra-doc links to private items with plain prose. The doc comments added in PR #1098 referenced `do_render_string` and `do_render_bytes`, which are private helpers that don't appear in published docs.rs output.

## Why the helpers take `RenderOptions` (not `JsValue`)

I originally tried having the no-options entry points delegate via `JsValue::UNDEFINED`:

```rust
pub fn render_html(input: &str) -> Result<String, JsValue> {
    render_html_with_options(input, JsValue::UNDEFINED)
}
```

…but that fails the native `#[test]` suite (`test_render_html_returns_content`, etc.) because `JsValue::UNDEFINED` is a `wasm-bindgen` import that panics on non-wasm targets:

```
thread 'tests::test_render_html_returns_content' panicked at wasm-bindgen-0.2.117/src/lib.rs:1216:1:
cannot call wasm-bindgen imported functions on non-wasm targets
```

The chosen approach (helpers take `RenderOptions` directly) avoids the wasm-bindgen-imported types on the no-options path entirely, so the native tests keep working AND we still dedupe the resolve_config + dispatch boilerplate.

A new `deserialize_options(JsValue) -> Result<RenderOptions>` helper also lets the `*_with_options` entry points accept `undefined` / `null` as valid input (treated as default options) — minor UX improvement for JS callers who pass an explicit but unset second argument.

## Test results

```
$ cargo test -p chordsketch-wasm
running 8 tests
test tests::config_parse_invalid_rrjson_returns_err ... ok
test tests::config_parse_valid_rrjson_returns_ok ... ok
test tests::config_preset_known_and_unknown_names ... ok
test tests::test_empty_input_returns_ok ... ok
test tests::test_render_html_returns_content ... ok
test tests::test_render_pdf_returns_bytes ... ok
test tests::test_render_text_returns_content ... ok
test tests::test_version_returns_string ... ok
test result: ok. 8 passed; 0 failed

$ cargo clippy -p chordsketch-wasm -- -D warnings
... clean

$ cargo doc -p chordsketch-wasm --no-deps
... no warnings
```

Closes #1059
Closes #1099