### PR TITLE
Add preventive rules and CI checks for recurring bug patterns

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -10,3 +10,39 @@
 - Tests go in `#[cfg(test)] mod tests` inside the same file, or in a `tests/` directory
   for integration tests.
 - Keep modules small and focused. Prefer many small files over few large ones.
+
+## Error Handling
+
+- Do not silently swallow errors with `unwrap_or_default()`, `unwrap_or("")`,
+  or `.ok()` when the error indicates a bug or invalid input. Errors that callers
+  need to know about must propagate. If a silent fallback is intentional, add a
+  comment explaining why it is safe and what conditions trigger it.
+
+## Resource Limits
+
+- Every loop or recursion that processes untrusted input must have a bounded
+  iteration count. Define a named `MAX_*` constant for the bound — do not use
+  a bare integer literal.
+- Allocation sizes derived from untrusted input must be validated against a
+  `MAX_*` constant before allocating.
+
+## Unicode Safety
+
+- Never index a `&str` by raw byte offset unless the offset is proven to be a
+  character boundary (e.g., obtained from `char_indices()`). Prefer `chars()`,
+  `char_indices()`, or the `unicode-width` crate for text measurement.
+- Never cast `u8` to `char` via `byte as char` outside ASCII-only contexts.
+  Use `char::from(b)` only when `b.is_ascii()` is guaranteed; otherwise
+  decode with `str::chars()`.
+
+## Test Quality
+
+- Every `#[test]` function must contain at least one meaningful assertion
+  (`assert!`, `assert_eq!`, `assert_ne!`, or a call that panics on failure).
+  Tests that call a function without asserting on its return value prove nothing.
+- `let _ = result;` in a test is prohibited — it discards the value and makes
+  the test a no-op with respect to correctness.
+- Assert on the **actual output** of the function under test. Asserting a
+  hardcoded string that is never computed by the function under test is meaningless.
+- When adding a test to cover a bug fix, verify the test fails when the fix is
+  reverted before committing.

--- a/.claude/rules/defensive-inputs.md
+++ b/.claude/rules/defensive-inputs.md
@@ -1,0 +1,37 @@
+# Defensive Input Handling
+
+## Input Validation
+
+- Every `pub fn` validates its arguments at the boundary — never rely on callers
+  to pass valid data.
+- Structs with invariants (e.g., numeric fields that must stay in range) use
+  **private fields** and a `Result`-returning constructor that enforces them.
+- Numeric inputs: reject `NaN`, `Infinity`, negative values where invalid, and
+  values outside the documented range. Check both the lower and upper bound.
+- String inputs: check length before processing; guard against empty strings when
+  the function requires non-empty input; reject or strip control characters where
+  the caller expects printable text.
+- Named limit constants (`MAX_*`, `LIMIT_*`) with a doc comment explaining the
+  bound must be defined for every hard upper bound derived from an invariant.
+
+## File and Path Safety
+
+- **Open-then-fstat**, never stat-then-open. Obtain an `fs::File` first, then
+  call `file.metadata()` on the open handle. The reverse order creates a TOCTOU
+  window between the check and the use.
+- On Unix, use `O_NOFOLLOW` (or `OpenOptions::custom_flags`) for paths that
+  must not be symlinks.
+- Never construct a temp-file path from a PID or timestamp. Use the
+  [`tempfile`](https://docs.rs/tempfile) crate; its RAII types (`NamedTempFile`,
+  `TempDir`) delete the file or directory automatically — including on panic.
+- In tests, create temporary directories via `tempfile::tempdir()` so they are
+  cleaned up even when an assertion fails. Manual `remove_dir_all` calls are
+  skipped on test failure.
+
+## Resource Bounds
+
+- Every loop or recursion that processes untrusted input must have a bounded
+  iteration count. Define a named `MAX_*` constant for the bound.
+- Allocation sizes derived from untrusted input must be validated against the
+  relevant `MAX_*` constant before allocating. Prefer `Vec::try_reserve` or an
+  explicit size check over unbounded `Vec::with_capacity(untrusted_len)`.

--- a/.claude/rules/doc-maintenance.md
+++ b/.claude/rules/doc-maintenance.md
@@ -20,6 +20,7 @@ promptly.
 | New workflow or process introduced | `.claude/rules/` — add new file |
 | Existing rule no longer applies | Remove or update the relevant `.claude/rules/` file |
 | Dependency policy changed | `CLAUDE.md` Dependency Policy section |
+| Public function signature or behavior changed | Doc comment on the changed item — verify examples, parameter descriptions, and return-value semantics still match the new implementation |
 
 ## Phase Completion Review
 
@@ -35,3 +36,6 @@ one scheduled (non-event-driven) documentation checkpoint.
   history for that.
 - If a trigger applies but the change is trivial (e.g., a typo fix), it may be batched
   with the next documentation PR rather than requiring its own.
+- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS="-D warnings"` is enforced in
+  CI. Broken intra-doc links, invalid doc-test examples, and rustdoc warnings all fail
+  the build. Fix them in the same PR that changes the code.

--- a/.claude/rules/golden-tests.md
+++ b/.claude/rules/golden-tests.md
@@ -7,3 +7,9 @@
   change in the PR description.
 - New ChordPro directives or syntax support must include at least one golden test before
   merging.
+- When a golden test covers a keyword-terminated loop (e.g., a directive that scans
+  tokens until a closing keyword), at least one fixture must contain **another keyword
+  inside the scanned region**. This catches stop-word collisions where the parser exits
+  early on an unrelated keyword. For example, a fixture for
+  `{start_of_chorus}...{end_of_chorus}` should include a `{comment: ...}` line inside
+  the chorus body.

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -75,6 +75,22 @@ All review findings must be:
    enumeration are not acceptable. Every finding must be enumerable and
    traceable.
 
+### Duplicate Prevention
+
+Before creating an issue, search existing open issues to avoid filing the same finding
+twice. This is especially important during automated reviews, where the same code smell
+can be reported across multiple review cycles.
+
+```bash
+# Search by filename, function name, or error keyword
+gh issue list -S "keyword" --state open -R koedame/chordsketch
+```
+
+- If an equivalent open issue already exists, add a comment to it with any new
+  context rather than opening a new issue.
+- If a duplicate is found after creation, close the newer one as a duplicate and
+  link it to the existing issue.
+
 ### Creating Sub-Issue Relationships
 
 ```bash

--- a/.claude/rules/renderer-parity.md
+++ b/.claude/rules/renderer-parity.md
@@ -1,0 +1,27 @@
+# Renderer Parity
+
+ChordSketch has three renderers — text (`crates/render-text`), HTML
+(`crates/render-html`), and PDF (`crates/render-pdf`) — plus bindings (WASM, FFI,
+napi). All three renderers consume the same AST and must produce semantically
+equivalent output for the same input unless a divergence is explicitly documented.
+
+## Rules
+
+- **Bug fixes**: when fixing a bug in one renderer, check the other two for the
+  same bug before marking the issue closed. File separate issues for confirmed
+  bugs in sibling renderers.
+- **New directives / AST nodes**: implement support in all three renderers in the
+  same PR. Do not merge partial support where one renderer silently ignores the
+  new node.
+- **Shared constants** (e.g., `MAX_CHORUS_RECALLS`, `MAX_COLUMNS`, limit values):
+  define them once in `chordsketch-core` and import them. Do not copy the value
+  across crates.
+- **Intentional divergence** (e.g., PDF has page limits, text renderer has no
+  image support): document the divergence with an inline comment citing the
+  rationale. Undocumented divergence is treated as a bug.
+- **Regression tests**: when adding a regression test for one renderer, add an
+  equivalent test for the other two — or include a comment explaining why the
+  other renderers are not affected.
+- **Bindings**: parameter validation ranges (e.g., transpose semitone limits)
+  must be identical across WASM, FFI, and napi. A mismatch is a Medium-severity
+  finding.

--- a/.claude/rules/sanitizer-security.md
+++ b/.claude/rules/sanitizer-security.md
@@ -1,0 +1,33 @@
+# Sanitizer Security
+
+## Design Principles
+
+- Sanitizers use **allowlists**, not denylists. An allowlist enumerates every
+  safe construct explicitly; a denylist attempts to enumerate dangerous ones and
+  inevitably misses novel bypasses.
+- Operate on a **parsed representation** (DOM, token stream) wherever feasible —
+  not raw text with line-by-line or byte-by-byte pattern matching. Line-split
+  attacks and multi-byte sequences exploit parsers that do not track tag
+  boundaries.
+- All element and attribute comparisons must be **case-insensitive**: use
+  `eq_ignore_ascii_case`, `to_ascii_lowercase`, or equivalent. Mixed-case
+  variants (e.g., `ScRiPt`) must not bypass checks.
+- Never cast `u8` to `char` (e.g., `bytes[i] as char`) outside ASCII-only
+  contexts. This pattern silently corrupts multi-byte UTF-8 sequences and can
+  allow sanitizer bypasses via crafted byte patterns. Use `char::from(b)` only
+  when `b.is_ascii()` is proven; otherwise iterate with `str::chars()`.
+- URI scheme detection must strip control characters and whitespace before
+  comparing the scheme name. Fixed byte-length caps on scheme detection windows
+  are not sufficient.
+
+## Coverage Requirements
+
+- Sanitization must be applied **consistently across every code path** that emits
+  the same data type. If HTML content is sanitized in the HTML renderer, the same
+  sanitizer must cover equivalent content in the PDF and text renderers.
+- When adding a new output path (renderer, API binding, FFI function, WASM export)
+  that handles user-supplied or external-tool content, audit all existing
+  sanitizers to confirm the new path is covered.
+- When fixing a sanitizer bypass: (1) add a regression test for the bypass,
+  (2) audit sibling sanitizers (e.g., if you fixed the SVG sanitizer, check the
+  CSS and URI sanitizers) for the same gap.

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -1,0 +1,21 @@
+name: Action Pin Check
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+concurrency:
+  group: action-pins-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-pins:
+    name: Verify action SHA pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check all action references are SHA-pinned
+        run: bash scripts/check-action-pins.sh .github

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Find conflicted PRs
         id: find-prs
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const MAX_PRS = 5;
@@ -65,7 +65,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.find-prs.outputs.prs != '[]'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.CLAUDE_PAT }}
           fetch-depth: 0

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Request resolution for conflicted PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.CLAUDE_PAT }}
           script: |

--- a/.github/workflows/auto-update-branch.yml
+++ b/.github/workflows/auto-update-branch.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Update PR branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.CLAUDE_PAT }}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,22 @@ jobs:
       - name: Clippy lints
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  doc:
+    name: Doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Check docs
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --no-deps
+
   test:
     name: Test (${{ matrix.os }}, ${{ matrix.rust }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -18,11 +18,11 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@21302532c2959a4f8f5e445004f617ef8b7b1dd7 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "dependabot[bot]"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,7 @@ jobs:
       actions: read
     steps:
       - name: Request Claude review
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.CLAUDE_PAT }}
           script: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,12 +37,12 @@ jobs:
     steps:
       # Use CLAUDE_PAT so that git pushes by Claude trigger CI workflows.
       # GITHUB_TOKEN pushes do not trigger other workflows (GitHub anti-loop).
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.CLAUDE_PAT }}
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@21302532c2959a4f8f5e445004f617ef8b7b1dd7 # v1
         id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Detect conflicts and notify
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const LABEL_NAME = 'has-conflicts';

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -11,15 +11,15 @@ jobs:
     name: Extended tests (external tools)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get upstream latest release
         id: upstream

--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -345,7 +345,7 @@ fn musescore_cmd() -> Option<&'static str> {
 
 /// Returns `true` if MuseScore (`mscore` or `musescore`) is available.
 ///
-/// The result is cached at the process level; see [`musescore_cmd`].
+/// The result is cached at the process level.
 #[must_use]
 pub fn has_musescore() -> bool {
     musescore_cmd().is_some()

--- a/crates/core/src/formatter.rs
+++ b/crates/core/src/formatter.rs
@@ -1,6 +1,6 @@
 //! ChordPro source formatter.
 //!
-//! The [`format`] function normalizes ChordPro text to a canonical style:
+//! The [`format()`] function normalizes ChordPro text to a canonical style:
 //! directive names are expanded to their canonical form, spacing inside
 //! directives is normalized, chord spelling is canonicalized, and blank lines
 //! between sections are made consistent.
@@ -18,7 +18,7 @@
 use crate::ast::DirectiveKind;
 use crate::chord::parse_chord;
 
-/// Options that control which normalizations [`format`] applies.
+/// Options that control which normalizations [`format()`] applies.
 #[derive(Debug, Clone)]
 pub struct FormatOptions {
     /// Expand directive name aliases to their canonical long form.

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# check-action-pins.sh — Verify all GitHub Actions references are SHA-pinned.
+#
+# Exits with status 1 and prints offending lines if any `uses:` reference
+# points to a mutable tag (@v*, @main, @master) instead of a full 40-char
+# commit SHA.
+set -euo pipefail
+
+WORKFLOWS_DIR="${1:-.github}"
+FOUND=0
+
+while IFS= read -r -d '' file; do
+  while IFS= read -r line; do
+    # Match "uses: owner/repo@REF" where REF is not a 40-char hex SHA
+    if echo "$line" | grep -qE '^\s*uses:\s+[^@]+@[^#[:space:]]+'; then
+      ref=$(echo "$line" | sed -E 's/.*@([^# ]+).*/\1/')
+      # A valid SHA is exactly 40 lowercase hex characters
+      if ! echo "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "NOT SHA-PINNED: $file"
+        echo "  $line"
+        FOUND=1
+      fi
+    fi
+  done < "$file"
+done < <(find "$WORKFLOWS_DIR" -name '*.yml' -print0)
+
+if [ "$FOUND" -eq 1 ]; then
+  echo ""
+  echo "All 'uses:' action references must be pinned to a full 40-character commit SHA."
+  echo "Replace tag references (e.g. @v3) with the corresponding SHA and add a comment:"
+  echo "  uses: actions/checkout@<40-char-sha> # v6"
+  exit 1
+fi
+
+echo "All action references are SHA-pinned."


### PR DESCRIPTION
## What

Converts the findings from an analysis of all 801 project issues into
prevention mechanisms, choosing the optimal tool for each pattern:

### New Claude Code rules (3 files)

| File | Pattern(s) covered | Issues prevented |
|------|-------------------|-----------------|
| `.claude/rules/defensive-inputs.md` | pub API boundary validation, TOCTOU races, temp resource leaks, resource limits | ~90 |
| `.claude/rules/sanitizer-security.md` | sanitizer bypass chains, security path asymmetry | ~53 |
| `.claude/rules/renderer-parity.md` | cross-renderer bug propagation, shared constants drift | ~45 |

### Existing rule amendments (4 files)

| File | What was added |
|------|---------------|
| `.claude/rules/code-style.md` | Error handling (no silent fallback), resource limits, Unicode safety, test quality |
| `.claude/rules/golden-tests.md` | Stop-word collision test requirement |
| `.claude/rules/doc-maintenance.md` | Doc/code drift trigger + cargo doc CI note |
| `.claude/rules/issue-workflow.md` | Duplicate prevention step |

### New CI checks (2)

- **`doc` job in `ci.yml`**: `cargo doc --workspace --no-deps` with
  `RUSTDOCFLAGS="-D warnings"` — catches broken intra-doc links and stale doc
  examples on every PR.
- **`action-pins.yml` + `scripts/check-action-pins.sh`**: verifies all
  `uses:` references in workflow files are SHA-pinned (not tag-based) whenever
  a workflow file is changed.

### Prerequisite: SHA-pin existing tag references

14 tag-based action references across 9 workflow files were pinned to their
full commit SHA to pass the new `action-pins` check:
- `actions/github-script@v7` → SHA (5 files)
- `actions/checkout@v6` → SHA (4 files)
- `anthropics/claude-code-action@v1` → SHA (2 files)
- `Swatinem/rust-cache@v2` → SHA (1 file)
- `actions/setup-node@v4` → SHA (1 file)
- `dtolnay/rust-toolchain@stable` → SHA (1 file)

### Pre-existing rustdoc warnings fixed

Three doc warnings that would have failed the new `doc` CI job were fixed:
- `formatter.rs`: ambiguous `[format]` link (function vs macro) — changed to `[format()]`
- `external_tool.rs`: public doc linking to private item `musescore_cmd`

## Why

Analysis of all 801 GitHub issues found that ~70% cluster into 16 recurring
root-cause patterns. The three most common patterns (input validation: 82 issues,
sanitizer bypass: 53, renderer parity: 45) had no corresponding preventive
rules. The action pinning regression pattern (7 issues) had no mechanical
enforcement. This PR closes those gaps.

The two CI checks (`doc` and `action-pins`) enforce properties mechanically
that cannot be left to review-time judgment. The rule files encode design
principles that require human/AI judgment to apply correctly.

## Test results

- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS="-D warnings"`: passes
- `bash scripts/check-action-pins.sh .github`: passes
- `cargo clippy --workspace --all-targets -- -D warnings`: unchanged
- `cargo test --workspace`: unchanged

## Review summary

No Rust logic was changed — only documentation, CI configuration, and doc
comment fixes. The new rule files follow the same style as existing `.claude/rules/`
files (concise, imperative, actionable). The SHA pins are mechanical substitutions
verified by the new lint script.

Closes #1312