### PR TITLE
fix(vscode): spread existing state in setViewMode to prevent future data loss

### DIFF
--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -189,7 +189,9 @@ function setViewMode(mode: ViewMode): void {
     return; // No-op: avoid redundant WASM call and iframe flicker.
   }
   viewMode = mode;
-  vscode.setState({ mode } satisfies PanelState);
+  // Spread the existing state before writing back so that any fields added to
+  // PanelState in a future PR are not silently wiped on every mode toggle.
+  vscode.setState({ ...(vscode.getState() as PanelState | null) ?? {}, mode } satisfies PanelState);
   syncButtonStates();
 
   renderPreview(lastText);


### PR DESCRIPTION
## What

Use a state-spread pattern in `setViewMode` when calling `vscode.setState` to preserve any future `PanelState` fields.

## Why

`vscode.setState({ mode })` replaces the entire WebView state with just `{ mode }`. Today `PanelState` has only the `mode` field, so there is no current data loss. However, if a future PR adds a second persisted field (e.g. `scrollPosition`, `transpose`) without also spreading the existing state, that field would be silently wiped on every mode toggle.

## Changes

Change:
```ts
vscode.setState({ mode } satisfies PanelState);
```
To:
```ts
vscode.setState({ ...(vscode.getState() as PanelState | null) ?? {}, mode } satisfies PanelState);
```

And add a comment explaining why the spread is necessary.

## Test results

- `npx tsc --noEmit` passes with zero errors.

## Review summary

Non-blocking defensive fix surfaced during review of PR #1381.

Closes #1382