### PR TITLE
ci: add continue-on-error to optional-environment publish jobs

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -160,6 +160,11 @@ jobs:
     # and move CENTRAL_PORTAL_USERNAME, CENTRAL_PORTAL_PASSWORD,
     # GPG_SIGNING_KEY, GPG_SIGNING_PASSWORD from repository secrets to
     # environment secrets.
+    #
+    # If the "maven-central" environment does not exist (fork, fresh instance),
+    # GitHub cannot start this job. continue-on-error keeps the overall workflow
+    # green when CI succeeded but publishing infrastructure is absent. See #1443.
+    continue-on-error: true
     environment:
       name: maven-central
       url: https://repo1.maven.org/maven2/io/github/koedame/chordsketch/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,11 @@ jobs:
     # One-time human setup: create the "npm" environment at
     #   https://github.com/koedame/chordsketch/settings/environments
     # and move NPM_TOKEN from repository secrets to environment secrets.
+    #
+    # If the "npm" environment does not exist (fork, fresh instance), GitHub
+    # cannot start this job. continue-on-error keeps the overall workflow green
+    # when CI succeeded but publishing infrastructure is absent. See #1443.
+    continue-on-error: true
     environment:
       name: npm
       url: https://www.npmjs.com/package/@chordsketch/wasm

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -175,6 +175,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # If the "pypi" environment does not exist (fork, fresh instance), GitHub
+    # cannot start this job. continue-on-error keeps the overall workflow green
+    # when GHCR/CI succeeded but publishing infrastructure is absent. See #1443.
+    continue-on-error: true
     environment:
       name: pypi
       url: https://pypi.org/p/chordsketch

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -172,16 +172,17 @@ jobs:
     #   https://pypi.org/manage/project/chordsketch/settings/publishing/
     # for this repo + workflow + environment, otherwise the very first
     # publish fails with 403 Forbidden. See #1068.
-    permissions:
-      contents: read
-      id-token: write
+    #
     # If the "pypi" environment does not exist (fork, fresh instance), GitHub
     # cannot start this job. continue-on-error keeps the overall workflow green
-    # when GHCR/CI succeeded but publishing infrastructure is absent. See #1443.
+    # when CI succeeded but publishing infrastructure is absent. See #1443.
     continue-on-error: true
     environment:
       name: pypi
       url: https://pypi.org/p/chordsketch
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -201,6 +201,10 @@ jobs:
     # for this repo + workflow + environment, otherwise the very first
     # publish fails with 403 Forbidden. The environment name ("rubygems")
     # must match the environment gate set below.
+    # If the "rubygems" environment does not exist (fork, fresh instance), GitHub
+    # cannot start this job. continue-on-error keeps the overall workflow green
+    # when CI succeeded but publishing infrastructure is absent. See #1443.
+    continue-on-error: true
     environment:
       name: rubygems
       url: https://rubygems.org/gems/chordsketch

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -201,6 +201,7 @@ jobs:
     # for this repo + workflow + environment, otherwise the very first
     # publish fails with 403 Forbidden. The environment name ("rubygems")
     # must match the environment gate set below.
+    #
     # If the "rubygems" environment does not exist (fork, fresh instance), GitHub
     # cannot start this job. continue-on-error keeps the overall workflow green
     # when CI succeeded but publishing infrastructure is absent. See #1443.

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -106,6 +106,11 @@ jobs:
     #   3. Create the "vscode-marketplace" environment at
     #      https://github.com/koedame/chordsketch/settings/environments
     #      and add the PAT as the VSCE_PAT environment secret.
+    #
+    # If the "vscode-marketplace" environment does not exist (fork, fresh instance),
+    # GitHub cannot start this job. continue-on-error keeps the overall workflow
+    # green when CI succeeded but publishing infrastructure is absent. See #1443.
+    continue-on-error: true
     environment:
       name: vscode-marketplace
       url: https://marketplace.visualstudio.com/items?itemName=koedame.chordsketch


### PR DESCRIPTION
## What

Add `continue-on-error: true` (with an explanatory comment) to the environment-gated `publish` job in five workflows:

| Workflow | Job | Environment |
|---|---|---|
| `python.yml` | `publish` | `pypi` |
| `ruby.yml` | `publish` | `rubygems` |
| `npm-publish.yml` | `publish` | `npm` |
| `kotlin.yml` | `publish` | `maven-central` |
| `vscode-extension.yml` | `publish` | `vscode-marketplace` |

## Why

PR #1442 added `continue-on-error: true` to the `docker-hub` job in `docker.yml` so that a missing environment does not mark a successful release workflow red. The same ergonomics gap exists for all other optional-environment publish jobs.

When any of these environments do not exist on a fork or a fresh instance, GitHub cannot start the job and marks the overall workflow run red — even though CI passed and publishing infrastructure is simply not configured for that instance.

Publishing to external registries is optional infrastructure. The rationale is identical to the `docker-hub` job in `docker.yml` (see #1437, #1442).

## Test results

CI structural checks (pin verification, format, clippy, tests) are unchanged. The `continue-on-error` effect is only observable on job failure, which does not occur in PR CI runs.

## Review summary

No prior review — first submission.

Closes #1443