### PR TITLE
fix(vscode): dispose exportOutputChannel on deactivation and extend isWasmRenderModule tests

### DIFF
--- a/packages/vscode-extension/src/command-utils.test.ts
+++ b/packages/vscode-extension/src/command-utils.test.ts
@@ -86,7 +86,16 @@ test('isWasmRenderModule: rejects object where render_text is not a function', (
   assert.equal(isWasmRenderModule(mod), false);
 });
 
-test('isWasmRenderModule: rejects object where render_pdf is not a function', () => {
+test('isWasmRenderModule: rejects object where render_text is undefined', () => {
+  // undefined is the most common real-world case: a partially-initialised module
+  // that exports render_html and render_pdf but not render_text.
+  const mod = { render_html: () => '', render_text: undefined, render_pdf: () => new Uint8Array(0) };
+  assert.equal(isWasmRenderModule(mod), false);
+});
+
+test('isWasmRenderModule: rejects object where render_pdf is not a function (null)', () => {
+  // `typeof null === "object"` is truthy, so null bypasses the early non-object
+  // guard and must be caught by the per-property typeof check.
   const mod = { render_html: () => '', render_text: () => '', render_pdf: null };
   assert.equal(isWasmRenderModule(mod), false);
 });

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -30,10 +30,16 @@ import {
  */
 let exportOutputChannel: vscode.OutputChannel | undefined;
 
-/** Returns the shared ChordSketch output channel, creating it if necessary. */
-function getExportChannel(): vscode.OutputChannel {
+/**
+ * Returns the shared ChordSketch output channel, creating it if necessary.
+ *
+ * On first creation the channel is pushed to `context.subscriptions` so VS Code
+ * disposes it automatically when the extension is deactivated.
+ */
+function getExportChannel(context: vscode.ExtensionContext): vscode.OutputChannel {
   if (!exportOutputChannel) {
     exportOutputChannel = vscode.window.createOutputChannel('ChordSketch');
+    context.subscriptions.push(exportOutputChannel);
   }
   return exportOutputChannel;
 }
@@ -199,7 +205,7 @@ export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disp
     try {
       wasm = loadWasmRender(context.extensionPath);
     } catch (err) {
-      const ch = getExportChannel();
+      const ch = getExportChannel(context);
       ch.appendLine(`[convertTo] Failed to load WASM renderer: ${String(err)}`);
       ch.show(true);
       void vscode.window.showErrorMessage(
@@ -220,7 +226,7 @@ export function registerConvertTo(context: vscode.ExtensionContext): vscode.Disp
         await vscode.workspace.fs.writeFile(saveUri, Buffer.from(rendered, 'utf-8'));
       }
     } catch (err) {
-      const ch = getExportChannel();
+      const ch = getExportChannel(context);
       ch.appendLine(`[convertTo] Export failed: ${String(err)}`);
       ch.show(true);
       void vscode.window.showErrorMessage(


### PR DESCRIPTION
## What

- **#1417** — `getExportChannel()` now accepts `context: vscode.ExtensionContext` and
  pushes the lazily created `OutputChannel` to `context.subscriptions` on first use.
  VS Code calls `.dispose()` on every item in that list when the extension deactivates,
  so the channel is properly cleaned up on reload.
- **#1420** — Added `isWasmRenderModule: rejects object where render_text is undefined`
  test to cover the most common real-world partial-init scenario (a module that exports
  `render_html`/`render_pdf` but not `render_text`).
- **#1419** — Renamed and annotated the `render_pdf: null` test to document the
  `typeof null === "object"` JavaScript edge case that justifies this specific case.

## Why

The `exportOutputChannel` singleton was created on first use but never registered for
disposal. Each extension reload within the same VS Code session left a dangling
`OutputChannel` instance. The fix is minimal: pass `context` into the factory and
call `context.subscriptions.push(channel)` once, at creation time.

The two test improvements were filed as nit findings in the review of PR #1418 and
make the intent of the existing coverage explicit.

## Test results

```
node --experimental-transform-types --test src/command-utils.test.ts
# tests 21
# pass 21
# fail 0
```

## Review summary

Three low/nit findings from post-#1418 review, all addressed in this PR.

Closes #1417
Closes #1419
Closes #1420