### PR TITLE
ci(ruby): add retention-days to bindings artifact and fix stale comment

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -188,10 +188,13 @@ jobs:
         # Uploaded after tests pass so the artifact represents a validated
         # binding file. The publish job downloads this instead of rebuilding
         # the FFI crate and re-running uniffi-bindgen. See #1448.
+        # 7-day retention is sufficient; the artifact is only consumed within
+        # the same workflow run by the publish job. See #1452.
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ruby-bindings
           path: packages/ruby/lib/chordsketch_uniffi.rb
+          retention-days: 7
 
   publish:
     name: Publish to RubyGems

--- a/packages/ruby/lib/chordsketch.rb
+++ b/packages/ruby/lib/chordsketch.rb
@@ -70,6 +70,6 @@ end
 Chordsketch::NativeLoader.load!
 
 # Load the UniFFI-generated bindings. Their `ffi_lib` line is rewritten
-# to reference `Chordsketch::NATIVE_LIB_PATH` (set above) by a sed step
-# in the gem build pipeline. See `.github/workflows/ruby.yml` and #1082.
+# to reference `Chordsketch::NATIVE_LIB_PATH` (set above) by a Python script
+# in the CI workflow. See `.github/workflows/ruby.yml` and #1082.
 require_relative "chordsketch_uniffi"


### PR DESCRIPTION
## What

- `.github/workflows/ruby.yml`: set `retention-days: 7` on the `Upload Ruby bindings` step in `generate-and-test`.
- `packages/ruby/lib/chordsketch.rb`: update the loader comment from "a sed step in the gem build pipeline" to "a Python script in the CI workflow".

## Why

**retention-days (#1452):** The `ruby-bindings` artifact defaults to 90-day retention, which is excessive. It is only consumed by the `publish` job within the same workflow run; it is never needed after the run completes. 7 days is a safe margin with negligible storage impact.

**stale comment (#1451):** The `ffi_lib` line rewrite has used a Python script since #1082. The original "sed step" wording predated that change and was never updated.

## Test results

No logic changes. CI passes for all check types (fmt, clippy, tests, SHA pin verification). The `ruby.yml` workflow path is triggered by this PR.

## Review summary

Two independent Nit/Low findings from the PR #1449 review, bundled into one minimal PR.

Closes #1451
Closes #1452