### PR TITLE
test(core): add brace-only orphaned lyric edge case assertion

### DIFF
--- a/crates/core/src/abc_importer.rs
+++ b/crates/core/src/abc_importer.rs
@@ -1148,4 +1148,18 @@ mod tests {
             "text inside braces must be preserved (braces stripped), got: {out}"
         );
     }
+
+    #[test]
+    fn orphaned_lyric_brace_only_emits_no_blank_line() {
+        // A w: line containing only braces sanitizes to an empty string and
+        // must not produce a blank line in the output.
+        let input = "X:1\nT:T\nK:C\nw:{}\n";
+        let out = convert_abc(input);
+        // The header block ends with "\n\n"; the brace-only lyric must not
+        // append an additional "\n" that would produce "\n\n\n".
+        assert!(
+            !out.ends_with("\n\n\n"),
+            "brace-only orphaned lyric must not emit an extra blank line, got: {out:?}"
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds `orphaned_lyric_brace_only_emits_no_blank_line` to cover the specific guard change introduced in #1349: switching the orphaned-lyric emptiness guard from `!w.is_empty()` to `!safe.is_empty()`.

A `w:` line containing only braces (e.g. `w:{}`) sanitizes to `""`. The `!safe.is_empty()` guard prevents any output. The test asserts that the output does not end with `"\n\n\n"` — which would indicate a spurious trailing blank line was emitted.

## Why

The previous test `orphaned_lyric_braces_sanitized` (from #1349) covered the injection case (`{inject}` stripped) but did not catch the specific blank-line regression. The brace-only case requires checking the raw trailing newline count, which `lines()` + `filter` approaches cannot reliably detect (since empty lines are indistinguishable after `str::lines()`). The `ends_with("\n\n\n")` check is the minimal, correct assertion for this edge case.

## Verification

Reverting the guard from `!safe.is_empty()` back to `!w.is_empty()` causes the test to **FAIL**, confirming it catches the intended regression.

## Test results

```
cargo test -p chordsketch-core   → 1043 passed, 0 failed
cargo clippy -- -D warnings      → clean
cargo fmt --check                 → clean
```

Closes #1350