### PR TITLE
docs(heuristic): document valid ranges for PlainTextImporter fields

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -65,9 +65,29 @@ pub enum InputFormat {
 pub struct PlainTextImporter {
     /// Minimum fraction of whitespace-separated tokens that must be valid chord
     /// names for a line to be classified as a chord line. Default: `0.5`.
+    ///
+    /// **Valid range: `[0.0, 1.0]`.**
+    /// - `0.0` — every non-empty, non-punctuated line is classified as a chord
+    ///   line regardless of content.
+    /// - `1.0` — all tokens must be valid chord names for the line to qualify.
+    /// - Values above `1.0` disable chord-line detection entirely (the ratio of
+    ///   chord tokens can never exceed `1.0`).
+    /// - Negative values behave like `0.0`.
+    ///
+    /// Prefer [`PlainTextImporter::with_thresholds`] to construct an importer
+    /// with validated values.
     pub chord_threshold: f64,
     /// Minimum number of chord tokens required to classify a line as a chord
     /// line. Default: `2`.
+    ///
+    /// **Valid range: `>= 1`.**
+    /// Setting this to `0` disables the minimum-count guard: any non-empty,
+    /// non-punctuated line that meets [`chord_threshold`][Self::chord_threshold]
+    /// will be classified as a chord line, even if it contains only a single
+    /// token.
+    ///
+    /// Prefer [`PlainTextImporter::with_thresholds`] to construct an importer
+    /// with validated values.
     pub min_chord_tokens: usize,
 }
 
@@ -85,6 +105,42 @@ impl PlainTextImporter {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates a new importer with explicit threshold values, returning an
+    /// error string if any value is out of its valid range.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if:
+    /// - `chord_threshold` is not in `[0.0, 1.0]`
+    /// - `min_chord_tokens` is `0`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chordsketch_core::heuristic::PlainTextImporter;
+    ///
+    /// let importer = PlainTextImporter::with_thresholds(0.75, 3).unwrap();
+    /// assert_eq!(importer.chord_threshold, 0.75);
+    /// assert_eq!(importer.min_chord_tokens, 3);
+    ///
+    /// assert!(PlainTextImporter::with_thresholds(1.5, 2).is_err());
+    /// assert!(PlainTextImporter::with_thresholds(0.5, 0).is_err());
+    /// ```
+    pub fn with_thresholds(chord_threshold: f64, min_chord_tokens: usize) -> Result<Self, String> {
+        if !(0.0..=1.0).contains(&chord_threshold) {
+            return Err(format!(
+                "chord_threshold must be in [0.0, 1.0], got {chord_threshold}"
+            ));
+        }
+        if min_chord_tokens == 0 {
+            return Err("min_chord_tokens must be >= 1".to_string());
+        }
+        Ok(Self {
+            chord_threshold,
+            min_chord_tokens,
+        })
     }
 
     /// Returns `true` if `line` appears to be a chord line.


### PR DESCRIPTION
## What

- Adds range documentation to `PlainTextImporter::chord_threshold` and
  `PlainTextImporter::min_chord_tokens`, explaining edge-case behavior.
- Adds `PlainTextImporter::with_thresholds(chord_threshold, min_chord_tokens) -> Result<Self, String>`,
  a validated constructor that returns `Err` for out-of-range inputs.

## Why

Both fields were public with no documentation of valid ranges or edge-case
effects, leaving callers to discover by experimentation that:

- `chord_threshold = 0.0` causes every non-empty, non-punctuated line to
  be classified as a chord line.
- `chord_threshold > 1.0` disables chord-line detection entirely.
- `min_chord_tokens = 0` disables the minimum-count guard.

Surfaced as finding N-3 in the delta review of PR #1277.

## Changes

**`chord_threshold` doc comment** — documents the valid range `[0.0, 1.0]`
and the behavior of out-of-range values.

**`min_chord_tokens` doc comment** — documents that `0` disables the
count guard and effectively matches any non-empty line.

**`with_thresholds` constructor** — validates inputs and returns
`Err(String)` for invalid values:
- `chord_threshold` not in `[0.0, 1.0]`
- `min_chord_tokens == 0`

## Test results

```
cargo test -p chordsketch-core   # 35 tests pass (1 new doctest)
cargo clippy -- -D warnings      # clean
cargo fmt --check                # clean
```

Closes #1281