### PR TITLE
feat: add piano/keyboard chord voicing support

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -178,6 +178,39 @@ impl Song {
         result
     }
 
+    /// Returns keyboard chord definitions as `(name, keys)` pairs.
+    ///
+    /// Scans `{define}` / `{chord}` directives for entries that use the `keys`
+    /// attribute (e.g., `{define: Am keys 0 3 7}`). Fretted, copy, and
+    /// display-only definitions are excluded.  Later definitions override
+    /// earlier ones for the same chord name.
+    ///
+    /// The `keys` values are the raw integers from the directive — typically
+    /// MIDI note numbers (0–127) or semitone offsets.
+    #[must_use]
+    pub fn keyboard_defines(&self) -> Vec<(String, Vec<i32>)> {
+        let mut result: Vec<(String, Vec<i32>)> = Vec::new();
+        for line in &self.lines {
+            if let Line::Directive(directive) = line {
+                if directive.kind == DirectiveKind::Define
+                    || directive.kind == DirectiveKind::ChordDirective
+                {
+                    if let Some(ref value) = directive.value {
+                        let def = ChordDefinition::parse_value(value);
+                        if let Some(keys) = def.keys {
+                            if let Some(pos) = result.iter().position(|(n, _)| *n == def.name) {
+                                result[pos].1 = keys;
+                            } else {
+                                result.push((def.name, keys));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+
     /// Returns the unique chord names used in the song, in order of first appearance.
     ///
     /// Scans every [`LyricsSegment`] in every [`LyricsLine`] in the song. The

--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -402,12 +402,234 @@ pub fn render_ascii(data: &DiagramData) -> String {
     }
 }
 
+/// Data needed to render a keyboard (piano) chord diagram.
+///
+/// MIDI note numbers (0–127) identify which keys to highlight. Values in
+/// the range 0–11 are treated as pitch-class offsets (C=0 … B=11) and
+/// automatically mapped to octave 4 (MIDI 60–71) for display.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_core::chord_diagram::{KeyboardVoicing, render_keyboard_svg};
+///
+/// let v = KeyboardVoicing {
+///     name: "Cmaj7".to_string(),
+///     display_name: None,
+///     keys: vec![60, 64, 67, 71],
+///     root_key: 60,
+/// };
+/// let svg = render_keyboard_svg(&v);
+/// assert!(svg.contains("<svg"));
+/// assert!(svg.contains("Cmaj7"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct KeyboardVoicing {
+    /// Chord name (identifier used for matching).
+    pub name: String,
+    /// Display name override from `{define}` `display` attribute.
+    ///
+    /// When present, diagram titles show this instead of `name`.
+    pub display_name: Option<String>,
+    /// MIDI note numbers (0–127) for the chord tones to highlight.
+    ///
+    /// When all values are in the range 0–11 they are treated as
+    /// pitch-class offsets (C=0 … B=11) and displayed in octave 4
+    /// (MIDI 60–71).
+    pub keys: Vec<u8>,
+    /// MIDI note number of the root key.
+    ///
+    /// Displayed with extra visual emphasis (darker fill). When `keys` are
+    /// normalised from pitch classes, `root_key` is normalised accordingly.
+    pub root_key: u8,
+}
+
+impl KeyboardVoicing {
+    /// Returns the title to display above the diagram.
+    ///
+    /// Uses the `display_name` override if present, otherwise falls back to `name`.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        self.display_name.as_deref().unwrap_or(&self.name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard SVG layout constants
+// ---------------------------------------------------------------------------
+
+/// White key width in pixels for keyboard diagrams.
+const KBD_WHITE_W: f32 = 15.0;
+/// White key height in pixels.
+const KBD_WHITE_H: f32 = 60.0;
+/// Black key width in pixels.
+const KBD_BLACK_W: f32 = 9.0;
+/// Black key height in pixels.
+const KBD_BLACK_H: f32 = 36.0;
+/// Vertical space above keyboard for the chord name.
+const KBD_TOP_PAD: f32 = 30.0;
+/// Horizontal margin on each side.
+const KBD_SIDE_PAD: f32 = 8.0;
+
+/// White key semitone offsets within an octave and their left-edge x-offsets
+/// (in pixels, relative to the octave's starting C key).
+const WHITE_KEY_POSITIONS: [(u8, f32); 7] = [
+    (0, 0.0 * KBD_WHITE_W),  // C
+    (2, 1.0 * KBD_WHITE_W),  // D
+    (4, 2.0 * KBD_WHITE_W),  // E
+    (5, 3.0 * KBD_WHITE_W),  // F
+    (7, 4.0 * KBD_WHITE_W),  // G
+    (9, 5.0 * KBD_WHITE_W),  // A
+    (11, 6.0 * KBD_WHITE_W), // B
+];
+
+/// Black key semitone offsets within an octave and their left-edge x-offsets
+/// (in pixels, relative to the octave's starting C key).
+///
+/// Each black key is centred at the boundary between its two adjacent white
+/// keys: `left_edge = (right_edge_of_left_white) - BLACK_W / 2`.
+const BLACK_KEY_POSITIONS: [(u8, f32); 5] = [
+    (1, 10.0),  // C# (between C and D: 15 − 4.5 ≈ 10)
+    (3, 25.0),  // D# (between D and E: 30 − 4.5 ≈ 25)
+    (6, 55.0),  // F# (between F and G: 60 − 4.5 ≈ 55)
+    (8, 70.0),  // G# (between G and A: 75 − 4.5 ≈ 70)
+    (10, 85.0), // A# (between A and B: 90 − 4.5 ≈ 85)
+];
+
+/// Normalise `keys` and `root_key` for display.
+///
+/// When all keys are in 0–11 (pitch classes), shifts them to octave 4
+/// (adds 60). Otherwise returns them unchanged.
+fn normalise_keyboard_keys(keys: &[u8], root_key: u8) -> (Vec<u8>, u8) {
+    if keys.iter().all(|&k| k < 12) {
+        let normalised: Vec<u8> = keys.iter().map(|&k| k.saturating_add(60)).collect();
+        let root = if root_key < 12 {
+            root_key.saturating_add(60)
+        } else {
+            root_key
+        };
+        (normalised, root)
+    } else {
+        (keys.to_vec(), root_key)
+    }
+}
+
+/// Render a keyboard chord diagram as an inline SVG string.
+///
+/// Shows the piano octave(s) containing the chord tones, with highlighted
+/// keys for each chord tone and extra emphasis on the root key.
+///
+/// Returns an empty string when `voicing.keys` is empty.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_core::chord_diagram::{KeyboardVoicing, render_keyboard_svg};
+///
+/// let v = KeyboardVoicing {
+///     name: "Am".to_string(),
+///     display_name: None,
+///     keys: vec![69, 72, 76],
+///     root_key: 69,
+/// };
+/// let svg = render_keyboard_svg(&v);
+/// assert!(svg.contains("<svg"));
+/// assert!(svg.contains("Am"));
+/// assert!(svg.contains("class=\"keyboard-diagram\""));
+/// ```
+#[must_use]
+pub fn render_keyboard_svg(voicing: &KeyboardVoicing) -> String {
+    if voicing.keys.is_empty() {
+        return String::new();
+    }
+
+    let (keys, root) = normalise_keyboard_keys(&voicing.keys, voicing.root_key);
+
+    let min_key = *keys.iter().min().unwrap_or(&60);
+    let max_key = *keys.iter().max().unwrap_or(&71);
+
+    // Start from C of the octave containing the lowest key.
+    let start_octave = u32::from(min_key / 12);
+    let end_octave = u32::from(max_key / 12);
+    // Show at least 2 octaves, cap at 3 for readability.
+    let num_octaves = ((end_octave - start_octave) + 1).clamp(2, 3) as usize;
+    let start_midi = (start_octave * 12) as u8;
+
+    let kbd_w = num_octaves as f32 * 7.0 * KBD_WHITE_W;
+    let total_w = kbd_w + KBD_SIDE_PAD * 2.0;
+    let total_h = KBD_TOP_PAD + KBD_WHITE_H + 8.0;
+
+    let mut svg = format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{total_w}\" height=\"{total_h}\" \
+         viewBox=\"0 0 {total_w} {total_h}\" class=\"keyboard-diagram\">\n"
+    );
+
+    // Chord name label
+    let name_x = total_w / 2.0;
+    svg.push_str(&format!(
+        "<text x=\"{name_x}\" y=\"15\" text-anchor=\"middle\" \
+         font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\">{}</text>\n",
+        crate::escape::escape_xml(voicing.title())
+    ));
+
+    // --- Draw white keys first (black keys are drawn on top) ---
+    for oct in 0..num_octaves {
+        let oct_midi = start_midi.saturating_add((oct * 12) as u8);
+        let oct_x = KBD_SIDE_PAD + oct as f32 * 7.0 * KBD_WHITE_W;
+        for (semitone, x_off) in WHITE_KEY_POSITIONS {
+            let midi = oct_midi.saturating_add(semitone);
+            let x = oct_x + x_off;
+            let highlighted = keys.contains(&midi);
+            let is_root = highlighted && midi == root;
+            let fill = if is_root {
+                "#1a5fb4" // root key: dark blue
+            } else if highlighted {
+                "#4a90e2" // chord tone: medium blue
+            } else {
+                "white"
+            };
+            svg.push_str(&format!(
+                "<rect x=\"{x}\" y=\"{KBD_TOP_PAD}\" width=\"{KBD_WHITE_W}\" \
+                 height=\"{KBD_WHITE_H}\" fill=\"{fill}\" stroke=\"black\" \
+                 stroke-width=\"0.5\"/>\n"
+            ));
+        }
+    }
+
+    // --- Draw black keys on top ---
+    for oct in 0..num_octaves {
+        let oct_midi = start_midi.saturating_add((oct * 12) as u8);
+        let oct_x = KBD_SIDE_PAD + oct as f32 * 7.0 * KBD_WHITE_W;
+        for (semitone, x_off) in BLACK_KEY_POSITIONS {
+            let midi = oct_midi.saturating_add(semitone);
+            let x = oct_x + x_off;
+            let highlighted = keys.contains(&midi);
+            let is_root = highlighted && midi == root;
+            let fill = if is_root {
+                "#1a5fb4" // root: dark blue
+            } else if highlighted {
+                "#4a90e2" // chord tone: medium blue (contrasts with default dark key)
+            } else {
+                "#222" // normal black key
+            };
+            svg.push_str(&format!(
+                "<rect x=\"{x}\" y=\"{KBD_TOP_PAD}\" width=\"{KBD_BLACK_W}\" \
+                 height=\"{KBD_BLACK_H}\" fill=\"{fill}\" stroke=\"black\" \
+                 stroke-width=\"0.5\"/>\n"
+            ));
+        }
+    }
+
+    svg.push_str("</svg>");
+    svg
+}
+
 /// Resolves the active instrument for a `{diagrams}` directive value.
 ///
 /// Returns `None` when diagrams are disabled (`value` is `"off"`,
 /// case-insensitive).  Returns `Some(instrument_name)` otherwise, normalising
-/// known aliases (`"uke"` → `"ukulele"`) and falling back to
-/// `default_instrument` for unrecognised values.
+/// known aliases (`"uke"` → `"ukulele"`, `"keyboard"` / `"keys"` → `"piano"`)
+/// and falling back to `default_instrument` for unrecognised values.
 ///
 /// This helper is shared by all renderer crates so the instrument-matching
 /// logic stays in one place.
@@ -420,7 +642,10 @@ pub fn render_ascii(data: &DiagramData) -> String {
 /// assert_eq!(resolve_diagrams_instrument(None, "guitar"), Some("guitar".to_string()));
 /// assert_eq!(resolve_diagrams_instrument(Some("off"), "guitar"), None);
 /// assert_eq!(resolve_diagrams_instrument(Some("uke"), "guitar"), Some("ukulele".to_string()));
-/// assert_eq!(resolve_diagrams_instrument(Some("piano"), "guitar"), Some("guitar".to_string()));
+/// assert_eq!(resolve_diagrams_instrument(Some("piano"), "guitar"), Some("piano".to_string()));
+/// assert_eq!(resolve_diagrams_instrument(Some("keys"), "guitar"), Some("piano".to_string()));
+/// assert_eq!(resolve_diagrams_instrument(Some("keyboard"), "guitar"), Some("piano".to_string()));
+/// assert_eq!(resolve_diagrams_instrument(Some("unknown"), "guitar"), Some("guitar".to_string()));
 /// ```
 #[must_use]
 pub fn resolve_diagrams_instrument(
@@ -434,6 +659,7 @@ pub fn resolve_diagrams_instrument(
     let instr = match val.to_ascii_lowercase().as_str() {
         "ukulele" | "uke" => "ukulele",
         "guitar" => "guitar",
+        "piano" | "keyboard" | "keys" => "piano",
         _ => default_instrument,
     };
     Some(instr.to_string())
@@ -1166,5 +1392,98 @@ mod tests {
         let data = DiagramData::from_raw_infer("X", "frets 1 2 3").unwrap();
         assert_eq!(data.strings, 3);
         assert_eq!(data.frets.len(), 3);
+    }
+
+    // ---------------------------------------------------------------------------
+    // KeyboardVoicing and render_keyboard_svg tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_render_keyboard_svg_absolute_midi() {
+        let v = KeyboardVoicing {
+            name: "Cmaj7".to_string(),
+            display_name: None,
+            keys: vec![60, 64, 67, 71],
+            root_key: 60,
+        };
+        let svg = render_keyboard_svg(&v);
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("</svg>"));
+        assert!(svg.contains("Cmaj7"));
+        assert!(svg.contains("class=\"keyboard-diagram\""));
+        // Highlighted keys use blue fill
+        assert!(svg.contains("#4a90e2") || svg.contains("#1a5fb4"));
+    }
+
+    #[test]
+    fn test_render_keyboard_svg_pitch_classes_normalised_to_octave4() {
+        // keys 0 3 7 (pitch classes) should be shown in octave 4
+        let v = KeyboardVoicing {
+            name: "Am".to_string(),
+            display_name: None,
+            keys: vec![0, 3, 7],
+            root_key: 0,
+        };
+        let svg = render_keyboard_svg(&v);
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("Am"));
+    }
+
+    #[test]
+    fn test_render_keyboard_svg_empty_keys_returns_empty() {
+        let v = KeyboardVoicing {
+            name: "X".to_string(),
+            display_name: None,
+            keys: vec![],
+            root_key: 60,
+        };
+        assert_eq!(render_keyboard_svg(&v), "");
+    }
+
+    #[test]
+    fn test_render_keyboard_svg_display_name_override() {
+        let v = KeyboardVoicing {
+            name: "Am".to_string(),
+            display_name: Some("A minor".to_string()),
+            keys: vec![69, 72, 76],
+            root_key: 69,
+        };
+        let svg = render_keyboard_svg(&v);
+        assert!(svg.contains("A minor"));
+        assert!(!svg.contains(">Am<"));
+    }
+
+    #[test]
+    fn test_keyboard_voicing_title() {
+        let v = KeyboardVoicing {
+            name: "G".to_string(),
+            display_name: Some("G major".to_string()),
+            keys: vec![67, 71, 74],
+            root_key: 67,
+        };
+        assert_eq!(v.title(), "G major");
+        let v2 = KeyboardVoicing {
+            name: "G".to_string(),
+            display_name: None,
+            keys: vec![67, 71, 74],
+            root_key: 67,
+        };
+        assert_eq!(v2.title(), "G");
+    }
+
+    #[test]
+    fn test_resolve_diagrams_instrument_piano() {
+        assert_eq!(
+            resolve_diagrams_instrument(Some("piano"), "guitar"),
+            Some("piano".to_string())
+        );
+        assert_eq!(
+            resolve_diagrams_instrument(Some("keys"), "guitar"),
+            Some("piano".to_string())
+        );
+        assert_eq!(
+            resolve_diagrams_instrument(Some("keyboard"), "guitar"),
+            Some("piano".to_string())
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -37,7 +37,9 @@ pub use parser::{
 };
 pub use render_result::RenderResult;
 pub use token::{Position, Span, Token, TokenKind};
-pub use voicings::{guitar_voicing, lookup_diagram, ukulele_voicing};
+pub use voicings::{
+    guitar_voicing, keyboard_voicing, lookup_diagram, lookup_keyboard_voicing, ukulele_voicing,
+};
 
 /// Returns the library version.
 #[must_use]

--- a/crates/core/src/voicings.rs
+++ b/crates/core/src/voicings.rs
@@ -734,6 +734,431 @@ pub fn lookup_diagram(
 }
 
 // ---------------------------------------------------------------------------
+// Piano / keyboard voicings
+// ---------------------------------------------------------------------------
+
+use crate::chord_diagram::KeyboardVoicing;
+
+/// Internal static piano voicing record.
+struct StaticKeyVoicing {
+    /// Chord name (sharp spelling).
+    name: &'static str,
+    /// MIDI note numbers for the chord tones (absolute, octave 4 unless noted).
+    keys: &'static [u8],
+    /// MIDI note number of the root key.
+    root_key: u8,
+}
+
+impl StaticKeyVoicing {
+    fn to_voicing(&self, requested_name: &str) -> KeyboardVoicing {
+        KeyboardVoicing {
+            name: requested_name.to_string(),
+            display_name: None,
+            keys: self.keys.to_vec(),
+            root_key: self.root_key,
+        }
+    }
+}
+
+// Piano major voicings – root position, octave 4 (C4 = MIDI 60).
+// Intervals: root (R), major third (+4), perfect fifth (+7).
+const PIANO_MAJOR: &[StaticKeyVoicing] = &[
+    StaticKeyVoicing {
+        name: "C",
+        keys: &[60, 64, 67],
+        root_key: 60,
+    },
+    StaticKeyVoicing {
+        name: "C#",
+        keys: &[61, 65, 68],
+        root_key: 61,
+    },
+    StaticKeyVoicing {
+        name: "D",
+        keys: &[62, 66, 69],
+        root_key: 62,
+    },
+    StaticKeyVoicing {
+        name: "D#",
+        keys: &[63, 67, 70],
+        root_key: 63,
+    },
+    StaticKeyVoicing {
+        name: "E",
+        keys: &[64, 68, 71],
+        root_key: 64,
+    },
+    StaticKeyVoicing {
+        name: "F",
+        keys: &[65, 69, 72],
+        root_key: 65,
+    },
+    StaticKeyVoicing {
+        name: "F#",
+        keys: &[66, 70, 73],
+        root_key: 66,
+    },
+    StaticKeyVoicing {
+        name: "G",
+        keys: &[67, 71, 74],
+        root_key: 67,
+    },
+    StaticKeyVoicing {
+        name: "G#",
+        keys: &[68, 72, 75],
+        root_key: 68,
+    },
+    StaticKeyVoicing {
+        name: "A",
+        keys: &[69, 73, 76],
+        root_key: 69,
+    },
+    StaticKeyVoicing {
+        name: "A#",
+        keys: &[70, 74, 77],
+        root_key: 70,
+    },
+    StaticKeyVoicing {
+        name: "B",
+        keys: &[71, 75, 78],
+        root_key: 71,
+    },
+];
+
+// Piano minor voicings.
+// Intervals: root, minor third (+3), perfect fifth (+7).
+const PIANO_MINOR: &[StaticKeyVoicing] = &[
+    StaticKeyVoicing {
+        name: "Cm",
+        keys: &[60, 63, 67],
+        root_key: 60,
+    },
+    StaticKeyVoicing {
+        name: "C#m",
+        keys: &[61, 64, 68],
+        root_key: 61,
+    },
+    StaticKeyVoicing {
+        name: "Dm",
+        keys: &[62, 65, 69],
+        root_key: 62,
+    },
+    StaticKeyVoicing {
+        name: "D#m",
+        keys: &[63, 66, 70],
+        root_key: 63,
+    },
+    StaticKeyVoicing {
+        name: "Em",
+        keys: &[64, 67, 71],
+        root_key: 64,
+    },
+    StaticKeyVoicing {
+        name: "Fm",
+        keys: &[65, 68, 72],
+        root_key: 65,
+    },
+    StaticKeyVoicing {
+        name: "F#m",
+        keys: &[66, 69, 73],
+        root_key: 66,
+    },
+    StaticKeyVoicing {
+        name: "Gm",
+        keys: &[67, 70, 74],
+        root_key: 67,
+    },
+    StaticKeyVoicing {
+        name: "G#m",
+        keys: &[68, 71, 75],
+        root_key: 68,
+    },
+    StaticKeyVoicing {
+        name: "Am",
+        keys: &[69, 72, 76],
+        root_key: 69,
+    },
+    StaticKeyVoicing {
+        name: "A#m",
+        keys: &[70, 73, 77],
+        root_key: 70,
+    },
+    StaticKeyVoicing {
+        name: "Bm",
+        keys: &[71, 74, 78],
+        root_key: 71,
+    },
+];
+
+// Piano dominant-seventh voicings.
+// Intervals: root, major third (+4), perfect fifth (+7), minor seventh (+10).
+const PIANO_DOM7: &[StaticKeyVoicing] = &[
+    StaticKeyVoicing {
+        name: "C7",
+        keys: &[60, 64, 67, 70],
+        root_key: 60,
+    },
+    StaticKeyVoicing {
+        name: "C#7",
+        keys: &[61, 65, 68, 71],
+        root_key: 61,
+    },
+    StaticKeyVoicing {
+        name: "D7",
+        keys: &[62, 66, 69, 72],
+        root_key: 62,
+    },
+    StaticKeyVoicing {
+        name: "D#7",
+        keys: &[63, 67, 70, 73],
+        root_key: 63,
+    },
+    StaticKeyVoicing {
+        name: "E7",
+        keys: &[64, 68, 71, 74],
+        root_key: 64,
+    },
+    StaticKeyVoicing {
+        name: "F7",
+        keys: &[65, 69, 72, 75],
+        root_key: 65,
+    },
+    StaticKeyVoicing {
+        name: "F#7",
+        keys: &[66, 70, 73, 76],
+        root_key: 66,
+    },
+    StaticKeyVoicing {
+        name: "G7",
+        keys: &[67, 71, 74, 77],
+        root_key: 67,
+    },
+    StaticKeyVoicing {
+        name: "G#7",
+        keys: &[68, 72, 75, 78],
+        root_key: 68,
+    },
+    StaticKeyVoicing {
+        name: "A7",
+        keys: &[69, 73, 76, 79],
+        root_key: 69,
+    },
+    StaticKeyVoicing {
+        name: "A#7",
+        keys: &[70, 74, 77, 80],
+        root_key: 70,
+    },
+    StaticKeyVoicing {
+        name: "B7",
+        keys: &[71, 75, 78, 81],
+        root_key: 71,
+    },
+];
+
+// Piano major-seventh voicings.
+// Intervals: root, major third (+4), perfect fifth (+7), major seventh (+11).
+const PIANO_MAJ7: &[StaticKeyVoicing] = &[
+    StaticKeyVoicing {
+        name: "Cmaj7",
+        keys: &[60, 64, 67, 71],
+        root_key: 60,
+    },
+    StaticKeyVoicing {
+        name: "C#maj7",
+        keys: &[61, 65, 68, 72],
+        root_key: 61,
+    },
+    StaticKeyVoicing {
+        name: "Dmaj7",
+        keys: &[62, 66, 69, 73],
+        root_key: 62,
+    },
+    StaticKeyVoicing {
+        name: "D#maj7",
+        keys: &[63, 67, 70, 74],
+        root_key: 63,
+    },
+    StaticKeyVoicing {
+        name: "Emaj7",
+        keys: &[64, 68, 71, 75],
+        root_key: 64,
+    },
+    StaticKeyVoicing {
+        name: "Fmaj7",
+        keys: &[65, 69, 72, 76],
+        root_key: 65,
+    },
+    StaticKeyVoicing {
+        name: "F#maj7",
+        keys: &[66, 70, 73, 77],
+        root_key: 66,
+    },
+    StaticKeyVoicing {
+        name: "Gmaj7",
+        keys: &[67, 71, 74, 78],
+        root_key: 67,
+    },
+    StaticKeyVoicing {
+        name: "G#maj7",
+        keys: &[68, 72, 75, 79],
+        root_key: 68,
+    },
+    StaticKeyVoicing {
+        name: "Amaj7",
+        keys: &[69, 73, 76, 80],
+        root_key: 69,
+    },
+    StaticKeyVoicing {
+        name: "A#maj7",
+        keys: &[70, 74, 77, 81],
+        root_key: 70,
+    },
+    StaticKeyVoicing {
+        name: "Bmaj7",
+        keys: &[71, 75, 78, 82],
+        root_key: 71,
+    },
+];
+
+// Piano minor-seventh voicings.
+// Intervals: root, minor third (+3), perfect fifth (+7), minor seventh (+10).
+const PIANO_MIN7: &[StaticKeyVoicing] = &[
+    StaticKeyVoicing {
+        name: "Cm7",
+        keys: &[60, 63, 67, 70],
+        root_key: 60,
+    },
+    StaticKeyVoicing {
+        name: "C#m7",
+        keys: &[61, 64, 68, 71],
+        root_key: 61,
+    },
+    StaticKeyVoicing {
+        name: "Dm7",
+        keys: &[62, 65, 69, 72],
+        root_key: 62,
+    },
+    StaticKeyVoicing {
+        name: "D#m7",
+        keys: &[63, 66, 70, 73],
+        root_key: 63,
+    },
+    StaticKeyVoicing {
+        name: "Em7",
+        keys: &[64, 67, 71, 74],
+        root_key: 64,
+    },
+    StaticKeyVoicing {
+        name: "Fm7",
+        keys: &[65, 68, 72, 75],
+        root_key: 65,
+    },
+    StaticKeyVoicing {
+        name: "F#m7",
+        keys: &[66, 69, 73, 76],
+        root_key: 66,
+    },
+    StaticKeyVoicing {
+        name: "Gm7",
+        keys: &[67, 70, 74, 77],
+        root_key: 67,
+    },
+    StaticKeyVoicing {
+        name: "G#m7",
+        keys: &[68, 71, 75, 78],
+        root_key: 68,
+    },
+    StaticKeyVoicing {
+        name: "Am7",
+        keys: &[69, 72, 76, 79],
+        root_key: 69,
+    },
+    StaticKeyVoicing {
+        name: "A#m7",
+        keys: &[70, 73, 77, 80],
+        root_key: 70,
+    },
+    StaticKeyVoicing {
+        name: "Bm7",
+        keys: &[71, 74, 78, 81],
+        root_key: 71,
+    },
+];
+
+/// Looks up a built-in piano/keyboard voicing for `chord_name`.
+///
+/// Returns `None` if no voicing is available for the requested chord.
+/// Accepts both sharp and flat spellings (e.g., `"Bb"` → same as `"A#"`).
+///
+/// The built-in database covers major, minor, dominant-seventh, major-seventh,
+/// and minor-seventh chord families for all twelve roots.
+#[must_use]
+pub fn keyboard_voicing(chord_name: &str) -> Option<KeyboardVoicing> {
+    let canonical = flat_to_sharp(chord_name);
+    let name = canonical.as_deref().unwrap_or(chord_name);
+    let tables: &[&[StaticKeyVoicing]] =
+        &[PIANO_MAJOR, PIANO_MINOR, PIANO_DOM7, PIANO_MAJ7, PIANO_MIN7];
+    for table in tables {
+        if let Some(v) = table.iter().find(|v| v.name == name) {
+            return Some(v.to_voicing(chord_name));
+        }
+    }
+    None
+}
+
+/// Looks up a keyboard voicing by chord name using a prioritised chain.
+///
+/// # Lookup order
+///
+/// 1. `keyboard_defines` — `{define: Name keys n1 n2 ...}` entries from the
+///    song file (highest priority).
+/// 2. Built-in piano voicing database ([`keyboard_voicing`]).
+///
+/// Returns `None` when no voicing is found.
+///
+/// # Parameters
+///
+/// - `chord_name` — chord name as it appears in the lyrics (e.g., `"Am"`, `"Cmaj7"`).
+/// - `keyboard_defines` — list of `(name, keys)` pairs from keyboard `{define}`
+///   directives. Obtain via [`Song::keyboard_defines`](crate::ast::Song::keyboard_defines).
+#[must_use]
+pub fn lookup_keyboard_voicing(
+    chord_name: &str,
+    keyboard_defines: &[(String, Vec<i32>)],
+) -> Option<KeyboardVoicing> {
+    // 1. Song-level {define: name keys ...} directives take priority.
+    let canonical_owned = flat_to_sharp(chord_name);
+    let canonical = canonical_owned.as_deref().unwrap_or(chord_name);
+    if let Some((_, keys)) = keyboard_defines.iter().find(|(n, _)| {
+        let cn_owned = flat_to_sharp(n.as_str());
+        let cn = cn_owned.as_deref().unwrap_or(n.as_str());
+        cn == canonical
+    }) {
+        let keys_u8: Vec<u8> = keys
+            .iter()
+            .filter_map(|&k| {
+                if (0i32..=127).contains(&k) {
+                    Some(k as u8)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !keys_u8.is_empty() {
+            let root = keys_u8[0];
+            return Some(KeyboardVoicing {
+                name: chord_name.to_string(),
+                display_name: None,
+                keys: keys_u8,
+                root_key: root,
+            });
+        }
+    }
+    // 2. Built-in database.
+    keyboard_voicing(chord_name)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1049,5 +1474,66 @@ mod tests {
         )];
         let d = lookup_diagram("A#", &defines, "guitar", 5).unwrap();
         assert_eq!(d.frets, vec![1, 2, 3, 4, 5, 1]);
+    }
+
+    // --- piano / keyboard voicing lookups ---
+
+    #[test]
+    fn piano_major_c_voicing() {
+        let v = keyboard_voicing("C").unwrap();
+        assert_eq!(v.keys, vec![60, 64, 67]);
+        assert_eq!(v.root_key, 60);
+        assert_eq!(v.name, "C");
+    }
+
+    #[test]
+    fn piano_minor_am_voicing() {
+        let v = keyboard_voicing("Am").unwrap();
+        assert_eq!(v.keys, vec![69, 72, 76]);
+        assert_eq!(v.root_key, 69);
+    }
+
+    #[test]
+    fn piano_maj7_cmaj7_voicing() {
+        let v = keyboard_voicing("Cmaj7").unwrap();
+        assert_eq!(v.keys, vec![60, 64, 67, 71]);
+        assert_eq!(v.root_key, 60);
+    }
+
+    #[test]
+    fn piano_flat_alias_bb() {
+        // Bb is stored as A#; lookup_keyboard_voicing with flat name should work.
+        let v = keyboard_voicing("Bb").unwrap();
+        // name preserved as requested
+        assert_eq!(v.name, "Bb");
+        // keys are for A# major (same as Bb major)
+        assert_eq!(v.keys, vec![70, 74, 77]);
+    }
+
+    #[test]
+    fn piano_unknown_chord_returns_none() {
+        assert!(keyboard_voicing("Xyzzy").is_none());
+    }
+
+    #[test]
+    fn lookup_keyboard_voicing_define_overrides_builtin() {
+        let defines = vec![("Am".to_string(), vec![57i32, 60, 64])];
+        let v = lookup_keyboard_voicing("Am", &defines).unwrap();
+        assert_eq!(v.keys, vec![57, 60, 64]);
+        assert_eq!(v.root_key, 57);
+    }
+
+    #[test]
+    fn lookup_keyboard_voicing_falls_back_to_builtin() {
+        let v = lookup_keyboard_voicing("G7", &[]).unwrap();
+        assert_eq!(v.keys, vec![67, 71, 74, 77]);
+    }
+
+    #[test]
+    fn lookup_keyboard_voicing_flat_sharp_alias_in_define() {
+        // Define uses A# but lookup uses Bb
+        let defines = vec![("A#".to_string(), vec![58i32, 62, 65])];
+        let v = lookup_keyboard_voicing("Bb", &defines).unwrap();
+        assert_eq!(v.keys, vec![58, 62, 65]);
     }
 }

--- a/crates/core/src/voicings.rs
+++ b/crates/core/src/voicings.rs
@@ -1121,6 +1121,13 @@ pub fn keyboard_voicing(chord_name: &str) -> Option<KeyboardVoicing> {
 /// - `chord_name` — chord name as it appears in the lyrics (e.g., `"Am"`, `"Cmaj7"`).
 /// - `keyboard_defines` — list of `(name, keys)` pairs from keyboard `{define}`
 ///   directives. Obtain via [`Song::keyboard_defines`](crate::ast::Song::keyboard_defines).
+///
+/// # Root key convention
+///
+/// When a voicing is constructed from a song-level `{define}` entry, the
+/// **first key in the `keys` list** is treated as the root key. Song authors
+/// should list the root note first (e.g., `{define: Am keys 57 60 64}` where
+/// 57 = A3 is the root). Built-in voicings always have the root first.
 #[must_use]
 pub fn lookup_keyboard_voicing(
     chord_name: &str,

--- a/crates/core/tests/fixtures/diagrams-piano/expected.txt
+++ b/crates/core/tests/fixtures/diagrams-piano/expected.txt
@@ -1,0 +1,90 @@
+Song {
+    metadata: Metadata {
+        title: Some(
+            "Piano Diagrams Test",
+        ),
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "title",
+                value: Some(
+                    "Piano Diagrams Test",
+                ),
+                kind: Title,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "diagrams",
+                value: Some(
+                    "piano",
+                ),
+                kind: Diagrams,
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "Hello ",
+                        spans: [],
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "C",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: C,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "world",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/core/tests/fixtures/diagrams-piano/input.cho
+++ b/crates/core/tests/fixtures/diagrams-piano/input.cho
@@ -1,0 +1,3 @@
+{title: Piano Diagrams Test}
+{diagrams: piano}
+[Am]Hello [C]world

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -533,31 +533,59 @@ fn render_song_body(
         html.push_str("</div>\n");
     }
 
-    // Auto-inject diagram grid when {diagrams} (or {diagrams: guitar/ukulele/on}) was seen.
+    // Auto-inject diagram grid when {diagrams} (or {diagrams: guitar/ukulele/piano/on}) was seen.
     if let Some(ref instrument) = auto_diagrams_instrument {
-        let defines = song.fretted_defines();
         // Skip chords that were actually rendered inline via {define} (i.e., show_diagrams
         // was true at the time).  Compare in canonical sharp form to catch enharmonic
         // pairs like {define: Bb …} vs [A#] in lyrics.
-        let diagrams: Vec<_> = song
+        let chord_names: Vec<String> = song
             .used_chord_names()
             .into_iter()
             .filter(|name| !inline_defined.contains(&canonical_chord_name(name)))
-            .filter_map(|name| {
-                chordsketch_core::lookup_diagram(&name, &defines, instrument, diagram_frets)
-            })
             .collect();
-        if !diagrams.is_empty() {
-            html.push_str("<section class=\"chord-diagrams\">\n");
-            html.push_str("<div class=\"section-label\">Chord Diagrams</div>\n");
-            html.push_str("<div class=\"chord-diagrams-grid\">\n");
-            for diagram in &diagrams {
-                html.push_str("<div class=\"chord-diagram-container\">");
-                html.push_str(&chordsketch_core::chord_diagram::render_svg(diagram));
+
+        if instrument == "piano" {
+            // Keyboard instrument: use the piano voicing database.
+            let kbd_defines = song.keyboard_defines();
+            let voicings: Vec<_> = chord_names
+                .into_iter()
+                .filter_map(|name| chordsketch_core::lookup_keyboard_voicing(&name, &kbd_defines))
+                .collect();
+            if !voicings.is_empty() {
+                html.push_str("<section class=\"chord-diagrams\">\n");
+                html.push_str("<div class=\"section-label\">Chord Diagrams</div>\n");
+                html.push_str("<div class=\"chord-diagrams-grid\">\n");
+                for voicing in &voicings {
+                    html.push_str("<div class=\"chord-diagram-container\">");
+                    html.push_str(&chordsketch_core::chord_diagram::render_keyboard_svg(
+                        voicing,
+                    ));
+                    html.push_str("</div>\n");
+                }
                 html.push_str("</div>\n");
+                html.push_str("</section>\n");
             }
-            html.push_str("</div>\n");
-            html.push_str("</section>\n");
+        } else {
+            // Fretted instruments (guitar, ukulele, etc.).
+            let defines = song.fretted_defines();
+            let diagrams: Vec<_> = chord_names
+                .into_iter()
+                .filter_map(|name| {
+                    chordsketch_core::lookup_diagram(&name, &defines, instrument, diagram_frets)
+                })
+                .collect();
+            if !diagrams.is_empty() {
+                html.push_str("<section class=\"chord-diagrams\">\n");
+                html.push_str("<div class=\"section-label\">Chord Diagrams</div>\n");
+                html.push_str("<div class=\"chord-diagrams-grid\">\n");
+                for diagram in &diagrams {
+                    html.push_str("<div class=\"chord-diagram-container\">");
+                    html.push_str(&chordsketch_core::chord_diagram::render_svg(diagram));
+                    html.push_str("</div>\n");
+                }
+                html.push_str("</div>\n");
+                html.push_str("</section>\n");
+            }
         }
     }
 
@@ -1336,7 +1364,34 @@ fn render_directive_inner(
             if show_diagrams {
                 if let Some(ref value) = directive.value {
                     let def = chordsketch_core::ast::ChordDefinition::parse_value(value);
-                    if let Some(ref raw) = def.raw {
+                    // Keyboard defines: render a piano keyboard SVG.
+                    if let Some(ref keys_raw) = def.keys {
+                        let keys_u8: Vec<u8> = keys_raw
+                            .iter()
+                            .filter_map(|&k| {
+                                if (0i32..=127).contains(&k) {
+                                    Some(k as u8)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+                        if !keys_u8.is_empty() {
+                            let root = keys_u8[0];
+                            let voicing = chordsketch_core::chord_diagram::KeyboardVoicing {
+                                name: def.name.clone(),
+                                display_name: def.display.clone(),
+                                keys: keys_u8,
+                                root_key: root,
+                            };
+                            html.push_str("<div class=\"chord-diagram-container\">");
+                            html.push_str(&chordsketch_core::chord_diagram::render_keyboard_svg(
+                                &voicing,
+                            ));
+                            html.push_str("</div>\n");
+                        }
+                    } else if let Some(ref raw) = def.raw {
+                        // Fretted defines: render the standard fret-grid SVG.
                         if let Some(mut diagram) =
                             chordsketch_core::chord_diagram::DiagramData::from_raw_infer_frets(
                                 &def.name,
@@ -2561,10 +2616,42 @@ Verse text\n\
     }
 
     #[test]
-    fn test_define_keyboard_no_diagram() {
+    fn test_define_keyboard_renders_keyboard_svg() {
+        // {define: Am keys 0 3 7} should now render a keyboard diagram SVG.
         let html = render("{define: Am keys 0 3 7}");
-        // Keyboard definitions don't produce SVG diagrams
-        assert!(!html.contains("<svg"));
+        assert!(
+            html.contains("<svg"),
+            "keyboard define should produce an SVG"
+        );
+        assert!(
+            html.contains("keyboard-diagram"),
+            "should use keyboard-diagram CSS class"
+        );
+        assert!(html.contains("Am"), "chord name should appear in SVG");
+    }
+
+    #[test]
+    fn test_define_keyboard_absolute_midi_renders_svg() {
+        // Absolute MIDI note numbers (as in the issue spec example).
+        let html = render("{define: Cmaj7 keys 60 64 67 71}");
+        assert!(html.contains("<svg"));
+        assert!(html.contains("keyboard-diagram"));
+        assert!(html.contains("Cmaj7"));
+    }
+
+    #[test]
+    fn test_diagrams_piano_auto_inject() {
+        let input = "{diagrams: piano}\n[Am]Hello [C]world";
+        let html = render(input);
+        // Should auto-inject keyboard diagrams for Am and C
+        assert!(
+            html.contains("keyboard-diagram"),
+            "piano instrument should use keyboard diagrams"
+        );
+        assert!(
+            html.contains("chord-diagrams"),
+            "diagram section should be present"
+        );
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -1375,6 +1375,12 @@ fn render_keyboard_diagram_pdf(
         (10, 5.6), // A#
     ];
 
+    // Colors used for highlighting keys.
+    const ROOT_BLUE: (f32, f32, f32) = (0.102, 0.373, 0.706); // dark blue: root key
+    const CHORD_BLUE: (f32, f32, f32) = (0.290, 0.565, 0.886); // medium blue: chord tone
+    const WHITE_KEY: (f32, f32, f32) = (1.0, 1.0, 1.0); // unlit white key
+    const DARK_KEY: (f32, f32, f32) = (0.133, 0.133, 0.133); // unlit black key
+
     // Draw white keys
     for oct in 0..num_octaves {
         let oct_midi = start_midi.saturating_add((oct * 12) as u8);
@@ -1386,16 +1392,12 @@ fn render_keyboard_diagram_pdf(
             let is_root = highlighted && midi == root;
             // PDF bottom-up: key bottom is kbd_top_y - white_h
             let y_bottom = kbd_top_y - white_h;
-            // Colors: root = dark blue, chord tone = medium blue, neutral = white
-            const ROOT_BLUE: (f32, f32, f32) = (0.102, 0.373, 0.706);
-            const CHORD_BLUE: (f32, f32, f32) = (0.290, 0.565, 0.886);
-            const WHITE: (f32, f32, f32) = (1.0, 1.0, 1.0);
             let color = if is_root {
                 ROOT_BLUE
             } else if highlighted {
                 CHORD_BLUE
             } else {
-                WHITE
+                WHITE_KEY
             };
             doc.filled_rect_color(x, y_bottom, white_w - 0.5, white_h, color);
             doc.rect_stroke(x, y_bottom, white_w - 0.5, white_h, 0.3);
@@ -1412,11 +1414,10 @@ fn render_keyboard_diagram_pdf(
             let highlighted = keys.contains(&midi);
             let is_root = highlighted && midi == root;
             let y_bottom = kbd_top_y - black_h;
-            const DARK_KEY: (f32, f32, f32) = (0.133, 0.133, 0.133);
             let color = if is_root {
-                (0.102, 0.373, 0.706)
+                ROOT_BLUE
             } else if highlighted {
-                (0.290, 0.565, 0.886)
+                CHORD_BLUE
             } else {
                 DARK_KEY
             };

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -638,22 +638,33 @@ fn render_song_into_doc(
         }
     }
 
-    // Auto-inject diagram block when {diagrams} was seen.
+    // Auto-inject diagram block when {diagrams} (or {diagrams: piano/guitar/ukulele}) was seen.
     if let Some(ref instrument) = auto_diagrams_instrument {
-        let defines = song.fretted_defines();
-        // Skip chords that were actually rendered inline via {define} (i.e., show_diagrams
-        // was true at the time).  Compare in canonical sharp form to catch enharmonic
-        // pairs like {define: Bb …} vs [A#] in lyrics.
-        let diagrams: Vec<_> = song
+        // Skip chords rendered inline via {define} while show_diagrams was true.
+        let chord_names: Vec<String> = song
             .used_chord_names()
             .into_iter()
             .filter(|name| !inline_defined.contains(&canonical_chord_name(name)))
-            .filter_map(|name| {
-                chordsketch_core::lookup_diagram(&name, &defines, instrument, diagram_frets)
-            })
             .collect();
-        for diagram in &diagrams {
-            render_chord_diagram_pdf(diagram, doc);
+
+        if instrument == "piano" {
+            let kbd_defines = song.keyboard_defines();
+            for name in chord_names {
+                if let Some(voicing) =
+                    chordsketch_core::lookup_keyboard_voicing(&name, &kbd_defines)
+                {
+                    render_keyboard_diagram_pdf(&voicing, doc);
+                }
+            }
+        } else {
+            let defines = song.fretted_defines();
+            for name in chord_names {
+                if let Some(diagram) =
+                    chordsketch_core::lookup_diagram(&name, &defines, instrument, diagram_frets)
+                {
+                    render_chord_diagram_pdf(&diagram, doc);
+                }
+            }
         }
     }
 }
@@ -859,6 +870,31 @@ fn render_directive(
     if directive.kind == DirectiveKind::Define && show_diagrams {
         if let Some(ref value) = directive.value {
             let def = chordsketch_core::ast::ChordDefinition::parse_value(value);
+            // Keyboard defines: render a piano keyboard diagram.
+            if let Some(ref keys_raw) = def.keys {
+                let keys_u8: Vec<u8> = keys_raw
+                    .iter()
+                    .filter_map(|&k| {
+                        if (0i32..=127).contains(&k) {
+                            Some(k as u8)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                if !keys_u8.is_empty() {
+                    let root = keys_u8[0];
+                    let voicing = chordsketch_core::chord_diagram::KeyboardVoicing {
+                        name: def.name.clone(),
+                        display_name: def.display.clone(),
+                        keys: keys_u8,
+                        root_key: root,
+                    };
+                    render_keyboard_diagram_pdf(&voicing, doc);
+                    return;
+                }
+            }
+            // Fretted defines: render the standard fret-grid diagram.
             if let Some(ref raw) = def.raw {
                 if let Some(mut diagram) =
                     chordsketch_core::chord_diagram::DiagramData::from_raw_infer_frets(
@@ -1260,6 +1296,131 @@ fn render_chord_diagram_pdf(
                     doc.white_text_at(&label, Font::Helvetica, 5.0, x - 1.5, y - 1.5);
                 }
             }
+        }
+    }
+
+    doc.advance_y(total_h);
+    doc.newline(LINE_GAP);
+}
+
+/// Render a keyboard (piano) chord diagram directly into the PDF content stream.
+///
+/// Draws a 2-octave piano keyboard strip with filled rectangles for each key,
+/// highlighting chord tones in blue and the root key in darker blue.
+fn render_keyboard_diagram_pdf(
+    voicing: &chordsketch_core::chord_diagram::KeyboardVoicing,
+    doc: &mut PdfDocument,
+) {
+    if voicing.keys.is_empty() {
+        return;
+    }
+
+    // Normalise pitch-class keys (0–11) to octave 4.
+    let (keys, root) = {
+        if voicing.keys.iter().all(|&k| k < 12) {
+            let k: Vec<u8> = voicing.keys.iter().map(|&k| k.saturating_add(60)).collect();
+            let r = if voicing.root_key < 12 {
+                voicing.root_key.saturating_add(60)
+            } else {
+                voicing.root_key
+            };
+            (k, r)
+        } else {
+            (voicing.keys.clone(), voicing.root_key)
+        }
+    };
+
+    let min_key = *keys.iter().min().unwrap_or(&60);
+    let max_key = *keys.iter().max().unwrap_or(&71);
+    let start_octave = u32::from(min_key / 12);
+    let end_octave = u32::from(max_key / 12);
+    let num_octaves = ((end_octave - start_octave) + 1).clamp(2, 3) as usize;
+    let start_midi = (start_octave * 12) as u8;
+
+    // PDF layout (points). Smaller than SVG to fit on the printed page.
+    let white_w: f32 = 8.0;
+    let white_h: f32 = 30.0;
+    let black_w: f32 = 5.0;
+    let black_h: f32 = 18.0;
+    let name_h: f32 = 10.0;
+    let total_h = name_h + white_h + 6.0;
+
+    doc.ensure_space(total_h);
+
+    let base_x = doc.margin_left();
+    let top_y = doc.y();
+
+    // Chord name
+    doc.text_at(voicing.title(), Font::HelveticaBold, 7.0, base_x, top_y);
+
+    // Y for top of keyboard (PDF Y goes down when we subtract)
+    let kbd_top_y = top_y - name_h;
+
+    // White key semitone offsets within an octave and x-offset from octave start.
+    const WHITE_KEYS_PDF: [(u8, f32); 7] = [
+        (0, 0.0),  // C
+        (2, 1.0),  // D
+        (4, 2.0),  // E
+        (5, 3.0),  // F
+        (7, 4.0),  // G
+        (9, 5.0),  // A
+        (11, 6.0), // B
+    ];
+    // Black key semitone offsets and x-offsets within octave.
+    const BLACK_KEYS_PDF: [(u8, f32); 5] = [
+        (1, 0.6),  // C#
+        (3, 1.6),  // D#
+        (6, 3.6),  // F#
+        (8, 4.6),  // G#
+        (10, 5.6), // A#
+    ];
+
+    // Draw white keys
+    for oct in 0..num_octaves {
+        let oct_midi = start_midi.saturating_add((oct * 12) as u8);
+        let oct_x = base_x + oct as f32 * 7.0 * white_w;
+        for (semitone, x_idx) in WHITE_KEYS_PDF {
+            let midi = oct_midi.saturating_add(semitone);
+            let x = oct_x + x_idx * white_w;
+            let highlighted = keys.contains(&midi);
+            let is_root = highlighted && midi == root;
+            // PDF bottom-up: key bottom is kbd_top_y - white_h
+            let y_bottom = kbd_top_y - white_h;
+            // Colors: root = dark blue, chord tone = medium blue, neutral = white
+            const ROOT_BLUE: (f32, f32, f32) = (0.102, 0.373, 0.706);
+            const CHORD_BLUE: (f32, f32, f32) = (0.290, 0.565, 0.886);
+            const WHITE: (f32, f32, f32) = (1.0, 1.0, 1.0);
+            let color = if is_root {
+                ROOT_BLUE
+            } else if highlighted {
+                CHORD_BLUE
+            } else {
+                WHITE
+            };
+            doc.filled_rect_color(x, y_bottom, white_w - 0.5, white_h, color);
+            doc.rect_stroke(x, y_bottom, white_w - 0.5, white_h, 0.3);
+        }
+    }
+
+    // Draw black keys on top
+    for oct in 0..num_octaves {
+        let oct_midi = start_midi.saturating_add((oct * 12) as u8);
+        let oct_x = base_x + oct as f32 * 7.0 * white_w;
+        for (semitone, x_idx) in BLACK_KEYS_PDF {
+            let midi = oct_midi.saturating_add(semitone);
+            let x = oct_x + x_idx * white_w;
+            let highlighted = keys.contains(&midi);
+            let is_root = highlighted && midi == root;
+            let y_bottom = kbd_top_y - black_h;
+            const DARK_KEY: (f32, f32, f32) = (0.133, 0.133, 0.133);
+            let color = if is_root {
+                (0.102, 0.373, 0.706)
+            } else if highlighted {
+                (0.290, 0.565, 0.886)
+            } else {
+                DARK_KEY
+            };
+            doc.filled_rect_color(x, y_bottom, black_w, black_h, color);
         }
     }
 
@@ -2103,6 +2264,26 @@ impl PdfDocument {
             fmt_f32(y1),
             fmt_f32(x2),
             fmt_f32(y2)
+        ));
+        ops.push("Q".to_string());
+    }
+
+    /// Draw a filled rectangle with an RGB colour.
+    ///
+    /// `color` is `(r, g, b)` with each component in the 0.0–1.0 range.
+    /// The fill is solid with no stroke. Wraps the operation in `q`/`Q`
+    /// to avoid colour leakage.
+    fn filled_rect_color(&mut self, x: f32, y: f32, w: f32, h: f32, color: (f32, f32, f32)) {
+        let (r, g, b) = color;
+        let ops = self.current_page_mut();
+        ops.push("q".to_string());
+        ops.push(format!("{} {} {} rg", fmt_f32(r), fmt_f32(g), fmt_f32(b)));
+        ops.push(format!(
+            "{} {} {} {} re f",
+            fmt_f32(x),
+            fmt_f32(y),
+            fmt_f32(w),
+            fmt_f32(h)
         ));
         ops.push("Q".to_string());
     }
@@ -3725,12 +3906,31 @@ mod chord_diagram_pdf_tests {
     }
 
     #[test]
-    fn test_define_keyboard_no_diagram_in_pdf() {
+    fn test_define_keyboard_renders_in_pdf() {
+        // {define: Am keys 0 3 7} should produce a valid PDF (keyboard diagram rendered).
         let input = "{define: Am keys 0 3 7}\n[Am]Hello";
         let song = chordsketch_core::parse(input).unwrap();
         let bytes = render_song(&song);
         assert!(bytes.starts_with(b"%PDF"));
-        // Should still be valid
+        assert!(bytes.ends_with(b"%%EOF\n"));
+    }
+
+    #[test]
+    fn test_define_keyboard_absolute_midi_pdf() {
+        let input = "{define: Cmaj7 keys 60 64 67 71}\n[Cmaj7]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        assert!(bytes.starts_with(b"%PDF-1.4"));
+        assert!(bytes.ends_with(b"%%EOF\n"));
+    }
+
+    #[test]
+    fn test_diagrams_piano_auto_inject_pdf() {
+        let input = "{diagrams: piano}\n[Am]Hello [C]world";
+        let song = chordsketch_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        assert!(bytes.starts_with(b"%PDF-1.4"));
+        assert!(bytes.ends_with(b"%%EOF\n"));
     }
 
     #[test]

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -206,29 +206,58 @@ fn render_song_impl(
         }
     }
 
-    // Auto-inject ASCII diagram block when {diagrams} was seen.
+    // Auto-inject ASCII diagram block when {diagrams} (or {diagrams: guitar/ukulele/piano}) was seen.
     if let Some(ref instrument) = auto_diagrams_instrument {
-        let frets_shown = _config
-            .get_path("diagrams.frets")
-            .as_f64()
-            .map_or(chordsketch_core::chord_diagram::DEFAULT_FRETS_SHOWN, |n| {
-                (n as usize).max(1)
-            });
-        let defines = song.fretted_defines();
-        let diagrams: Vec<_> = song
-            .used_chord_names()
-            .into_iter()
-            .filter_map(|name| {
-                chordsketch_core::lookup_diagram(&name, &defines, instrument, frets_shown)
-            })
-            .collect();
-        if !diagrams.is_empty() {
-            output.push(String::new());
-            output.push("[Chord Diagrams]".to_string());
-            for diagram in &diagrams {
+        if instrument == "piano" {
+            // Plain-text rendering of keyboard diagrams is not supported; emit a note
+            // listing the chord names so the reader knows which chords are in use.
+            let kbd_defines = song.keyboard_defines();
+            let voicings: Vec<_> = song
+                .used_chord_names()
+                .into_iter()
+                .filter_map(|name| chordsketch_core::lookup_keyboard_voicing(&name, &kbd_defines))
+                .collect();
+            if !voicings.is_empty() {
                 output.push(String::new());
-                for diagram_line in chordsketch_core::chord_diagram::render_ascii(diagram).lines() {
-                    output.push(diagram_line.to_string());
+                output.push("[Chord Diagrams]".to_string());
+                for voicing in &voicings {
+                    output.push(format!(
+                        "  {}: keys {}",
+                        voicing.title(),
+                        voicing
+                            .keys
+                            .iter()
+                            .map(|k| k.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    ));
+                }
+            }
+        } else {
+            let frets_shown = _config
+                .get_path("diagrams.frets")
+                .as_f64()
+                .map_or(chordsketch_core::chord_diagram::DEFAULT_FRETS_SHOWN, |n| {
+                    (n as usize).max(1)
+                });
+            let defines = song.fretted_defines();
+            let diagrams: Vec<_> = song
+                .used_chord_names()
+                .into_iter()
+                .filter_map(|name| {
+                    chordsketch_core::lookup_diagram(&name, &defines, instrument, frets_shown)
+                })
+                .collect();
+            if !diagrams.is_empty() {
+                output.push(String::new());
+                output.push("[Chord Diagrams]".to_string());
+                for diagram in &diagrams {
+                    output.push(String::new());
+                    for diagram_line in
+                        chordsketch_core::chord_diagram::render_ascii(diagram).lines()
+                    {
+                        output.push(diagram_line.to_string());
+                    }
                 }
             }
         }
@@ -1243,6 +1272,19 @@ mod delegate_tests {
             !output.contains("[Chord Diagrams]"),
             "{{diagrams: off}} should suppress ASCII diagram block"
         );
+    }
+
+    #[test]
+    fn test_diagrams_piano_auto_inject_text() {
+        let output = render("{diagrams: piano}\n[Am]Hello [C]world");
+        assert!(
+            output.contains("[Chord Diagrams]"),
+            "piano instrument should include Chord Diagrams header"
+        );
+        // Text renderer emits chord name + key numbers (no ASCII art for piano).
+        assert!(output.contains("Am:"), "Am entry expected");
+        assert!(output.contains("C:"), "C entry expected");
+        assert!(output.contains("keys"), "key list label expected");
     }
 
     #[test]


### PR DESCRIPTION
## What

Add first-class piano/keyboard chord diagram support across the ChordSketch rendering pipeline:

- **`KeyboardVoicing` struct** (`chord_diagram.rs`) — holds chord name, optional display name, MIDI note numbers, and root key
- **SVG renderer** (`render_keyboard_svg`) — 2-octave inline SVG with root key highlighted dark blue, other chord tones medium blue; pitch-class values 0–11 normalised to octave 4 automatically
- **PDF renderer** (`render_keyboard_diagram_pdf`) — native PDF drawing ops (rectangles, lines) for the same 2-octave keyboard layout
- **60 built-in voicings** (`voicings.rs`) — major, minor, dom7, maj7, min7 families × 12 chromatic roots (C through B)
- **`keyboard_voicing` / `lookup_keyboard_voicing`** — public lookup API; song-level `{define}` overrides take priority over the built-in database
- **`Song::keyboard_defines()`** (`ast.rs`) — scans directives for `{define}` / `{chord}` entries with a `keys` attribute and returns them as `(name, Vec<i32>)` pairs
- **`{diagrams: piano}` auto-inject** — both HTML and PDF renderers auto-inject keyboard diagrams for all chords used in the song when the instrument is set to piano/keyboard/keys

## Why

Closes #1139 — the existing diagram system only supported fretted instruments (guitar, ukulele). Piano/keyboard players have no way to get chord diagrams from ChordSketch.

## Test results

```
cargo test        # 1001+ tests pass (core), 184 (pdf), 182 (html)
cargo clippy      # clean (zero warnings)
cargo fmt --check # clean
```

New test coverage includes: SVG rendering with absolute MIDI values, pitch-class normalisation, display name override, empty-key guard, PDF rendering, define-overrides-builtin, flat/sharp alias lookup, and `{diagrams: piano}` auto-inject for both renderers.

## Review summary

No prior review — CI is the first gate.

Closes #1139