### PR TITLE
ci(docker): add continue-on-error to docker-hub job for optional-infra ergonomics

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,10 +108,19 @@ jobs:
     # or its secrets are absent, the `ghcr` job (which runs first) still
     # succeeds and GHCR publishing is unaffected. See #1435.
     #
+    # `continue-on-error: true` extends that optional-infrastructure intent
+    # to the environment-gate level: if the "docker-hub" environment does not
+    # exist (e.g. a fork, a fresh instance, or a temporary environment
+    # deletion), GitHub cannot start the job and would otherwise mark the
+    # whole workflow run red — even though GHCR publishing succeeded. Docker
+    # Hub is secondary to GHCR, so a blocked or missing environment should
+    # not color a successful release workflow red. See #1437.
+    #
     # One-time human setup: create the "docker-hub" environment at
     #   https://github.com/koedame/chordsketch/settings/environments
     # and move DOCKERHUB_USERNAME and DOCKERHUB_TOKEN from repository
     # secrets to environment secrets.
+    continue-on-error: true
     environment:
       name: docker-hub
       url: https://hub.docker.com/r/koedame/chordsketch


### PR DESCRIPTION
## What

Add `continue-on-error: true` to the `docker-hub` job in `docker.yml`, with an explanatory comment.

## Why

After PR #1436 split the `docker` job into `ghcr` (always runs) and `docker-hub` (gated on `environment: docker-hub`), one ergonomics gap remained: if the `docker-hub` environment does not exist on a GitHub instance (e.g. a fork without environment setup, a fresh repo copy, or a temporary environment deletion), GitHub cannot start the `docker-hub` job and marks the overall workflow run red — even though GHCR publishing succeeded.

Docker Hub is explicitly secondary, optional infrastructure:
- The `DOCKERHUB_TOKEN`-absent path already exits the job with code 0 (graceful token-level degradation from #1072).
- The job comment already says "optional infrastructure".

`continue-on-error: true` extends this "Docker Hub is optional" intent to the environment-gate level: a blocked or missing environment should not color a successful release workflow red. The comment explains the reasoning so the choice is not silently surprising to future maintainers.

**Tradeoff:** If Docker Hub itself fails (API error, service outage) in a production environment where the environment and secrets are correctly configured, the workflow will still show green. This is an accepted tradeoff: GHCR is the primary registry; Docker Hub outages are external service failures, not our release failures. The Docker Hub job status is still visible in the workflow run detail view for operators who need to investigate.

Closes #1437

## Test results

CI structural checks are unchanged. The effect of `continue-on-error` is only observable on job failure, which does not occur in PR CI runs.

## Review summary

No prior review — first submission.