### PR TITLE
refactor: deduplicate pitch-class normalisation and update keyboard voicing docs

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -500,7 +500,16 @@ const BLACK_KEY_POSITIONS: [(u8, f32); 5] = [
 ///
 /// When all keys are in 0–11 (pitch classes), shifts them to octave 4
 /// (adds 60). Otherwise returns them unchanged.
-fn normalise_keyboard_keys(keys: &[u8], root_key: u8) -> (Vec<u8>, u8) {
+///
+/// # Convention
+///
+/// When keys contain pitch classes, `root_key` is expected to also be a pitch
+/// class (0–11). If `root_key >= 12` while the chord tones are all pitch
+/// classes, it is left unchanged (no normalisation applied to the root).
+/// Callers should ensure both `keys` and `root_key` use the same
+/// representation.
+#[must_use]
+pub fn normalise_keyboard_keys(keys: &[u8], root_key: u8) -> (Vec<u8>, u8) {
     if keys.iter().all(|&k| k < 12) {
         let normalised: Vec<u8> = keys.iter().map(|&k| k.saturating_add(60)).collect();
         let root = if root_key < 12 {

--- a/crates/core/src/voicings.rs
+++ b/crates/core/src/voicings.rs
@@ -1,7 +1,12 @@
-//! Built-in chord voicing database for guitar and ukulele.
+//! Built-in chord voicing database for guitar, ukulele, and piano/keyboard.
 //!
-//! Provides 96 pre-defined chord voicings (60 guitar + 36 ukulele) stored as compile-time static
-//! data — no external files, no runtime I/O. The lookup priority is:
+//! Provides 156 pre-defined chord voicings:
+//! - 60 guitar voicings (5 families × 12 roots)
+//! - 36 ukulele voicings (3 families × 12 roots)
+//! - 60 keyboard/piano voicings (5 families × 12 roots: major, minor, dom7, maj7, min7)
+//!
+//! All data is stored as compile-time static data — no external files, no runtime I/O.
+//! The lookup priority is:
 //!
 //! 1. `{define}` in the song file (handled by the parser/AST)
 //! 2. User `chordsketch.json` (future — not yet implemented)
@@ -700,7 +705,9 @@ pub fn ukulele_voicing(chord_name: &str) -> Option<DiagramData> {
 /// - `defines` — list of `(name, raw)` pairs from `{define}` directives.
 ///   Obtain via [`Song::fretted_defines`](crate::ast::Song::fretted_defines).
 /// - `instrument` — `"guitar"` or `"ukulele"` (case-insensitive). Anything else
-///   falls back to guitar.
+///   falls back to guitar. **Do not pass `"piano"` here**; the renderers branch
+///   on the instrument before calling this function, routing piano to
+///   [`lookup_keyboard_voicing`] instead.
 /// - `frets_shown` — number of fret rows to display in the diagram.
 #[must_use]
 pub fn lookup_diagram(

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -1316,19 +1316,8 @@ fn render_keyboard_diagram_pdf(
     }
 
     // Normalise pitch-class keys (0–11) to octave 4.
-    let (keys, root) = {
-        if voicing.keys.iter().all(|&k| k < 12) {
-            let k: Vec<u8> = voicing.keys.iter().map(|&k| k.saturating_add(60)).collect();
-            let r = if voicing.root_key < 12 {
-                voicing.root_key.saturating_add(60)
-            } else {
-                voicing.root_key
-            };
-            (k, r)
-        } else {
-            (voicing.keys.clone(), voicing.root_key)
-        }
-    };
+    let (keys, root) =
+        chordsketch_core::chord_diagram::normalise_keyboard_keys(&voicing.keys, voicing.root_key);
 
     let min_key = *keys.iter().min().unwrap_or(&60);
     let max_key = *keys.iter().max().unwrap_or(&71);


### PR DESCRIPTION
## What

Three small follow-up fixes from PR #1328 review:

1. **`normalise_keyboard_keys` made public** (`chord_diagram.rs`) — was private, so the PDF renderer couldn't call it and had to duplicate the logic. Now exported as `pub fn`. Doc comment updated to describe the root_key convention and the pitch-class/absolute-MIDI mixing edge case. Closes #1331.

2. **PDF renderer deduplication** (`render-pdf/src/lib.rs`) — the copy-pasted 10-line inline normalisation block in `render_keyboard_diagram_pdf` is replaced with a call to the shared `chord_diagram::normalise_keyboard_keys`. Closes #1331; supersedes #1329.

3. **`lookup_diagram` doc warning** (`voicings.rs`) — added a note that callers must not pass `"piano"` to this function; they should use `lookup_keyboard_voicing` instead. Closes #1332.

4. **Module doc count updated** (`voicings.rs`) — was "96 pre-defined chord voicings (60 guitar + 36 ukulele)"; updated to 156 with the 60 keyboard voicings listed. Closes #1333.

## Why

All three issues were filed as follow-up from the PR #1328 code review (Low severity findings that didn't block merge).

## Test results

```
cargo test     # all pass (1001+ core, 182 html, 184 pdf, 75 text)
cargo clippy   # clean
cargo fmt      # clean
```

Closes #1331
Closes #1332
Closes #1333