### PR TITLE
ci: add environment gates to npm-publish.yml and docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,19 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
+    # Scopes DOCKERHUB_TOKEN and DOCKERHUB_USERNAME to this environment,
+    # consistent with python.yml (pypi), ruby.yml (rubygems),
+    # kotlin.yml (maven-central), vscode-extension.yml (vscode-marketplace),
+    # and npm-publish.yml (npm).
+    # GHCR push uses GITHUB_TOKEN (automatic — not environment-scoped).
+    #
+    # One-time human setup: create the "docker-hub" environment at
+    #   https://github.com/koedame/chordsketch/settings/environments
+    # and move DOCKERHUB_USERNAME and DOCKERHUB_TOKEN from repository
+    # secrets to environment secrets.
+    environment:
+      name: docker-hub
+      url: https://hub.docker.com/r/koedame/chordsketch
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,16 @@ jobs:
   publish:
     name: Publish @chordsketch/wasm
     runs-on: ubuntu-latest
+    # Scopes NPM_TOKEN to this environment, consistent with python.yml (pypi),
+    # ruby.yml (rubygems), kotlin.yml (maven-central), and
+    # vscode-extension.yml (vscode-marketplace).
+    #
+    # One-time human setup: create the "npm" environment at
+    #   https://github.com/koedame/chordsketch/settings/environments
+    # and move NPM_TOKEN from repository secrets to environment secrets.
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@chordsketch/wasm
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## What

Adds job-level `environment:` declarations to the `publish` job in `npm-publish.yml` and the `docker` job in `docker.yml`, completing the environment-gate pattern now used across all publish workflows.

## Why

After PRs #1430 (vscode-marketplace) and #1432 (maven-central), `npm-publish.yml` and `docker.yml` were the only two publish workflows without an environment gate. Consistency matters here: all six publish paths should scope their secrets to a named environment.

| Workflow | Environment | Secrets scoped |
|---|---|---|
| `python.yml` | `pypi` | *(OIDC, no long-lived secret)* |
| `ruby.yml` | `rubygems` | *(OIDC, no long-lived secret)* |
| `kotlin.yml` | `maven-central` (#1432) | `CENTRAL_PORTAL_*`, `GPG_SIGNING_*` |
| `vscode-extension.yml` | `vscode-marketplace` (#1430) | `VSCE_PAT` |
| `npm-publish.yml` | `npm` (this PR) | `NPM_TOKEN` |
| `docker.yml` | `docker-hub` (this PR) | `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` |

Note: GHCR pushes in `docker.yml` use `GITHUB_TOKEN` (automatic — no environment scoping needed).

## Changes

- `npm-publish.yml`: `publish` job gains `environment: { name: npm, url: https://www.npmjs.com/package/@chordsketch/wasm }`
- `docker.yml`: `docker` job gains `environment: { name: docker-hub, url: https://hub.docker.com/r/koedame/chordsketch }`
- Both have prerequisite comments documenting the one-time human setup steps

## Prerequisites (one-time human setup)

For each environment:
1. Create the environment at <https://github.com/koedame/chordsketch/settings/environments>
2. Move the relevant secrets from repository scope to environment scope

## Test results

No functional code changed. No new action pins introduced. Both jobs still run only on `release: [published]` events — their `if:` conditions are unchanged.

Closes #1433