### PR TITLE
ci: add retention-days: 7 to intermediate build artifacts

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
+          retention-days: 7
 
   build-wheels:
     name: Build ${{ matrix.target }} wheels on ${{ matrix.os }}
@@ -72,6 +73,7 @@ jobs:
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: dist
+          retention-days: 7
 
   test:
     name: Test Python bindings (${{ matrix.os }})

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           name: native-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.lib }}
+          retention-days: 7
 
   generate-and-test:
     name: Generate bindings and test


### PR DESCRIPTION
## What

- `ruby.yml`: add `retention-days: 7` to the `Upload native library` step in the `build-native` job (5 platforms)
- `python.yml`: add `retention-days: 7` to the `wheels-sdist` and `wheels-${{ matrix.os }}-${{ matrix.target }}` upload steps in `build-sdist` and `build-wheels` jobs

## Why

These artifacts are intermediate build products consumed only within the same workflow run (by `generate-and-test`/`publish` in ruby.yml, and by `test`/`publish` in python.yml). The default 90-day retention accumulates hundreds of artifacts across PR and push runs unnecessarily.

Continues the retention-days cleanup started in #1453 (`ruby-bindings` artifact). The `ruby-bindings` artifact was already set to 7 days; this PR makes the `native-*` and `wheels-*` artifacts consistent.

## Test results

CI-only change — no Rust, Ruby, or Python code changes.

Closes #1456