### PR TITLE
docker.yml: gate Docker Hub push on DOCKERHUB_TOKEN availability (#1072)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,19 +68,51 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Detect Docker Hub credentials
+        # Decouple Docker Hub from GHCR: if `DOCKERHUB_TOKEN` is unset
+        # (fork PRs, manual recovery runs, an org-side credential rotation),
+        # the GHCR push should still succeed instead of taking the entire
+        # workflow down with it. Secrets aren't available in step `if:`
+        # expressions directly, so we surface the boolean via a step output.
+        # See #1072.
+        id: dockerhub
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "${DOCKERHUB_TOKEN:-}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::DOCKERHUB_TOKEN is not set; skipping Docker Hub push (GHCR will still publish). See #1072."
+          fi
+
       - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.available == 'true'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Compute image list
+        # Build the metadata-action `images:` value dynamically so we
+        # only push to Docker Hub when its credentials are available.
+        # See #1072.
+        id: images
+        run: |
+          {
+            echo "list<<EOF"
+            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+            if [ "${{ steps.dockerhub.outputs.available }}" = "true" ]; then
+              echo "docker.io/${{ env.IMAGE_NAME }}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            docker.io/${{ env.IMAGE_NAME }}
+          images: ${{ steps.images.outputs.list }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## What

Decouple Docker Hub from GHCR in `.github/workflows/docker.yml`. Previously a missing or expired `DOCKERHUB_TOKEN` took the entire workflow down — including the GHCR push that doesn't depend on Docker Hub at all.

## Why

The previous workflow:

```yaml
- name: Log in to GHCR             # always
- name: Log in to Docker Hub       # always — fails on missing token
- name: Extract metadata           # both images
- name: Build and push             # both registries
```

If `DOCKERHUB_TOKEN` was unset (fork PRs, manual recovery runs, an org-side credential rotation), the Docker Hub login failed and the entire job aborted. GHCR — which uses `secrets.GITHUB_TOKEN`, always available — got nothing despite being independent.

## How

Three coordinated changes:

1. **`Detect Docker Hub credentials`** (new step) reads `DOCKERHUB_TOKEN` from env (secrets aren't available in step `if:` expressions directly) and surfaces a boolean via `steps.dockerhub.outputs.available`. When the token is missing it logs a `::warning::` so the gap is visible in the workflow summary.

2. **`Log in to Docker Hub`** is now gated on `if: steps.dockerhub.outputs.available == 'true'`. The GHCR login above remains unconditional.

3. **`Compute image list`** (new step) builds the `images:` value for `docker/metadata-action` dynamically. Always includes `${REGISTRY}/${IMAGE_NAME}` (GHCR); only adds `docker.io/${IMAGE_NAME}` when Docker Hub credentials are available. `docker/build-push-action` then pushes only to the registries we've actually authenticated against.

## Behaviour change

| Scenario | Before | After |
|----------|--------|-------|
| Both tokens present | GHCR + Docker Hub published | GHCR + Docker Hub published (unchanged) |
| `DOCKERHUB_TOKEN` missing | **Whole workflow fails before any push** | GHCR published; Docker Hub skipped with `::warning::` in summary |
| Both tokens missing | Whole workflow fails | GHCR fails (unchanged — `GITHUB_TOKEN` is always present) |

## Why not split into two parallel jobs

The "two parallel jobs" alternative was considered (one for each registry) but rejected because it would either:
- Build the multi-arch images twice (slow)
- Or require sharing build artifacts between jobs via cache, adding complexity for a Low-priority defense-in-depth fix.

The conditional-step approach is small and surgical.

## Test results

This PR's CI exercises the path with `DOCKERHUB_TOKEN` PRESENT (the repo secret is set), so the new compute step emits both registries and the workflow behaves identically to before. The "missing token" path is harder to test in-tree without an actual fork PR; the existing GHCR-only smoke check (in `readme-smoke.yml`) confirms GHCR continues to work.

Closes #1072