### PR TITLE
fix(vscode): guard debounce timer callback against disposed panel

### DIFF
--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -118,6 +118,9 @@ class PreviewPanel {
 
     // Handle messages from the WebView.
     this.panel.webview.onDidReceiveMessage((raw: unknown) => {
+      if (this.disposed) {
+        return;
+      }
       if (!isWebviewToExt(raw)) {
         // Unknown or malformed message — silently ignore.
         return;

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -93,6 +93,8 @@ class PreviewPanel {
   private pendingText: string | undefined;
   /** Lazily created output channel for surfacing render errors from this panel. */
   private outputChannel: vscode.OutputChannel | undefined;
+  /** Set to true once the panel is disposed so stale timer callbacks are no-ops. */
+  private disposed = false;
 
   constructor(context: vscode.ExtensionContext, document: vscode.TextDocument) {
     this.context = context;
@@ -126,7 +128,8 @@ class PreviewPanel {
       } else if (raw.type === 'error') {
         // The WebView surfaces render errors; they are also displayed inline
         // in the panel so we only log here and don't show a notification.
-        // The channel lifetime tracks this panel — it is disposed in dispose().
+        // The channel lifetime tracks this panel — disposed in onDidDispose (tab
+        // close) and in dispose() (extension deactivation via disposeAll()).
         if (!this.outputChannel) {
           this.outputChannel = vscode.window.createOutputChannel('ChordSketch Preview');
         }
@@ -136,9 +139,10 @@ class PreviewPanel {
 
     // Remove this panel from the map when the user closes it, and clean up
     // associated resources immediately so they do not outlive the panel tab.
-    // The outputChannel?.dispose() + = undefined pattern ensures double-dispose
-    // is safe when disposeAll() later calls dispose() on the same instance.
+    // Setting disposed=true before clearTimeout guards against a stale timer
+    // callback that may already be queued when onDidDispose fires.
     this.panel.onDidDispose(() => {
+      this.disposed = true;
       panels.delete(this.document.uri.toString());
       if (this.debounceTimer !== undefined) {
         clearTimeout(this.debounceTimer);
@@ -170,7 +174,7 @@ class PreviewPanel {
     }
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = undefined;
-      if (this.pendingText !== undefined) {
+      if (this.pendingText !== undefined && !this.disposed) {
         this.sendUpdate(this.pendingText);
         this.pendingText = undefined;
       }
@@ -185,6 +189,7 @@ class PreviewPanel {
 
   /** Disposes the panel, its output channel, and any pending debounce timer. */
   dispose(): void {
+    this.disposed = true;
     if (this.debounceTimer !== undefined) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = undefined;


### PR DESCRIPTION
## What

- Add a `private disposed = false` flag to `PreviewPanel`.
- Set `this.disposed = true` at the start of both `dispose()` (called by `disposeAll()`) and the `panel.onDidDispose()` callback.
- Guard the debounce timer callback with `!this.disposed` before calling `sendUpdate`.
- Update the stale comment on lazy `outputChannel` creation to mention both disposal sites.

## Why

If a debounce timer expires just before `onDidDispose` fires (e.g. the user closes the panel while a keystroke-triggered update is pending), the timer callback is already queued in the macrotask queue. `clearTimeout` cannot remove a callback that has already been placed in the queue. Without the `disposed` guard, `sendUpdate` → `postMessage` would be called on a disposed `WebviewPanel`. VS Code currently silently no-ops on such calls, but this is an undocumented implementation detail. The guard makes the intent explicit and prevents a future regression if VS Code's behaviour changes.

The same race applies when `disposeAll()` calls `dispose()`, so `disposed = true` is also set there.

## Test results

- `npx tsc --noEmit` passes with zero errors.

## Review summary

Implements the Low finding from the security review of PR #1375, and closes the stale-comment doc gap tracked in #1378.

Closes #1376
Closes #1378