### PR TITLE
ci: wire check-action-pins.sh into CI and use printf for POSIX safety

### DIFF
--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -1,0 +1,31 @@
+name: Check Action Pins
+
+# Verify that all GitHub Actions 'uses:' references in workflow files are
+# pinned to an immutable SHA (40-char git commit SHA or docker sha256 digest).
+# Mutable tags (@v3, @main) are rejected.
+#
+# This is a global-property check: any workflow file in the repo could
+# introduce an unpinned reference, so we run on every PR regardless of which
+# files it touches — no paths: filter. Same reasoning applies to push: main.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-action-pins-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-action-pins:
+    name: Verify all action refs are SHA-pinned
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check action pins
+        run: ./scripts/check-action-pins.sh .github

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -19,14 +19,14 @@ FOUND=0
 while IFS= read -r -d '' file; do
   while IFS= read -r line; do
     # Match "uses: owner/repo@REF" or "uses: docker://image@REF"
-    if echo "$line" | grep -qE '^\s*uses:\s+[^@]+@[^#[:space:]]+'; then
-      ref=$(echo "$line" | sed -E 's/.*@([^# ]+).*/\1/')
+    if printf '%s\n' "$line" | grep -qE '^\s*uses:\s+[^@]+@[^#[:space:]]+'; then
+      ref=$(printf '%s\n' "$line" | sed -E 's/.*@([^# ]+).*/\1/')
       # Accept a 40-char git commit SHA
-      if echo "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+      if printf '%s\n' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
         continue
       fi
       # Accept a Docker image digest: sha256:<64-char hex>
-      if echo "$ref" | grep -qE '^sha256:[0-9a-f]{64}$'; then
+      if printf '%s\n' "$ref" | grep -qE '^sha256:[0-9a-f]{64}$'; then
         continue
       fi
       echo "NOT SHA-PINNED: $file"


### PR DESCRIPTION
## What

- Add `.github/workflows/check-action-pins.yml` to enforce the SHA-pinning invariant for all GitHub Actions `uses:` references on every PR and push to `main`.
- Replace `echo "$line"` / `echo "$ref"` with `printf '%s\n' "$line"` / `printf '%s\n' "$ref"` throughout `scripts/check-action-pins.sh` for POSIX safety.

## Why

`scripts/check-action-pins.sh` was added in #1322 but was never wired into CI. Without enforcement, a future PR could introduce an unpinned action reference that would only be caught by manual script execution.

The `echo` builtin may misinterpret leading flags (e.g. `-n`, `-e`) in the string as options depending on the shell implementation. `printf '%s\n'` is the POSIX-safe alternative.

The workflow runs on every PR without a `paths:` filter because SHA-pinning is a global repository invariant — any workflow file could introduce an unpinned reference, so restricting by path would produce a false sense of safety.

## Test results

```
$ ./scripts/check-action-pins.sh .github
All action references are SHA-pinned.
```

## Review summary

Both issues are addressed in a single commit. The workflow file is itself checked by the script and passes the SHA-pin verification.

Closes #1323
Closes #1324