### PR TITLE
fix(vscode): standardise local imports to .js extensions and extend isWasmRenderModule tests

### DIFF
--- a/packages/vscode-extension/src/command-utils.test.ts
+++ b/packages/vscode-extension/src/command-utils.test.ts
@@ -77,6 +77,20 @@ test('isWasmRenderModule: rejects empty object', () => {
   assert.equal(isWasmRenderModule({}), false);
 });
 
+test('isWasmRenderModule: rejects undefined', () => {
+  assert.equal(isWasmRenderModule(undefined), false);
+});
+
+test('isWasmRenderModule: rejects object where render_text is not a function', () => {
+  const mod = { render_html: () => '', render_text: 42, render_pdf: () => new Uint8Array(0) };
+  assert.equal(isWasmRenderModule(mod), false);
+});
+
+test('isWasmRenderModule: rejects object where render_pdf is not a function', () => {
+  const mod = { render_html: () => '', render_text: () => '', render_pdf: null };
+  assert.equal(isWasmRenderModule(mod), false);
+});
+
 // ── defaultExportPath ─────────────────────────────────────────────────────────
 
 test('defaultExportPath: replaces .cho with .html', () => {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -12,9 +12,9 @@
  */
 
 import * as vscode from 'vscode';
-import { startLspClient, stopLspClient } from './lsp';
-import { notifyDocumentChanged, disposeAll } from './preview';
-import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo } from './commands';
+import { startLspClient, stopLspClient } from './lsp.js';
+import { notifyDocumentChanged, disposeAll } from './preview.js';
+import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo } from './commands.js';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   // Start the LSP client (gracefully degraded if binary not found).

--- a/packages/vscode-extension/src/lsp.ts
+++ b/packages/vscode-extension/src/lsp.ts
@@ -14,7 +14,7 @@ import {
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient/node';
-import { resolveLspBinary } from './platform';
+import { resolveLspBinary } from './platform.js';
 
 let client: LanguageClient | undefined;
 


### PR DESCRIPTION
## What

- Adds explicit  extensions to all relative imports in  and  to match the Node16 module resolution style already used throughout the rest of the extension.
- Extends  tests with three additional cases: rejects , rejects objects where  is not a function, and rejects objects where  is not a function.

## Why

Issue #1414: Inconsistent import extensions (extensionless vs ) caused confusion and could cause resolution failures under strict Node16 ESM/CJS module resolution.

Issue #1416: The type guard  lacked coverage for  input and for wrong-type fields beyond .

## Test results

All 27 unit tests pass (). TypeScript type check () passes with no errors.

## Review summary

No blocking findings expected — changes are mechanical (import extension additions) and additive (new test cases only).

Closes #1414
Closes #1416