### PR TITLE
nit(vscode): remove redundant inner type check after isExtToWebview guard

### DIFF
--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -147,9 +147,8 @@ async function main(): Promise<void> {
       // Unknown or malformed message — silently ignore.
       return;
     }
-    if (event.data.type === 'update') {
-      renderPreview(event.data.text);
-    }
+    // isExtToWebview already asserts type === 'update'; no inner dispatch needed.
+    renderPreview(event.data.text);
   });
 
   // Tell the extension host that the WebView is ready to receive content.

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -147,7 +147,7 @@ async function main(): Promise<void> {
       // Unknown or malformed message — silently ignore.
       return;
     }
-    // isExtToWebview already asserts type === 'update'; no inner dispatch needed.
+    // isExtToWebview guarantees type === 'update'; no inner dispatch needed.
     renderPreview(event.data.text);
   });
 


### PR DESCRIPTION
## What

Remove the dead inner `if (event.data.type === 'update')` branch from the WebView message handler in `packages/vscode-extension/webview/preview.ts`.

## Why

`isExtToWebview` already validates `r['type'] === 'update'` and only returns `true` for that type. The subsequent `if (event.data.type === 'update')` was therefore always `true` after the guard, making the `false` branch unreachable. The redundant check was misleading — it implied other variants might arrive when none exist in the current `ExtToWebview` union.

A brief comment now explains that the single-dispatch is intentional, so that adding a second variant in Phase B will prompt restoring a dispatch switch at that point.

## Test results

- `npx tsc --noEmit` passes with zero errors.

## Review summary

Nit cleanup following the delta review of PR #1371.

Closes #1374
Closes #1372