### PR TITLE
feat(vscode): add transpose controls to preview panel

### DIFF
--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -277,6 +277,34 @@ class PreviewPanel {
     #toolbar .view-btn:not(.active):hover {
       background: var(--vscode-button-secondaryHoverBackground, #3a3a3a);
     }
+    .toolbar-separator {
+      width: 1px;
+      height: 16px;
+      background: var(--vscode-editorGroup-border, #444);
+      margin: 0 6px;
+      flex-shrink: 0;
+    }
+    #toolbar .transpose-btn {
+      background: transparent;
+      border: 1px solid var(--vscode-button-secondaryBackground, #555);
+      color: var(--vscode-foreground, #ccc);
+      padding: 2px 7px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      border-radius: 3px;
+      font-family: inherit;
+      line-height: 1;
+    }
+    #toolbar .transpose-btn:hover {
+      background: var(--vscode-button-secondaryHoverBackground, #3a3a3a);
+    }
+    #transpose-label {
+      font-size: 0.75rem;
+      color: var(--vscode-foreground, #ccc);
+      min-width: 2.5rem;
+      text-align: center;
+      font-variant-numeric: tabular-nums;
+    }
     /* Toolbar is disabled until WASM finishes loading so that clicking
        buttons before init completes is not possible. The script removes
        the 'disabled' class after a successful init(). */
@@ -325,6 +353,10 @@ class PreviewPanel {
   <div id="toolbar" class="disabled">
     <button id="btn-html" class="view-btn active" title="HTML preview">HTML</button>
     <button id="btn-text" class="view-btn" title="Plain text preview">Plain text</button>
+    <span class="toolbar-separator" role="separator"></span>
+    <button id="btn-transpose-down" class="transpose-btn" title="Transpose down one semitone">−</button>
+    <span id="transpose-label" aria-label="Transpose offset" title="Semitone transposition offset">±0</span>
+    <button id="btn-transpose-up" class="transpose-btn" title="Transpose up one semitone">+</button>
   </div>
   <div id="loading">Initializing ChordSketch preview…</div>
   <div id="error"></div>

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -4,7 +4,7 @@
  * Runs in the sandboxed WebView context (browser environment). Initialises
  * the `@chordsketch/wasm` module using the WASM binary URI provided by the
  * extension host, then listens for document-update messages and renders them
- * using the active view mode (HTML or plain text).
+ * using the active view mode (HTML or plain text) and transpose setting.
  *
  * The WASM URI is injected by the extension host as
  * `<meta name="chordsketch-wasm-uri" content="...">`. A `data-` attribute on
@@ -12,7 +12,7 @@
  * always `null` for `type="module"` scripts (HTML spec).
  */
 
-import init, { render_html, render_text } from '@chordsketch/wasm';
+import init, { render_html_with_options, render_text_with_options } from '@chordsketch/wasm';
 
 /** VS Code WebView API acquired from the global injected by the host. */
 declare function acquireVsCodeApi(): {
@@ -29,6 +29,8 @@ type ViewMode = 'html' | 'text';
 /** Persisted panel state saved and restored via the VS Code WebView API. */
 interface PanelState {
   mode?: ViewMode;
+  /** Semitone transposition offset; any integer value (renderer reduces mod 12). */
+  transpose?: number;
 }
 
 /** Message types received from the extension host. */
@@ -55,15 +57,26 @@ const previewFrame = document.getElementById('preview-frame') as HTMLIFrameEleme
 const textFrame = document.getElementById('text-frame') as HTMLPreElement;
 const btnHtml = document.getElementById('btn-html') as HTMLButtonElement;
 const btnText = document.getElementById('btn-text') as HTMLButtonElement;
+const btnTransposeDown = document.getElementById('btn-transpose-down') as HTMLButtonElement;
+const btnTransposeUp = document.getElementById('btn-transpose-up') as HTMLButtonElement;
+const transposeLabel = document.getElementById('transpose-label') as HTMLSpanElement;
 
 /** Currently active view mode. Loaded from persisted state in `main()`. */
 let viewMode: ViewMode = 'html';
 
 /**
+ * Current semitone transposition offset.
+ *
+ * Any integer value is accepted — the WASM renderer reduces it modulo 12
+ * internally (same behaviour as the CLI `--transpose` flag).
+ */
+let transpose = 0;
+
+/**
  * Most recently rendered source text.
  *
- * Kept so that switching view modes re-renders the existing content without
- * waiting for the next document-change message from the extension host.
+ * Kept so that switching view modes or adjusting transpose re-renders the
+ * existing content without waiting for the next document-change message.
  */
 let lastText = '';
 
@@ -131,13 +144,20 @@ function syncButtonStates(): void {
   btnText.classList.toggle('active', viewMode === 'text');
 }
 
+/** Formats the transpose value for the toolbar label (e.g. `±0`, `+3`, `−2`). */
+function formatTranspose(t: number): string {
+  if (t === 0) return '±0';
+  return t > 0 ? `+${t}` : `${t}`;
+}
+
 /**
- * Renders the given ChordPro source text according to the active view mode.
+ * Renders the given ChordPro source text according to the active view mode
+ * and current transpose offset.
  *
- * In HTML mode, `render_html` is called and the output is loaded into the
- * sandboxed iframe via `srcdoc`. In plain text mode, `render_text` is called
- * and the output is set as `textContent` of the `<pre>` element (safe — no
- * HTML parsing occurs).
+ * In HTML mode, `render_html_with_options` is called and the output is loaded
+ * into the sandboxed iframe via `srcdoc`. In plain text mode,
+ * `render_text_with_options` is called and the output is set as `textContent`
+ * of the `<pre>` element (safe — no HTML parsing occurs).
  */
 function renderPreview(text: string): void {
   lastText = text;
@@ -156,16 +176,17 @@ function renderPreview(text: string): void {
     return;
   }
 
+  const options = { transpose };
+
   try {
     if (viewMode === 'html') {
-      // TODO(Phase B): call render_html_with_options with transpose options instead of render_html.
-      const html = render_html(text);
+      const html = render_html_with_options(text, options);
       hideError();
       previewFrame.srcdoc = wrapHtml(html);
       previewFrame.style.display = 'block';
       textFrame.style.display = 'none';
     } else {
-      const plain = render_text(text);
+      const plain = render_text_with_options(text, options);
       hideError();
       // textContent assignment is safe: no HTML parsing, no XSS risk.
       textFrame.textContent = plain;
@@ -197,12 +218,37 @@ function setViewMode(mode: ViewMode): void {
   renderPreview(lastText);
 }
 
+/**
+ * Adjusts the transpose offset by `delta` semitones and re-renders.
+ *
+ * The offset is clamped to [-11, +11]; values outside this range produce
+ * the same chord output since the renderer reduces modulo 12 internally.
+ * The clamp prevents the label from growing without bound on repeated clicks.
+ *
+ * Called only after WASM has successfully loaded.
+ */
+function adjustTranspose(delta: -1 | 1): void {
+  const next = transpose + delta;
+  // Clamp to [-11, +11]: one full chromatic octave in each direction.
+  transpose = Math.max(-11, Math.min(11, next));
+  transposeLabel.textContent = formatTranspose(transpose);
+  // Spread the existing state to preserve other PanelState fields.
+  vscode.setState({ ...(vscode.getState() as PanelState | null) ?? {}, transpose } satisfies PanelState);
+
+  renderPreview(lastText);
+}
+
 async function main(): Promise<void> {
-  // Restore the persisted view mode so the user's choice survives hide/show.
+  // Restore the persisted view mode and transpose so the user's choices
+  // survive hide/show cycles.
   const saved = vscode.getState() as PanelState | null;
   if (saved?.mode === 'html' || saved?.mode === 'text') {
     viewMode = saved.mode;
     syncButtonStates();
+  }
+  if (typeof saved?.transpose === 'number') {
+    transpose = saved.transpose;
+    transposeLabel.textContent = formatTranspose(transpose);
   }
 
   // Read the WASM binary URI injected by the extension host.
@@ -229,9 +275,11 @@ async function main(): Promise<void> {
   // by default; removing the class re-enables it.
   toolbar.classList.remove('disabled');
 
-  // Register toggle button handlers after WASM is ready.
+  // Register all toolbar button handlers after WASM is ready.
   btnHtml.addEventListener('click', () => setViewMode('html'));
   btnText.addEventListener('click', () => setViewMode('text'));
+  btnTransposeDown.addEventListener('click', () => adjustTranspose(-1));
+  btnTransposeUp.addEventListener('click', () => adjustTranspose(1));
 
   // Listen for messages from the extension host.
   window.addEventListener('message', (event: MessageEvent) => {

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -29,7 +29,7 @@ type ViewMode = 'html' | 'text';
 /** Persisted panel state saved and restored via the VS Code WebView API. */
 interface PanelState {
   mode?: ViewMode;
-  /** Semitone transposition offset; any integer value (renderer reduces mod 12). */
+  /** Semitone transposition offset; clamped to [-11, +11] by adjustTranspose. */
   transpose?: number;
 }
 
@@ -147,7 +147,27 @@ function syncButtonStates(): void {
 /** Formats the transpose value for the toolbar label (e.g. `±0`, `+3`, `−2`). */
 function formatTranspose(t: number): string {
   if (t === 0) return '±0';
-  return t > 0 ? `+${t}` : `${t}`;
+  // Use U+2212 MINUS SIGN to match the − character used on the decrement button.
+  return t > 0 ? `+${t}` : `\u2212${Math.abs(t)}`;
+}
+
+/**
+ * Returns a validated copy of the persisted WebView state.
+ *
+ * `vscode.getState()` returns `unknown`; this function narrows the result to a
+ * well-typed `PanelState` with each field individually validated, so that a
+ * corrupted or forward-incompatible stored value cannot bypass type-level checks.
+ */
+function safeGetState(): PanelState {
+  const raw = vscode.getState() as Record<string, unknown> | null;
+  const result: PanelState = {};
+  if (raw?.['mode'] === 'html' || raw?.['mode'] === 'text') {
+    result.mode = raw['mode'] as ViewMode;
+  }
+  if (typeof raw?.['transpose'] === 'number' && Number.isFinite(raw['transpose'])) {
+    result.transpose = Math.max(-11, Math.min(11, raw['transpose'] as number));
+  }
+  return result;
 }
 
 /**
@@ -210,9 +230,7 @@ function setViewMode(mode: ViewMode): void {
     return; // No-op: avoid redundant WASM call and iframe flicker.
   }
   viewMode = mode;
-  // Spread the existing state before writing back so that any fields added to
-  // PanelState in a future PR are not silently wiped on every mode toggle.
-  vscode.setState({ ...(vscode.getState() as PanelState | null) ?? {}, mode } satisfies PanelState);
+  vscode.setState({ ...safeGetState(), mode } satisfies PanelState);
   syncButtonStates();
 
   renderPreview(lastText);
@@ -232,23 +250,30 @@ function adjustTranspose(delta: -1 | 1): void {
   // Clamp to [-11, +11]: one full chromatic octave in each direction.
   transpose = Math.max(-11, Math.min(11, next));
   transposeLabel.textContent = formatTranspose(transpose);
-  // Spread the existing state to preserve other PanelState fields.
-  vscode.setState({ ...(vscode.getState() as PanelState | null) ?? {}, transpose } satisfies PanelState);
+  // Disable the ± buttons when the limit is reached so the user gets explicit
+  // visual feedback rather than a silent no-op click.
+  btnTransposeDown.disabled = transpose === -11;
+  btnTransposeUp.disabled = transpose === 11;
+  vscode.setState({ ...safeGetState(), transpose } satisfies PanelState);
 
   renderPreview(lastText);
 }
 
 async function main(): Promise<void> {
   // Restore the persisted view mode and transpose so the user's choices
-  // survive hide/show cycles.
-  const saved = vscode.getState() as PanelState | null;
-  if (saved?.mode === 'html' || saved?.mode === 'text') {
+  // survive hide/show cycles. safeGetState() validates and clamps each field
+  // so that stale or corrupted state from a previous extension version cannot
+  // bypass the runtime invariants enforced by adjustTranspose().
+  const saved = safeGetState();
+  if (saved.mode !== undefined) {
     viewMode = saved.mode;
     syncButtonStates();
   }
-  if (typeof saved?.transpose === 'number') {
+  if (saved.transpose !== undefined) {
     transpose = saved.transpose;
     transposeLabel.textContent = formatTranspose(transpose);
+    btnTransposeDown.disabled = transpose === -11;
+    btnTransposeUp.disabled = transpose === 11;
   }
 
   // Read the WASM binary URI injected by the extension host.


### PR DESCRIPTION
## What

Add semitone transpose controls to the ChordSketch VS Code preview panel toolbar.

- `−` button decreases transpose by one semitone
- `+` button increases transpose by one semitone
- Centre label shows the current offset (e.g. `±0`, `+3`, `−2`)
- Offset is clamped to `[−11, +11]` (one full chromatic octave each way); values outside this range produce identical chord output since the WASM renderer reduces modulo 12 internally
- Transpose state is persisted with `vscode.setState` so it survives hide/show cycles

## Why

Resolves #1384. Users frequently need to preview a song in a different key without editing the source file.

## Implementation

- `webview/preview.ts`: Import `render_html_with_options` / `render_text_with_options` instead of the plain variants; add `transpose` state variable and `adjustTranspose(delta)` function; extend `PanelState` interface with `transpose?: number`; persist and restore transpose via `vscode.setState` / `getState`
- `src/preview.ts` (`buildHtml`): Add CSS for `.toolbar-separator`, `.transpose-btn`, `#transpose-label`, and `#toolbar.disabled`; add three new toolbar elements (`−` button, offset label, `+` button)

## Test results

`npx tsc --noEmit` passes with no errors in the `packages/vscode-extension` directory.

## Review summary

No prior review findings.

Closes #1384