### PR TITLE
fix: reject piano instrument in lookup_diagram and document normalise_keyboard_keys edge cases

### DIFF
--- a/crates/core/src/chord_diagram.rs
+++ b/crates/core/src/chord_diagram.rs
@@ -508,6 +508,13 @@ const BLACK_KEY_POSITIONS: [(u8, f32); 5] = [
 /// classes, it is left unchanged (no normalisation applied to the root).
 /// Callers should ensure both `keys` and `root_key` use the same
 /// representation.
+///
+/// # Empty-slice behaviour
+///
+/// When `keys` is empty, `all(|k| k < 12)` is vacuously true, so
+/// `root_key` is still shifted to octave 4 if it is less than 12. Both
+/// current callers guard against empty keys before calling this function,
+/// but future callers should be aware of this edge case.
 #[must_use]
 pub fn normalise_keyboard_keys(keys: &[u8], root_key: u8) -> (Vec<u8>, u8) {
     if keys.iter().all(|&k| k < 12) {
@@ -1494,5 +1501,38 @@ mod tests {
             resolve_diagrams_instrument(Some("keyboard"), "guitar"),
             Some("piano".to_string())
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // normalise_keyboard_keys — public API contract
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn normalise_keyboard_keys_empty_slice_shifts_pitch_class_root() {
+        // When keys is empty, all() is vacuously true, so a pitch-class root_key
+        // is still shifted to octave 4.  Both current callers guard against
+        // empty keys before calling this function, but the contract is
+        // machine-checked here so regressions are caught.
+        let (keys_out, root_out) = normalise_keyboard_keys(&[], 0);
+        assert!(keys_out.is_empty());
+        assert_eq!(
+            root_out, 60,
+            "pitch-class root 0 should be shifted to C4 (60)"
+        );
+
+        let (keys_out2, root_out2) = normalise_keyboard_keys(&[], 9);
+        assert!(keys_out2.is_empty());
+        assert_eq!(
+            root_out2, 69,
+            "pitch-class root 9 should be shifted to A4 (69)"
+        );
+    }
+
+    #[test]
+    fn normalise_keyboard_keys_empty_slice_absolute_root_unchanged() {
+        // A root_key >= 12 is not shifted, even when keys is empty.
+        let (keys_out, root_out) = normalise_keyboard_keys(&[], 60);
+        assert!(keys_out.is_empty());
+        assert_eq!(root_out, 60, "absolute root_key must not be shifted");
     }
 }

--- a/crates/core/src/voicings.rs
+++ b/crates/core/src/voicings.rs
@@ -705,9 +705,9 @@ pub fn ukulele_voicing(chord_name: &str) -> Option<DiagramData> {
 /// - `defines` — list of `(name, raw)` pairs from `{define}` directives.
 ///   Obtain via [`Song::fretted_defines`](crate::ast::Song::fretted_defines).
 /// - `instrument` — `"guitar"` or `"ukulele"` (case-insensitive). Anything else
-///   falls back to guitar. **Do not pass `"piano"` here**; the renderers branch
-///   on the instrument before calling this function, routing piano to
-///   [`lookup_keyboard_voicing`] instead.
+///   falls back to guitar. Returns `None` immediately for keyboard-family
+///   instruments (`"piano"`, `"keyboard"`, `"keys"`); use
+///   [`lookup_keyboard_voicing`] for those.
 /// - `frets_shown` — number of fret rows to display in the diagram.
 #[must_use]
 pub fn lookup_diagram(
@@ -716,6 +716,14 @@ pub fn lookup_diagram(
     instrument: &str,
     frets_shown: usize,
 ) -> Option<crate::chord_diagram::DiagramData> {
+    // Keyboard instruments have no fretted diagrams.
+    if matches!(
+        instrument.to_ascii_lowercase().as_str(),
+        "piano" | "keyboard" | "keys"
+    ) {
+        return None;
+    }
+
     // 1. Song-level {define} directives take priority.
     // Normalize both the lookup key and the define names to their canonical sharp
     // form so that e.g. a {define: A# …} entry is found when looking up "Bb",
@@ -1549,5 +1557,25 @@ mod tests {
         let defines = vec![("A#".to_string(), vec![58i32, 62, 65])];
         let v = lookup_keyboard_voicing("Bb", &defines).unwrap();
         assert_eq!(v.keys, vec![58, 62, 65]);
+    }
+
+    // --- lookup_diagram piano rejection ---
+
+    #[test]
+    fn lookup_diagram_rejects_piano_instrument() {
+        // Passing "piano" to lookup_diagram must return None; it has no fretted
+        // diagram database. Callers should use lookup_keyboard_voicing instead.
+        assert!(
+            lookup_diagram("Am", &[], "piano", 5).is_none(),
+            "piano should return None from lookup_diagram"
+        );
+        assert!(
+            lookup_diagram("Am", &[], "keyboard", 5).is_none(),
+            "keyboard should return None from lookup_diagram"
+        );
+        assert!(
+            lookup_diagram("Am", &[], "keys", 5).is_none(),
+            "keys should return None from lookup_diagram"
+        );
     }
 }


### PR DESCRIPTION
## What

Two small correctness and documentation fixes following the review of PRs #1328 and #1334:

1. **`lookup_diagram` returns `None` for keyboard instruments** (`voicings.rs`) — previously calling `lookup_diagram("Am", &[], "piano", 5)` would fall through to the guitar database and silently return guitar voicings. Now it returns `None` immediately for `"piano"`, `"keyboard"`, and `"keys"`. Renderers already branch on the instrument before calling this function, so no renderer output changes. Closes #1336.

2. **`normalise_keyboard_keys` empty-slice doc + tests** (`chord_diagram.rs`) — the public API doc comment now explicitly states that when `keys` is empty, `all(|k| k < 12)` is vacuously true so a pitch-class `root_key` is still shifted to octave 4. Two new unit tests machine-check this contract. Closes #1335.

## Why

- #1336: Defensive-inputs rule requires validation at the boundary. A caller accidentally passing `"piano"` would get silently wrong guitar voicings instead of `None`.
- #1335: Public API contract should be fully specified; the vacuous-truth edge case is non-obvious.

## Test results

```
cargo test -p chordsketch-core   # 1004 tests pass
cargo clippy                     # clean
cargo fmt --check                # clean
```

Closes #1335
Closes #1336