### PR TITLE
docs(heuristic): expand with_thresholds doctest to cover boundary inputs

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -121,11 +121,19 @@ impl PlainTextImporter {
     /// ```
     /// use chordsketch_core::heuristic::PlainTextImporter;
     ///
+    /// // Valid mid-range value.
     /// let importer = PlainTextImporter::with_thresholds(0.75, 3).unwrap();
     /// assert_eq!(importer.chord_threshold, 0.75);
     /// assert_eq!(importer.min_chord_tokens, 3);
     ///
+    /// // Boundary values are valid.
+    /// assert!(PlainTextImporter::with_thresholds(0.0, 1).is_ok());
+    /// assert!(PlainTextImporter::with_thresholds(1.0, 1).is_ok());
+    ///
+    /// // Out-of-range values are rejected.
     /// assert!(PlainTextImporter::with_thresholds(1.5, 2).is_err());
+    /// assert!(PlainTextImporter::with_thresholds(-0.1, 2).is_err());
+    /// assert!(PlainTextImporter::with_thresholds(f64::NAN, 2).is_err());
     /// assert!(PlainTextImporter::with_thresholds(0.5, 0).is_err());
     /// ```
     pub fn with_thresholds(chord_threshold: f64, min_chord_tokens: usize) -> Result<Self, String> {


### PR DESCRIPTION
## What

Expands the `PlainTextImporter::with_thresholds` doctest to cover all
boundary and edge-case inputs:

- `chord_threshold = 0.0` (lower boundary) → `Ok`
- `chord_threshold = 1.0` (upper boundary) → `Ok`
- `chord_threshold = -0.1` (negative) → `Err`
- `chord_threshold = f64::NAN` → `Err`

## Why

The original doctest only verified one valid mid-range call and two
rejection cases. The boundary values and NaN case were untested, leaving
gaps in the documented API contract.

Closes #1302