### PR TITLE
fix(vscode): dispose PreviewPanel resources when user closes panel tab

### DIFF
--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -134,9 +134,18 @@ class PreviewPanel {
       }
     });
 
-    // Remove this panel from the map when the user closes it.
+    // Remove this panel from the map when the user closes it, and clean up
+    // associated resources immediately so they do not outlive the panel tab.
+    // The outputChannel?.dispose() + = undefined pattern ensures double-dispose
+    // is safe when disposeAll() later calls dispose() on the same instance.
     this.panel.onDidDispose(() => {
       panels.delete(this.document.uri.toString());
+      if (this.debounceTimer !== undefined) {
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = undefined;
+      }
+      this.outputChannel?.dispose();
+      this.outputChannel = undefined;
     });
   }
 


### PR DESCRIPTION
## What

Dispose the output channel (and any pending debounce timer) immediately when the user closes the preview panel tab, not only at extension deactivation.

## Why

`PreviewPanel.dispose()` already cleaned up all resources correctly when called via `disposeAll()` at deactivation. However, the `panel.onDidDispose()` callback — which fires when the user closes the tab — only removed the panel from the tracking map. The output channel therefore persisted in the Output dropdown until the extension was deactivated.

## Changes

- `panel.onDidDispose()` now also clears the pending debounce timer and disposes the output channel, mirroring the cleanup already in `dispose()`.
- The existing `this.outputChannel = undefined` reset in `dispose()` ensures double-dispose is safe: when `disposeAll()` later calls `dispose()` on the same instance, `this.outputChannel` is already `undefined` so the optional-chaining call is a no-op.

## Test results

- `npx tsc --noEmit` passes with zero errors.

## Review summary

Targeted fix for the resource leak identified in the delta review of PR #1371.

Closes #1373