### PR TITLE
ci(kotlin): add environment gate to Maven Central publish job

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -151,6 +151,18 @@ jobs:
     if: |
       startsWith(github.ref, 'refs/tags/v') ||
       (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    # Scopes the four signing and publishing secrets to this environment,
+    # matching the pattern used in python.yml (pypi), ruby.yml (rubygems),
+    # and vscode-extension.yml (vscode-marketplace).
+    #
+    # One-time human setup: create the "maven-central" environment at
+    #   https://github.com/koedame/chordsketch/settings/environments
+    # and move CENTRAL_PORTAL_USERNAME, CENTRAL_PORTAL_PASSWORD,
+    # GPG_SIGNING_KEY, GPG_SIGNING_PASSWORD from repository secrets to
+    # environment secrets.
+    environment:
+      name: maven-central
+      url: https://repo1.maven.org/maven2/io/github/koedame/chordsketch/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## What

Adds a job-level `environment:` declaration to the `publish` job in `kotlin.yml`, bringing it into parity with the other publish jobs in this repository.

## Why

All other publish jobs use GitHub Environments to scope their secrets:

| Workflow | Environment |
|---|---|
| `python.yml` | `pypi` |
| `ruby.yml` | `rubygems` |
| `vscode-extension.yml` | `vscode-marketplace` (added in #1430) |
| `kotlin.yml` | *(was missing)* |

GitHub Environments allow required-reviewer protection rules and scope secrets to the specific job, limiting blast radius if a runner is compromised. `kotlin.yml` was the only publish workflow missing this gate.

## Changes

- `kotlin.yml`: `publish` job gains `environment: { name: maven-central, url: https://repo1.maven.org/maven2/io/github/koedame/chordsketch/ }`
- Comment documents the one-time human setup steps (create environment, move secrets from repository to environment scope)

## Prerequisites (one-time human setup)

1. Create the `maven-central` environment at <https://github.com/koedame/chordsketch/settings/environments>
2. Move `CENTRAL_PORTAL_USERNAME`, `CENTRAL_PORTAL_PASSWORD`, `GPG_SIGNING_KEY`, `GPG_SIGNING_PASSWORD` from repository secrets to environment secrets

## Test results

No functional code changed. The publish job still only runs on `v*` tag pushes or `workflow_dispatch` with a tag — the `if:` condition is unchanged.

## Review summary

Single-file change; no new action pins; follows established pattern from `python.yml`, `ruby.yml`, and `vscode-extension.yml`.

Closes #1431