### PR TITLE
docs(heuristic): fix sanitize_directive_value doc to mention name sanitization

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -659,8 +659,8 @@ fn pair_chords_with_lyric(positions: &[(usize, String)], lyric: &str) -> LyricsL
 // ---------------------------------------------------------------------------
 
 /// Strips `{` and `}` from a string so it is safe to embed as a ChordPro
-/// directive value.  ChordPro has no escape mechanism inside directive values,
-/// so brace characters would produce malformed output.
+/// directive name or value.  ChordPro has no escape mechanism inside directive
+/// names or values, so brace characters would produce malformed output.
 fn sanitize_directive_value(s: &str) -> std::borrow::Cow<'_, str> {
     if s.contains('{') || s.contains('}') {
         std::borrow::Cow::Owned(s.replace(['{', '}'], ""))


### PR DESCRIPTION
## What

Updates the doc comment on `sanitize_directive_value` in
`crates/core/src/heuristic.rs` to reflect that it is used to sanitize
both directive **names** and directive **values**.

## Why

The function was originally written for value-only use (PR #1290), then
extended to also sanitize directive names (PR #1293). The doc comment was
not updated at that point.

## Test results

No behavior change — doc comment only.

```
cargo clippy -- -D warnings  # clean
cargo fmt --check            # clean
```

Closes #1294