### PR TITLE
ci(vscode): add environment gate and fix stale comment on publish job

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -97,14 +97,18 @@ jobs:
     name: Publish to VS Code Marketplace
     needs: [build]
     runs-on: ubuntu-latest
-    # Publish only on version tag pushes or when workflow_dispatch supplies a tag.
+    # Publish only on GitHub Release (published) events or when workflow_dispatch supplies a tag.
     #
     # Prerequisites (one-time human setup before this job can succeed):
     #   1. Register publisher "koedame" at https://marketplace.visualstudio.com/manage
     #   2. Generate a Personal Access Token (PAT) with "Marketplace (Publish)" scope
     #      at https://dev.azure.com/koedame/_usersSettings/tokens
-    #   3. Add the PAT as repository secret VSCE_PAT in
-    #      https://github.com/koedame/chordsketch/settings/secrets/actions
+    #   3. Add the PAT as repository secret VSCE_PAT in the vscode-marketplace environment:
+    #      https://github.com/koedame/chordsketch/settings/environments
+    #   4. Create the "vscode-marketplace" environment in repo settings (step 3 above)
+    environment:
+      name: vscode-marketplace
+      url: https://marketplace.visualstudio.com/items?itemName=koedame.chordsketch
     if: >-
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.tag != '')

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -103,9 +103,9 @@ jobs:
     #   1. Register publisher "koedame" at https://marketplace.visualstudio.com/manage
     #   2. Generate a Personal Access Token (PAT) with "Marketplace (Publish)" scope
     #      at https://dev.azure.com/koedame/_usersSettings/tokens
-    #   3. Add the PAT as repository secret VSCE_PAT in the vscode-marketplace environment:
+    #   3. Create the "vscode-marketplace" environment at
     #      https://github.com/koedame/chordsketch/settings/environments
-    #   4. Create the "vscode-marketplace" environment in repo settings (step 3 above)
+    #      and add the PAT as the VSCE_PAT environment secret.
     environment:
       name: vscode-marketplace
       url: https://marketplace.visualstudio.com/items?itemName=koedame.chordsketch


### PR DESCRIPTION
## What

Two follow-up fixes to the publish job added in #1427:

1. **Environment gate** (#1428): Added `environment: { name: vscode-marketplace, url: https://marketplace.visualstudio.com/items?itemName=koedame.chordsketch }` to the publish job, consistent with `python.yml` (pypi) and `ruby.yml` (rubygems). GitHub Environments allow required-reviewer protection and environment-scoped secrets before `VSCE_PAT` is injected into the runner.

2. **Stale comment fix** (#1429): Updated the comment from "Publish only on version tag pushes…" to "Publish only on GitHub Release (published) events…", accurately reflecting the `release: [published]` trigger (the `push: tags:` trigger was intentionally removed in #1427's second commit to avoid the `paths:` filter problem).

## Why

Both issues were filed by the auto-review on #1427. The comment was factually incorrect after the trigger was changed, and the missing environment gate was flagged as inconsistent with the python/ruby publish patterns.

## Changes

- `.github/workflows/vscode-extension.yml`: publish job gains `environment:` and has its trigger comment corrected
- Prerequisites comment updated to reference environment settings (where `VSCE_PAT` should live once the environment is created)

## Test results

No functional code changed; CI build and SHA-pin checks are unaffected. The `publish` job still correctly skips on PR/branch events (its `if:` condition is unchanged).

## Review summary

Single-file change; no logic changes; no new action pins introduced.

Closes #1428
Closes #1429