### PR TITLE
docs(rules): clarify RAII cleanup crate restrictions in defensive-inputs

### DIFF
--- a/.claude/rules/defensive-inputs.md
+++ b/.claude/rules/defensive-inputs.md
@@ -25,10 +25,14 @@ document preconditions with `# Panics`.
 
 ### Temporary resource cleanup
 
-- Use RAII guards (e.g. `scopeguard`, `Drop` impls) to clean up temp files
-  and directories. Never rely on caller discipline or process-exit cleanup.
-- Use `tempfile::TempDir` or equivalent; do not manually `fs::remove_dir_all`
-  in `Ok` paths and forget the `Err` path.
+- Use RAII guards to clean up temp files and directories. Never rely on caller
+  discipline or process-exit cleanup.
+  - **Non-core crates**: prefer the `scopeguard` crate or `tempfile::TempDir`
+    (both are external dependencies).
+  - **`chordsketch-core`**: must use `Drop` impls or other stdlib-only RAII
+    patterns — external crates are prohibited in core.
+- Do not manually call `fs::remove_dir_all` in `Ok` paths and forget the `Err`
+  path; use an RAII type that runs cleanup unconditionally.
 
 ## Why
 


### PR DESCRIPTION
## What

Clarifies the RAII cleanup guidance in `.claude/rules/defensive-inputs.md` to
distinguish between non-core crates (which may use `scopeguard` and
`tempfile::TempDir`) and `chordsketch-core` (which must use `Drop` impls or
stdlib-only RAII patterns due to the zero-external-dependencies policy).

## Why

A contributor following the rule as written might attempt to add `scopeguard`
or `tempfile` to `chordsketch-core`, violating the dependency policy in
`CLAUDE.md`. The clarification removes the ambiguity.

## Changes

- `.claude/rules/defensive-inputs.md`: rewrites the "Temporary resource cleanup"
  bullet to separate core vs non-core crate guidance.

## Test results

Documentation-only change; no build artefacts affected.

Closes #1320