### PR TITLE
fix(core): sanitize orphaned w: lyric lines in flush_block

### DIFF
--- a/crates/core/src/abc_importer.rs
+++ b/crates/core/src/abc_importer.rs
@@ -335,8 +335,9 @@ fn flush_block(music_lines: &[String], w_lines: &[String], out: &mut String) {
     if music_lines.is_empty() {
         // Orphaned lyric lines with no preceding music: output as plain text.
         for w in w_lines {
-            if !w.is_empty() {
-                out.push_str(w);
+            let safe = sanitize_lyric_text(w);
+            if !safe.is_empty() {
+                out.push_str(&safe);
                 out.push('\n');
             }
         }
@@ -1127,6 +1128,24 @@ mod tests {
         assert!(
             out.contains("world"),
             "lyric text inside braces must be preserved (braces stripped), got: {out}"
+        );
+    }
+
+    // --- orphaned lyric sanitization (issue #1348) ---
+
+    #[test]
+    fn orphaned_lyric_braces_sanitized() {
+        // w: lines with no preceding music line are output as plain text.
+        // They must still have { and } stripped to prevent directive injection.
+        let input = "X:1\nT:T\nK:C\nw:Orphaned {inject} line\n";
+        let out = convert_abc(input);
+        assert!(
+            !out.contains("{inject}"),
+            "brace injection must be stripped from orphaned lyrics, got: {out}"
+        );
+        assert!(
+            out.contains("inject"),
+            "text inside braces must be preserved (braces stripped), got: {out}"
         );
     }
 }


### PR DESCRIPTION
## What

The orphaned-lyric branch in `flush_block` (triggered when `w:` lines appear before any music line in an ABC body) was pushing the raw `w:` content to output without stripping `{` and `}`. This created an asymmetry with the main lyric path (`build_chordpro_line`), which had `sanitize_lyric_text` applied in #1347.

## Changes

- Apply `sanitize_lyric_text` to each orphaned lyric line before appending to output.
- Switch the emptiness guard from `!w.is_empty()` (raw) to `!safe.is_empty()` (sanitized), so a line containing only braces (e.g. `w:{}`) does not emit a blank line.
- Add `orphaned_lyric_braces_sanitized` test covering the injection case.

## Why

Symmetric sanitization across all lyric output paths is required per the sanitizer-security rule. The orphaned path is the last path that was missing it.

## Test results

```
cargo test -p chordsketch-core   → 1042 passed, 0 failed
cargo clippy -- -D warnings      → clean
cargo fmt --check                 → clean
```

Closes #1348