### PR TITLE
test(vscode): add unit tests for resolveDefaultMode config helper

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -56,6 +56,10 @@ jobs:
         run: npm run lint
         working-directory: packages/vscode-extension
 
+      - name: Unit tests
+        run: npm test
+        working-directory: packages/vscode-extension
+
       - name: Build
         run: npm run build
         working-directory: packages/vscode-extension

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -128,6 +128,7 @@
     "build": "node esbuild.mjs",
     "build:watch": "node esbuild.mjs --watch",
     "lint": "tsc --noEmit",
+    "test": "node --experimental-transform-types --test src/config.test.ts",
     "package": "vsce package --no-dependencies",
     "prepackage": "npm run build"
   },

--- a/packages/vscode-extension/src/config.test.ts
+++ b/packages/vscode-extension/src/config.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for the pure configuration utilities in config.ts.
+ *
+ * Run with:
+ *   npm test
+ *   node --experimental-transform-types --test src/config.test.ts
+ *
+ * No VS Code host or external test runner required.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+// Use .ts extension — this file is run directly by Node with
+// --experimental-transform-types, not compiled by tsc.
+import { resolveDefaultMode } from './config.ts';
+
+test('resolveDefaultMode: "text" maps to "text"', () => {
+  assert.equal(resolveDefaultMode('text'), 'text');
+});
+
+test('resolveDefaultMode: "html" maps to "html"', () => {
+  assert.equal(resolveDefaultMode('html'), 'html');
+});
+
+test('resolveDefaultMode: "HTML" (uppercase) maps to "html"', () => {
+  assert.equal(resolveDefaultMode('HTML'), 'html');
+});
+
+test('resolveDefaultMode: unknown string maps to "html"', () => {
+  assert.equal(resolveDefaultMode('unknown'), 'html');
+});
+
+test('resolveDefaultMode: empty string maps to "html"', () => {
+  assert.equal(resolveDefaultMode(''), 'html');
+});
+
+test('resolveDefaultMode: undefined maps to "html"', () => {
+  assert.equal(resolveDefaultMode(undefined), 'html');
+});

--- a/packages/vscode-extension/src/config.ts
+++ b/packages/vscode-extension/src/config.ts
@@ -14,7 +14,7 @@
  * - Case-variants (`'HTML'`, `'Text'`) are treated as unknown rather than
  *   silently accepted.
  *
- * Exported for unit testing; also used in `preview.ts`.
+ * Used in `preview.ts` and independently testable without a VS Code host.
  */
 export function resolveDefaultMode(raw: string | undefined): 'html' | 'text' {
   return raw === 'text' ? 'text' : 'html';

--- a/packages/vscode-extension/src/config.ts
+++ b/packages/vscode-extension/src/config.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure configuration utilities for the ChordSketch extension.
+ *
+ * Functions in this module have no dependencies on the VS Code API so they can
+ * be unit-tested with Node.js's built-in test runner without a VS Code host.
+ */
+
+/**
+ * Maps a raw `chordsketch.preview.defaultMode` configuration value to a valid
+ * view-mode string.
+ *
+ * Any value that is not exactly `'text'` maps to `'html'` so that:
+ * - Unrecognised future enum values degrade gracefully to the default.
+ * - Case-variants (`'HTML'`, `'Text'`) are treated as unknown rather than
+ *   silently accepted.
+ *
+ * Exported for unit testing; also used in `preview.ts`.
+ */
+export function resolveDefaultMode(raw: string | undefined): 'html' | 'text' {
+  return raw === 'text' ? 'text' : 'html';
+}

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -9,6 +9,7 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import * as path from 'path';
+import { resolveDefaultMode } from './config.js';
 
 /** Message types sent from the extension host to the WebView. */
 type ExtToWebview = { type: 'update'; text: string } | { type: 'transpose'; delta: 1 | -1 };
@@ -268,7 +269,7 @@ class PreviewPanel {
     const rawMode = vscode.workspace
       .getConfiguration('chordsketch')
       .get<string>('preview.defaultMode', 'html');
-    const defaultMode: 'html' | 'text' = rawMode === 'text' ? 'text' : 'html';
+    const defaultMode = resolveDefaultMode(rawMode);
 
     // cspSource includes the extension's own dist/webview/ origin.
     const csp = webview.cspSource;

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -13,5 +13,5 @@
     "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "webview"]
+  "exclude": ["node_modules", "dist", "webview", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## What

Extract the `defaultMode` clamping logic from `preview.ts` into an exported pure function `resolveDefaultMode()` in a new `src/config.ts` module, then add 6 unit tests.

## Why

The acceptance criteria from #1396 require tests that fail if the clamping logic is inverted. The function lives in `buildHtml()` in `preview.ts`, which imports from `vscode` — making it impossible to test without a VS Code host. Extracting to a standalone module solves this.

## Tests

Run with `npm test` (no new dependencies):

```
node --experimental-transform-types --test src/config.test.ts
```

Uses Node.js 22's built-in `node:test` runner and `--experimental-transform-types` for TypeScript support. Covers:
- `'text'` → `'text'`
- `'html'` → `'html'`
- `'HTML'` (wrong case) → `'html'`
- `'unknown'` → `'html'`
- `''` (empty) → `'html'`
- `undefined` → `'html'`

## CI

Added `Unit tests` step to `.github/workflows/vscode-extension.yml` between Type-check and Build.

Closes #1396