### PR TITLE
fix(vscode): address post-MVP review findings (WASM URI, async resolution, channel leaks, type guard, CI)

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: packages/vscode-extension
 
       - name: Verify packaged files
-        run: npx @vscode/vsce ls
+        run: ./node_modules/.bin/vsce ls
         working-directory: packages/vscode-extension
 
       - name: Upload VSIX artifact

--- a/packages/vscode-extension/src/lsp.ts
+++ b/packages/vscode-extension/src/lsp.ts
@@ -19,6 +19,13 @@ import { resolveLspBinary } from './platform';
 let client: LanguageClient | undefined;
 
 /**
+ * Single output channel reused across `startLspClient` calls to avoid
+ * accumulating duplicate "ChordSketch LSP" entries in the Output dropdown
+ * when the binary is not found and the user repeatedly toggles the setting.
+ */
+let notFoundChannel: vscode.OutputChannel | undefined;
+
+/**
  * Starts the LSP client if it is not already running.
  *
  * If the `chordsketch-lsp` binary cannot be found, logs a warning and shows
@@ -33,18 +40,20 @@ export async function startLspClient(context: vscode.ExtensionContext): Promise<
   }
 
   const configuredPath = config.get<string>('path', '');
-  const binaryPath = resolveLspBinary(context.extensionPath, configuredPath);
+  const binaryPath = await resolveLspBinary(context.extensionPath, configuredPath);
 
   if (!binaryPath) {
     const msg =
       'ChordSketch: chordsketch-lsp binary not found. ' +
       'Install it via cargo/Homebrew/Scoop or set chordsketch.lsp.path in settings.';
-    const outputChannel = vscode.window.createOutputChannel('ChordSketch LSP');
-    outputChannel.appendLine(msg);
-    outputChannel.appendLine(
+    if (!notFoundChannel) {
+      notFoundChannel = vscode.window.createOutputChannel('ChordSketch LSP');
+      context.subscriptions.push(notFoundChannel);
+    }
+    notFoundChannel.appendLine(msg);
+    notFoundChannel.appendLine(
       'Syntax highlighting and the preview panel will still work without the LSP.',
     );
-    context.subscriptions.push(outputChannel);
 
     void vscode.window.showInformationMessage(msg, 'Open Settings').then((choice) => {
       if (choice === 'Open Settings') {

--- a/packages/vscode-extension/src/platform.ts
+++ b/packages/vscode-extension/src/platform.ts
@@ -10,7 +10,10 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
 
 /** Maps VS Code platform identifiers to the binary directory names used in release archives. */
 const PLATFORM_MAP: Record<string, Record<string, string>> = {
@@ -32,15 +35,16 @@ export function lspBinaryName(): string {
 /**
  * Checks whether `chordsketch-lsp` is available on the system PATH.
  *
- * Uses `which` (Unix) or `where` (Windows) via a synchronous child process.
+ * Uses `which` (Unix) or `where` (Windows) asynchronously to avoid blocking
+ * the extension host event loop during activation.
  * Returns the resolved absolute path, or `undefined` if not found.
  */
-function findOnPath(): string | undefined {
+async function findOnPath(): Promise<string | undefined> {
   const cmd = process.platform === 'win32' ? 'where' : 'which';
   try {
-    const result = execFileSync(cmd, [lspBinaryName()], { encoding: 'utf8' }).trim();
+    const { stdout } = await execFileAsync(cmd, [lspBinaryName()], { encoding: 'utf8' });
     // `which` may return multiple lines; take the first.
-    const first = result.split('\n')[0].trim();
+    const first = stdout.trim().split('\n')[0].trim();
     if (first && fs.existsSync(first)) {
       return first;
     }
@@ -73,10 +77,10 @@ function findBundled(extensionPath: string): string | undefined {
  *
  * Returns the resolved path, or `undefined` if the binary cannot be found.
  */
-export function resolveLspBinary(
+export async function resolveLspBinary(
   extensionPath: string,
   configuredPath: string,
-): string | undefined {
+): Promise<string | undefined> {
   // Tier 1: user override.
   if (configuredPath.trim()) {
     const p = configuredPath.trim();
@@ -84,7 +88,7 @@ export function resolveLspBinary(
   }
 
   // Tier 2: system PATH.
-  const onPath = findOnPath();
+  const onPath = await findOnPath();
   if (onPath) {
     return onPath;
   }

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -16,6 +16,26 @@ type ExtToWebview = { type: 'update'; text: string };
 /** Message types received from the WebView in the extension host. */
 type WebviewToExt = { type: 'ready' } | { type: 'error'; message: string };
 
+/**
+ * Type guard for messages received from the WebView.
+ *
+ * Validates the shape of `raw` before casting to `WebviewToExt` so that
+ * field accesses are safe even if the WebView sends a malformed message.
+ */
+function isWebviewToExt(raw: unknown): raw is WebviewToExt {
+  if (typeof raw !== 'object' || raw === null) {
+    return false;
+  }
+  const r = raw as Record<string, unknown>;
+  if (r['type'] === 'ready') {
+    return true;
+  }
+  if (r['type'] === 'error') {
+    return typeof r['message'] === 'string';
+  }
+  return false;
+}
+
 /** Debounce delay in milliseconds. */
 const DEBOUNCE_MS = 300;
 
@@ -71,6 +91,8 @@ class PreviewPanel {
   private readonly document: vscode.TextDocument;
   private debounceTimer: NodeJS.Timeout | undefined;
   private pendingText: string | undefined;
+  /** Lazily created output channel for surfacing render errors from this panel. */
+  private outputChannel: vscode.OutputChannel | undefined;
 
   constructor(context: vscode.ExtensionContext, document: vscode.TextDocument) {
     this.context = context;
@@ -94,15 +116,21 @@ class PreviewPanel {
 
     // Handle messages from the WebView.
     this.panel.webview.onDidReceiveMessage((raw: unknown) => {
-      const msg = raw as WebviewToExt;
-      if (msg.type === 'ready') {
+      if (!isWebviewToExt(raw)) {
+        // Unknown or malformed message — silently ignore.
+        return;
+      }
+      if (raw.type === 'ready') {
         // WebView is ready — send the current document content.
         this.sendUpdate(this.document.getText());
-      } else if (msg.type === 'error') {
+      } else if (raw.type === 'error') {
         // The WebView surfaces render errors; they are also displayed inline
         // in the panel so we only log here and don't show a notification.
-        const outputChannel = vscode.window.createOutputChannel('ChordSketch Preview');
-        outputChannel.appendLine(`Preview render error: ${msg.message}`);
+        if (!this.outputChannel) {
+          this.outputChannel = vscode.window.createOutputChannel('ChordSketch Preview');
+          this.context.subscriptions.push(this.outputChannel);
+        }
+        this.outputChannel.appendLine(`Preview render error: ${raw.message}`);
       }
     });
 
@@ -159,8 +187,10 @@ class PreviewPanel {
    * Builds the WebView HTML.
    *
    * Uses a CSP nonce to allow only the bundled script. The WASM binary URI
-   * is embedded as a data attribute on a container element so the WebView
-   * script can pass it to `init()` at runtime without a network fetch.
+   * is injected via a `<meta name="chordsketch-wasm-uri">` element so the
+   * WebView script can read it at runtime. A `data-` attribute on
+   * `<script type="module">` cannot be used because `document.currentScript`
+   * is always `null` for ES module scripts (HTML spec).
    */
   private buildHtml(): string {
     const webview = this.panel.webview;
@@ -196,6 +226,7 @@ class PreviewPanel {
     connect-src ${csp};
   ">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="chordsketch-wasm-uri" content="${wasmUri}">
   <title>ChordSketch Preview</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -232,12 +263,7 @@ class PreviewPanel {
     sandbox="allow-popups allow-popups-to-escape-sandbox"
     title="ChordPro preview"
   ></iframe>
-  <script
-    nonce="${nonce}"
-    src="${scriptUri}"
-    type="module"
-    data-wasm-uri="${wasmUri}"
-  ></script>
+  <script nonce="${nonce}" src="${scriptUri}" type="module"></script>
 </body>
 </html>`;
   }

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -6,11 +6,13 @@
  * extension host, then listens for document-update messages and renders them
  * as HTML via the iframe.
  *
- * The WASM URI is passed via the `data-wasm-uri` attribute on this script's
- * own `<script>` element, injected by the extension host in `preview.ts`.
+ * The WASM URI is injected by the extension host as
+ * `<meta name="chordsketch-wasm-uri" content="...">`. A `data-` attribute on
+ * the `<script>` element cannot be used because `document.currentScript` is
+ * always `null` for `type="module"` scripts (HTML spec).
  */
 
-import init, { render_html, render_html_with_options } from '@chordsketch/wasm';
+import init, { render_html } from '@chordsketch/wasm';
 
 /** VS Code WebView API acquired from the global injected by the host. */
 declare function acquireVsCodeApi(): {
@@ -104,15 +106,13 @@ function renderPreview(text: string): void {
   }
 }
 
-// Suppress unused-variable lint: render_html_with_options is exported for
-// future use by Phase B (transpose controls).
-void render_html_with_options;
-
 async function main(): Promise<void> {
   // Read the WASM binary URI injected by the extension host.
-  // The script tag that loads this module carries a `data-wasm-uri` attribute.
-  const scriptEl = document.currentScript as HTMLScriptElement | null;
-  const wasmUri = scriptEl?.dataset.wasmUri ?? '';
+  // A <meta name="chordsketch-wasm-uri"> is used instead of a data- attribute
+  // on the <script> tag because document.currentScript is null for ES modules.
+  const wasmUri =
+    document.querySelector<HTMLMetaElement>('meta[name="chordsketch-wasm-uri"]')?.content ?? '';
+  // TODO(Phase B): use render_html_with_options here for transpose controls.
 
   try {
     if (wasmUri) {


### PR DESCRIPTION
## What

Six follow-up fixes to the MVP VS Code extension (#1353), all identified in the post-merge review.

## Why

- WASM URI never reached the WebView script because `document.currentScript` is `null` for `type="module"` scripts (HTML spec) — the explicit URI was dead code
- `execFileSync` blocks the extension host event loop during activation
- Repeated binary-not-found activations accumulate duplicate "ChordSketch LSP" entries in the Output dropdown
- WebView message fields were accessed without validating the message shape
- A new output channel was created on every render error message
- `npx @vscode/vsce` in CI re-downloads the package ignoring the lock file

## Changes

| File | Change |
|---|---|
| `src/preview.ts` | Inject WASM URI via `<meta name="chordsketch-wasm-uri">` instead of `data-` on `<script type="module">` |
| `webview/preview.ts` | Read URI from meta tag; remove unused `render_html_with_options` import; add Phase B TODO |
| `src/platform.ts` | Replace `execFileSync` + `child_process` with `promisify(execFile)` — async PATH lookup |
| `src/lsp.ts` | Await `resolveLspBinary`; reuse singleton `notFoundChannel` across calls |
| `src/preview.ts` | Add `isWebviewToExt()` type guard; make preview error channel a lazy class field |
| `.github/workflows/vscode-extension.yml` | Use `./node_modules/.bin/vsce ls` instead of `npx @vscode/vsce ls` |

## Test results

- `npm run lint` (tsc --noEmit): ✅ zero errors
- `npm run build`: ✅ builds cleanly

## Closes

Closes #1354, #1355, #1356, #1357, #1358, #1359
Closes #1360, #1361, #1362, #1363, #1364, #1365

## Review summary

No automated review yet — CI will run on push.