### PR TITLE
docs(vscode): update stale adjustTranspose comment after early listener

### DIFF
--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -272,7 +272,10 @@ function setViewMode(mode: ViewMode): void {
  * the same chord output since the renderer reduces modulo 12 internally.
  * The clamp prevents the label from growing without bound on repeated clicks.
  *
- * Called only after WASM has successfully loaded.
+ * May be called before WASM has loaded (e.g., via a `transpose` message sent
+ * by the extension host during the init window). In that case `renderPreview`
+ * exits early at the `wasmReady` guard without calling any WASM export; the
+ * updated `transpose` value is applied on the next render after init completes.
  */
 function adjustTranspose(delta: -1 | 1): void {
   const next = transpose + delta;


### PR DESCRIPTION
## What

Update the `adjustTranspose` doc comment which was stale after #1395.

## Why

Before #1395 the message listener was registered after `await init()`, so `adjustTranspose` could only be called once WASM was loaded. After #1395, the listener is moved before `await init()` — `adjustTranspose` can now be called during the WASM loading window via a `transpose` message. The comment "Called only after WASM has successfully loaded." was no longer accurate.

The new comment explains the pre-init path is safe: `renderPreview` returns at the `wasmReady` guard without touching WASM.

Closes #1397