### PR TITLE
feat(vscode): add chordsketch.convertTo export command

### DIFF
--- a/packages/vscode-extension/esbuild.mjs
+++ b/packages/vscode-extension/esbuild.mjs
@@ -56,6 +56,27 @@ if (fs.existsSync(wasmSrc)) {
   console.warn('         Run `npm install` in packages/vscode-extension/ to fetch @chordsketch/wasm.');
 }
 
+// Copy the WASM Node.js CJS build for the extension host (convertTo command).
+// The files are NOT bundled by esbuild — they are loaded at runtime via createRequire
+// so that the module's own __dirname resolves to dist/node/ where the .wasm binary lives.
+const nodeDir = path.join(here, 'dist', 'node');
+fs.mkdirSync(nodeDir, { recursive: true });
+// Write a package.json declaring CJS type so Node resolves the .js as CommonJS.
+fs.writeFileSync(path.join(nodeDir, 'package.json'), JSON.stringify({ type: 'commonjs' }, null, 2) + '\n');
+const wasmNodeFiles = ['chordsketch_wasm.js', 'chordsketch_wasm_bg.wasm'];
+for (const file of wasmNodeFiles) {
+  const npmSrc = path.join(here, 'node_modules', '@chordsketch', 'wasm', 'node', file);
+  const localSrc = path.join(repoRoot, 'packages', 'npm', 'node', file);
+  const src = fs.existsSync(npmSrc) ? npmSrc : localSrc;
+  if (fs.existsSync(src)) {
+    fs.copyFileSync(src, path.join(nodeDir, file));
+    console.log(`Copied ${path.relative(here, src)} → dist/node/${file}`);
+  } else {
+    console.warn(`WARNING: dist/node/${file} not found in node_modules or local build.`);
+    console.warn('         Run `npm install` in packages/vscode-extension/ to fetch @chordsketch/wasm.');
+  }
+}
+
 /** @type {esbuild.BuildOptions} */
 const extensionBuild = {
   entryPoints: ['src/extension.ts'],

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -69,6 +69,10 @@
       {
         "command": "chordsketch.transposeDown",
         "title": "ChordSketch: Transpose Down"
+      },
+      {
+        "command": "chordsketch.convertTo",
+        "title": "ChordSketch: Export As…"
       }
     ],
     "menus": {
@@ -94,6 +98,10 @@
         },
         {
           "command": "chordsketch.transposeDown",
+          "when": "editorLangId == chordpro"
+        },
+        {
+          "command": "chordsketch.convertTo",
           "when": "editorLangId == chordpro"
         }
       ]

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -14,11 +14,45 @@ import { createOrShow, notifyTranspose } from './preview';
  * Minimal type for the exports consumed from the `@chordsketch/wasm` Node.js
  * CJS build that is copied to `dist/node/` at build time.  Only the three
  * render functions used by `convertTo` are declared here.
+ *
+ * **Throws**: All three functions throw a JS exception on render failure
+ * (the Rust wasm-bindgen glue converts `Err(JsValue)` into a thrown JS
+ * value).  Callers must always wrap invocations in a try/catch.
+ *
+ * **HTML security note**: `render_html` produces a self-contained
+ * `<!DOCTYPE html>` document.  Delegate-section environments such as
+ * `{start_of_textblock}` emit their content verbatim (by spec).  The
+ * exported file must therefore NOT be served to untrusted users without
+ * additional sanitisation — it reflects the same content as the source
+ * `.cho` file, which the user is assumed to own.
  */
 interface WasmRenderModule {
   render_html(input: string): string;
   render_text(input: string): string;
   render_pdf(input: string): Uint8Array;
+}
+
+/**
+ * Type guard that verifies a `require()` result exposes the three render
+ * functions expected from `@chordsketch/wasm`.
+ *
+ * Prevents a silently broken or zero-byte copy of the WASM module from being
+ * permanently cached after it is first loaded.  Without this check a module
+ * object that is truthy but whose exports are absent (e.g., an incomplete
+ * deployment) would be cached indefinitely, causing every subsequent export
+ * attempt in the session to fail with `TypeError: wasm.render_X is not a
+ * function`.
+ */
+function isWasmRenderModule(m: unknown): m is WasmRenderModule {
+  if (typeof m !== 'object' || m === null) {
+    return false;
+  }
+  const mod = m as Record<string, unknown>;
+  return (
+    typeof mod['render_html'] === 'function' &&
+    typeof mod['render_text'] === 'function' &&
+    typeof mod['render_pdf'] === 'function'
+  );
 }
 
 /** Lazily loaded WASM render module singleton. */
@@ -33,13 +67,25 @@ let wasmRenderCache: WasmRenderModule | undefined;
  * therefore points to `dist/node/`, where `chordsketch_wasm_bg.wasm` is
  * located, so WASM initialisation succeeds.
  *
+ * The shape of the loaded module is validated by {@link isWasmRenderModule}
+ * before caching so that a broken or incomplete deployment is detected
+ * immediately rather than being permanently cached for the session.
+ *
  * The result is cached so the WASM binary is only parsed once per session.
+ *
+ * @throws {Error} If the module file is missing or its exports are absent.
  */
 function loadWasmRender(extensionPath: string): WasmRenderModule {
   if (!wasmRenderCache) {
     const modPath = path.join(extensionPath, 'dist', 'node', 'chordsketch_wasm.js');
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    wasmRenderCache = require(modPath) as WasmRenderModule;
+    const mod: unknown = require(modPath);
+    if (!isWasmRenderModule(mod)) {
+      throw new Error(
+        `WASM module at ${modPath} does not export the expected render functions`,
+      );
+    }
+    wasmRenderCache = mod;
   }
   return wasmRenderCache;
 }

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -3,10 +3,46 @@
  *
  * - `chordsketch.openPreview` — open preview in the active column
  * - `chordsketch.openPreviewToSide` — open preview to the side
+ * - `chordsketch.convertTo` — export the active ChordPro document as HTML/PDF/text
  */
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { createOrShow, notifyTranspose } from './preview';
+
+/**
+ * Minimal type for the exports consumed from the `@chordsketch/wasm` Node.js
+ * CJS build that is copied to `dist/node/` at build time.  Only the three
+ * render functions used by `convertTo` are declared here.
+ */
+interface WasmRenderModule {
+  render_html(input: string): string;
+  render_text(input: string): string;
+  render_pdf(input: string): Uint8Array;
+}
+
+/** Lazily loaded WASM render module singleton. */
+let wasmRenderCache: WasmRenderModule | undefined;
+
+/**
+ * Loads the `@chordsketch/wasm` Node.js CJS build from the extension's own
+ * `dist/node/` directory.
+ *
+ * Using a runtime-computed path prevents esbuild from statically bundling the
+ * module into `dist/extension.js`.  The loaded module's own `__dirname`
+ * therefore points to `dist/node/`, where `chordsketch_wasm_bg.wasm` is
+ * located, so WASM initialisation succeeds.
+ *
+ * The result is cached so the WASM binary is only parsed once per session.
+ */
+function loadWasmRender(extensionPath: string): WasmRenderModule {
+  if (!wasmRenderCache) {
+    const modPath = path.join(extensionPath, 'dist', 'node', 'chordsketch_wasm.js');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    wasmRenderCache = require(modPath) as WasmRenderModule;
+  }
+  return wasmRenderCache;
+}
 
 /**
  * Resolves the active ChordPro document from the active text editor.
@@ -79,6 +115,120 @@ export function registerTransposeDown(): vscode.Disposable {
     const editor = vscode.window.activeTextEditor;
     if (editor && editor.document.languageId === 'chordpro') {
       notifyTranspose(editor.document.uri.toString(), -1);
+    }
+  });
+}
+
+/** Label constants for the export format QuickPick. */
+const FORMAT_HTML = 'HTML' as const;
+const FORMAT_TEXT = 'Plain text' as const;
+const FORMAT_PDF = 'PDF' as const;
+type ExportFormat = typeof FORMAT_HTML | typeof FORMAT_TEXT | typeof FORMAT_PDF;
+
+/**
+ * Returns the default file extension for an export format.
+ *
+ * @param format - One of the three supported export formats.
+ * @returns The file extension string including the leading dot.
+ */
+function extensionForFormat(format: ExportFormat): string {
+  if (format === FORMAT_PDF) return '.pdf';
+  if (format === FORMAT_TEXT) return '.txt';
+  return '.html';
+}
+
+/**
+ * Exports the active ChordPro document as HTML, plain text, or PDF.
+ *
+ * The command:
+ * 1. Resolves the active ChordPro document (errors if none is open).
+ * 2. Prompts the user to choose an output format via QuickPick.
+ * 3. Opens a Save dialog pre-filled with the source file name (extension
+ *    replaced by the chosen format's extension).
+ * 4. Loads the `@chordsketch/wasm` Node.js CJS build lazily and renders the
+ *    document in the chosen format.
+ * 5. Writes the output to the chosen path and offers to open/reveal it.
+ *
+ * The WASM module is loaded from `dist/node/chordsketch_wasm.js` (copied
+ * there by `esbuild.mjs` at build time) so its `__dirname` correctly points
+ * to the directory that contains `chordsketch_wasm_bg.wasm`.
+ */
+export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disposable {
+  return vscode.commands.registerCommand('chordsketch.convertTo', async () => {
+    const doc = resolveActiveChordProDocument();
+    if (!doc) {
+      return;
+    }
+
+    const format = await vscode.window.showQuickPick([FORMAT_HTML, FORMAT_TEXT, FORMAT_PDF], {
+      placeHolder: 'Select output format',
+    });
+    if (!format) {
+      return;
+    }
+
+    const ext = extensionForFormat(format as ExportFormat);
+    const defaultUri = vscode.Uri.file(doc.uri.fsPath.replace(/\.[^.]+$/, ext));
+
+    let filters: { [name: string]: string[] };
+    if (format === FORMAT_PDF) {
+      filters = { 'PDF Documents': ['pdf'] };
+    } else if (format === FORMAT_TEXT) {
+      filters = { 'Plain Text': ['txt'] };
+    } else {
+      filters = { 'HTML Documents': ['html', 'htm'] };
+    }
+
+    const saveUri = await vscode.window.showSaveDialog({ defaultUri, filters });
+    if (!saveUri) {
+      return;
+    }
+
+    let wasm: WasmRenderModule;
+    try {
+      wasm = loadWasmRender(context.extensionPath);
+    } catch (err) {
+      void vscode.window.showErrorMessage(
+        `ChordSketch: Failed to load WASM renderer: ${String(err)}`,
+      );
+      return;
+    }
+
+    try {
+      if (format === FORMAT_PDF) {
+        const bytes = wasm.render_pdf(doc.getText());
+        await vscode.workspace.fs.writeFile(saveUri, bytes);
+      } else if (format === FORMAT_TEXT) {
+        const rendered = wasm.render_text(doc.getText());
+        await vscode.workspace.fs.writeFile(saveUri, Buffer.from(rendered, 'utf-8'));
+      } else {
+        const rendered = wasm.render_html(doc.getText());
+        await vscode.workspace.fs.writeFile(saveUri, Buffer.from(rendered, 'utf-8'));
+      }
+    } catch (err) {
+      void vscode.window.showErrorMessage(`ChordSketch: Export failed: ${String(err)}`);
+      return;
+    }
+
+    if (format === FORMAT_PDF) {
+      const revealBtn = 'Reveal in Explorer';
+      const choice = await vscode.window.showInformationMessage(
+        `ChordSketch: Exported PDF to ${saveUri.fsPath}`,
+        revealBtn,
+      );
+      if (choice === revealBtn) {
+        await vscode.commands.executeCommand('revealFileInOS', saveUri);
+      }
+    } else {
+      const openBtn = 'Open File';
+      const choice = await vscode.window.showInformationMessage(
+        `ChordSketch: Exported to ${saveUri.fsPath}`,
+        openBtn,
+      );
+      if (choice === openBtn) {
+        const opened = await vscode.workspace.openTextDocument(saveUri);
+        await vscode.window.showTextDocument(opened);
+      }
     }
   });
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -14,7 +14,7 @@
 import * as vscode from 'vscode';
 import { startLspClient, stopLspClient } from './lsp';
 import { notifyDocumentChanged, disposeAll } from './preview';
-import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown } from './commands';
+import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo } from './commands';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   // Start the LSP client (gracefully degraded if binary not found).
@@ -26,6 +26,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     registerOpenPreviewToSide(context),
     registerTransposeUp(),
     registerTransposeDown(),
+    registerConvertTo(context),
   );
 
   // Propagate document changes to open preview panels (debounced inside PreviewPanel).


### PR DESCRIPTION
## What

Adds `chordsketch.convertTo` — a new command palette action **"ChordSketch: Export As…"** that exports the active ChordPro document as HTML, plain text, or PDF.

## Why

Issue #1401 requested a way to convert open ChordPro files to other formats directly from VS Code without leaving the editor.

## How it works

1. User opens a `.cho` / `.chordpro` file and runs **"ChordSketch: Export As…"** from the command palette (hidden when a non-ChordPro file is active).
2. A QuickPick lets them choose **HTML**, **Plain text**, or **PDF**.
3. A Save dialog opens, pre-filled with the source filename and the appropriate extension.
4. The `@chordsketch/wasm` Node.js CJS build renders the document in the extension host process (no child process spawn needed).
5. The output is written to the chosen path. A notification offers to **Open File** (HTML/text) or **Reveal in Explorer** (PDF).

### WASM loading strategy

`esbuild.mjs` copies `node/chordsketch_wasm.js` and `node/chordsketch_wasm_bg.wasm` from the installed `@chordsketch/wasm` package into `dist/node/` at build time (with a companion `dist/node/package.json` declaring `"type": "commonjs"`).

The command handler loads the module via `require(runtimePath)` — a variable-path require that esbuild cannot statically analyse, so the module is **not** inlined into `dist/extension.js`. At runtime the module's own `__dirname` resolves to `dist/node/`, where the `.wasm` binary lives. The loaded module is cached after the first call so the WASM binary is only parsed once per session.

## Changes

| File | Change |
|---|---|
| `esbuild.mjs` | Copy node WASM files to `dist/node/` and write companion `package.json` |
| `src/commands.ts` | Add `WasmRenderModule` interface, `loadWasmRender()` helper, `registerConvertTo()` |
| `src/extension.ts` | Register the new command in `activate()` |
| `package.json` | Declare `chordsketch.convertTo` command + `commandPalette` when-clause |

## Test results

- `npm run lint` (tsc --noEmit): passes ✓
- `npm test` (config unit tests): 6/6 pass ✓

## Review summary

No auto-review has been run yet; waiting for CI.

Closes #1401