### PR TITLE
ci(docker): fix tag env: hardening, MAJOR_MINOR computation, and sync comment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,9 +43,8 @@ jobs:
       - name: Download and extract release binaries
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-
           # Download musl binaries from the release
           gh release download "$TAG" \
             -p "chordsketch-${TAG}-x86_64-unknown-linux-musl.tar.gz" \
@@ -171,8 +170,15 @@ jobs:
 
       - name: Copy tags from GHCR to Docker Hub
         # `docker buildx imagetools create` copies the multi-platform manifest
-        # list from GHCR to Docker Hub without a rebuild. Tag logic mirrors the
-        # metadata-action configuration in the `ghcr` job.
+        # list from GHCR to Docker Hub without a rebuild.
+        #
+        # Tag logic must stay in sync with the metadata-action config in the
+        # `ghcr` job:
+        #   type=semver,pattern={{version}}         → X.Y.Z
+        #   type=semver,pattern={{major}}.{{minor}} → X.Y
+        #   type=raw,value=latest (release only)    → latest
+        # When adding a new tag pattern in `ghcr`, add the corresponding copy
+        # command here. See #1440.
         if: steps.dockerhub.outputs.available == 'true'
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -181,7 +187,11 @@ jobs:
           DST: docker.io/${{ env.IMAGE_NAME }}
         run: |
           VERSION="${TAG#v}"
-          MAJOR_MINOR="${VERSION%.*}"
+          # Use cut to extract major.minor so that 2-part tags (e.g. v1.2)
+          # produce "1.2" instead of "1" (which ${VERSION%.*} would give).
+          # This matches metadata-action's {{major}}.{{minor}} output exactly.
+          # See #1439.
+          MAJOR_MINOR="$(echo "${VERSION}" | cut -d. -f1,2)"
 
           docker buildx imagetools create \
             -t "${DST}:${VERSION}" \


### PR DESCRIPTION
## What

Three small corrections to `.github/workflows/docker.yml` following post-#1436 review:

1. **`env:` hardening for download step** — move `steps.version.outputs.tag` out of the `run:` body into the `env:` block, consistent with the #1115 convention.
2. **`MAJOR_MINOR` correctness for 2-part semver** — replace `${VERSION%.*}` with `cut -d. -f1,2`. The old computation produces `"1"` for `v1.2` (stripping the last `.`-separated component), which mismatches the GHCR tag that `metadata-action`'s `{{major}}.{{minor}}` would produce (`"1.2"`).
3. **Tag sync comment** — add a comment in the "Copy tags" step cross-referencing the `ghcr` job's `metadata-action` tag configuration, reminding maintainers to keep both in sync when adding new tag patterns.

## Why

- Fix 1 (#1438): pre-existing pattern inconsistency filed after #1436 review
- Fix 2 (#1439): correctness bug filed after #1436 review; theoretical today (all releases use 3-part semver) but real if a 2-part tag is ever cut
- Fix 3 (#1440): documentation gap filed after #1436 review; prevents silent drift if tag patterns are added in `ghcr` but not copied to `docker-hub`

## Test results

CI structural checks (pin verification, format, clippy, tests) are unchanged. The copy-step logic is not exercised on PRs (only on release events). Tag computation change verified manually:

| Input | `${VERSION%.*}` (old) | `cut -d. -f1,2` (new) | Expected |
|---|---|---|---|
| `v1.2.3` | `1.2` ✓ | `1.2` ✓ | `1.2` |
| `v1.2` | `1` ✗ | `1.2` ✓ | `1.2` |
| `v10.20.30` | `10.20` ✓ | `10.20` ✓ | `10.20` |

## Review summary

No prior review — first submission.

Closes #1438
Closes #1439
Closes #1440