### PR TITLE
nit(heuristic): improve #[must_use] message wording on with_thresholds

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -136,7 +136,7 @@ impl PlainTextImporter {
     /// assert!(PlainTextImporter::with_thresholds(f64::NAN, 2).is_err());
     /// assert!(PlainTextImporter::with_thresholds(0.5, 0).is_err());
     /// ```
-    #[must_use = "this `Result` should be handled; use `.unwrap()` or `?` to apply the thresholds"]
+    #[must_use = "this `Result` should be handled; use `.unwrap()` or `?` to obtain the configured importer"]
     pub fn with_thresholds(chord_threshold: f64, min_chord_tokens: usize) -> Result<Self, String> {
         if !(0.0..=1.0).contains(&chord_threshold) {
             return Err(format!(


### PR DESCRIPTION
## What

Fixes the `#[must_use]` message on `PlainTextImporter::with_thresholds`:

Before: `"use .unwrap() or ? to apply the thresholds"`  
After: `"use .unwrap() or ? to obtain the configured importer"`

## Why

"Apply the thresholds" is misleading — the thresholds are applied *inside* the function during construction. `.unwrap()` and `?` extract the `PlainTextImporter` from the `Ok` variant; they don't "apply" anything.

Closes #1313