### PR TITLE
feat(vscode): add transposeUp / transposeDown command palette actions

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -61,6 +61,14 @@
         "command": "chordsketch.openPreviewToSide",
         "title": "ChordSketch: Open Preview to the Side",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "chordsketch.transposeUp",
+        "title": "ChordSketch: Transpose Up"
+      },
+      {
+        "command": "chordsketch.transposeDown",
+        "title": "ChordSketch: Transpose Down"
       }
     ],
     "menus": {
@@ -78,6 +86,14 @@
         },
         {
           "command": "chordsketch.openPreviewToSide",
+          "when": "editorLangId == chordpro"
+        },
+        {
+          "command": "chordsketch.transposeUp",
+          "when": "editorLangId == chordpro"
+        },
+        {
+          "command": "chordsketch.transposeDown",
           "when": "editorLangId == chordpro"
         }
       ]

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -6,7 +6,7 @@
  */
 
 import * as vscode from 'vscode';
-import { createOrShow } from './preview';
+import { createOrShow, notifyTranspose } from './preview';
 
 /**
  * Resolves the active ChordPro document from the active text editor.
@@ -47,6 +47,32 @@ export function registerOpenPreviewToSide(
     const doc = resolveActiveChordProDocument();
     if (doc) {
       createOrShow(context, doc, vscode.ViewColumn.Beside);
+    }
+  });
+}
+
+/**
+ * Increments the transpose offset of the active document's preview panel by
+ * +1 semitone. No-op if no preview panel is open for the active document.
+ */
+export function registerTransposeUp(): vscode.Disposable {
+  return vscode.commands.registerCommand('chordsketch.transposeUp', () => {
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+      notifyTranspose(editor.document.uri.toString(), 1);
+    }
+  });
+}
+
+/**
+ * Decrements the transpose offset of the active document's preview panel by
+ * −1 semitone. No-op if no preview panel is open for the active document.
+ */
+export function registerTransposeDown(): vscode.Disposable {
+  return vscode.commands.registerCommand('chordsketch.transposeDown', () => {
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+      notifyTranspose(editor.document.uri.toString(), -1);
     }
   });
 }

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -53,12 +53,16 @@ export function registerOpenPreviewToSide(
 
 /**
  * Increments the transpose offset of the active document's preview panel by
- * +1 semitone. No-op if no preview panel is open for the active document.
+ * +1 semitone. No-op if no ChordPro preview panel is open for the active
+ * document. The `when` clause in `package.json` hides this command from the
+ * command palette when a non-ChordPro file is focused, but programmatic
+ * invocation (e.g. keyboard shortcuts without a `when` guard) can still reach
+ * the handler — the `languageId` check here provides the same defence.
  */
 export function registerTransposeUp(): vscode.Disposable {
   return vscode.commands.registerCommand('chordsketch.transposeUp', () => {
     const editor = vscode.window.activeTextEditor;
-    if (editor) {
+    if (editor && editor.document.languageId === 'chordpro') {
       notifyTranspose(editor.document.uri.toString(), 1);
     }
   });
@@ -66,12 +70,14 @@ export function registerTransposeUp(): vscode.Disposable {
 
 /**
  * Decrements the transpose offset of the active document's preview panel by
- * −1 semitone. No-op if no preview panel is open for the active document.
+ * −1 semitone. No-op if no ChordPro preview panel is open for the active
+ * document. The `languageId` guard mirrors `registerTransposeUp` to prevent
+ * an unexpected transpose action when a non-ChordPro editor is focused.
  */
 export function registerTransposeDown(): vscode.Disposable {
   return vscode.commands.registerCommand('chordsketch.transposeDown', () => {
     const editor = vscode.window.activeTextEditor;
-    if (editor) {
+    if (editor && editor.document.languageId === 'chordpro') {
       notifyTranspose(editor.document.uri.toString(), -1);
     }
   });

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -14,7 +14,7 @@
 import * as vscode from 'vscode';
 import { startLspClient, stopLspClient } from './lsp';
 import { notifyDocumentChanged, disposeAll } from './preview';
-import { registerOpenPreview, registerOpenPreviewToSide } from './commands';
+import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown } from './commands';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   // Start the LSP client (gracefully degraded if binary not found).
@@ -24,6 +24,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(
     registerOpenPreview(context),
     registerOpenPreviewToSide(context),
+    registerTransposeUp(),
+    registerTransposeDown(),
   );
 
   // Propagate document changes to open preview panels (debounced inside PreviewPanel).

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -11,7 +11,7 @@ import * as crypto from 'crypto';
 import * as path from 'path';
 
 /** Message types sent from the extension host to the WebView. */
-type ExtToWebview = { type: 'update'; text: string };
+type ExtToWebview = { type: 'update'; text: string } | { type: 'transpose'; delta: 1 | -1 };
 
 /** Message types received from the WebView in the extension host. */
 type WebviewToExt = { type: 'ready' } | { type: 'error'; message: string };
@@ -73,6 +73,20 @@ export function notifyDocumentChanged(event: vscode.TextDocumentChangeEvent): vo
   const panel = panels.get(key);
   if (panel) {
     panel.scheduleUpdate(event.document.getText());
+  }
+}
+
+/**
+ * Sends a transpose delta to the preview panel for the given document URI.
+ *
+ * Looks up the panel by URI string (the key used in `panels`). No-op if no
+ * panel is currently open for that document — the command degrades gracefully
+ * when no preview is open.
+ */
+export function notifyTranspose(documentUri: string, delta: 1 | -1): void {
+  const panel = panels.get(documentUri);
+  if (panel) {
+    panel.transpose(delta);
   }
 }
 
@@ -187,6 +201,20 @@ class PreviewPanel {
   /** Sends an update message to the WebView immediately. */
   private sendUpdate(text: string): void {
     const msg: ExtToWebview = { type: 'update', text };
+    void this.panel.webview.postMessage(msg);
+  }
+
+  /**
+   * Sends a transpose delta to the WebView.
+   *
+   * The WebView applies the delta to its own in-memory transpose state (clamped
+   * to [−11, +11]) and re-renders. No-op if the panel is already disposed.
+   */
+  transpose(delta: 1 | -1): void {
+    if (this.disposed) {
+      return;
+    }
+    const msg: ExtToWebview = { type: 'transpose', delta };
     void this.panel.webview.postMessage(msg);
   }
 

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -34,7 +34,9 @@ interface PanelState {
 }
 
 /** Message types received from the extension host. */
-type ExtToWebview = { type: 'update'; text: string };
+type ExtToWebview =
+  | { type: 'update'; text: string }
+  | { type: 'transpose'; delta: 1 | -1 };
 
 /**
  * Type guard for messages received from the extension host.
@@ -47,7 +49,13 @@ function isExtToWebview(raw: unknown): raw is ExtToWebview {
     return false;
   }
   const r = raw as Record<string, unknown>;
-  return r['type'] === 'update' && typeof r['text'] === 'string';
+  if (r['type'] === 'update') {
+    return typeof r['text'] === 'string';
+  }
+  if (r['type'] === 'transpose') {
+    return r['delta'] === 1 || r['delta'] === -1;
+  }
+  return false;
 }
 
 const toolbar = document.getElementById('toolbar') as HTMLDivElement;
@@ -312,8 +320,11 @@ async function main(): Promise<void> {
       // Unknown or malformed message — silently ignore.
       return;
     }
-    // isExtToWebview guarantees type === 'update'; no inner dispatch needed.
-    renderPreview(event.data.text);
+    if (event.data.type === 'update') {
+      renderPreview(event.data.text);
+    } else if (event.data.type === 'transpose') {
+      adjustTranspose(event.data.delta);
+    }
   });
 
   // Tell the extension host that the WebView is ready to receive content.


### PR DESCRIPTION
## What

Add `chordsketch.transposeUp` and `chordsketch.transposeDown` to the command palette so users can transpose the preview without clicking the toolbar buttons.

## Why

Keyboard-driven workflows benefit from command palette access. The toolbar buttons require mouse interaction; command palette actions can be bound to keyboard shortcuts.

## Implementation

- Added `{ type: 'transpose'; delta: 1 | -1 }` to `ExtToWebview` (both extension host and WebView script)
- Added `PreviewPanel.transpose(delta)` method and `notifyTranspose(uri, delta)` export in `src/preview.ts`
- Added `registerTransposeUp()` / `registerTransposeDown()` in `src/commands.ts`
- Registered both commands in `src/extension.ts`
- Extended `isExtToWebview` type guard in `webview/preview.ts` to validate the new message type
- Declared both commands in `package.json` with `when: editorLangId == chordpro`

Both commands are no-ops when no preview panel is open for the active document.

## Test results

`tsc --noEmit` passes with no errors.

## Review summary

No prior review findings.

Closes #1390