### PR TITLE
test(heuristic): add detect_format tests for multi-bracket and mixed content

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -869,6 +869,23 @@ mod tests {
     }
 
     #[test]
+    fn detects_multi_bracket_line_as_chordpro() {
+        // `[Am][G]` on a single line has inner content `Am][G` which contains `[`,
+        // so the whole-line guard does NOT trigger. The scan finds `[Am]` → ChordPro.
+        assert_eq!(detect_format("[Am][G]"), InputFormat::ChordPro);
+        // Three brackets also triggers correctly.
+        assert_eq!(detect_format("[C][G][Am]"), InputFormat::ChordPro);
+    }
+
+    #[test]
+    fn detects_mixed_section_label_and_inline_chord_as_chordpro() {
+        // A whole-line section label `[Verse]` does NOT trigger ChordPro detection
+        // on its own, but a mid-line inline chord on another line does.
+        let input = "[Verse]\nHello [Am]world\n";
+        assert_eq!(detect_format(input), InputFormat::ChordPro);
+    }
+
+    #[test]
     fn detects_unknown_for_pure_lyrics() {
         let input = "Hello beautiful world\nOnce upon a time\nSomething happened here";
         assert_eq!(detect_format(input), InputFormat::Unknown);


### PR DESCRIPTION
## What

Adds two unit tests for edge cases in `detect_format` that were missing
after PR #1299:

1. **`detects_multi_bracket_line_as_chordpro`** — verifies that `[Am][G]`
   (two bracket pairs on one line) is correctly detected as ChordPro. The
   whole-line guard skips lines where `trimmed` starts with `[` and ends
   with `]` with no nested `[`, but `[Am][G]` has inner content `Am][G`
   which *contains* `[`, so the guard does NOT fire and the scan correctly
   finds `[Am]` as a chord token.

2. **`detects_mixed_section_label_and_inline_chord_as_chordpro`** — verifies
   that a whole-line section label (`[Verse]`) combined with a mid-line inline
   chord (`Hello [Am]world`) on a separate line is detected as ChordPro.

## Test results

```
cargo test -p chordsketch-core   # 35 tests pass (2 new)
cargo clippy -- -D warnings      # clean
cargo fmt --check                # clean
```

Closes #1305