### PR TITLE
feat(vscode): add chordsketch.preview.defaultMode setting

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -119,7 +119,7 @@
             "Open the preview in plain text mode."
           ],
           "default": "html",
-          "description": "Default view mode for new ChordSketch preview panels. Persisted state from a previous session always takes priority."
+          "description": "Default view mode when opening a new ChordSketch preview panel. Takes effect only when no persisted state exists for that panel (first open or after state is cleared). Changes to this setting require opening a new preview to take effect."
         }
       }
     }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -110,6 +110,16 @@
           "type": "string",
           "default": "",
           "description": "Path to the chordsketch-lsp binary. If empty, the extension looks on the system PATH first, then falls back to the bundled binary (if present)."
+        },
+        "chordsketch.preview.defaultMode": {
+          "type": "string",
+          "enum": ["html", "text"],
+          "enumDescriptions": [
+            "Open the preview in HTML rendering mode.",
+            "Open the preview in plain text mode."
+          ],
+          "default": "html",
+          "description": "Default view mode for new ChordSketch preview panels. Persisted state from a previous session always takes priority."
         }
       }
     }

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -233,11 +233,17 @@ class PreviewPanel {
   /**
    * Builds the WebView HTML.
    *
-   * Uses a CSP nonce to allow only the bundled script. The WASM binary URI
-   * is injected via a `<meta name="chordsketch-wasm-uri">` element so the
-   * WebView script can read it at runtime. A `data-` attribute on
-   * `<script type="module">` cannot be used because `document.currentScript`
-   * is always `null` for ES module scripts (HTML spec).
+   * Uses a CSP nonce to allow only the bundled script. Extension-provided
+   * values are injected via `<meta>` elements so the WebView script can read
+   * them at runtime:
+   *   - `chordsketch-wasm-uri`: the WASM binary URI (VS Code WebView URI)
+   *   - `chordsketch-default-mode`: the `chordsketch.preview.defaultMode`
+   *     setting value, used as the initial view mode when no persisted state
+   *     exists (only `"html"` and `"text"` are accepted; anything else falls
+   *     back to `"html"` in the WebView script).
+   *
+   * A `data-` attribute on `<script type="module">` cannot be used because
+   * `document.currentScript` is always `null` for ES module scripts (HTML spec).
    */
   private buildHtml(): string {
     const webview = this.panel.webview;
@@ -257,6 +263,13 @@ class PreviewPanel {
       ),
     );
 
+    // Read the default mode setting and clamp to the known-valid set so that
+    // an out-of-range config value cannot affect the WebView's behaviour.
+    const rawMode = vscode.workspace
+      .getConfiguration('chordsketch')
+      .get<string>('preview.defaultMode', 'html');
+    const defaultMode: 'html' | 'text' = rawMode === 'text' ? 'text' : 'html';
+
     // cspSource includes the extension's own dist/webview/ origin.
     const csp = webview.cspSource;
 
@@ -274,6 +287,7 @@ class PreviewPanel {
   ">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="chordsketch-wasm-uri" content="${wasmUri}">
+  <meta name="chordsketch-default-mode" content="${defaultMode}">
   <title>ChordSketch Preview</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -274,9 +274,19 @@ async function main(): Promise<void> {
   // bypass the runtime invariants enforced by adjustTranspose().
   const saved = safeGetState();
   if (saved.mode !== undefined) {
+    // Persisted state takes priority over the default-mode setting.
     viewMode = saved.mode;
-    syncButtonStates();
+  } else {
+    // No persisted state — fall back to the chordsketch.preview.defaultMode
+    // setting injected by the extension host as a <meta> element.
+    const metaMode = document.querySelector<HTMLMetaElement>(
+      'meta[name="chordsketch-default-mode"]',
+    )?.content;
+    if (metaMode === 'html' || metaMode === 'text') {
+      viewMode = metaMode;
+    }
   }
+  syncButtonStates();
   if (saved.transpose !== undefined) {
     transpose = saved.transpose;
     transposeLabel.textContent = formatTranspose(transpose);


### PR DESCRIPTION
## What

Add a `chordsketch.preview.defaultMode` setting (`"html"` | `"text"`, default `"html"`) that controls which view mode a new preview panel opens in.

## Why

Users who prefer the plain-text view currently have to toggle it every time they open a preview. The setting avoids that friction.

## Implementation

The setting value is injected as a `<meta name="chordsketch-default-mode" content="...">` element (same pattern as the WASM URI), so the WebView can read it without a message round-trip:

1. **`src/preview.ts`**: read and validate `chordsketch.preview.defaultMode`, clamp to `"html" | "text"`, inject as `<meta>` in `buildHtml()`.
2. **`webview/preview.ts`**: read the `<meta>` element in `main()` as the initial `viewMode` — only when `safeGetState().mode` is `undefined` (no persisted state). Persisted state always wins.
3. **`package.json`**: declare the setting with `enum`, `enumDescriptions`, and `default`.

## Test results

`tsc --noEmit` passes with no errors.

## Review summary

No prior review findings.

Closes #1393