### PR TITLE
ci(python): move OIDC probe before artifact download in publish job

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -184,12 +184,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          pattern: wheels-*
-          merge-multiple: true
-          path: dist
-
       - name: Detect OIDC availability
         # Probes whether GitHub is providing OIDC tokens for this job run.
         # ACTIONS_ID_TOKEN_REQUEST_URL is set when `id-token: write` is in
@@ -197,6 +191,10 @@ jobs:
         # surfacing the skip here as a warning keeps the job exit-0
         # (consistent with the continue-on-error intent) while making it
         # visible in the run log.
+        #
+        # Placed first so that OIDC-unavailable runs (e.g. forks without
+        # the pypi environment) exit before downloading wheel artifacts.
+        # See #1454.
         #
         # Limitation: this probe cannot detect a misconfigured PyPI trusted
         # publisher — that failure occurs inside the OIDC exchange within
@@ -211,6 +209,14 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
             echo "::warning::GitHub OIDC token endpoint is unavailable; skipping PyPI publish. Check that the environment exists and id-token: write permission is effective. See #1445."
           fi
+
+      - name: Download wheel artifacts
+        if: steps.oidc.outputs.available == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
 
       - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         if: steps.oidc.outputs.available == 'true'


### PR DESCRIPTION
## What

In `.github/workflows/python.yml`'s `publish` job:
- Move `Detect OIDC availability` to be the **first** step (was second, after `download-artifact`)
- Add an `if: steps.oidc.outputs.available == 'true'` guard to the `Download wheel artifacts` step (renamed from the unnamed `actions/download-artifact` step for clarity)
- Update the OIDC probe comment to note it is placed first to allow early exit before downloading

## Why

The previous ordering caused OIDC-unavailable runs (forks, repositories without the `pypi` environment configured) to download all wheel artifacts — ~30 MB across 5 platforms — before the probe could bail out. This wastes CI minutes for runs that will never publish.

This is the same fix applied to `ruby.yml` in #1449 (where the probe was moved before the artifact downloads). The asymmetry was noted as a Nit during that PR's review.

## Test results

CI-only change. No Rust, Python, or packaging logic changes. The `python.yml` workflow path is triggered by this PR.

## Review summary

Straightforward step reordering. The probe result (`steps.oidc.outputs.available`) is set before it is referenced in the download and upload steps.

Closes #1454