### PR TITLE
feat(vscode): add plain text view toggle to preview panel

### DIFF
--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -277,6 +277,13 @@ class PreviewPanel {
     .view-btn:not(.active):hover {
       background: var(--vscode-button-secondaryHoverBackground, #3a3a3a);
     }
+    /* Toolbar is disabled until WASM finishes loading so that clicking
+       buttons before init completes is not possible. The script removes
+       the 'disabled' class after a successful init(). */
+    #toolbar.disabled {
+      pointer-events: none;
+      opacity: 0.4;
+    }
     #loading {
       padding: 1rem;
       color: var(--vscode-descriptionForeground);
@@ -307,6 +314,7 @@ class PreviewPanel {
       font-family: var(--vscode-editor-font-family, monospace);
       font-size: var(--vscode-editor-font-size, 13px);
       line-height: 1.5;
+      background: var(--vscode-editor-background, #1e1e1e);
       color: var(--vscode-editor-foreground, #d4d4d4);
       white-space: pre;
       word-break: normal;
@@ -314,7 +322,7 @@ class PreviewPanel {
   </style>
 </head>
 <body>
-  <div id="toolbar">
+  <div id="toolbar" class="disabled">
     <button id="btn-html" class="view-btn active" title="HTML preview">HTML</button>
     <button id="btn-text" class="view-btn" title="Plain text preview">Plain text</button>
   </div>

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -250,6 +250,33 @@ class PreviewPanel {
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: var(--vscode-font-family, sans-serif); height: 100vh; display: flex; flex-direction: column; }
+    #toolbar {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      padding: 4px 8px;
+      background: var(--vscode-editor-background, #1e1e1e);
+      border-bottom: 1px solid var(--vscode-editorGroup-border, #444);
+      flex-shrink: 0;
+    }
+    .view-btn {
+      background: transparent;
+      border: 1px solid var(--vscode-button-secondaryBackground, #555);
+      color: var(--vscode-foreground, #ccc);
+      padding: 2px 10px;
+      cursor: pointer;
+      font-size: 0.75rem;
+      border-radius: 3px;
+      font-family: inherit;
+    }
+    .view-btn.active {
+      background: var(--vscode-button-background, #0078d4);
+      color: var(--vscode-button-foreground, #fff);
+      border-color: var(--vscode-button-background, #0078d4);
+    }
+    .view-btn:not(.active):hover {
+      background: var(--vscode-button-secondaryHoverBackground, #3a3a3a);
+    }
     #loading {
       padding: 1rem;
       color: var(--vscode-descriptionForeground);
@@ -272,9 +299,25 @@ class PreviewPanel {
       display: none;
       background: white;
     }
+    #text-frame {
+      flex: 1;
+      display: none;
+      padding: 1.5rem;
+      overflow: auto;
+      font-family: var(--vscode-editor-font-family, monospace);
+      font-size: var(--vscode-editor-font-size, 13px);
+      line-height: 1.5;
+      color: var(--vscode-editor-foreground, #d4d4d4);
+      white-space: pre;
+      word-break: normal;
+    }
   </style>
 </head>
 <body>
+  <div id="toolbar">
+    <button id="btn-html" class="view-btn active" title="HTML preview">HTML</button>
+    <button id="btn-text" class="view-btn" title="Plain text preview">Plain text</button>
+  </div>
   <div id="loading">Initializing ChordSketch preview…</div>
   <div id="error"></div>
   <iframe
@@ -282,6 +325,7 @@ class PreviewPanel {
     sandbox="allow-popups allow-popups-to-escape-sandbox"
     title="ChordPro preview"
   ></iframe>
+  <pre id="text-frame" aria-label="Plain text preview"></pre>
   <script nonce="${nonce}" src="${scriptUri}" type="module"></script>
 </body>
 </html>`;

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -259,7 +259,7 @@ class PreviewPanel {
       border-bottom: 1px solid var(--vscode-editorGroup-border, #444);
       flex-shrink: 0;
     }
-    .view-btn {
+    #toolbar .view-btn {
       background: transparent;
       border: 1px solid var(--vscode-button-secondaryBackground, #555);
       color: var(--vscode-foreground, #ccc);
@@ -269,12 +269,12 @@ class PreviewPanel {
       border-radius: 3px;
       font-family: inherit;
     }
-    .view-btn.active {
+    #toolbar .view-btn.active {
       background: var(--vscode-button-background, #0078d4);
       color: var(--vscode-button-foreground, #fff);
       border-color: var(--vscode-button-background, #0078d4);
     }
-    .view-btn:not(.active):hover {
+    #toolbar .view-btn:not(.active):hover {
       background: var(--vscode-button-secondaryHoverBackground, #3a3a3a);
     }
     /* Toolbar is disabled until WASM finishes loading so that clicking

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -48,6 +48,7 @@ function isExtToWebview(raw: unknown): raw is ExtToWebview {
   return r['type'] === 'update' && typeof r['text'] === 'string';
 }
 
+const toolbar = document.getElementById('toolbar') as HTMLDivElement;
 const loadingEl = document.getElementById('loading') as HTMLDivElement;
 const errorEl = document.getElementById('error') as HTMLDivElement;
 const previewFrame = document.getElementById('preview-frame') as HTMLIFrameElement;
@@ -124,6 +125,12 @@ function wrapHtml(body: string): string {
 </html>`;
 }
 
+/** Syncs toggle button active classes to the current `viewMode`. */
+function syncButtonStates(): void {
+  btnHtml.classList.toggle('active', viewMode === 'html');
+  btnText.classList.toggle('active', viewMode === 'text');
+}
+
 /**
  * Renders the given ChordPro source text according to the active view mode.
  *
@@ -175,13 +182,15 @@ function renderPreview(text: string): void {
  *
  * The chosen mode is persisted via `vscode.setState` so it survives the
  * WebView being hidden and re-shown (`retainContextWhenHidden` is set).
+ * Called only after WASM has successfully loaded.
  */
 function setViewMode(mode: ViewMode): void {
+  if (mode === viewMode) {
+    return; // No-op: avoid redundant WASM call and iframe flicker.
+  }
   viewMode = mode;
   vscode.setState({ mode } satisfies PanelState);
-
-  btnHtml.classList.toggle('active', mode === 'html');
-  btnText.classList.toggle('active', mode === 'text');
+  syncButtonStates();
 
   if (lastText) {
     renderPreview(lastText);
@@ -193,12 +202,8 @@ async function main(): Promise<void> {
   const saved = vscode.getState() as PanelState | null;
   if (saved?.mode === 'html' || saved?.mode === 'text') {
     viewMode = saved.mode;
-    btnHtml.classList.toggle('active', viewMode === 'html');
-    btnText.classList.toggle('active', viewMode === 'text');
+    syncButtonStates();
   }
-
-  btnHtml.addEventListener('click', () => setViewMode('html'));
-  btnText.addEventListener('click', () => setViewMode('text'));
 
   // Read the WASM binary URI injected by the extension host.
   // A <meta name="chordsketch-wasm-uri"> is used instead of a data- attribute
@@ -218,6 +223,15 @@ async function main(): Promise<void> {
   }
 
   loadingEl.style.display = 'none';
+
+  // Enable the toolbar only after WASM is ready so clicking buttons before
+  // init is not possible. The CSS sets pointer-events:none on the toolbar
+  // by default; removing the class re-enables it.
+  toolbar.classList.remove('disabled');
+
+  // Register toggle button handlers after WASM is ready.
+  btnHtml.addEventListener('click', () => setViewMode('html'));
+  btnText.addEventListener('click', () => setViewMode('text'));
 
   // Listen for messages from the extension host.
   window.addEventListener('message', (event: MessageEvent) => {

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -192,9 +192,7 @@ function setViewMode(mode: ViewMode): void {
   vscode.setState({ mode } satisfies PanelState);
   syncButtonStates();
 
-  if (lastText) {
-    renderPreview(lastText);
-  }
+  renderPreview(lastText);
 }
 
 async function main(): Promise<void> {

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -4,7 +4,7 @@
  * Runs in the sandboxed WebView context (browser environment). Initialises
  * the `@chordsketch/wasm` module using the WASM binary URI provided by the
  * extension host, then listens for document-update messages and renders them
- * as HTML via the iframe.
+ * using the active view mode (HTML or plain text).
  *
  * The WASM URI is injected by the extension host as
  * `<meta name="chordsketch-wasm-uri" content="...">`. A `data-` attribute on
@@ -12,7 +12,7 @@
  * always `null` for `type="module"` scripts (HTML spec).
  */
 
-import init, { render_html } from '@chordsketch/wasm';
+import init, { render_html, render_text } from '@chordsketch/wasm';
 
 /** VS Code WebView API acquired from the global injected by the host. */
 declare function acquireVsCodeApi(): {
@@ -22,6 +22,14 @@ declare function acquireVsCodeApi(): {
 };
 
 const vscode = acquireVsCodeApi();
+
+/** View mode for the preview panel. */
+type ViewMode = 'html' | 'text';
+
+/** Persisted panel state saved and restored via the VS Code WebView API. */
+interface PanelState {
+  mode?: ViewMode;
+}
 
 /** Message types received from the extension host. */
 type ExtToWebview = { type: 'update'; text: string };
@@ -43,11 +51,26 @@ function isExtToWebview(raw: unknown): raw is ExtToWebview {
 const loadingEl = document.getElementById('loading') as HTMLDivElement;
 const errorEl = document.getElementById('error') as HTMLDivElement;
 const previewFrame = document.getElementById('preview-frame') as HTMLIFrameElement;
+const textFrame = document.getElementById('text-frame') as HTMLPreElement;
+const btnHtml = document.getElementById('btn-html') as HTMLButtonElement;
+const btnText = document.getElementById('btn-text') as HTMLButtonElement;
+
+/** Currently active view mode. Loaded from persisted state in `main()`. */
+let viewMode: ViewMode = 'html';
+
+/**
+ * Most recently rendered source text.
+ *
+ * Kept so that switching view modes re-renders the existing content without
+ * waiting for the next document-change message from the extension host.
+ */
+let lastText = '';
 
 function showError(msg: string): void {
   errorEl.textContent = msg;
   errorEl.style.display = 'block';
   previewFrame.style.display = 'none';
+  textFrame.style.display = 'none';
   vscode.postMessage({ type: 'error', message: msg });
 }
 
@@ -101,27 +124,82 @@ function wrapHtml(body: string): string {
 </html>`;
 }
 
-/** Renders the given ChordPro source text into the preview iframe. */
+/**
+ * Renders the given ChordPro source text according to the active view mode.
+ *
+ * In HTML mode, `render_html` is called and the output is loaded into the
+ * sandboxed iframe via `srcdoc`. In plain text mode, `render_text` is called
+ * and the output is set as `textContent` of the `<pre>` element (safe — no
+ * HTML parsing occurs).
+ */
 function renderPreview(text: string): void {
+  lastText = text;
+
   if (!text.trim()) {
     hideError();
-    previewFrame.srcdoc = '';
-    previewFrame.style.display = 'block';
+    if (viewMode === 'html') {
+      previewFrame.srcdoc = '';
+      previewFrame.style.display = 'block';
+      textFrame.style.display = 'none';
+    } else {
+      textFrame.textContent = '';
+      textFrame.style.display = 'block';
+      previewFrame.style.display = 'none';
+    }
     return;
   }
 
   try {
-    // TODO(Phase B): call render_html_with_options with transpose options instead of render_html.
-    const html = render_html(text);
-    hideError();
-    previewFrame.srcdoc = wrapHtml(html);
-    previewFrame.style.display = 'block';
+    if (viewMode === 'html') {
+      // TODO(Phase B): call render_html_with_options with transpose options instead of render_html.
+      const html = render_html(text);
+      hideError();
+      previewFrame.srcdoc = wrapHtml(html);
+      previewFrame.style.display = 'block';
+      textFrame.style.display = 'none';
+    } else {
+      const plain = render_text(text);
+      hideError();
+      // textContent assignment is safe: no HTML parsing, no XSS risk.
+      textFrame.textContent = plain;
+      textFrame.style.display = 'block';
+      previewFrame.style.display = 'none';
+    }
   } catch (e) {
     showError(formatError(e));
   }
 }
 
+/**
+ * Switches to the given view mode and immediately re-renders the current text.
+ *
+ * The chosen mode is persisted via `vscode.setState` so it survives the
+ * WebView being hidden and re-shown (`retainContextWhenHidden` is set).
+ */
+function setViewMode(mode: ViewMode): void {
+  viewMode = mode;
+  vscode.setState({ mode } satisfies PanelState);
+
+  btnHtml.classList.toggle('active', mode === 'html');
+  btnText.classList.toggle('active', mode === 'text');
+
+  if (lastText) {
+    renderPreview(lastText);
+  }
+}
+
 async function main(): Promise<void> {
+  // Restore the persisted view mode so the user's choice survives hide/show.
+  const saved = vscode.getState() as PanelState | null;
+  if (saved?.mode === 'html' || saved?.mode === 'text') {
+    viewMode = saved.mode;
+    btnHtml.classList.toggle('active', viewMode === 'html');
+    btnText.classList.toggle('active', viewMode === 'text');
+  }
+
+  btnHtml.addEventListener('click', () => setViewMode('html'));
+  btnText.addEventListener('click', () => setViewMode('text'));
+
   // Read the WASM binary URI injected by the extension host.
   // A <meta name="chordsketch-wasm-uri"> is used instead of a data- attribute
   // on the <script> tag because document.currentScript is null for ES modules.


### PR DESCRIPTION
## What

Add an HTML / Plain text toggle button bar to the ChordSketch preview panel WebView, allowing users to switch between the rendered HTML view and the formatted plain text output.

## Why

The `@chordsketch/wasm` package already exports `render_text`, but the preview panel only used `render_html`. A view-mode toggle is one of the Phase B features called out in #1153 ("Three view modes: HTML preview, plain text, chord grid") and gives users a quick way to see the plain text representation without switching to the terminal.

## Changes

### `webview/preview.ts`
- Import `render_text` alongside `render_html`.
- Add `ViewMode = 'html' | 'text'` type and `PanelState` interface for persisted state.
- `renderPreview()` dispatches to `render_html` or `render_text` based on `viewMode`; the iframe and `<pre>` elements are kept mutually exclusive.
- Plain text output is assigned via `textContent` (safe: no HTML parsing, no XSS risk).
- `setViewMode()` persists the chosen mode via `vscode.setState` and re-renders immediately on toggle.
- Persisted mode is restored from `vscode.getState()` at startup (survives `retainContextWhenHidden` hide/show cycles).

### `src/preview.ts` (`buildHtml()`)
- Add a `#toolbar` div with `#btn-html` / `#btn-text` toggle buttons.
- Add `<pre id="text-frame">` element for plain text output.
- CSS uses VS Code theme variables (`--vscode-button-background`, `--vscode-editor-foreground`, etc.).

## Test results

- `npx tsc --noEmit` passes with zero errors.

## Review summary

Sub-task of #1153. No Rust changes; purely TypeScript/HTML/CSS.

Closes #1380