### PR TITLE
PR1102 follow-ups: pin Rust builder digest (#1103) + fix gem→package wording (#1104)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 # Multi-stage Dockerfile for building ChordSketch from source.
 # For pre-built multi-arch images, see ghcr.io/koedame/chordsketch.
 
-FROM rust:1.85-bookworm AS builder
+# Builder stage pinned to its sha256 manifest list digest for the same
+# reason the runtime stage is below: a tag republish on Docker Hub could
+# otherwise produce a tampered builder that quietly compiles malicious
+# binary into the trusted runtime layer. The tag is kept alongside the
+# digest so Dependabot can correlate the bump. See #1103.
+FROM rust:1.85-bookworm@sha256:e51d0265072d2d9d5d320f6a44dde6b9ef13653b035098febd68cce8fa7c0bc4 AS builder
 
 WORKDIR /build
 COPY . .

--- a/packages/kotlin/lib/src/main/kotlin/uniffi/chordsketch/ChordSketch.kt
+++ b/packages/kotlin/lib/src/main/kotlin/uniffi/chordsketch/ChordSketch.kt
@@ -4,7 +4,7 @@
 // case difference — on Linux they are two separate files; on macOS they
 // would collide). The generated file is the one that contains the real
 // bindings. This `ChordSketch.kt` file is intentionally empty so that
-// the directory exists in git, but the gem will not work end-to-end
+// the directory exists in git, but the package will not work end-to-end
 // until `uniffi-bindgen generate` has been run.
 //
 // If your `./gradlew test` fails with `cannot load library 'chordsketch_ffi'`


### PR DESCRIPTION
## What

Two small follow-ups from the auto-review on PR #1102:

| # | Type | File | Change |
|---|------|------|--------|
| #1103 | ci | `Dockerfile` | Pin builder stage `rust:1.85-bookworm` to its sha256 manifest list digest |
| #1104 | docs | `packages/kotlin/lib/src/main/kotlin/uniffi/chordsketch/ChordSketch.kt` | Replace "gem" (Ruby term) with "package" in the placeholder warning comment |

## Why

### #1103

PR #1102 pinned the runtime stage of `Dockerfile` (`debian:bookworm-...`) and the only stage of `Dockerfile.release` (`alpine:3.23.3`) to sha256 digests, but left the builder stage (`rust:1.85-bookworm`) tag-only. A re-tagged or tampered builder image could quietly compile a malicious binary into the trusted runtime layer, partially defeating the runtime-image hardening.

```dockerfile
FROM rust:1.85-bookworm@sha256:e51d0265072d2d9d5d320f6a44dde6b9ef13653b035098febd68cce8fa7c0bc4 AS builder
```

The tag is kept alongside the digest so Dependabot can correlate the bump and humans can read the version at a glance, matching the pattern from #1100/#1102.

### #1104

The Kotlin placeholder file added in PR #1102 used the word "gem" on line 7 — that's a Ruby ecosystem term, not a Kotlin one. The Swift counterpart correctly says "package". One-word fix to match. Caught by the auto-review on PR #1102.

## Test results

Both are minimal changes (Dockerfile FROM line + 1 word in a comment-only file). The Phase 21 binding workflows on this PR exercise the placeholder file path. The builder image pin is exercised by the docker build path.

Closes #1103
Closes #1104