### PR TITLE
test(vscode): extract command-state.ts and add resetCommandSingletons unit tests

### DIFF
--- a/packages/vscode-extension/src/command-state.test.ts
+++ b/packages/vscode-extension/src/command-state.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for command-state.ts.
+ *
+ * `command-state.ts` contains no runtime VS Code dependency (all VS Code
+ * types are `import type` only), so these tests run with plain Node.js:
+ *
+ *   node --experimental-transform-types --test src/command-state.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { commandState, resetCommandSingletons } from './command-state.ts';
+
+// ── resetCommandSingletons ────────────────────────────────────────────────────
+
+test('resetCommandSingletons: exported and callable without throwing when all singletons are undefined', () => {
+  // Default state: both fields are undefined. Reset should be a no-op.
+  assert.doesNotThrow(() => resetCommandSingletons());
+});
+
+test('resetCommandSingletons: clears exportOutputChannel to undefined', () => {
+  // Simulate a channel having been created by injecting a truthy value.
+  commandState.exportOutputChannel = {} as never;
+  resetCommandSingletons();
+  assert.equal(commandState.exportOutputChannel, undefined);
+});
+
+test('resetCommandSingletons: clears wasmRenderCache to undefined', () => {
+  // Simulate a cached WASM module by injecting a truthy value.
+  commandState.wasmRenderCache = {} as never;
+  resetCommandSingletons();
+  assert.equal(commandState.wasmRenderCache, undefined);
+});
+
+test('resetCommandSingletons: clears both fields in a single call', () => {
+  commandState.exportOutputChannel = {} as never;
+  commandState.wasmRenderCache = {} as never;
+  resetCommandSingletons();
+  assert.equal(commandState.exportOutputChannel, undefined);
+  assert.equal(commandState.wasmRenderCache, undefined);
+});
+
+test('resetCommandSingletons: callable multiple times without throwing', () => {
+  assert.doesNotThrow(() => {
+    resetCommandSingletons();
+    resetCommandSingletons();
+  });
+});

--- a/packages/vscode-extension/src/command-state.ts
+++ b/packages/vscode-extension/src/command-state.ts
@@ -1,0 +1,57 @@
+/**
+ * Module-level singleton state for the ChordSketch command handlers.
+ *
+ * Extracted from `commands.ts` into a separate, VS Code–free module so the
+ * state lifecycle (`resetCommandSingletons`) can be exercised by unit tests
+ * with plain Node.js (`--experimental-transform-types`) without requiring the
+ * VS Code extension host.
+ *
+ * All VS Code types are referenced via `import type` so they are erased at
+ * compile time and do not introduce a runtime dependency on the `vscode` module.
+ */
+
+import type { OutputChannel } from 'vscode';
+import type { WasmRenderModule } from './command-utils.js';
+
+/** Shared mutable singleton state for the convertTo command handlers. */
+export const commandState: {
+  /**
+   * Lazily created output channel used to log full error details (WASM load
+   * failures, render errors) without cluttering the user-facing notification.
+   * Registered in `context.subscriptions` on creation; disposed automatically
+   * by VS Code when the extension is deactivated.
+   */
+  exportOutputChannel: OutputChannel | undefined;
+
+  /**
+   * Lazily loaded `@chordsketch/wasm` Node.js CJS build singleton.
+   * Cached after the first successful `require()` so the WASM binary is only
+   * parsed once per session.
+   */
+  wasmRenderCache: WasmRenderModule | undefined;
+} = {
+  exportOutputChannel: undefined,
+  wasmRenderCache: undefined,
+};
+
+/**
+ * Resets all module-level singletons so that a subsequent re-activation within
+ * the same VS Code host process (e.g., after `Developer: Restart Extension Host`)
+ * creates fresh, properly-subscribed instances rather than reusing a disposed
+ * channel or a stale WASM module cache.
+ *
+ * **Note on `require.cache`**: `commandState.wasmRenderCache` is set to
+ * `undefined` so `loadWasmRender` will call `require()` again on next use.
+ * However, Node.js's `require.cache` persists across Extension Host restarts
+ * within the same VS Code process. This means the subsequent `require()` call
+ * returns the in-process cached module rather than re-reading the binary from
+ * disk. In practice this is harmless unless a new WASM binary was deployed
+ * at the same path between restarts — in that case a full VS Code process
+ * restart is required to pick up the new binary.
+ *
+ * Must be called from `deactivate()` in `extension.ts`.
+ */
+export function resetCommandSingletons(): void {
+  commandState.exportOutputChannel = undefined;
+  commandState.wasmRenderCache = undefined;
+}

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -19,16 +19,9 @@ import {
   extensionForFormat,
   defaultExportPath,
 } from './command-utils.js';
+import { commandState } from './command-state.js';
 
-/**
- * Lazily created output channel used by `registerConvertTo` to log full error
- * details (WASM load failures, render errors) without exposing them in the
- * user-facing notification popup.
- *
- * Created on first use to avoid cluttering the Output panel for users who
- * never invoke the export command.
- */
-let exportOutputChannel: vscode.OutputChannel | undefined;
+export { resetCommandSingletons } from './command-state.js';
 
 /**
  * Returns the shared ChordSketch output channel, creating it if necessary.
@@ -37,26 +30,14 @@ let exportOutputChannel: vscode.OutputChannel | undefined;
  * disposes it automatically when the extension is deactivated.
  */
 function getExportChannel(context: vscode.ExtensionContext): vscode.OutputChannel {
-  if (!exportOutputChannel) {
-    exportOutputChannel = vscode.window.createOutputChannel('ChordSketch');
-    context.subscriptions.push(exportOutputChannel);
+  if (!commandState.exportOutputChannel) {
+    const ch = vscode.window.createOutputChannel('ChordSketch');
+    context.subscriptions.push(ch);
+    commandState.exportOutputChannel = ch;
   }
-  return exportOutputChannel;
-}
-
-/** Lazily loaded WASM render module singleton. */
-let wasmRenderCache: WasmRenderModule | undefined;
-
-/**
- * Resets all module-level singletons so that a subsequent re-activation within
- * the same VS Code host process (e.g., after `Developer: Restart Extension Host`)
- * creates fresh instances rather than reusing disposed/stale ones.
- *
- * Must be called from `deactivate()` in `extension.ts`.
- */
-export function resetCommandSingletons(): void {
-  exportOutputChannel = undefined;
-  wasmRenderCache = undefined;
+  // exportOutputChannel is guaranteed non-undefined: it was either non-undefined
+  // on entry or just assigned in the branch above.
+  return commandState.exportOutputChannel as vscode.OutputChannel;
 }
 
 /**
@@ -74,10 +55,18 @@ export function resetCommandSingletons(): void {
  *
  * The result is cached so the WASM binary is only parsed once per session.
  *
+ * **Note on `require.cache`**: Node.js's `require.cache` persists across
+ * Extension Host restarts within the same VS Code process.  After
+ * `resetCommandSingletons()` clears `wasmRenderCache`, the next call here
+ * will invoke `require(modPath)` again, but Node.js returns the in-process
+ * cached module rather than re-reading the file from disk.  A freshly
+ * deployed WASM binary at the same path is only guaranteed to be picked up
+ * after a full VS Code process restart.
+ *
  * @throws {Error} If the module file is missing or its exports are absent.
  */
 function loadWasmRender(extensionPath: string): WasmRenderModule {
-  if (!wasmRenderCache) {
+  if (!commandState.wasmRenderCache) {
     const modPath = path.join(extensionPath, 'dist', 'node', 'chordsketch_wasm.js');
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const mod: unknown = require(modPath);
@@ -86,9 +75,10 @@ function loadWasmRender(extensionPath: string): WasmRenderModule {
         'WASM module does not export the expected render functions',
       );
     }
-    wasmRenderCache = mod;
+    commandState.wasmRenderCache = mod;
   }
-  return wasmRenderCache;
+  // wasmRenderCache is guaranteed non-undefined here.
+  return commandState.wasmRenderCache as WasmRenderModule;
 }
 
 /**

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -37,7 +37,8 @@ function getExportChannel(context: vscode.ExtensionContext): vscode.OutputChanne
   }
   // exportOutputChannel is guaranteed non-undefined: it was either non-undefined
   // on entry or just assigned in the branch above.
-  return commandState.exportOutputChannel as vscode.OutputChannel;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return commandState.exportOutputChannel!;
 }
 
 /**
@@ -78,7 +79,8 @@ function loadWasmRender(extensionPath: string): WasmRenderModule {
     commandState.wasmRenderCache = mod;
   }
   // wasmRenderCache is guaranteed non-undefined here.
-  return commandState.wasmRenderCache as WasmRenderModule;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return commandState.wasmRenderCache!;
 }
 
 /**


### PR DESCRIPTION
## What

- Extract `exportOutputChannel`, `wasmRenderCache`, and `resetCommandSingletons()` from `commands.ts` into a new `command-state.ts` module.
- All VS Code types in `command-state.ts` are `import type` only — no runtime dependency on the VS Code extension host API.
- Add `command-state.test.ts` with 5 unit tests for `resetCommandSingletons`, running with `node --experimental-transform-types`.
- `commands.ts` re-exports `resetCommandSingletons` from `command-state.ts` — `extension.ts` requires no change.
- Add a comment in `loadWasmRender` documenting the `require.cache` persistence limitation.

## Why

**#1424** — `resetCommandSingletons()` had no unit test. Testing it directly from `commands.ts` was blocked because `commands.ts` has a top-level `import * as vscode from 'vscode'` that fails without the extension host. Extracting the state to a VS Code–free module unlocks plain-Node.js testing.

**#1425** — After `resetCommandSingletons()` clears `wasmRenderCache`, the next `require(modPath)` call returns the in-process cached module from `require.cache` rather than re-reading from disk. This is documented in `loadWasmRender` so future contributors are aware of the limitation.

## Test results

```
node --experimental-transform-types --test 'src/**/*.test.ts'
# tests 33
# pass 33
# fail 0
```

## Review summary

Addresses findings from the review of PR #1423.

Closes #1424
Closes #1425