### PR TITLE
playground: import @chordsketch/wasm via vite alias (#1057)

### DIFF
--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -5,7 +5,7 @@ import init, {
   render_html_with_options,
   render_text_with_options,
   render_pdf_with_options,
-} from '../../npm/web/chordsketch_wasm.js';
+} from '@chordsketch/wasm';
 import { SAMPLE_CHORDPRO } from './sample';
 
 const editor = document.getElementById('editor') as HTMLTextAreaElement;

--- a/packages/playground/src/wasm.d.ts
+++ b/packages/playground/src/wasm.d.ts
@@ -1,4 +1,4 @@
-declare module '../../npm/web/chordsketch_wasm.js' {
+declare module '@chordsketch/wasm' {
   export function render_html(input: string): string;
   export function render_text(input: string): string;
   export function render_pdf(input: string): Uint8Array;

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -8,7 +8,11 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@chordsketch/wasm": ["../npm/web/chordsketch_wasm.js"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,9 +1,24 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   base: '/chordsketch/',
   build: {
     outDir: 'dist',
+  },
+  resolve: {
+    alias: {
+      // Decouple the playground source from the npm package's internal
+      // layout. The deep relative path `../../npm/web/chordsketch_wasm.js`
+      // had to move whenever the npm package's directory structure
+      // changed (#1026 dual-package layout broke deploy-playground.yml
+      // before #1061 was filed). Importing under the published name lets
+      // future layout changes only touch the alias here. See #1057.
+      '@chordsketch/wasm': resolve(here, '../npm/web/chordsketch_wasm.js'),
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
## What

Replace the deep relative `import ... from '../../npm/web/chordsketch_wasm.js'` in the playground with a vite alias under the published package name `@chordsketch/wasm`. Decouples the playground source from the npm package's internal directory layout.

## Why

`packages/playground/src/main.ts` and `wasm.d.ts` previously imported the WASM package via the deep relative path:

```ts
import init, * as wasm from '../../npm/web/chordsketch_wasm.js';
```

Every change to the npm package's directory layout had to be tracked through three files (the import, the type declaration, and the deploy workflow). PR #1026's dual-package split (`packages/npm/{web,node}/`) is the change that broke `deploy-playground.yml` and motivated PR #1050. The deep import was the structural reason.

This PR moves the layout-coupling into a single vite alias:

```ts
// packages/playground/vite.config.ts
resolve: {
  alias: {
    '@chordsketch/wasm': resolve(here, '../npm/web/chordsketch_wasm.js'),
  },
},
```

…with a matching `tsconfig.json` `paths` entry so `tsc` follows the same alias as vite. After this change, future layout changes only need to touch the alias.

## Files touched

| File | Change |
|------|--------|
| `packages/playground/vite.config.ts` | Add `resolve.alias` for `@chordsketch/wasm` (uses `import.meta.url` since the playground is ESM) |
| `packages/playground/tsconfig.json` | Add `paths` entry mirroring the alias |
| `packages/playground/src/wasm.d.ts` | `declare module '@chordsketch/wasm'` instead of the deep relative path |
| `packages/playground/src/main.ts` | `import ... from '@chordsketch/wasm'` instead of the deep relative path |

## Test results

Verified locally end-to-end:

```
$ cd packages/npm && npm run build
... wasm-pack build complete.

$ cd ../playground && npm install && npm run build
> tsc && vite build
vite v6.4.1 building for production...
✓ 6 modules transformed.
dist/index.html                                  1.78 kB │ gzip:   0.86 kB
dist/assets/chordsketch_wasm_bg-k1bDcVk6.wasm  361.31 kB │ gzip: 147.44 kB
dist/assets/index-DCB2R0SB.css                   2.45 kB │ gzip:   0.97 kB
dist/assets/index-DUAa7OsO.js                   10.78 kB │ gzip:   4.32 kB
✓ built in 242ms
```

The deploy-playground.yml workflow on this PR exercises the same build path end-to-end.

Closes #1057