### PR TITLE
fix(core): abc-importer bug fixes and golden test coverage

### DIFF
--- a/crates/core/src/abc_importer.rs
+++ b/crates/core/src/abc_importer.rs
@@ -154,7 +154,7 @@ fn convert_tune(input: &str) -> String {
                 }
                 'T' => title = Some(value.to_string()),
                 'C' => composer = Some(value.to_string()),
-                'Q' => tempo = Some(extract_tempo_bpm(value)),
+                'Q' => tempo = extract_tempo_bpm(value),
                 'K' => {
                     if in_header {
                         // K: is the last required header field; emit directives now.
@@ -242,15 +242,20 @@ fn parse_field_line(line: &str) -> Option<(char, &str)> {
 ///
 /// Handles bare numbers (`"120"`), note-length annotations (`"1/4=120"`),
 /// and tempos with text labels (`"1/4=120 Allegro"`).
-fn extract_tempo_bpm(value: &str) -> String {
-    if let Some(pos) = value.find('=') {
-        value[pos + 1..]
-            .split_whitespace()
-            .next()
-            .unwrap_or(value)
-            .to_string()
+///
+/// Returns `None` if no numeric BPM can be extracted (e.g. `"Q:Allegro"` or
+/// `"Q:1/4=Allegro"`), so the caller can omit the `{tempo}` directive rather
+/// than emitting a non-numeric value that would be invalid ChordPro.
+fn extract_tempo_bpm(value: &str) -> Option<String> {
+    let candidate = if let Some(pos) = value.find('=') {
+        value[pos + 1..].split_whitespace().next().unwrap_or("")
     } else {
-        value.split_whitespace().next().unwrap_or(value).to_string()
+        value.split_whitespace().next().unwrap_or("")
+    };
+    if !candidate.is_empty() && candidate.bytes().all(|b| b.is_ascii_digit()) {
+        Some(candidate.to_string())
+    } else {
+        None
     }
 }
 
@@ -339,13 +344,15 @@ fn flush_block(music_lines: &[String], w_lines: &[String], out: &mut String) {
         return;
     }
 
-    // Use the first w: line (multiple w: lines = multiple verses; future
-    // enhancement could output all verses).
-    let syllables = parse_abc_lyrics(&w_lines[0]);
-    let line = build_chordpro_line(&chord_at_note, &syllables);
-    if !line.trim().is_empty() {
-        out.push_str(&line);
-        out.push('\n');
+    // Emit all w: lines as separate ChordPro lyric lines.  Each line
+    // represents one verse sung over the same melody.
+    for w_line in w_lines {
+        let syllables = parse_abc_lyrics(w_line);
+        let line = build_chordpro_line(&chord_at_note, &syllables);
+        if !line.trim().is_empty() {
+            out.push_str(&line);
+            out.push('\n');
+        }
     }
 }
 
@@ -738,17 +745,32 @@ mod tests {
 
     #[test]
     fn tempo_bare_number() {
-        assert_eq!(extract_tempo_bpm("120"), "120");
+        assert_eq!(extract_tempo_bpm("120"), Some("120".to_string()));
     }
 
     #[test]
     fn tempo_note_length() {
-        assert_eq!(extract_tempo_bpm("1/4=120"), "120");
+        assert_eq!(extract_tempo_bpm("1/4=120"), Some("120".to_string()));
     }
 
     #[test]
     fn tempo_with_label() {
-        assert_eq!(extract_tempo_bpm("1/4=140 Allegro"), "140");
+        assert_eq!(
+            extract_tempo_bpm("1/4=140 Allegro"),
+            Some("140".to_string())
+        );
+    }
+
+    #[test]
+    fn tempo_text_only_returns_none() {
+        // "Q:Allegro" has no numeric BPM — must not emit {tempo: Allegro}.
+        assert_eq!(extract_tempo_bpm("Allegro"), None);
+    }
+
+    #[test]
+    fn tempo_note_length_text_only_returns_none() {
+        // "Q:1/4=Allegro" — after '=' the token is non-numeric.
+        assert_eq!(extract_tempo_bpm("1/4=Allegro"), None);
     }
 
     // --- extract_chords_and_notes ---
@@ -1021,6 +1043,47 @@ mod tests {
         assert!(
             out.contains("[Amtitle: evil]"),
             "sanitized chord name should be present, got: {out}"
+        );
+    }
+
+    // --- non-numeric tempo (issue #1339) ---
+
+    #[test]
+    fn convert_tempo_text_only_omitted() {
+        // Q:Allegro — no numeric BPM, so {tempo} must not be emitted.
+        let input = "X:1\nT:T\nQ:Allegro\nK:C\n";
+        let out = convert_abc(input);
+        assert!(
+            !out.contains("{tempo:"),
+            "non-numeric tempo must not produce a {{tempo}} directive, got: {out}"
+        );
+    }
+
+    #[test]
+    fn convert_tempo_note_length_text_omitted() {
+        // Q:1/4=Allegro — after '=' the token is non-numeric.
+        let input = "X:1\nT:T\nQ:1/4=Allegro\nK:C\n";
+        let out = convert_abc(input);
+        assert!(
+            !out.contains("{tempo:"),
+            "non-numeric tempo must not produce a {{tempo}} directive, got: {out}"
+        );
+    }
+
+    // --- multiple w: verses (issue #1340) ---
+
+    #[test]
+    fn convert_multi_verse_emits_all_verses() {
+        // Two w: lines for the same music block — both verses must appear in output.
+        let input = "X:1\nT:T\nK:C\n\"C\" C D E F|\nw:First verse here\nw:Second verse here\n";
+        let out = convert_abc(input);
+        assert!(
+            out.contains("First"),
+            "first verse must be present, got: {out}"
+        );
+        assert!(
+            out.contains("Second"),
+            "second verse must be present, got: {out}"
         );
     }
 }

--- a/crates/core/tests/fixtures/abc-basic-conversion/expected.cho
+++ b/crates/core/tests/fixtures/abc-basic-conversion/expected.cho
@@ -1,0 +1,7 @@
+{title: Scarborough Fair}
+{composer: Traditional}
+{tempo: 80}
+{key: Am}
+
+[Am]Are [G]you [Am]go-ing [C]to Scar-[Am]bo-rough Fair
+[Am]Pars-[G]ley [Am]sage rose-[C]ma-ry [Am]and thyme

--- a/crates/core/tests/fixtures/abc-basic-conversion/input.abc
+++ b/crates/core/tests/fixtures/abc-basic-conversion/input.abc
@@ -1,0 +1,8 @@
+X:1
+T:Scarborough Fair
+C:Traditional
+Q:1/4=80
+K:Am
+"Am" A2 "G" G2 "Am" A2 c2|"C" e3 d "Am" c2 A2|
+w:Are you go-ing to Scar-bo-rough Fair
+w:Pars-ley sage rose-ma-ry and thyme

--- a/crates/core/tests/golden_abc.rs
+++ b/crates/core/tests/golden_abc.rs
@@ -1,0 +1,92 @@
+//! Golden tests for the ABC notation → ChordPro importer.
+//!
+//! Each subdirectory under `tests/fixtures/` that contains an `input.abc` file
+//! is treated as an ABC importer test case.  The `input.abc` is converted with
+//! [`chordsketch_core::convert_abc`]; the result is compared against the
+//! corresponding `expected.cho` file.
+//!
+//! # Adding a new fixture
+//!
+//! 1. Create a subdirectory under `crates/core/tests/fixtures/` with a
+//!    descriptive kebab-case name (e.g., `abc-my-case`).
+//! 2. Add an `input.abc` containing the ABC notation source.
+//! 3. Run `UPDATE_GOLDEN=1 cargo test -p chordsketch-core --test golden_abc`
+//!    to generate `expected.cho` from the current converter output.
+//! 4. Review `expected.cho` and commit both files.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+fn discover_fixtures() -> Vec<PathBuf> {
+    let dir = fixtures_dir();
+    let mut fixtures: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("cannot read fixtures directory {}: {}", dir.display(), e))
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.is_dir() && path.join("input.abc").exists() {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    fixtures.sort();
+    fixtures
+}
+
+#[test]
+fn abc_golden_tests() {
+    let update = std::env::var("UPDATE_GOLDEN").is_ok();
+    let fixtures = discover_fixtures();
+    assert!(
+        !fixtures.is_empty(),
+        "no ABC fixtures found (expected directories with input.abc)"
+    );
+
+    let mut failed = false;
+
+    for fixture in &fixtures {
+        let name = fixture.file_name().unwrap().to_string_lossy();
+        let input_path = fixture.join("input.abc");
+        let expected_path = fixture.join("expected.cho");
+
+        let input = fs::read_to_string(&input_path).unwrap_or_else(|e| {
+            panic!("{name}: cannot read input.abc: {e}");
+        });
+
+        let actual = chordsketch_core::convert_abc(&input);
+
+        if update {
+            fs::write(&expected_path, &actual).unwrap_or_else(|e| {
+                panic!("{name}: cannot write expected.cho: {e}");
+            });
+            println!("updated: {}", expected_path.display());
+        } else {
+            let expected = fs::read_to_string(&expected_path).unwrap_or_else(|e| {
+                panic!(
+                    "{name}: cannot read expected.cho: {e}\n\
+                     Run `UPDATE_GOLDEN=1 cargo test -p chordsketch-core --test golden_abc` \
+                     to generate it."
+                );
+            });
+            // Normalize CRLF → LF before comparing.
+            let expected_norm = expected.replace("\r\n", "\n");
+            let actual_norm = actual.replace("\r\n", "\n");
+            if actual_norm != expected_norm {
+                eprintln!(
+                    "FAIL: {name}\n--- expected ---\n{expected_norm}\n--- actual ---\n{actual_norm}"
+                );
+                failed = true;
+            }
+        }
+    }
+
+    assert!(!failed, "one or more ABC golden tests failed (see above)");
+}


### PR DESCRIPTION
## What

Fix three abc-importer issues and add golden test infrastructure.

**#1339 — Non-numeric tempo values produce invalid `{tempo}` directive**

`extract_tempo_bpm` now returns `Option<String>` instead of `String`. The extracted token is validated to contain only ASCII digits; if it is non-numeric (e.g. `Q:Allegro` or `Q:1/4=Allegro`), `None` is returned and the `{tempo}` directive is omitted rather than emitting an invalid value.

**#1340 — Multiple `w:` verse lines silently drop all verses after the first**

`flush_block` now iterates over all `w:` lines instead of only `w_lines[0]`. Each verse is emitted as a separate ChordPro lyric line over the same chord structure.

**#1341 — No golden test fixture for ABC → ChordPro conversion**

Added `crates/core/tests/golden_abc.rs` — a test harness that discovers fixture directories containing `input.abc` files and compares `convert_abc` output against `expected.cho` snapshots (same pattern as `golden_heuristic.rs`). Added the `abc-basic-conversion` fixture covering title, composer, numeric tempo, key, inline chords, and two-verse lyrics.

## Why

- Emitting `{tempo: Allegro}` is a spec violation: the `{tempo}` directive must carry a numeric BPM value.
- Silently discarding verse data surprises users and loses information with no diagnostic.
- Golden-test rule requires snapshot coverage for all importer behaviours.

## Test results

```
cargo test -p chordsketch-core   → 1040 passed, 0 failed
cargo clippy -- -D warnings      → clean
cargo fmt --check                 → clean
```

## Review summary

No blocking findings.

Closes #1339
Closes #1340
Closes #1341