### PR TITLE
ci+docs: add preventive rules and doc CI check

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -10,3 +10,35 @@
 - Tests go in `#[cfg(test)] mod tests` inside the same file, or in a `tests/` directory
   for integration tests.
 - Keep modules small and focused. Prefer many small files over few large ones.
+
+## Test Quality
+
+- Every test must make at least one meaningful assertion that would fail if the
+  tested behaviour regressed. Empty tests or tests that only assert `true` are
+  not acceptable.
+- Tests must cover both the happy path and the error / edge-case paths.
+- When adding a test for a bug fix, the test must fail without the fix applied.
+
+## Silent Fallback
+
+- Never use a default or fallback value where a missing value indicates a bug
+  or a contract violation. Return `None`, `Err`, or `Option` to force callers
+  to make an explicit decision.
+- Document any intentional fallback with a comment explaining why the default
+  is safe in context.
+
+## Resource Limits
+
+- Never accept unbounded input sizes without a documented limit. If a parser or
+  converter can receive arbitrarily large input, either enforce a limit or document
+  the memory/time complexity and the maximum safe input size.
+- Prefer streaming / incremental processing over loading entire inputs into memory
+  when processing files.
+
+## Unicode Safety
+
+- Do not use byte indices to slice strings that may contain multi-byte characters.
+  Use `.chars()`, `char_indices()`, or crate helpers that respect char boundaries.
+- When byte offsets are unavoidable (e.g., interoperating with ASCII chord lines),
+  document why the bytes are known to be ASCII and add a golden test with a
+  multi-byte lyric to catch regressions.

--- a/.claude/rules/defensive-inputs.md
+++ b/.claude/rules/defensive-inputs.md
@@ -1,0 +1,37 @@
+# Defensive Input Handling
+
+## Public API Validation
+
+Every public function or method that accepts caller-supplied values MUST
+validate them at the boundary before use. Do not rely on downstream code
+to catch bad inputs — validate at the entry point and return `Result` or
+document preconditions with `# Panics`.
+
+### Required practices
+
+- **Range checks**: If a parameter has a valid range, check it and return
+  `Err` on violation. Document the range in the `///` doc comment.
+- **`#[must_use]`**: Functions returning `Result` or `Option` must have
+  `#[must_use]` so callers cannot silently discard errors.
+- **Non-empty checks**: If an empty slice or string is invalid, check and
+  return `Err` rather than relying on loop-exit or sentinel values.
+
+### TOCTOU races
+
+- Never check a resource then act on it in separate steps (check-then-use).
+  Use atomic operations: `File::create_new`, `rename`, `compare-and-swap`.
+- Prefer passing already-opened handles instead of file paths across API
+  boundaries.
+
+### Temporary resource cleanup
+
+- Use RAII guards (e.g. `scopeguard`, `Drop` impls) to clean up temp files
+  and directories. Never rely on caller discipline or process-exit cleanup.
+- Use `tempfile::TempDir` or equivalent; do not manually `fs::remove_dir_all`
+  in `Ok` paths and forget the `Err` path.
+
+## Why
+
+82 public API input validation issues and 14 TOCTOU issues were filed against
+this codebase. The majority were caused by trusting that callers would supply
+valid inputs, or by relying on sequential check-then-act patterns.

--- a/.claude/rules/doc-maintenance.md
+++ b/.claude/rules/doc-maintenance.md
@@ -20,6 +20,13 @@ promptly.
 | New workflow or process introduced | `.claude/rules/` — add new file |
 | Existing rule no longer applies | Remove or update the relevant `.claude/rules/` file |
 | Dependency policy changed | `CLAUDE.md` Dependency Policy section |
+| Public API contract changes | Doc comment on the affected function/struct |
+
+## CI Doc Check
+
+`cargo doc --workspace --no-deps` is run in CI with `RUSTDOCFLAGS="-D warnings"`.
+Doc warnings (broken intra-doc links, missing `# Safety` sections, etc.) are treated
+as errors. Ensure all public items have valid doc comments before pushing.
 
 ## Phase Completion Review
 

--- a/.claude/rules/golden-tests.md
+++ b/.claude/rules/golden-tests.md
@@ -7,3 +7,17 @@
   change in the PR description.
 - New ChordPro directives or syntax support must include at least one golden test before
   merging.
+
+## Stop-Word Collision Tests
+
+When adding or modifying the chord parser or heuristic importer, add at least one
+golden test (or unit test) for each of the following stop-word collision patterns:
+
+- A word that starts with a valid root note letter but is NOT a chord (e.g., `Am` in
+  `Amazing`, `Em` in `Empty`, `G` in `Get`).
+- A section label whose first letter is a valid chord root (e.g., `Chorus`, `Bridge`,
+  `Dm` as a label).
+
+These collisions are the most common source of chord-detection false positives and
+regressions. A test that explicitly asserts rejection prevents future parsers from
+silently accepting them.

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -9,6 +9,25 @@
   - **Acceptance Criteria**: Checkboxes for done-ness
   - **Phase**: Which roadmap phase this belongs to
 
+## Duplicate Prevention
+
+Before creating a new issue, search existing open and closed issues for the same
+root cause:
+
+```bash
+gh issue list -R koedame/chordsketch --state all --search "<keyword>"
+```
+
+If a duplicate exists:
+- If it is **open**: add a comment linking the new reproduction case; do not create a
+  new issue.
+- If it is **closed**: reopen with a comment describing the regression, or create a new
+  issue that explicitly references the closed one and explains why it is a distinct
+  recurrence.
+
+Duplicate issues waste triage time and fragment the discussion. The PR that fixes a
+bug should close all linked issues.
+
 ## Issue Labels
 
 | Category | Labels |

--- a/.claude/rules/renderer-parity.md
+++ b/.claude/rules/renderer-parity.md
@@ -1,0 +1,32 @@
+# Renderer Parity
+
+## Rule
+
+Every ChordPro directive or AST node that is rendered by one renderer MUST
+be handled by **all** renderers (text, HTML, PDF). A missing case in one
+renderer is a correctness bug.
+
+## Required practices
+
+- When adding a new directive or AST node, add rendering support to all
+  three renderers in the same PR (or in explicitly tracked follow-up issues
+  that are linked and prioritised).
+- When fixing a rendering bug in one renderer, check all other renderers for
+  the same bug and fix them in the same PR.
+- Golden tests for each renderer must cover the same set of directives. If
+  a fixture exercises a directive in the text renderer, an equivalent fixture
+  must exist (or be explicitly tracked) for HTML and PDF.
+
+## Audit pattern
+
+Before closing a PR that touches any renderer:
+
+1. Search for all `match` arms on `Line`, `Directive`, or equivalent AST
+   enums in the changed renderer.
+2. Verify every arm exists in the other renderers.
+3. If an arm is missing, either add it or file a sub-issue.
+
+## Why
+
+45 renderer parity issues were filed — the most common was a new directive
+handled in the text renderer but silently ignored or panicking in HTML/PDF.

--- a/.claude/rules/sanitizer-security.md
+++ b/.claude/rules/sanitizer-security.md
@@ -1,0 +1,36 @@
+# Sanitizer and Security Rules
+
+## Sanitizer Bypass Chains
+
+Any string that will be embedded in structured output (ChordPro directives,
+HTML, PDF annotations, JSON) MUST be sanitized before use. Apply sanitizers
+at the **output boundary**, not at the parse boundary.
+
+### Rules
+
+- **ChordPro output**: Strip or escape `{` and `}` from all directive names
+  and values. Use `sanitize_directive_token` (see `heuristic.rs`) or an
+  equivalent at every call site that produces ChordPro text.
+- **HTML output**: Escape `<`, `>`, `&`, `"`, and `'` in any user-supplied
+  string. Never concatenate raw strings into HTML.
+- **No partial sanitization**: If a sanitizer is applied to a value, it must
+  also be applied to the corresponding name field and vice versa. Asymmetric
+  sanitization is a common source of bypass vulnerabilities.
+- **Test sanitization with adversarial inputs**: Every sanitizer must have
+  at least one test containing the exact character being stripped or escaped
+  in both the name and value positions.
+
+## Security Asymmetry
+
+When a security property (e.g. sanitization, access control, rate limiting)
+is applied to one code path, audit all parallel code paths for the same
+property. Asymmetric treatment is a structural vulnerability.
+
+Example: if directive *values* are sanitized, directive *names* must be
+sanitized too — they appear in the same output context.
+
+## Why
+
+53 sanitizer bypass issues and 18 security asymmetry issues were filed.
+The most common pattern was sanitizing only one field of a multi-field
+record, leaving the other fields exploitable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,22 @@ jobs:
       - name: Clippy lints
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  doc:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build docs (warnings as errors)
+        run: cargo doc --workspace --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+
   test:
     name: Test (${{ matrix.os }}, ${{ matrix.rust }})
     runs-on: ${{ matrix.os }}

--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -345,7 +345,7 @@ fn musescore_cmd() -> Option<&'static str> {
 
 /// Returns `true` if MuseScore (`mscore` or `musescore`) is available.
 ///
-/// The result is cached at the process level; see [`musescore_cmd`].
+/// The result is cached at the process level.
 #[must_use]
 pub fn has_musescore() -> bool {
     musescore_cmd().is_some()

--- a/crates/core/src/formatter.rs
+++ b/crates/core/src/formatter.rs
@@ -1,6 +1,6 @@
 //! ChordPro source formatter.
 //!
-//! The [`format`] function normalizes ChordPro text to a canonical style:
+//! The [`format()`] function normalizes ChordPro text to a canonical style:
 //! directive names are expanded to their canonical form, spacing inside
 //! directives is normalized, chord spelling is canonicalized, and blank lines
 //! between sections are made consistent.
@@ -18,7 +18,7 @@
 use crate::ast::DirectiveKind;
 use crate::chord::parse_chord;
 
-/// Options that control which normalizations [`format`] applies.
+/// Options that control which normalizations [`format()`] applies.
 #[derive(Debug, Clone)]
 pub struct FormatOptions {
     /// Expand directive name aliases to their canonical long form.


### PR DESCRIPTION
## What

Addresses the top recurring bug patterns identified in issue #1312 by adding
new `.claude/rules/` files, amending existing ones, and adding a `cargo doc`
CI job.

## New rules files

| File | Patterns covered | Issues |
|---|---|---|
| `defensive-inputs.md` | Public API validation, TOCTOU races, temp resource cleanup | 82 + 14 + 7 |
| `sanitizer-security.md` | Sanitizer bypass chains, security asymmetry | 53 + 18 |
| `renderer-parity.md` | Renderer parity gaps | 45 |

## Amended rules files

| File | Addition |
|---|---|
| `code-style.md` | Test quality, silent fallback, resource limits, Unicode safety |
| `golden-tests.md` | Stop-word collision test requirement |
| `doc-maintenance.md` | Doc/code drift trigger + CI doc check note |
| `issue-workflow.md` | Duplicate prevention guidance |

## CI change

Adds `doc` job to `ci.yml`:

```yaml
- name: Build docs (warnings as errors)
  run: cargo doc --workspace --no-deps
  env:
    RUSTDOCFLAGS: "-D warnings"
```

## Doc warning fixes (pre-existing)

Two intra-doc link warnings existed in the codebase before this PR:

- `crates/core/src/formatter.rs` lines 3 and 21: `[format]` is ambiguous
  (matches both the `format!` macro and the `format()` function in scope).
  Fixed by using `[format()]`.
- `crates/core/src/external_tool.rs` line 348: `[musescore_cmd]` is a
  private function, not linkable from a public doc. Removed the intra-doc
  link.

## Test results

```
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps  # clean
cargo test -p chordsketch-core                              # 35 pass
cargo clippy --workspace --all-targets -- -D warnings       # clean
cargo fmt --check                                           # clean
```

Closes #1312