### PR TITLE
ci: add OIDC availability probe to python.yml and ruby.yml publish jobs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -190,7 +190,29 @@ jobs:
           merge-multiple: true
           path: dist
 
+      - name: Detect OIDC availability
+        # Probes whether GitHub is providing OIDC tokens for this job run.
+        # ACTIONS_ID_TOKEN_REQUEST_URL is set when `id-token: write` is in
+        # effect. If absent, maturin upload would fail with an auth error;
+        # surfacing the skip here as a warning keeps the job exit-0
+        # (consistent with the continue-on-error intent) while making it
+        # visible in the run log.
+        #
+        # Limitation: this probe cannot detect a misconfigured PyPI trusted
+        # publisher — that failure occurs inside the OIDC exchange within
+        # maturin upload and would still be absorbed by continue-on-error.
+        # See #1445.
+        id: oidc
+        run: |
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GitHub OIDC token endpoint is unavailable; skipping PyPI publish. Check that the environment exists and id-token: write permission is effective. See #1445."
+          fi
+
       - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
+        if: steps.oidc.outputs.available == 'true'
         with:
           command: upload
           args: --non-interactive --skip-existing dist/*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -203,6 +203,7 @@ jobs:
         # maturin upload and would still be absorbed by continue-on-error.
         # See #1445.
         id: oidc
+        shell: bash
         run: |
           if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -283,7 +283,29 @@ jobs:
         with:
           ruby-version: "3.3"
 
+      - name: Detect OIDC availability
+        # Probes whether GitHub is providing OIDC tokens for this job run.
+        # ACTIONS_ID_TOKEN_REQUEST_URL is set when `id-token: write` is in
+        # effect. If absent, the OIDC exchange in configure-rubygems-credentials
+        # would fail; surfacing the skip here as a warning keeps the job exit-0
+        # (consistent with the continue-on-error intent) while making it
+        # visible in the run log.
+        #
+        # Limitation: this probe cannot detect a misconfigured RubyGems trusted
+        # publisher — that failure occurs inside the OIDC exchange within the
+        # rubygems action and would still be absorbed by continue-on-error.
+        # See #1445.
+        id: oidc
+        run: |
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GitHub OIDC token endpoint is unavailable; skipping RubyGems publish. Check that the environment exists and id-token: write permission is effective. See #1445."
+          fi
+
       - name: Configure RubyGems trusted publisher credentials
+        if: steps.oidc.outputs.available == 'true'
         # Exchanges the GitHub Actions OIDC token for a short-lived
         # RubyGems API key and writes it to ~/.gem/credentials, which
         # `gem push` will pick up automatically. This action is the same
@@ -293,6 +315,7 @@ jobs:
         uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
 
       - name: Build and push gem
+        if: steps.oidc.outputs.available == 'true'
         working-directory: packages/ruby
         run: |
           gem build chordsketch.gemspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -296,6 +296,7 @@ jobs:
         # rubygems action and would still be absorbed by continue-on-error.
         # See #1445.
         id: oidc
+        shell: bash
         run: |
           if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Add a "Detect OIDC availability" step before the publish steps in `python.yml` and `ruby.yml`.

The step checks whether `ACTIONS_ID_TOKEN_REQUEST_URL` is set — the env var GitHub populates when `id-token: write` is in effect. If absent:
- Emits a `::warning::` annotation
- Sets `available=false` as a step output
- Subsequent publish steps are guarded with `if: steps.oidc.outputs.available == 'true'` and skip cleanly

## Why

PR #1444 added `continue-on-error: true` to all environment-gated publish jobs. Review finding L4 noted that the two OIDC workflows (python.yml, ruby.yml) lacked a step-level probe analogous to the docker-hub job's "Detect Docker Hub credentials" step. Without the probe, OIDC permission failures are silently absorbed by `continue-on-error`, leaving no visible warning.

The probe mirrors the docker-hub pattern established in #1442 and documents its known limitation: it cannot detect a misconfigured trusted publisher on PyPI/RubyGems side — that failure occurs inside the OIDC exchange itself.

## Test results

The probe step runs a simple env-var check; it does not make network requests. The `ACTIONS_ID_TOKEN_REQUEST_URL` check is the same pattern used throughout the GitHub Actions ecosystem. The probe will always return `available=true` in a correctly configured job (environment exists, `id-token: write` is in effect), so production publishing behavior is unchanged.

## Review summary

No prior review — first submission.

Closes #1445