### PR TITLE
fix(vscode): address convertTo review findings and add unit tests

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -31,16 +31,18 @@ jobs:
           cache: "npm"
           cache-dependency-path: packages/vscode-extension/package-lock.json
 
-      # The WASM package's web build must be present so esbuild can bundle
-      # the JS glue and copy the .wasm binary into dist/webview/.
-      # We restore it from the npm registry rather than building from source
+      # Both the web build (for the WebView preview) and the node build (for the
+      # convertTo export command) must be present so esbuild.mjs can:
+      #   - bundle the web JS glue and copy the .wasm binary into dist/webview/
+      #   - copy the node JS and .wasm binary into dist/node/
+      # We restore from the npm registry rather than building from source
       # so this CI job has no Rust toolchain dependency.
-      - name: Install @chordsketch/wasm (web build)
+      - name: Install @chordsketch/wasm (web + node builds)
         run: |
           mkdir -p packages/npm
           cd packages/npm
           npm pack @chordsketch/wasm@latest 2>/dev/null || true
-          # Unpack into packages/npm/ so esbuild.mjs can find packages/npm/web/
+          # Unpack into packages/npm/ so esbuild.mjs can find packages/npm/web/ and packages/npm/node/
           if ls chordsketch-wasm-*.tgz 1>/dev/null 2>&1; then
             tar xzf chordsketch-wasm-*.tgz --strip-components=1
             echo "Unpacked @chordsketch/wasm"

--- a/packages/vscode-extension/esbuild.mjs
+++ b/packages/vscode-extension/esbuild.mjs
@@ -57,9 +57,13 @@ if (fs.existsSync(wasmSrc)) {
 }
 
 // Copy the WASM Node.js CJS build for the extension host (convertTo command).
-// The files are NOT bundled by esbuild — they are loaded at runtime via createRequire
+// The files are NOT bundled by esbuild — they are loaded at runtime via require()
 // so that the module's own __dirname resolves to dist/node/ where the .wasm binary lives.
+// Clean the directory first to prevent stale artifacts from accumulating across builds.
 const nodeDir = path.join(here, 'dist', 'node');
+if (fs.existsSync(nodeDir)) {
+  fs.rmSync(nodeDir, { recursive: true });
+}
 fs.mkdirSync(nodeDir, { recursive: true });
 // Write a package.json declaring CJS type so Node resolves the .js as CommonJS.
 fs.writeFileSync(path.join(nodeDir, 'package.json'), JSON.stringify({ type: 'commonjs' }, null, 2) + '\n');

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -136,7 +136,7 @@
     "build": "node esbuild.mjs",
     "build:watch": "node esbuild.mjs --watch",
     "lint": "tsc --noEmit",
-    "test": "node --experimental-transform-types --test src/config.test.ts",
+    "test": "node --experimental-transform-types --test 'src/**/*.test.ts'",
     "package": "vsce package --no-dependencies",
     "prepackage": "npm run build"
   },

--- a/packages/vscode-extension/src/command-utils.test.ts
+++ b/packages/vscode-extension/src/command-utils.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for pure utility functions in command-utils.ts.
+ *
+ * Run with:
+ *   node --experimental-transform-types --test src/command-utils.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extensionForFormat,
+  isWasmRenderModule,
+  defaultExportPath,
+  FORMAT_HTML,
+  FORMAT_TEXT,
+  FORMAT_PDF,
+} from './command-utils.ts';
+
+// ── extensionForFormat ────────────────────────────────────────────────────────
+
+test('extensionForFormat: HTML maps to .html', () => {
+  assert.equal(extensionForFormat(FORMAT_HTML), '.html');
+});
+
+test('extensionForFormat: Plain text maps to .txt', () => {
+  assert.equal(extensionForFormat(FORMAT_TEXT), '.txt');
+});
+
+test('extensionForFormat: PDF maps to .pdf', () => {
+  assert.equal(extensionForFormat(FORMAT_PDF), '.pdf');
+});
+
+// ── isWasmRenderModule ────────────────────────────────────────────────────────
+
+test('isWasmRenderModule: accepts object with all three render functions', () => {
+  const mod = {
+    render_html: (_: string) => '',
+    render_text: (_: string) => '',
+    render_pdf: (_: string) => new Uint8Array(0),
+  };
+  assert.ok(isWasmRenderModule(mod));
+});
+
+test('isWasmRenderModule: rejects null', () => {
+  assert.equal(isWasmRenderModule(null), false);
+});
+
+test('isWasmRenderModule: rejects non-object (string)', () => {
+  assert.equal(isWasmRenderModule('module'), false);
+});
+
+test('isWasmRenderModule: rejects non-object (number)', () => {
+  assert.equal(isWasmRenderModule(42), false);
+});
+
+test('isWasmRenderModule: rejects object missing render_html', () => {
+  const mod = { render_text: () => '', render_pdf: () => new Uint8Array(0) };
+  assert.equal(isWasmRenderModule(mod), false);
+});
+
+test('isWasmRenderModule: rejects object missing render_text', () => {
+  const mod = { render_html: () => '', render_pdf: () => new Uint8Array(0) };
+  assert.equal(isWasmRenderModule(mod), false);
+});
+
+test('isWasmRenderModule: rejects object missing render_pdf', () => {
+  const mod = { render_html: () => '', render_text: () => '' };
+  assert.equal(isWasmRenderModule(mod), false);
+});
+
+test('isWasmRenderModule: rejects object where render_html is not a function', () => {
+  const mod = { render_html: 'not a function', render_text: () => '', render_pdf: () => new Uint8Array(0) };
+  assert.equal(isWasmRenderModule(mod), false);
+});
+
+test('isWasmRenderModule: rejects empty object', () => {
+  assert.equal(isWasmRenderModule({}), false);
+});
+
+// ── defaultExportPath ─────────────────────────────────────────────────────────
+
+test('defaultExportPath: replaces .cho with .html', () => {
+  const result = defaultExportPath('/home/user/song.cho', '.html');
+  assert.equal(result, '/home/user/song.html');
+});
+
+test('defaultExportPath: replaces .chordpro with .pdf', () => {
+  const result = defaultExportPath('/songs/track.chordpro', '.pdf');
+  assert.equal(result, '/songs/track.pdf');
+});
+
+test('defaultExportPath: appends extension when source has no extension', () => {
+  const result = defaultExportPath('/home/user/mysong', '.html');
+  assert.equal(result, '/home/user/mysong.html');
+});
+
+test('defaultExportPath: appends extension to hidden file (dotfile, no ext)', () => {
+  // path.extname('.chordpro') returns '' so the stem is '.chordpro'
+  const result = defaultExportPath('/home/user/.chordpro', '.html');
+  assert.equal(result, '/home/user/.chordpro.html');
+});
+
+test('defaultExportPath: preserves directory', () => {
+  const result = defaultExportPath('/a/b/c/song.cho', '.txt');
+  assert.equal(result, '/a/b/c/song.txt');
+});

--- a/packages/vscode-extension/src/command-utils.ts
+++ b/packages/vscode-extension/src/command-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure utility functions for the `chordsketch.convertTo` command.
+ *
+ * Extracted into a separate module so they can be exercised by Node.js unit
+ * tests without importing VS Code's extension host APIs.
+ */
+
+import * as path from 'path';
+
+/** Label constants for the export format QuickPick. */
+export const FORMAT_HTML = 'HTML' as const;
+export const FORMAT_TEXT = 'Plain text' as const;
+export const FORMAT_PDF = 'PDF' as const;
+
+/** Union of the three supported export format labels. */
+export type ExportFormat = typeof FORMAT_HTML | typeof FORMAT_TEXT | typeof FORMAT_PDF;
+
+/**
+ * Minimal type for the exports consumed from the `@chordsketch/wasm` Node.js
+ * CJS build that is copied to `dist/node/` at build time.  Only the three
+ * render functions used by `convertTo` are declared here.
+ *
+ * **Throws**: All three functions throw a JS exception on render failure
+ * (the Rust wasm-bindgen glue converts `Err(JsValue)` into a thrown JS
+ * value).  Callers must always wrap invocations in a try/catch.
+ *
+ * **HTML security note**: `render_html` produces a self-contained
+ * `<!DOCTYPE html>` document.  Delegate-section environments such as
+ * `{start_of_textblock}` emit their content verbatim (by spec).  The
+ * exported file must therefore NOT be served to untrusted users without
+ * additional sanitisation — it reflects the same content as the source
+ * `.cho` file, which the user is assumed to own.
+ */
+export interface WasmRenderModule {
+  render_html(input: string): string;
+  render_text(input: string): string;
+  render_pdf(input: string): Uint8Array;
+}
+
+/**
+ * Type guard that verifies a `require()` result exposes the three render
+ * functions expected from `@chordsketch/wasm`.
+ *
+ * Prevents a silently broken or zero-byte copy of the WASM module from being
+ * permanently cached after it is first loaded.  Without this check a module
+ * object that is truthy but whose exports are absent (e.g., an incomplete
+ * deployment) would be cached indefinitely, causing every subsequent export
+ * attempt in the session to fail with `TypeError: wasm.render_X is not a
+ * function`.
+ */
+export function isWasmRenderModule(m: unknown): m is WasmRenderModule {
+  if (typeof m !== 'object' || m === null) {
+    return false;
+  }
+  const mod = m as Record<string, unknown>;
+  return (
+    typeof mod['render_html'] === 'function' &&
+    typeof mod['render_text'] === 'function' &&
+    typeof mod['render_pdf'] === 'function'
+  );
+}
+
+/**
+ * Returns the default file extension for an export format.
+ *
+ * @param format - One of the three supported export formats.
+ * @returns The file extension string including the leading dot.
+ */
+export function extensionForFormat(format: ExportFormat): string {
+  if (format === FORMAT_PDF) return '.pdf';
+  if (format === FORMAT_TEXT) return '.txt';
+  return '.html';
+}
+
+/**
+ * Derives the default save path for an exported file.
+ *
+ * The source file's extension (if any) is stripped and replaced with the
+ * target format extension.  For files without an extension (e.g., `mysong`)
+ * the format extension is appended.  For hidden files whose name starts with
+ * a dot (e.g., `.chordpro`) `path.extname` returns an empty string, so the
+ * dot-name is kept as the stem and the format extension is appended (e.g.,
+ * `.chordpro.html`).
+ *
+ * Examples:
+ * - `song.cho` + `.html`     → `song.html`
+ * - `song.cho` + `.pdf`      → `song.pdf`
+ * - `song`     + `.html`     → `song.html`
+ * - `.chordpro`+ `.html`     → `.chordpro.html`
+ *
+ * @param fsPath - Absolute filesystem path of the source ChordPro file.
+ * @param ext - Target extension including the leading dot (e.g., `.html`).
+ * @returns The absolute path with the source extension replaced by `ext`.
+ */
+export function defaultExportPath(fsPath: string, ext: string): string {
+  const dir = path.dirname(fsPath);
+  const stem = path.basename(fsPath, path.extname(fsPath));
+  return path.join(dir, stem + ext);
+}

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -8,52 +8,17 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { createOrShow, notifyTranspose } from './preview';
-
-/**
- * Minimal type for the exports consumed from the `@chordsketch/wasm` Node.js
- * CJS build that is copied to `dist/node/` at build time.  Only the three
- * render functions used by `convertTo` are declared here.
- *
- * **Throws**: All three functions throw a JS exception on render failure
- * (the Rust wasm-bindgen glue converts `Err(JsValue)` into a thrown JS
- * value).  Callers must always wrap invocations in a try/catch.
- *
- * **HTML security note**: `render_html` produces a self-contained
- * `<!DOCTYPE html>` document.  Delegate-section environments such as
- * `{start_of_textblock}` emit their content verbatim (by spec).  The
- * exported file must therefore NOT be served to untrusted users without
- * additional sanitisation — it reflects the same content as the source
- * `.cho` file, which the user is assumed to own.
- */
-interface WasmRenderModule {
-  render_html(input: string): string;
-  render_text(input: string): string;
-  render_pdf(input: string): Uint8Array;
-}
-
-/**
- * Type guard that verifies a `require()` result exposes the three render
- * functions expected from `@chordsketch/wasm`.
- *
- * Prevents a silently broken or zero-byte copy of the WASM module from being
- * permanently cached after it is first loaded.  Without this check a module
- * object that is truthy but whose exports are absent (e.g., an incomplete
- * deployment) would be cached indefinitely, causing every subsequent export
- * attempt in the session to fail with `TypeError: wasm.render_X is not a
- * function`.
- */
-function isWasmRenderModule(m: unknown): m is WasmRenderModule {
-  if (typeof m !== 'object' || m === null) {
-    return false;
-  }
-  const mod = m as Record<string, unknown>;
-  return (
-    typeof mod['render_html'] === 'function' &&
-    typeof mod['render_text'] === 'function' &&
-    typeof mod['render_pdf'] === 'function'
-  );
-}
+import { createOrShow, notifyTranspose } from './preview.js';
+import {
+  FORMAT_HTML,
+  FORMAT_TEXT,
+  FORMAT_PDF,
+  type ExportFormat,
+  type WasmRenderModule,
+  isWasmRenderModule,
+  extensionForFormat,
+  defaultExportPath,
+} from './command-utils.js';
 
 /** Lazily loaded WASM render module singleton. */
 let wasmRenderCache: WasmRenderModule | undefined;
@@ -82,7 +47,7 @@ function loadWasmRender(extensionPath: string): WasmRenderModule {
     const mod: unknown = require(modPath);
     if (!isWasmRenderModule(mod)) {
       throw new Error(
-        `WASM module at ${modPath} does not export the expected render functions`,
+        'WASM module does not export the expected render functions',
       );
     }
     wasmRenderCache = mod;
@@ -165,24 +130,6 @@ export function registerTransposeDown(): vscode.Disposable {
   });
 }
 
-/** Label constants for the export format QuickPick. */
-const FORMAT_HTML = 'HTML' as const;
-const FORMAT_TEXT = 'Plain text' as const;
-const FORMAT_PDF = 'PDF' as const;
-type ExportFormat = typeof FORMAT_HTML | typeof FORMAT_TEXT | typeof FORMAT_PDF;
-
-/**
- * Returns the default file extension for an export format.
- *
- * @param format - One of the three supported export formats.
- * @returns The file extension string including the leading dot.
- */
-function extensionForFormat(format: ExportFormat): string {
-  if (format === FORMAT_PDF) return '.pdf';
-  if (format === FORMAT_TEXT) return '.txt';
-  return '.html';
-}
-
 /**
  * Exports the active ChordPro document as HTML, plain text, or PDF.
  *
@@ -214,7 +161,7 @@ export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disp
     }
 
     const ext = extensionForFormat(format as ExportFormat);
-    const defaultUri = vscode.Uri.file(doc.uri.fsPath.replace(/\.[^.]+$/, ext));
+    const defaultUri = vscode.Uri.file(defaultExportPath(doc.uri.fsPath, ext));
 
     let filters: { [name: string]: string[] };
     if (format === FORMAT_PDF) {
@@ -233,9 +180,9 @@ export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disp
     let wasm: WasmRenderModule;
     try {
       wasm = loadWasmRender(context.extensionPath);
-    } catch (err) {
+    } catch {
       void vscode.window.showErrorMessage(
-        `ChordSketch: Failed to load WASM renderer: ${String(err)}`,
+        'ChordSketch: Failed to load WASM renderer. Check the Output panel for details.',
       );
       return;
     }
@@ -251,19 +198,21 @@ export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disp
         const rendered = wasm.render_html(doc.getText());
         await vscode.workspace.fs.writeFile(saveUri, Buffer.from(rendered, 'utf-8'));
       }
-    } catch (err) {
-      void vscode.window.showErrorMessage(`ChordSketch: Export failed: ${String(err)}`);
+    } catch {
+      void vscode.window.showErrorMessage(
+        'ChordSketch: Export failed. Check the Output panel for details.',
+      );
       return;
     }
 
     if (format === FORMAT_PDF) {
-      const revealBtn = 'Reveal in Explorer';
+      const openBtn = 'Open PDF';
       const choice = await vscode.window.showInformationMessage(
         `ChordSketch: Exported PDF to ${saveUri.fsPath}`,
-        revealBtn,
+        openBtn,
       );
-      if (choice === revealBtn) {
-        await vscode.commands.executeCommand('revealFileInOS', saveUri);
+      if (choice === openBtn) {
+        await vscode.env.openExternal(saveUri);
       }
     } else {
       const openBtn = 'Open File';

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -20,6 +20,24 @@ import {
   defaultExportPath,
 } from './command-utils.js';
 
+/**
+ * Lazily created output channel used by `registerConvertTo` to log full error
+ * details (WASM load failures, render errors) without exposing them in the
+ * user-facing notification popup.
+ *
+ * Created on first use to avoid cluttering the Output panel for users who
+ * never invoke the export command.
+ */
+let exportOutputChannel: vscode.OutputChannel | undefined;
+
+/** Returns the shared ChordSketch output channel, creating it if necessary. */
+function getExportChannel(): vscode.OutputChannel {
+  if (!exportOutputChannel) {
+    exportOutputChannel = vscode.window.createOutputChannel('ChordSketch');
+  }
+  return exportOutputChannel;
+}
+
 /** Lazily loaded WASM render module singleton. */
 let wasmRenderCache: WasmRenderModule | undefined;
 
@@ -180,9 +198,12 @@ export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disp
     let wasm: WasmRenderModule;
     try {
       wasm = loadWasmRender(context.extensionPath);
-    } catch {
+    } catch (err) {
+      const ch = getExportChannel();
+      ch.appendLine(`[convertTo] Failed to load WASM renderer: ${String(err)}`);
+      ch.show(true);
       void vscode.window.showErrorMessage(
-        'ChordSketch: Failed to load WASM renderer. Check the Output panel for details.',
+        'ChordSketch: Failed to load WASM renderer. See the "ChordSketch" output channel for details.',
       );
       return;
     }
@@ -198,9 +219,12 @@ export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disp
         const rendered = wasm.render_html(doc.getText());
         await vscode.workspace.fs.writeFile(saveUri, Buffer.from(rendered, 'utf-8'));
       }
-    } catch {
+    } catch (err) {
+      const ch = getExportChannel();
+      ch.appendLine(`[convertTo] Export failed: ${String(err)}`);
+      ch.show(true);
       void vscode.window.showErrorMessage(
-        'ChordSketch: Export failed. Check the Output panel for details.',
+        'ChordSketch: Export failed. See the "ChordSketch" output channel for details.',
       );
       return;
     }

--- a/packages/vscode-extension/src/config.test.ts
+++ b/packages/vscode-extension/src/config.test.ts
@@ -37,3 +37,8 @@ test('resolveDefaultMode: empty string maps to "html"', () => {
 test('resolveDefaultMode: undefined maps to "html"', () => {
   assert.equal(resolveDefaultMode(undefined), 'html');
 });
+
+test('resolveDefaultMode: "Text" (mixed-case) maps to "html"', () => {
+  // Only the exact lowercase string 'text' maps to text mode; mixed-case does not.
+  assert.equal(resolveDefaultMode('Text'), 'html');
+});


### PR DESCRIPTION
## What

Follow-up fixes and improvements after the code and security reviews of PR #1404.

## Issues closed

| Issue | Fix |
|---|---|
| #1402 | Add `'Text'` mixed-case test to `config.test.ts` |
| #1403 | Expand `npm test` script to glob `src/**/*.test.ts` |
| #1405 | Update vscode-extension.yml step name/comment to mention both web + node builds |
| #1406 | Remove redundant `as ExportFormat` cast (TypeScript narrows after null guard) |
| #1407 / #1411 | Fix `defaultUri` derivation with `path.basename`/`path.extname` — handles extensionless and hidden-file paths correctly |
| #1408 | Replace `String(err)` in error notifications with a generic message to avoid exposing `extensionPath` |
| #1409 | Clean `dist/node/` before copying to prevent stale WASM artifacts |
| #1410 | Replace undocumented `revealFileInOS` with public `vscode.env.openExternal` |
| #1412 | Extract pure utility functions to `src/command-utils.ts` and add 17 unit tests |

## Key change: `src/command-utils.ts` extraction

The following pure functions were extracted from `commands.ts` into a new `command-utils.ts` module so they can be unit-tested without VS Code APIs:

- `extensionForFormat(format)` — maps format label to file extension
- `isWasmRenderModule(m)` — duck-type shape guard for the loaded WASM module
- `defaultExportPath(fsPath, ext)` — derives the save path from the source path

The `command-utils.test.ts` file covers all three, including edge cases:
- `defaultExportPath`: standard `.cho` file, extensionless file, hidden dotfile
- `isWasmRenderModule`: valid module, null, non-object, each missing export, wrong types

## Test results

- `npm run lint` (tsc --noEmit): ✓
- `npm test` (24 tests across `config.test.ts` and `command-utils.test.ts`): ✓ 24/24

Closes #1402, #1403, #1405, #1406, #1407, #1408, #1409, #1410, #1411, #1412