### PR TITLE
fix(ci): scan *.yaml workflow files in check-action-pins.sh

### DIFF
--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -34,7 +34,7 @@ while IFS= read -r -d '' file; do
       FOUND=1
     fi
   done < "$file"
-done < <(find "$WORKFLOWS_DIR" -name '*.yml' -print0)
+done < <(find "$WORKFLOWS_DIR" \( -name '*.yml' -o -name '*.yaml' \) -print0)
 
 if [ "$FOUND" -eq 1 ]; then
   echo ""


### PR DESCRIPTION
## What

Extend the \`find\` invocation in \`scripts/check-action-pins.sh\` to match both \`*.yml\` and \`*.yaml\` workflow files.

## Why

GitHub Actions supports both \`.yml\` and \`.yaml\` as workflow file extensions. The previous pattern (\`-name '*.yml'\`) would silently skip any \`*.yaml\` file, allowing an unpinned action reference to pass the pin check undetected.

No \`.yaml\` files currently exist in \`.github/\`, so this is a defense-in-depth fix rather than an immediate regression.

## Test results

```
# .yaml file with unpinned ref is correctly rejected (exit 1)
$ printf 'jobs:\n  test:\n    steps:\n      uses: actions/checkout@v3\n' \
    > /tmp/test.yaml
$ ./scripts/check-action-pins.sh /tmp
NOT SHA-PINNED: /tmp/.github/workflows/test.yaml
        uses: actions/checkout@v3
...
exit=1

# Existing .github directory still passes (exit 0)
$ ./scripts/check-action-pins.sh .github
All action references are SHA-pinned.
```

## Review summary

Single-line change to the \`find\` pattern. No other behaviour changes.

Closes #1326