### PR TITLE
fix(vscode): fix resource leaks and add WebView message validation

### DIFF
--- a/packages/vscode-extension/src/lsp.ts
+++ b/packages/vscode-extension/src/lsp.ts
@@ -95,10 +95,12 @@ export async function startLspClient(context: vscode.ExtensionContext): Promise<
   await client.start();
 }
 
-/** Stops the LSP client gracefully. */
+/** Stops the LSP client gracefully and resets the not-found channel reference. */
 export async function stopLspClient(): Promise<void> {
   if (client) {
     await client.stop();
     client = undefined;
   }
+  // Reset so the next activation registers a fresh channel in the new context.
+  notFoundChannel = undefined;
 }

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -126,9 +126,9 @@ class PreviewPanel {
       } else if (raw.type === 'error') {
         // The WebView surfaces render errors; they are also displayed inline
         // in the panel so we only log here and don't show a notification.
+        // The channel lifetime tracks this panel — it is disposed in dispose().
         if (!this.outputChannel) {
           this.outputChannel = vscode.window.createOutputChannel('ChordSketch Preview');
-          this.context.subscriptions.push(this.outputChannel);
         }
         this.outputChannel.appendLine(`Preview render error: ${raw.message}`);
       }
@@ -174,12 +174,14 @@ class PreviewPanel {
     void this.panel.webview.postMessage(msg);
   }
 
-  /** Disposes the panel and clears any pending debounce timer. */
+  /** Disposes the panel, its output channel, and any pending debounce timer. */
   dispose(): void {
     if (this.debounceTimer !== undefined) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = undefined;
     }
+    this.outputChannel?.dispose();
+    this.outputChannel = undefined;
     this.panel.dispose();
   }
 

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -26,6 +26,20 @@ const vscode = acquireVsCodeApi();
 /** Message types received from the extension host. */
 type ExtToWebview = { type: 'update'; text: string };
 
+/**
+ * Type guard for messages received from the extension host.
+ *
+ * Validates the shape of `event.data` before field access so that unknown
+ * or malformed messages are silently ignored rather than causing TypeErrors.
+ */
+function isExtToWebview(raw: unknown): raw is ExtToWebview {
+  if (typeof raw !== 'object' || raw === null) {
+    return false;
+  }
+  const r = raw as Record<string, unknown>;
+  return r['type'] === 'update' && typeof r['text'] === 'string';
+}
+
 const loadingEl = document.getElementById('loading') as HTMLDivElement;
 const errorEl = document.getElementById('error') as HTMLDivElement;
 const previewFrame = document.getElementById('preview-frame') as HTMLIFrameElement;
@@ -97,6 +111,7 @@ function renderPreview(text: string): void {
   }
 
   try {
+    // TODO(Phase B): call render_html_with_options with transpose options instead of render_html.
     const html = render_html(text);
     hideError();
     previewFrame.srcdoc = wrapHtml(html);
@@ -112,7 +127,6 @@ async function main(): Promise<void> {
   // on the <script> tag because document.currentScript is null for ES modules.
   const wasmUri =
     document.querySelector<HTMLMetaElement>('meta[name="chordsketch-wasm-uri"]')?.content ?? '';
-  // TODO(Phase B): use render_html_with_options here for transpose controls.
 
   try {
     if (wasmUri) {
@@ -129,9 +143,12 @@ async function main(): Promise<void> {
 
   // Listen for messages from the extension host.
   window.addEventListener('message', (event: MessageEvent) => {
-    const msg = event.data as ExtToWebview;
-    if (msg.type === 'update') {
-      renderPreview(msg.text);
+    if (!isExtToWebview(event.data)) {
+      // Unknown or malformed message — silently ignore.
+      return;
+    }
+    if (event.data.type === 'update') {
+      renderPreview(event.data.text);
     }
   });
 


### PR DESCRIPTION
## What

Four follow-up fixes from the delta review of PR #1366.

## Changes

| Issue | File | Change |
|-------|------|--------|
| #1367 | `src/lsp.ts` | Reset `notFoundChannel` to `undefined` in `stopLspClient()` so a fresh channel is created and registered in the new `context` on next activation |
| #1368 | `webview/preview.ts` | Move Phase B TODO comment to `renderPreview()` adjacent to the `render_html` call where it will actually be applied |
| #1369 | `src/preview.ts` | Dispose `outputChannel` in `PreviewPanel.dispose()` instead of delegating to `context.subscriptions`; prevents stale "ChordSketch Preview" entries after panel open/close cycles |
| #1370 | `webview/preview.ts` | Add `isExtToWebview()` type guard in the `window.addEventListener('message', ...)` handler; unknown or malformed host messages are silently ignored |

## Why

- **#1367**: Module-level singleton not cleared → stale disposed channel reused on re-activation
- **#1368**: Comment in `main()` said "here" but `render_html_with_options` belongs in `renderPreview()`
- **#1369**: Per-panel channel was pushed to `context.subscriptions` (extension lifetime), not disposed with the panel → accumulated entries in the Output dropdown on repeated open/close
- **#1370**: `event.data as ExtToWebview` unsafe cast — if `text` is `undefined`, `renderPreview(undefined)` would throw `TypeError` from `.trim()`

## Test results

- `npm run lint` (tsc --noEmit): ✅ zero errors
- `npm run build`: ✅ builds cleanly

## Closes

Closes #1367, #1368, #1369, #1370