### PR TITLE
fix(vscode): reset command singletons on deactivation to prevent stale state on reload

### DIFF
--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -48,6 +48,18 @@ function getExportChannel(context: vscode.ExtensionContext): vscode.OutputChanne
 let wasmRenderCache: WasmRenderModule | undefined;
 
 /**
+ * Resets all module-level singletons so that a subsequent re-activation within
+ * the same VS Code host process (e.g., after `Developer: Restart Extension Host`)
+ * creates fresh instances rather than reusing disposed/stale ones.
+ *
+ * Must be called from `deactivate()` in `extension.ts`.
+ */
+export function resetCommandSingletons(): void {
+  exportOutputChannel = undefined;
+  wasmRenderCache = undefined;
+}
+
+/**
  * Loads the `@chordsketch/wasm` Node.js CJS build from the extension's own
  * `dist/node/` directory.
  *

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -14,7 +14,7 @@
 import * as vscode from 'vscode';
 import { startLspClient, stopLspClient } from './lsp.js';
 import { notifyDocumentChanged, disposeAll } from './preview.js';
-import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo } from './commands.js';
+import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo, resetCommandSingletons } from './commands.js';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   // Start the LSP client (gracefully degraded if binary not found).
@@ -51,4 +51,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 export async function deactivate(): Promise<void> {
   disposeAll();
   await stopLspClient();
+  resetCommandSingletons();
 }


### PR DESCRIPTION
## What

Export `resetCommandSingletons()` from `commands.ts` and call it at the end of `deactivate()` in `extension.ts`.

This resets both module-level singletons:
- `exportOutputChannel` — set to `undefined` so the next activation creates a fresh channel and registers it in the new context's subscriptions (rather than returning an already-disposed channel without subscription registration).
- `wasmRenderCache` — set to `undefined` so a re-deployed WASM binary is picked up rather than silently reusing the cached module from the prior activation.

## Why

PR #1421 fixed the main resource leak by pushing `exportOutputChannel` to `context.subscriptions`. A Low finding from that review noted that both singletons persist in module-level variables after deactivation. In normal extension lifecycle (deactivate → process exit) this is harmless, but `Developer: Restart Extension Host` reloads the extension in the same Node.js process without unloading the module, leaving stale/disposed values in both singletons.

## Test results

```
node --experimental-transform-types --test src/command-utils.test.ts
# tests 21
# pass 21
# fail 0
```

## Review summary

Addresses the Low finding from PR #1421 review. Filed as #1422.

Closes #1422