### PR TITLE
ci: add retention-days: 7 to remaining intermediate artifacts

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -97,6 +97,7 @@ jobs:
             target/${{ matrix.target }}/release/libchordsketch_ffi.so
             target/${{ matrix.target }}/release/libchordsketch_ffi.dylib
             target/${{ matrix.target }}/release/chordsketch_ffi.dll
+          retention-days: 7
 
   generate-and-test:
     name: Generate bindings and test
@@ -143,6 +144,7 @@ jobs:
         with:
           name: kotlin-bindings
           path: packages/kotlin/lib/src/main/kotlin/uniffi/
+          retention-days: 7
 
   publish:
     name: Publish to Maven Central

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -141,6 +141,7 @@ jobs:
         with:
           name: napi-${{ matrix.target }}
           path: crates/napi/*.node
+          retention-days: 7
 
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: ${{ env.ARCHIVE }}
+          retention-days: 7
 
   release:
     name: Create Release

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -196,12 +196,14 @@ jobs:
         with:
           name: xcframework
           path: chordsketch-xcframework.zip
+          retention-days: 7
 
       - name: Upload Swift source
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: swift-source
           path: generated/chordsketch.swift
+          retention-days: 7
 
   publish:
     name: Publish XCFramework

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -92,6 +92,7 @@ jobs:
           name: chordsketch-vsix
           path: packages/vscode-extension/*.vsix
           if-no-files-found: error
+          retention-days: 7
 
   publish:
     name: Publish to VS Code Marketplace


### PR DESCRIPTION
## What

Add `retention-days: 7` to all intermediate build artifacts in the remaining
workflows that were missed in earlier PRs:

- `kotlin.yml`: JNI library artifacts and Kotlin bindings
- `napi.yml`: native `.node` addon artifacts
- `release.yml`: release archive artifacts (consumed by the `release` job in the same run)
- `swift.yml`: XCFramework zip and Swift source
- `vscode-extension.yml`: VSIX artifact

## Why

GitHub's default artifact retention is 90 days. These are all intermediate
artifacts consumed within the same workflow run — they only need to exist long
enough for downstream jobs to download them. Setting `retention-days: 7` reduces
storage usage and keeps artifact lists clean.

This is a follow-up to PRs #1449, #1453, and #1457 which already applied this
pattern to `ruby.yml` and `python.yml`.

## Test results

CI will validate these workflow files parse correctly. No functional behavior
changes — `retention-days` only affects how long artifacts are kept after the run.

## Review summary

No logic changes. Pure YAML metadata addition.

Closes #1458