### PR TITLE
fix(heuristic): add #[must_use] to PlainTextImporter::with_thresholds

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -128,6 +128,7 @@ impl PlainTextImporter {
     /// assert!(PlainTextImporter::with_thresholds(1.5, 2).is_err());
     /// assert!(PlainTextImporter::with_thresholds(0.5, 0).is_err());
     /// ```
+    #[must_use = "this `Result` should be handled; use `.unwrap()` or `?` to apply the thresholds"]
     pub fn with_thresholds(chord_threshold: f64, min_chord_tokens: usize) -> Result<Self, String> {
         if !(0.0..=1.0).contains(&chord_threshold) {
             return Err(format!(


### PR DESCRIPTION
## What

Adds `#[must_use]` to `PlainTextImporter::with_thresholds` in
`crates/core/src/heuristic.rs`.

## Why

`with_thresholds` returns `Result<Self, String>`. Without `#[must_use]`, a
caller who writes:

```rust
PlainTextImporter::with_thresholds(1.5, 2); // silently discards Err
```

gets no compiler warning. Silently discarding this `Result` is almost
certainly a bug — the caller likely intended to unwrap or propagate it.

The project's `code-style.md` requires `#[must_use]` on functions whose
return values should not be silently discarded.

Surfaced as a Nit in the review of PR #1298.

## Test results

```
cargo test -p chordsketch-core   # 35 tests pass
cargo clippy -- -D warnings      # clean
cargo fmt --check                # clean
```

Closes #1303