### PR TITLE
docker.yml: pass step outputs via env: in compute-image-list (#1115)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,13 +97,24 @@ jobs:
         # Build the metadata-action `images:` value dynamically so we
         # only push to Docker Hub when its credentials are available.
         # See #1072.
+        #
+        # Step outputs and env values are passed to the shell via the
+        # `env:` block (rather than `${{ ... }}` interpolation inside
+        # the `run:` body) per GitHub's expression-injection hardening
+        # guidance — see #1115. The current values are always
+        # workflow-controlled, but the `env:` form is the safe pattern
+        # to keep using as the inputs evolve.
         id: images
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERHUB_AVAILABLE: ${{ steps.dockerhub.outputs.available }}
         run: |
           {
             echo "list<<EOF"
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-            if [ "${{ steps.dockerhub.outputs.available }}" = "true" ]; then
-              echo "docker.io/${{ env.IMAGE_NAME }}"
+            echo "${REGISTRY}/${IMAGE_NAME}"
+            if [ "${DOCKERHUB_AVAILABLE}" = "true" ]; then
+              echo "docker.io/${IMAGE_NAME}"
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Move the `${{ steps.dockerhub.outputs.available }}`, `${{ env.REGISTRY }}`, and `${{ env.IMAGE_NAME }}` interpolations from the `run:` body of the `Compute image list` step (added in #1072) into an `env:` block, and reference them as plain shell `$VAR`s.

## Why

Caught by the auto-review on PR #1114. Per [GitHub's expression-injection hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections), step outputs and env values that flow into a `run:` shell body should be passed via `env:` rather than `${{ ... }}` interpolation.

The current values are always workflow-controlled (the previous step writes either `'true'` or `'false'`, and the env values are static literals at the workflow file level), so this is not exploitable today. But the `env:` form is the safe pattern to keep using as the inputs evolve.

```yaml
env:
  REGISTRY: ${{ env.REGISTRY }}
  IMAGE_NAME: ${{ env.IMAGE_NAME }}
  DOCKERHUB_AVAILABLE: ${{ steps.dockerhub.outputs.available }}
run: |
  {
    echo "list<<EOF"
    echo "${REGISTRY}/${IMAGE_NAME}"
    if [ "${DOCKERHUB_AVAILABLE}" = "true" ]; then
      echo "docker.io/${IMAGE_NAME}"
    fi
    echo "EOF"
  } >> "$GITHUB_OUTPUT"
```

Behavior is unchanged.

Closes #1115