### PR TITLE
docs(heuristic): document empty-positions fast path in pair_chords_with_lyric

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -643,6 +643,9 @@ fn end_directive_for_section(canonical: &str) -> Directive {
 /// Each chord annotates the lyric text starting at its column position in the
 /// chord line. Text that precedes the first chord is emitted in a leading
 /// chord-free segment.
+///
+/// If `positions` is empty the function returns a single chord-free segment
+/// containing the full `lyric` string (rather than an empty `LyricsLine`).
 fn pair_chords_with_lyric(positions: &[(usize, String)], lyric: &str) -> LyricsLine {
     // Fast path: no chord positions — return the lyric as a single plain segment.
     if positions.is_empty() {


### PR DESCRIPTION
## What

Updates the doc comment on `pair_chords_with_lyric` in `heuristic.rs` to
describe the early-return fast path added in PR #1295.

## Why

Without the doc update, a reader of the function signature would not know
that an empty `positions` slice returns a single chord-free segment
containing the full lyric, rather than an empty `LyricsLine`.

Closes #1296