### PR TITLE
fix(vscode): add aria-live to transpose label for screen reader support

### DIFF
--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -355,7 +355,7 @@ class PreviewPanel {
     <button id="btn-text" class="view-btn" title="Plain text preview">Plain text</button>
     <span class="toolbar-separator" role="separator"></span>
     <button id="btn-transpose-down" class="transpose-btn" title="Transpose down one semitone">−</button>
-    <span id="transpose-label" aria-label="Transpose offset" title="Semitone transposition offset">±0</span>
+    <span id="transpose-label" aria-live="polite" aria-label="Transpose offset" title="Semitone transposition offset">±0</span>
     <button id="btn-transpose-up" class="transpose-btn" title="Transpose up one semitone">+</button>
   </div>
   <div id="loading">Initializing ChordSketch preview…</div>


### PR DESCRIPTION
## What

Add `aria-live="polite"` to the `#transpose-label` span in the preview panel toolbar.

## Why

The label updates dynamically on every `−`/`+` click but without an `aria-live`
region, screen readers won't announce the new value. `polite` is appropriate here
— the update is informational and should not interrupt ongoing speech.

## Test results

`tsc --noEmit` passes with no errors.

## Review summary

No prior review findings.

Closes #1388