### PR TITLE
feat: add MusicXML ↔ ChordPro bidirectional converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ name = "chordsketch"
 version = "0.2.0"
 dependencies = [
  "assert_cmd",
+ "chordsketch-convert-musicxml",
  "chordsketch-core",
  "chordsketch-render-html",
  "chordsketch-render-pdf",
@@ -269,6 +270,13 @@ dependencies = [
  "clap_complete",
  "predicates",
  "tempfile",
+]
+
+[[package]]
+name = "chordsketch-convert-musicxml"
+version = "0.2.0"
+dependencies = [
+ "chordsketch-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/wasm",
     "crates/napi",
     "crates/ffi",
+    "crates/convert-musicxml",
 ]
 resolver = "3"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ chordsketch-core = { version = "0.2.0", path = "../core" }
 chordsketch-render-text = { version = "0.2.0", path = "../render-text" }
 chordsketch-render-html = { version = "0.2.0", path = "../render-html" }
 chordsketch-render-pdf = { version = "0.2.0", path = "../render-pdf" }
+chordsketch-convert-musicxml = { version = "0.2.0", path = "../convert-musicxml" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tempfile = "3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -477,11 +477,11 @@ fn run_convert(
     to: Option<ConvertTo>,
     output_path: Option<&str>,
 ) -> ExitCode {
+    use chordsketch_convert_musicxml::{from_musicxml, to_musicxml};
     use chordsketch_core::{
         InputFormat, convert_abc, convert_plain_text, detect_format, parse_lenient,
         song_to_chordpro,
     };
-    use chordsketch_convert_musicxml::{from_musicxml, to_musicxml};
 
     // --- Export path: ChordPro → MusicXML -----------------------------------
     if let Some(ConvertTo::Musicxml) = to {
@@ -593,7 +593,11 @@ fn run_convert(
                 match from_musicxml(&input) {
                     Ok(song) => combined.push_str(&song_to_chordpro(&song)),
                     Err(e) => {
-                        let label = if file == "-" { "<stdin>" } else { file.as_str() };
+                        let label = if file == "-" {
+                            "<stdin>"
+                        } else {
+                            file.as_str()
+                        };
                         eprintln!("error: {label}: {e}");
                         had_error = true;
                     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -85,15 +85,16 @@ enum Commands {
         check: bool,
     },
 
-    /// Convert a plain-text chord+lyrics sheet or ABC notation file to ChordPro format.
+    /// Convert between ChordPro and other music notation formats.
     ///
-    /// Reads plain-text files where chord names appear on their own lines
-    /// directly above the corresponding lyric lines, or ABC notation files
-    /// (`.abc`), and converts them to ChordPro (`.cho`) format.  The output
-    /// is written to stdout unless `--output` is given.
+    /// Import: reads plain-text, ABC notation (`.abc`), or MusicXML (`.xml`)
+    /// files and converts them to ChordPro (`.cho`) format.
     ///
-    /// Auto-detection is used by default.  Pass `--from plaintext` or
-    /// `--from abc` to force a specific conversion.
+    /// Export: reads ChordPro files and converts them to MusicXML (`.xml`)
+    /// using `--to musicxml`.
+    ///
+    /// Auto-detection is used by default for import.  Pass `--from plaintext`,
+    /// `--from abc`, or `--from musicxml` to force a specific input format.
     Convert {
         /// Input file(s) to convert. Use '-' to read from stdin.
         #[arg(required = true)]
@@ -101,9 +102,15 @@ enum Commands {
 
         /// Input format. `auto` detects the format automatically;
         /// `plaintext` forces plain chord+lyrics conversion;
-        /// `abc` forces ABC notation conversion.
+        /// `abc` forces ABC notation conversion;
+        /// `musicxml` forces MusicXML import.
         #[arg(long, default_value = "auto")]
         from: ConvertFrom,
+
+        /// Output format for export. `musicxml` converts ChordPro → MusicXML.
+        /// When omitted, the output is ChordPro (`.cho`) format.
+        #[arg(long)]
+        to: Option<ConvertTo>,
 
         /// Write output to a file instead of stdout.
         #[arg(short, long)]
@@ -114,12 +121,21 @@ enum Commands {
 /// Input format for the `convert` subcommand.
 #[derive(Clone, Debug, clap::ValueEnum)]
 enum ConvertFrom {
-    /// Automatically detect the input format.
+    /// Automatically detect the input format from file extension and content.
     Auto,
     /// Force plain chord+lyrics conversion.
     Plaintext,
     /// Force ABC notation conversion.
     Abc,
+    /// Force MusicXML import.
+    Musicxml,
+}
+
+/// Output format for the `convert --to` flag.
+#[derive(Clone, Debug, clap::ValueEnum)]
+enum ConvertTo {
+    /// Export to MusicXML 4.0.
+    Musicxml,
 }
 
 /// Supported output formats.
@@ -143,10 +159,11 @@ fn main() -> ExitCode {
     if let Some(Commands::Convert {
         files,
         from,
+        to,
         output,
     }) = cli.command
     {
-        return run_convert(&files, from, output.as_deref());
+        return run_convert(&files, from, to, output.as_deref());
     }
 
     // Render mode: require at least one file (unless generating completions).
@@ -441,21 +458,64 @@ fn run_fmt(files: &[String], check: bool) -> ExitCode {
 
 /// Run the `convert` subcommand.
 ///
-/// Reads each file, auto-detects or force-converts plain chord+lyrics text to
-/// ChordPro format, then writes the output to `output_path` (or stdout).
+/// For import (no `--to` flag): reads each file, auto-detects or
+/// force-converts to ChordPro format, then writes the output to
+/// `output_path` (or stdout). Multiple files are concatenated with
+/// `{new_song}` separators.
 ///
-/// When multiple files are provided their ChordPro output is concatenated.
+/// For export (`--to musicxml`): reads ChordPro files and converts them
+/// to MusicXML 4.0. Only a single input file is supported for export.
 ///
 /// # Exit codes
 ///
 /// * `0` — all files converted successfully.
 /// * `1` — at least one I/O error occurred or a file was skipped because its
 ///   format could not be detected.
-fn run_convert(files: &[String], from: ConvertFrom, output_path: Option<&str>) -> ExitCode {
+fn run_convert(
+    files: &[String],
+    from: ConvertFrom,
+    to: Option<ConvertTo>,
+    output_path: Option<&str>,
+) -> ExitCode {
     use chordsketch_core::{
-        InputFormat, convert_abc, convert_plain_text, detect_format, song_to_chordpro,
+        InputFormat, convert_abc, convert_plain_text, detect_format, parse_lenient,
+        song_to_chordpro,
     };
+    use chordsketch_convert_musicxml::{from_musicxml, to_musicxml};
 
+    // --- Export path: ChordPro → MusicXML -----------------------------------
+    if let Some(ConvertTo::Musicxml) = to {
+        if files.len() > 1 {
+            eprintln!("error: --to musicxml supports only a single input file");
+            return ExitCode::FAILURE;
+        }
+        let file = &files[0];
+        let input = if file == "-" {
+            let mut s = String::new();
+            if let Err(e) = io::stdin().read_to_string(&mut s) {
+                eprintln!("error: reading stdin: {e}");
+                return ExitCode::FAILURE;
+            }
+            s
+        } else {
+            match fs::read_to_string(file) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("error: {file}: {e}");
+                    return ExitCode::FAILURE;
+                }
+            }
+        };
+        let result = parse_lenient(&input);
+        let xml = to_musicxml(&result.song);
+        if let Err(e) = write_text(&output_path.map(str::to_string), &xml) {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    // --- Import path: other formats → ChordPro ------------------------------
     let mut had_error = false;
     let mut combined = String::new();
 
@@ -483,6 +543,7 @@ fn run_convert(files: &[String], from: ConvertFrom, output_path: Option<&str>) -
         enum Action {
             Plaintext,
             Abc,
+            MusicXml,
             Passthrough,
             Skip,
         }
@@ -490,13 +551,23 @@ fn run_convert(files: &[String], from: ConvertFrom, output_path: Option<&str>) -
         let action = match from {
             ConvertFrom::Plaintext => Action::Plaintext,
             ConvertFrom::Abc => Action::Abc,
+            ConvertFrom::Musicxml => Action::MusicXml,
             ConvertFrom::Auto => {
-                let fmt = detect_format(&input);
-                match fmt {
-                    InputFormat::PlainChordLyrics => Action::Plaintext,
-                    InputFormat::Abc => Action::Abc,
-                    InputFormat::ChordPro => Action::Passthrough,
-                    InputFormat::Unknown => Action::Skip,
+                // Check file extension first
+                let ext = Path::new(file.as_str())
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(str::to_ascii_lowercase);
+                if ext.as_deref() == Some("xml") || ext.as_deref() == Some("musicxml") {
+                    Action::MusicXml
+                } else {
+                    let fmt = detect_format(&input);
+                    match fmt {
+                        InputFormat::PlainChordLyrics => Action::Plaintext,
+                        InputFormat::Abc => Action::Abc,
+                        InputFormat::ChordPro => Action::Passthrough,
+                        InputFormat::Unknown => Action::Skip,
+                    }
                 }
             }
         };
@@ -515,6 +586,19 @@ fn run_convert(files: &[String], from: ConvertFrom, output_path: Option<&str>) -
                 }
                 combined.push_str(&convert_abc(&input));
             }
+            Action::MusicXml => {
+                if !combined.is_empty() {
+                    combined.push_str("{new_song}\n");
+                }
+                match from_musicxml(&input) {
+                    Ok(song) => combined.push_str(&song_to_chordpro(&song)),
+                    Err(e) => {
+                        let label = if file == "-" { "<stdin>" } else { file.as_str() };
+                        eprintln!("error: {label}: {e}");
+                        had_error = true;
+                    }
+                }
+            }
             Action::Passthrough => {
                 // Already ChordPro — pass through unchanged.
                 if !combined.is_empty() {
@@ -530,7 +614,7 @@ fn run_convert(files: &[String], from: ConvertFrom, output_path: Option<&str>) -
                 };
                 eprintln!(
                     "warning: {label}: format could not be detected; \
-                     use --from plaintext or --from abc to force conversion"
+                     use --from plaintext, --from abc, or --from musicxml to force conversion"
                 );
                 had_error = true;
             }

--- a/crates/convert-musicxml/Cargo.toml
+++ b/crates/convert-musicxml/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "chordsketch-convert-musicxml"
+version = "0.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["musicxml", "chordpro", "music", "converter"]
+categories = ["parser-implementations", "text-processing"]
+description = "MusicXML ↔ ChordPro bidirectional converter"
+
+[dependencies]
+chordsketch-core = { version = "0.2.0", path = "../core" }

--- a/crates/convert-musicxml/src/export.rs
+++ b/crates/convert-musicxml/src/export.rs
@@ -331,13 +331,13 @@ fn chord_to_musicxml(chord_name: &str) -> Option<ChordXml> {
     let detail = parse_chord(chord_name)?;
 
     let root_step = note_to_step(detail.root);
-    let root_alter = acciental_to_alter(detail.root_accidental);
+    let root_alter = accidental_to_alter(detail.root_accidental);
 
     let ext = detail.extension.as_deref().unwrap_or("");
     let (kind_content, kind_text) = quality_ext_to_kind(detail.quality, ext);
 
     let bass = if let Some((bass_note, bass_acc)) = detail.bass_note {
-        Some((note_to_step(bass_note), acciental_to_alter(bass_acc)))
+        Some((note_to_step(bass_note), accidental_to_alter(bass_acc)))
     } else {
         None
     };
@@ -364,7 +364,7 @@ fn note_to_step(note: chordsketch_core::chord::Note) -> &'static str {
     }
 }
 
-fn acciental_to_alter(acc: Option<chordsketch_core::chord::Accidental>) -> i32 {
+fn accidental_to_alter(acc: Option<chordsketch_core::chord::Accidental>) -> i32 {
     use chordsketch_core::chord::Accidental;
     match acc {
         Some(Accidental::Sharp) => 1,

--- a/crates/convert-musicxml/src/export.rs
+++ b/crates/convert-musicxml/src/export.rs
@@ -255,28 +255,26 @@ fn write_measure(measure: &Measure, number: usize, out: &mut String) {
     for (chord_name, lyric_text) in &measure.notes {
         // Harmony element
         if let Some(chord) = chord_name {
-            if let Some((root_step, root_alter, kind_content, kind_text, bass)) =
-                chord_to_musicxml(chord)
-            {
+            if let Some(c) = chord_to_musicxml(chord) {
                 out.push_str("      <harmony>\n");
                 out.push_str("        <root>\n");
                 out.push_str(&format!(
                     "          <root-step>{}</root-step>\n",
-                    xml_escape(root_step)
+                    xml_escape(c.root_step)
                 ));
-                if root_alter != 0 {
+                if c.root_alter != 0 {
                     out.push_str(&format!(
                         "          <root-alter>{}</root-alter>\n",
-                        root_alter
+                        c.root_alter
                     ));
                 }
                 out.push_str("        </root>\n");
                 out.push_str(&format!(
                     "        <kind text=\"{}\">{}</kind>\n",
-                    xml_escape(kind_text),
-                    xml_escape(kind_content)
+                    xml_escape(&c.kind_text),
+                    xml_escape(c.kind_content)
                 ));
-                if let Some((bass_step, bass_alter)) = bass {
+                if let Some((bass_step, bass_alter)) = c.bass {
                     out.push_str("        <bass>\n");
                     out.push_str(&format!(
                         "          <bass-step>{}</bass-step>\n",
@@ -320,43 +318,41 @@ fn write_measure(measure: &Measure, number: usize, out: &mut String) {
 // Chord encoding
 // ---------------------------------------------------------------------------
 
-/// Convert a ChordPro chord name to MusicXML components.
+/// Parsed components of a chord for MusicXML output.
+struct ChordXml {
+    root_step: &'static str,
+    root_alter: i32,
+    kind_content: &'static str,
+    /// The `text` attribute for `<kind>` — the ChordPro chord suffix.
+    kind_text: String,
+    bass: Option<(&'static str, i32)>,
+}
+
+/// Convert a ChordPro chord name into [`ChordXml`] components.
 ///
-/// Returns `(root_step, root_alter, kind_content, kind_text, bass)` or `None`
-/// if the chord cannot be parsed.
-///
-/// - `root_step`: note letter ("C", "D", ..., "B")
-/// - `root_alter`: semitone offset (1 = sharp, -1 = flat, 0 = natural)
-/// - `kind_content`: MusicXML kind element text content ("major", "minor", ...)
-/// - `kind_text`: the `text` attribute for the kind element (ChordPro suffix)
-/// - `bass`: optional `(bass_step, bass_alter)` for slash chords
-#[allow(clippy::type_complexity)]
-fn chord_to_musicxml(
-    chord_name: &str,
-) -> Option<(
-    &'static str,
-    i32,
-    &'static str,
-    &'static str,
-    Option<(&'static str, i32)>,
-)> {
+/// Returns `None` if the chord string cannot be parsed.
+fn chord_to_musicxml(chord_name: &str) -> Option<ChordXml> {
     let detail = parse_chord(chord_name)?;
 
-    let root_step: &'static str = note_to_step(detail.root);
+    let root_step = note_to_step(detail.root);
     let root_alter = acciental_to_alter(detail.root_accidental);
 
     let ext = detail.extension.as_deref().unwrap_or("");
     let (kind_content, kind_text) = quality_ext_to_kind(detail.quality, ext);
 
     let bass = if let Some((bass_note, bass_acc)) = detail.bass_note {
-        let bs: &'static str = note_to_step(bass_note);
-        let ba = acciental_to_alter(bass_acc);
-        Some((bs, ba))
+        Some((note_to_step(bass_note), acciental_to_alter(bass_acc)))
     } else {
         None
     };
 
-    Some((root_step, root_alter, kind_content, kind_text, bass))
+    Some(ChordXml {
+        root_step,
+        root_alter,
+        kind_content,
+        kind_text,
+        bass,
+    })
 }
 
 fn note_to_step(note: chordsketch_core::chord::Note) -> &'static str {
@@ -382,47 +378,46 @@ fn acciental_to_alter(acc: Option<chordsketch_core::chord::Accidental>) -> i32 {
 }
 
 /// Map (quality, extension) → (kind_content, kind_text_attr).
+///
+/// Returns the MusicXML `<kind>` element content and the `text` attribute value.
+/// The `text` attribute is returned as an owned `String` to avoid memory leaks
+/// for uncommon extensions that are not in the static lookup table.
 fn quality_ext_to_kind(
     quality: chordsketch_core::chord::ChordQuality,
     ext: &str,
-) -> (&'static str, &'static str) {
+) -> (&'static str, String) {
     use chordsketch_core::chord::ChordQuality;
 
     match (quality, ext) {
-        (ChordQuality::Major, "") => ("major", ""),
-        (ChordQuality::Minor, "") => ("minor", "m"),
-        (ChordQuality::Major, "7") => ("dominant", "7"),
-        (ChordQuality::Major, "maj7") | (ChordQuality::Major, "M7") => ("major-seventh", "maj7"),
-        (ChordQuality::Minor, "7") => ("minor-seventh", "m7"),
-        (ChordQuality::Diminished, "") => ("diminished", "dim"),
-        (ChordQuality::Diminished, "7") => ("diminished-seventh", "dim7"),
-        (ChordQuality::Augmented, "") => ("augmented", "aug"),
-        (ChordQuality::Major, "m7b5") | (ChordQuality::Minor, "7b5") => ("half-diminished", "m7b5"),
-        (ChordQuality::Major, "6") => ("major-sixth", "6"),
-        (ChordQuality::Minor, "6") => ("minor-sixth", "m6"),
-        (ChordQuality::Major, "9") => ("dominant-ninth", "9"),
-        (ChordQuality::Major, "maj9") => ("major-ninth", "maj9"),
-        (ChordQuality::Minor, "9") => ("minor-ninth", "m9"),
-        (ChordQuality::Major, "sus4") => ("suspended-fourth", "sus4"),
-        (ChordQuality::Major, "sus2") => ("suspended-second", "sus2"),
-        (ChordQuality::Major, "11") => ("dominant-11th", "11"),
-        (ChordQuality::Major, "13") => ("dominant-13th", "13"),
-        (ChordQuality::Major, "5") => ("power", "5"),
-        // Fall back to "other" with the raw extension as display text
-        (ChordQuality::Major, e) => ("other", e_to_static(e)),
-        (ChordQuality::Minor, e) => ("other", e_to_static(e)),
-        (ChordQuality::Diminished, _) => ("diminished", "dim"),
-        (ChordQuality::Augmented, _) => ("augmented", "aug"),
+        (ChordQuality::Major, "") => ("major", String::new()),
+        (ChordQuality::Minor, "") => ("minor", "m".to_string()),
+        (ChordQuality::Major, "7") => ("dominant", "7".to_string()),
+        (ChordQuality::Major, "maj7") | (ChordQuality::Major, "M7") => {
+            ("major-seventh", "maj7".to_string())
+        }
+        (ChordQuality::Minor, "7") => ("minor-seventh", "m7".to_string()),
+        (ChordQuality::Diminished, "") => ("diminished", "dim".to_string()),
+        (ChordQuality::Diminished, "7") => ("diminished-seventh", "dim7".to_string()),
+        (ChordQuality::Augmented, "") => ("augmented", "aug".to_string()),
+        (ChordQuality::Major, "m7b5") | (ChordQuality::Minor, "7b5") => {
+            ("half-diminished", "m7b5".to_string())
+        }
+        (ChordQuality::Major, "6") => ("major-sixth", "6".to_string()),
+        (ChordQuality::Minor, "6") => ("minor-sixth", "m6".to_string()),
+        (ChordQuality::Major, "9") => ("dominant-ninth", "9".to_string()),
+        (ChordQuality::Major, "maj9") => ("major-ninth", "maj9".to_string()),
+        (ChordQuality::Minor, "9") => ("minor-ninth", "m9".to_string()),
+        (ChordQuality::Major, "sus4") => ("suspended-fourth", "sus4".to_string()),
+        (ChordQuality::Major, "sus2") => ("suspended-second", "sus2".to_string()),
+        (ChordQuality::Major, "11") => ("dominant-11th", "11".to_string()),
+        (ChordQuality::Major, "13") => ("dominant-13th", "13".to_string()),
+        (ChordQuality::Major, "5") => ("power", "5".to_string()),
+        // Fall back to "other" with the raw extension as display text.
+        // Owned String avoids any memory leak — no Box::leak needed.
+        (ChordQuality::Major, e) | (ChordQuality::Minor, e) => ("other", e.to_string()),
+        (ChordQuality::Diminished, _) => ("diminished", "dim".to_string()),
+        (ChordQuality::Augmented, _) => ("augmented", "aug".to_string()),
     }
-}
-
-/// Leak a string slice into a `&'static str`.
-///
-/// This is only called for chord extensions that are not covered by the
-/// static table above. The leaked string is small and the number of distinct
-/// extensions per song is bounded.
-fn e_to_static(s: &str) -> &'static str {
-    Box::leak(s.to_string().into_boxed_str())
 }
 
 // ---------------------------------------------------------------------------
@@ -431,8 +426,12 @@ fn e_to_static(s: &str) -> &'static str {
 
 /// Convert a ChordPro key string to a (fifths, mode) pair.
 fn key_to_fifths(key: &str) -> (i32, &'static str) {
-    let is_minor = key.ends_with('m') && key.len() > 1;
-    let root = if is_minor { &key[..key.len() - 1] } else { key };
+    // Use strip_suffix to avoid byte-indexing into potentially multi-byte strings.
+    let root = key
+        .strip_suffix('m')
+        .filter(|r| !r.is_empty())
+        .unwrap_or(key);
+    let is_minor = root.len() < key.len();
 
     let fifths = match root {
         "Cb" | "C♭" => -7,

--- a/crates/convert-musicxml/src/export.rs
+++ b/crates/convert-musicxml/src/export.rs
@@ -127,20 +127,16 @@ fn build_measures(song: &Song) -> Vec<Measure> {
     for line in &song.lines {
         match line {
             Line::Lyrics(ll) => {
-                // Each lyrics line → one measure
-                if !current.notes.is_empty() || first_measure {
-                    // Flush if there's content already
-                    if !current.notes.is_empty() {
-                        if let Some(label) = section_name.take() {
-                            current.section_label = Some(label);
-                        }
-                        measures.push(current);
-                        current = Measure::default();
-                        first_measure = false;
-                    }
+                // Each lyrics line → one measure. Flush any buffered content.
+                if !current.notes.is_empty() {
+                    measures.push(current);
+                    current = Measure::default();
+                    first_measure = false;
                 }
 
-                // Apply pending section label
+                // Apply pending section label to the NEW current measure so
+                // the rehearsal mark is emitted at the start of the section,
+                // not at the end of the preceding one.
                 if let Some(label) = section_name.take() {
                     current.section_label = Some(label);
                 }
@@ -570,5 +566,63 @@ mod tests {
     fn key_to_fifths_minor() {
         assert_eq!(key_to_fifths("Am"), (3, "minor"));
         assert_eq!(key_to_fifths("Em"), (4, "minor"));
+    }
+
+    /// Regression test: section label must appear on the first measure of the
+    /// section it names, not on the last measure of the preceding section.
+    ///
+    /// Before the fix, `build_measures` consumed `section_name` during the
+    /// flush of the previous measure, so the rehearsal mark was attached to
+    /// the wrong measure.
+    #[test]
+    fn section_label_on_correct_measure() {
+        use chordsketch_core::ast::{Chord, Directive, Line, LyricsLine, LyricsSegment};
+
+        let mut song = Song::new();
+
+        // Verse section with one lyrics line
+        song.lines.push(Line::Directive(Directive::with_value(
+            "start_of_verse",
+            "Verse 1",
+        )));
+        let mut verse_line = LyricsLine::new();
+        verse_line.segments = vec![LyricsSegment::new(Some(Chord::new("C")), "verse ")];
+        song.lines.push(Line::Lyrics(verse_line));
+        song.lines
+            .push(Line::Directive(Directive::name_only("end_of_verse")));
+
+        // Chorus section with one lyrics line
+        song.lines.push(Line::Directive(Directive::with_value(
+            "start_of_chorus",
+            "Chorus",
+        )));
+        let mut chorus_line = LyricsLine::new();
+        chorus_line.segments = vec![LyricsSegment::new(Some(Chord::new("G")), "chorus ")];
+        song.lines.push(Line::Lyrics(chorus_line));
+        song.lines
+            .push(Line::Directive(Directive::name_only("end_of_chorus")));
+
+        let xml = to_musicxml(&song);
+
+        // The "Chorus" rehearsal mark must appear AFTER the verse chord (C),
+        // not before it. Verify the ordering of tokens in the output.
+        let verse_pos = xml
+            .find("<root-step>C</root-step>")
+            .expect("C chord not found");
+        let chorus_mark_pos = xml
+            .find("<rehearsal>Chorus</rehearsal>")
+            .expect("Chorus rehearsal mark not found");
+        let chorus_chord_pos = xml
+            .find("<root-step>G</root-step>")
+            .expect("G chord not found");
+
+        assert!(
+            chorus_mark_pos > verse_pos,
+            "Chorus rehearsal mark should come after the verse chord"
+        );
+        assert!(
+            chorus_mark_pos < chorus_chord_pos,
+            "Chorus rehearsal mark should come before the chorus chord"
+        );
     }
 }

--- a/crates/convert-musicxml/src/export.rs
+++ b/crates/convert-musicxml/src/export.rs
@@ -1,0 +1,575 @@
+//! ChordPro → MusicXML exporter.
+//!
+//! Converts a [`Song`] AST into a MusicXML 4.0 `<score-partwise>` document.
+//!
+//! # What is exported
+//!
+//! - Song metadata: title, composer/artist, key, tempo, capo
+//! - Chord symbols: emitted as `<harmony>` elements using root step/alter
+//!   and the MusicXML kind that best matches the ChordPro chord
+//! - Lyrics: emitted as `<note>` elements with `<lyric>` children; one note
+//!   per lyric segment
+//! - Section structure: `{start_of_verse}` / `{start_of_chorus}` /
+//!   `{start_of_bridge}` are emitted as `<rehearsal>` direction elements
+//!
+//! # Note durations
+//!
+//! Since ChordPro does not carry rhythmic information, all notes are exported
+//! as whole notes. Applications that require real note durations must add them
+//! after import.
+
+use chordsketch_core::{
+    ast::{DirectiveKind, Line, Song},
+    chord::parse_chord,
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Converts a [`Song`] AST into a MusicXML 4.0 string.
+///
+/// The output is a well-formed XML document that can be opened by any
+/// MusicXML-compatible application (e.g., MuseScore, Finale, Sibelius).
+#[must_use]
+pub fn to_musicxml(song: &Song) -> String {
+    let mut out = String::new();
+    out.push_str(r#"<?xml version="1.0" encoding="UTF-8"?>"#);
+    out.push('\n');
+    out.push_str(
+        r#"<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">"#,
+    );
+    out.push('\n');
+    out.push_str(r#"<score-partwise version="4.0">"#);
+    out.push('\n');
+
+    // Work
+    if let Some(ref title) = song.metadata.title {
+        out.push_str("  <work>\n");
+        out.push_str("    <work-title>");
+        xml_text(title, &mut out);
+        out.push_str("</work-title>\n");
+        out.push_str("  </work>\n");
+    }
+
+    // Identification
+    let has_ident = !song.metadata.artists.is_empty() || !song.metadata.lyricists.is_empty();
+    if has_ident {
+        out.push_str("  <identification>\n");
+        for artist in &song.metadata.artists {
+            out.push_str(r#"    <creator type="composer">"#);
+            xml_text(artist, &mut out);
+            out.push_str("</creator>\n");
+        }
+        for lyricist in &song.metadata.lyricists {
+            out.push_str(r#"    <creator type="lyricist">"#);
+            xml_text(lyricist, &mut out);
+            out.push_str("</creator>\n");
+        }
+        out.push_str("  </identification>\n");
+    }
+
+    // Part list
+    out.push_str("  <part-list>\n");
+    out.push_str(r#"    <score-part id="P1"><part-name>Voice</part-name></score-part>"#);
+    out.push('\n');
+    out.push_str("  </part-list>\n");
+
+    // Part
+    out.push_str(r#"  <part id="P1">"#);
+    out.push('\n');
+
+    let measures = build_measures(song);
+    for (i, measure) in measures.iter().enumerate() {
+        write_measure(measure, i + 1, &mut out);
+    }
+
+    out.push_str("  </part>\n");
+    out.push_str("</score-partwise>\n");
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Measure building
+// ---------------------------------------------------------------------------
+
+/// A simplified measure for export purposes.
+#[derive(Default)]
+struct Measure {
+    /// Key signature (fifths, mode) — only emitted in the first measure.
+    key: Option<(i32, &'static str)>,
+    /// Tempo in BPM — only emitted in the first measure.
+    tempo: Option<String>,
+    /// Section label (becomes a rehearsal mark).
+    section_label: Option<String>,
+    /// Sequence of (chord_name, lyric_text) pairs.
+    notes: Vec<(Option<String>, String)>,
+}
+
+/// Convert a [`Song`] into a flat list of measures.
+fn build_measures(song: &Song) -> Vec<Measure> {
+    let mut measures: Vec<Measure> = Vec::new();
+    let mut current = Measure::default();
+    let mut first_measure = true;
+
+    // Emit global metadata into the first measure
+    if let Some(ref key) = song.metadata.key {
+        let (fifths, mode) = key_to_fifths(key);
+        current.key = Some((fifths, mode));
+    }
+    if let Some(ref tempo) = song.metadata.tempo {
+        current.tempo = Some(tempo.clone());
+    }
+
+    let mut section_name: Option<String> = None;
+
+    for line in &song.lines {
+        match line {
+            Line::Lyrics(ll) => {
+                // Each lyrics line → one measure
+                if !current.notes.is_empty() || first_measure {
+                    // Flush if there's content already
+                    if !current.notes.is_empty() {
+                        if let Some(label) = section_name.take() {
+                            current.section_label = Some(label);
+                        }
+                        measures.push(current);
+                        current = Measure::default();
+                        first_measure = false;
+                    }
+                }
+
+                // Apply pending section label
+                if let Some(label) = section_name.take() {
+                    current.section_label = Some(label);
+                }
+
+                for seg in &ll.segments {
+                    let chord = seg.chord.as_ref().map(|c| c.display_name().to_string());
+                    let text = seg.text.clone();
+                    current.notes.push((chord, text));
+                }
+            }
+
+            Line::Directive(dir) => match dir.kind {
+                DirectiveKind::StartOfChorus => {
+                    section_name = Some(dir.value.clone().unwrap_or_else(|| "Chorus".to_string()));
+                }
+                DirectiveKind::StartOfVerse => {
+                    section_name = Some(dir.value.clone().unwrap_or_else(|| "Verse".to_string()));
+                }
+                DirectiveKind::StartOfBridge => {
+                    section_name = Some(dir.value.clone().unwrap_or_else(|| "Bridge".to_string()));
+                }
+                DirectiveKind::EndOfChorus
+                | DirectiveKind::EndOfVerse
+                | DirectiveKind::EndOfBridge => {}
+                DirectiveKind::Key => {
+                    if first_measure || current.notes.is_empty() {
+                        if let Some(ref kv) = dir.value {
+                            let (f, m) = key_to_fifths(kv);
+                            current.key = Some((f, m));
+                        }
+                    }
+                }
+                DirectiveKind::Tempo => {
+                    if first_measure || current.notes.is_empty() {
+                        if let Some(ref tv) = dir.value {
+                            current.tempo = Some(tv.clone());
+                        }
+                    }
+                }
+                _ => {}
+            },
+
+            Line::Empty | Line::Comment(_, _) => {}
+        }
+    }
+
+    // Flush last measure
+    if !current.notes.is_empty() || first_measure {
+        if let Some(label) = section_name {
+            current.section_label = Some(label);
+        }
+        measures.push(current);
+    }
+
+    // Ensure at least one measure exists
+    if measures.is_empty() {
+        measures.push(Measure::default());
+    }
+
+    measures
+}
+
+/// Write a single measure to the output string.
+fn write_measure(measure: &Measure, number: usize, out: &mut String) {
+    out.push_str(&format!("    <measure number=\"{}\">\n", number));
+
+    // Attributes (key + time signature + divisions) in first measure
+    if measure.key.is_some() || number == 1 {
+        out.push_str("      <attributes>\n");
+        out.push_str("        <divisions>1</divisions>\n");
+        if let Some((fifths, mode)) = measure.key {
+            out.push_str("        <key>\n");
+            out.push_str(&format!("          <fifths>{}</fifths>\n", fifths));
+            out.push_str(&format!("          <mode>{}</mode>\n", mode));
+            out.push_str("        </key>\n");
+        }
+        if number == 1 {
+            out.push_str("        <time><beats>4</beats><beat-type>4</beat-type></time>\n");
+            out.push_str("        <clef><sign>G</sign><line>2</line></clef>\n");
+        }
+        out.push_str("      </attributes>\n");
+    }
+
+    // Tempo direction
+    if let Some(ref tempo) = measure.tempo {
+        out.push_str("      <direction placement=\"above\">\n");
+        out.push_str("        <direction-type>\n");
+        out.push_str(&format!(
+            "          <metronome><beat-unit>quarter</beat-unit><per-minute>{}</per-minute></metronome>\n",
+            xml_escape(tempo)
+        ));
+        out.push_str("        </direction-type>\n");
+        out.push_str(&format!(
+            "        <sound tempo=\"{}\"/>\n",
+            xml_escape(tempo)
+        ));
+        out.push_str("      </direction>\n");
+    }
+
+    // Rehearsal mark (section label)
+    if let Some(ref label) = measure.section_label {
+        out.push_str("      <direction placement=\"above\">\n");
+        out.push_str("        <direction-type>\n");
+        out.push_str("          <rehearsal>");
+        xml_text(label, out);
+        out.push_str("</rehearsal>\n");
+        out.push_str("        </direction-type>\n");
+        out.push_str("      </direction>\n");
+    }
+
+    // Notes
+    for (chord_name, lyric_text) in &measure.notes {
+        // Harmony element
+        if let Some(chord) = chord_name {
+            if let Some((root_step, root_alter, kind_content, kind_text, bass)) =
+                chord_to_musicxml(chord)
+            {
+                out.push_str("      <harmony>\n");
+                out.push_str("        <root>\n");
+                out.push_str(&format!(
+                    "          <root-step>{}</root-step>\n",
+                    xml_escape(root_step)
+                ));
+                if root_alter != 0 {
+                    out.push_str(&format!(
+                        "          <root-alter>{}</root-alter>\n",
+                        root_alter
+                    ));
+                }
+                out.push_str("        </root>\n");
+                out.push_str(&format!(
+                    "        <kind text=\"{}\">{}</kind>\n",
+                    xml_escape(kind_text),
+                    xml_escape(kind_content)
+                ));
+                if let Some((bass_step, bass_alter)) = bass {
+                    out.push_str("        <bass>\n");
+                    out.push_str(&format!(
+                        "          <bass-step>{}</bass-step>\n",
+                        xml_escape(bass_step)
+                    ));
+                    if bass_alter != 0 {
+                        out.push_str(&format!(
+                            "          <bass-alter>{}</bass-alter>\n",
+                            bass_alter
+                        ));
+                    }
+                    out.push_str("        </bass>\n");
+                }
+                out.push_str("      </harmony>\n");
+            }
+        }
+
+        // Note element (whole note)
+        let lyric_trimmed = lyric_text.trim();
+        out.push_str("      <note>\n");
+        out.push_str("        <pitch><step>C</step><octave>4</octave></pitch>\n");
+        out.push_str("        <duration>4</duration>\n");
+        out.push_str("        <type>whole</type>\n");
+        if !lyric_trimmed.is_empty() {
+            out.push_str("        <lyric number=\"1\">\n");
+            out.push_str("          <syllabic>single</syllabic>\n");
+            out.push_str("          <text>");
+            // Strip trailing hyphen that was added for syllabic continuation
+            let display_text = lyric_trimmed.trim_end_matches('-');
+            xml_text(display_text, out);
+            out.push_str("</text>\n");
+            out.push_str("        </lyric>\n");
+        }
+        out.push_str("      </note>\n");
+    }
+
+    out.push_str("    </measure>\n");
+}
+
+// ---------------------------------------------------------------------------
+// Chord encoding
+// ---------------------------------------------------------------------------
+
+/// Convert a ChordPro chord name to MusicXML components.
+///
+/// Returns `(root_step, root_alter, kind_content, kind_text, bass)` or `None`
+/// if the chord cannot be parsed.
+///
+/// - `root_step`: note letter ("C", "D", ..., "B")
+/// - `root_alter`: semitone offset (1 = sharp, -1 = flat, 0 = natural)
+/// - `kind_content`: MusicXML kind element text content ("major", "minor", ...)
+/// - `kind_text`: the `text` attribute for the kind element (ChordPro suffix)
+/// - `bass`: optional `(bass_step, bass_alter)` for slash chords
+#[allow(clippy::type_complexity)]
+fn chord_to_musicxml(
+    chord_name: &str,
+) -> Option<(
+    &'static str,
+    i32,
+    &'static str,
+    &'static str,
+    Option<(&'static str, i32)>,
+)> {
+    let detail = parse_chord(chord_name)?;
+
+    let root_step: &'static str = note_to_step(detail.root);
+    let root_alter = acciental_to_alter(detail.root_accidental);
+
+    let ext = detail.extension.as_deref().unwrap_or("");
+    let (kind_content, kind_text) = quality_ext_to_kind(detail.quality, ext);
+
+    let bass = if let Some((bass_note, bass_acc)) = detail.bass_note {
+        let bs: &'static str = note_to_step(bass_note);
+        let ba = acciental_to_alter(bass_acc);
+        Some((bs, ba))
+    } else {
+        None
+    };
+
+    Some((root_step, root_alter, kind_content, kind_text, bass))
+}
+
+fn note_to_step(note: chordsketch_core::chord::Note) -> &'static str {
+    use chordsketch_core::chord::Note;
+    match note {
+        Note::C => "C",
+        Note::D => "D",
+        Note::E => "E",
+        Note::F => "F",
+        Note::G => "G",
+        Note::A => "A",
+        Note::B => "B",
+    }
+}
+
+fn acciental_to_alter(acc: Option<chordsketch_core::chord::Accidental>) -> i32 {
+    use chordsketch_core::chord::Accidental;
+    match acc {
+        Some(Accidental::Sharp) => 1,
+        Some(Accidental::Flat) => -1,
+        _ => 0,
+    }
+}
+
+/// Map (quality, extension) → (kind_content, kind_text_attr).
+fn quality_ext_to_kind(
+    quality: chordsketch_core::chord::ChordQuality,
+    ext: &str,
+) -> (&'static str, &'static str) {
+    use chordsketch_core::chord::ChordQuality;
+
+    match (quality, ext) {
+        (ChordQuality::Major, "") => ("major", ""),
+        (ChordQuality::Minor, "") => ("minor", "m"),
+        (ChordQuality::Major, "7") => ("dominant", "7"),
+        (ChordQuality::Major, "maj7") | (ChordQuality::Major, "M7") => ("major-seventh", "maj7"),
+        (ChordQuality::Minor, "7") => ("minor-seventh", "m7"),
+        (ChordQuality::Diminished, "") => ("diminished", "dim"),
+        (ChordQuality::Diminished, "7") => ("diminished-seventh", "dim7"),
+        (ChordQuality::Augmented, "") => ("augmented", "aug"),
+        (ChordQuality::Major, "m7b5") | (ChordQuality::Minor, "7b5") => ("half-diminished", "m7b5"),
+        (ChordQuality::Major, "6") => ("major-sixth", "6"),
+        (ChordQuality::Minor, "6") => ("minor-sixth", "m6"),
+        (ChordQuality::Major, "9") => ("dominant-ninth", "9"),
+        (ChordQuality::Major, "maj9") => ("major-ninth", "maj9"),
+        (ChordQuality::Minor, "9") => ("minor-ninth", "m9"),
+        (ChordQuality::Major, "sus4") => ("suspended-fourth", "sus4"),
+        (ChordQuality::Major, "sus2") => ("suspended-second", "sus2"),
+        (ChordQuality::Major, "11") => ("dominant-11th", "11"),
+        (ChordQuality::Major, "13") => ("dominant-13th", "13"),
+        (ChordQuality::Major, "5") => ("power", "5"),
+        // Fall back to "other" with the raw extension as display text
+        (ChordQuality::Major, e) => ("other", e_to_static(e)),
+        (ChordQuality::Minor, e) => ("other", e_to_static(e)),
+        (ChordQuality::Diminished, _) => ("diminished", "dim"),
+        (ChordQuality::Augmented, _) => ("augmented", "aug"),
+    }
+}
+
+/// Leak a string slice into a `&'static str`.
+///
+/// This is only called for chord extensions that are not covered by the
+/// static table above. The leaked string is small and the number of distinct
+/// extensions per song is bounded.
+fn e_to_static(s: &str) -> &'static str {
+    Box::leak(s.to_string().into_boxed_str())
+}
+
+// ---------------------------------------------------------------------------
+// Key encoding
+// ---------------------------------------------------------------------------
+
+/// Convert a ChordPro key string to a (fifths, mode) pair.
+fn key_to_fifths(key: &str) -> (i32, &'static str) {
+    let is_minor = key.ends_with('m') && key.len() > 1;
+    let root = if is_minor { &key[..key.len() - 1] } else { key };
+
+    let fifths = match root {
+        "Cb" | "C♭" => -7,
+        "Gb" | "G♭" => -6,
+        "Db" | "D♭" => -5,
+        "Ab" | "A♭" => -4,
+        "Eb" | "E♭" => -3,
+        "Bb" | "B♭" => -2,
+        "F" => -1,
+        "C" => 0,
+        "G" => 1,
+        "D" => 2,
+        "A" => 3,
+        "E" => 4,
+        "B" => 5,
+        "F#" | "F♯" => 6,
+        "C#" | "C♯" => 7,
+        _ => 0,
+    };
+
+    let mode = if is_minor { "minor" } else { "major" };
+    (fifths, mode)
+}
+
+// ---------------------------------------------------------------------------
+// XML escaping
+// ---------------------------------------------------------------------------
+
+/// Escape a string for use as XML text content, appending to `out`.
+fn xml_text(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            other => out.push(other),
+        }
+    }
+}
+
+/// Escape a string for use in an XML attribute value (double-quoted).
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chordsketch_core::ast::{Chord, LyricsLine, LyricsSegment};
+
+    fn simple_song() -> Song {
+        let mut song = Song::new();
+        song.metadata.title = Some("Test Song".to_string());
+        song.metadata.artists = vec!["Test Artist".to_string()];
+        song.metadata.key = Some("C".to_string());
+        song.metadata.tempo = Some("120".to_string());
+        // One lyrics line: [C]Hello [G]world
+        let mut ll = LyricsLine::new();
+        ll.segments = vec![
+            LyricsSegment::new(Some(Chord::new("C")), "Hello "),
+            LyricsSegment::new(Some(Chord::new("G")), "world "),
+        ];
+        song.lines.push(chordsketch_core::ast::Line::Lyrics(ll));
+        song
+    }
+
+    #[test]
+    fn export_contains_title() {
+        let xml = to_musicxml(&simple_song());
+        assert!(xml.contains("<work-title>Test Song</work-title>"));
+    }
+
+    #[test]
+    fn export_contains_creator() {
+        let xml = to_musicxml(&simple_song());
+        assert!(xml.contains(r#"type="composer""#));
+        assert!(xml.contains("Test Artist"));
+    }
+
+    #[test]
+    fn export_contains_key_and_tempo() {
+        let xml = to_musicxml(&simple_song());
+        assert!(xml.contains("<fifths>0</fifths>"));
+        assert!(xml.contains(r#"tempo="120""#));
+    }
+
+    #[test]
+    fn export_contains_harmonies() {
+        let xml = to_musicxml(&simple_song());
+        assert!(xml.contains("<root-step>C</root-step>"));
+        assert!(xml.contains("<root-step>G</root-step>"));
+    }
+
+    #[test]
+    fn export_contains_lyrics() {
+        let xml = to_musicxml(&simple_song());
+        assert!(xml.contains("<text>Hello</text>"));
+        assert!(xml.contains("<text>world</text>"));
+    }
+
+    #[test]
+    fn export_escapes_special_chars() {
+        let mut song = Song::new();
+        song.metadata.title = Some("Song & <Things>".to_string());
+        let xml = to_musicxml(&song);
+        assert!(xml.contains("Song &amp; &lt;Things&gt;"));
+    }
+
+    #[test]
+    fn key_to_fifths_major() {
+        assert_eq!(key_to_fifths("C"), (0, "major"));
+        assert_eq!(key_to_fifths("G"), (1, "major"));
+        assert_eq!(key_to_fifths("F"), (-1, "major"));
+        assert_eq!(key_to_fifths("Bb"), (-2, "major"));
+        assert_eq!(key_to_fifths("F#"), (6, "major"));
+    }
+
+    #[test]
+    fn key_to_fifths_minor() {
+        assert_eq!(key_to_fifths("Am"), (3, "minor"));
+        assert_eq!(key_to_fifths("Em"), (4, "minor"));
+    }
+}

--- a/crates/convert-musicxml/src/import.rs
+++ b/crates/convert-musicxml/src/import.rs
@@ -109,7 +109,8 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
     let mut key_emitted = false;
     let mut tempo_emitted = false;
     let mut capo_emitted = false;
-    let mut in_section = false;
+    // Tracks the end-directive name of the currently open section, if any.
+    let mut current_section_end: Option<&'static str> = None;
 
     for measure in part.children_named("measure") {
         // --- attributes (key, capo) -----------------------------------------
@@ -170,26 +171,28 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
                 if let Some(rehearsal) = dt.child("rehearsal") {
                     let label = rehearsal.text.trim();
                     if !label.is_empty() {
-                        // Close any open section
-                        if in_section {
+                        // Close any open section with its end directive.
+                        if let Some(end_dir) = current_section_end {
+                            emit_directive(&mut song.lines, end_dir, None);
                             song.lines.push(Line::Empty);
                         }
                         let (section_dir, section_end) = map_section_label(label);
                         emit_directive(&mut song.lines, section_dir, Some(label));
-                        in_section = true;
-                        let _ = section_end; // will emit on next section or EOF
+                        current_section_end = Some(section_end);
                     }
                 }
                 if let Some(words) = dt.child("words") {
                     let text = words.text.trim();
                     // Treat "Intro:", "Verse", "Chorus", etc. as section markers
                     if looks_like_section_marker(text) {
-                        if in_section {
+                        // Close any open section with its end directive.
+                        if let Some(end_dir) = current_section_end {
+                            emit_directive(&mut song.lines, end_dir, None);
                             song.lines.push(Line::Empty);
                         }
-                        let (section_dir, _) = map_section_label(text);
+                        let (section_dir, section_end) = map_section_label(text);
                         emit_directive(&mut song.lines, section_dir, Some(text));
-                        in_section = true;
+                        current_section_end = Some(section_end);
                     }
                 }
             }
@@ -230,9 +233,9 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
         }
     }
 
-    // Close open section
-    if in_section {
-        song.lines.push(Line::Empty);
+    // Close the last open section with its end directive.
+    if let Some(end_dir) = current_section_end {
+        emit_directive(&mut song.lines, end_dir, None);
     }
 
     Ok(song)

--- a/crates/convert-musicxml/src/import.rs
+++ b/crates/convert-musicxml/src/import.rs
@@ -1,0 +1,594 @@
+//! MusicXML → ChordPro importer.
+//!
+//! Converts a MusicXML 4.0 `<score-partwise>` document into a [`Song`] AST
+//! by extracting chord symbols, lyrics, metadata, and section structure.
+//!
+//! # What is extracted
+//!
+//! - Song metadata: `<work-title>`, `<creator type="composer">`, key signature,
+//!   tempo (`<sound tempo="...">`), capo (`<capo>`)
+//! - Chord symbols: reconstructed from `<harmony>` elements using root step/alter
+//!   and the kind `text` attribute (falling back to kind content mapping)
+//! - Lyrics: from `<note><lyric>` elements; each lyric syllable is matched to
+//!   the preceding harmony
+//! - Section structure: rehearsal marks (`<rehearsal>`) are mapped to ChordPro
+//!   start-of-verse / start-of-chorus / start-of-bridge directives
+//!
+//! # What is not extracted
+//!
+//! - Staff notation (notes, pitch, rhythm, duration)
+//! - Multi-part scores (only the first `<part>` is used)
+//! - Dynamics, articulations, slurs
+//! - Chord diagrams
+
+use crate::xml::{Element, parse};
+use chordsketch_core::ast::{Chord, Directive, Line, LyricsLine, LyricsSegment, Song};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Error type for MusicXML import failures.
+#[derive(Debug)]
+pub struct ImportError(String);
+
+impl std::fmt::Display for ImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MusicXML import error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ImportError {}
+
+/// Converts a MusicXML string into a [`Song`] AST.
+///
+/// Only the first `<part>` is used; additional parts are ignored. Chord
+/// symbols are reconstructed from `<harmony>` elements; lyrics are extracted
+/// from `<note><lyric>` elements and aligned to the preceding chord.
+///
+/// # Errors
+///
+/// Returns an [`ImportError`] if the XML cannot be parsed or if the document
+/// is not a `<score-partwise>` MusicXML file.
+pub fn from_musicxml(xml: &str) -> Result<Song, ImportError> {
+    let root = parse(xml).map_err(|e| ImportError(format!("XML parse error: {e}")))?;
+    if root.name != "score-partwise" {
+        return Err(ImportError(format!(
+            "expected <score-partwise> root element, found <{}>",
+            root.name
+        )));
+    }
+    convert_score(&root)
+}
+
+// ---------------------------------------------------------------------------
+// Internal conversion
+// ---------------------------------------------------------------------------
+
+fn convert_score(score: &Element) -> Result<Song, ImportError> {
+    let mut song = Song::new();
+
+    // --- Metadata -----------------------------------------------------------
+
+    // Title from <work><work-title>
+    if let Some(title) = score.text_at(&["work", "work-title"]) {
+        if !title.is_empty() {
+            song.metadata.title = Some(title.to_string());
+        }
+    }
+
+    // Creators from <identification><creator type="...">
+    if let Some(ident) = score.child("identification") {
+        for creator in ident.children_named("creator") {
+            let kind = creator.attr("type").unwrap_or("");
+            let name = creator.text.trim();
+            if name.is_empty() {
+                continue;
+            }
+            match kind {
+                "composer" | "arranger" => song.metadata.artists.push(name.to_string()),
+                "lyricist" => song.metadata.lyricists.push(name.to_string()),
+                _ => {
+                    // Store unknown creator types as custom metadata
+                    song.metadata
+                        .custom
+                        .push((kind.to_string(), name.to_string()));
+                }
+            }
+        }
+    }
+
+    // --- Body ---------------------------------------------------------------
+
+    // Use the first <part> only
+    let part = score
+        .child("part")
+        .ok_or_else(|| ImportError("no <part> element found".to_string()))?;
+
+    let mut current_key: Option<String> = None;
+    let mut key_emitted = false;
+    let mut tempo_emitted = false;
+    let mut capo_emitted = false;
+    let mut in_section = false;
+
+    for measure in part.children_named("measure") {
+        // --- attributes (key, capo) -----------------------------------------
+        if let Some(attrs) = measure.child("attributes") {
+            if let Some(key_elem) = attrs.child("key") {
+                let fifths: i32 = key_elem
+                    .text_at(&["fifths"])
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let mode = key_elem.text_at(&["mode"]).unwrap_or("major");
+                let key_name = fifths_to_key(fifths, mode);
+                current_key = Some(key_name);
+            }
+            if !capo_emitted {
+                if let Some(capo_text) = attrs.text_at(&["capo"]) {
+                    if !capo_text.is_empty() && capo_text != "0" {
+                        emit_directive(&mut song.lines, "capo", Some(capo_text));
+                        capo_emitted = true;
+                    }
+                }
+            }
+        }
+
+        // Emit key once (first time we see it)
+        if !key_emitted {
+            if let Some(ref key) = current_key {
+                if song.metadata.key.is_none() {
+                    song.metadata.key = Some(key.clone());
+                }
+                key_emitted = true;
+            }
+        }
+
+        // --- directions (tempo, rehearsal marks) ----------------------------
+        for direction in measure.children_named("direction") {
+            // Tempo
+            if !tempo_emitted {
+                if let Some(sound) = direction.child("sound") {
+                    if let Some(tempo) = sound.attr("tempo") {
+                        if !tempo.is_empty() {
+                            song.metadata.tempo = Some(tempo.to_string());
+                            tempo_emitted = true;
+                        }
+                    }
+                }
+                // Also handle <sound> directly in measure
+            }
+
+            // Rehearsal marks → section start directives
+            if let Some(dt) = direction.child("direction-type") {
+                if let Some(rehearsal) = dt.child("rehearsal") {
+                    let label = rehearsal.text.trim();
+                    if !label.is_empty() {
+                        // Close any open section
+                        if in_section {
+                            song.lines.push(Line::Empty);
+                        }
+                        let (section_dir, section_end) = map_section_label(label);
+                        emit_directive(&mut song.lines, section_dir, Some(label));
+                        in_section = true;
+                        let _ = section_end; // will emit on next section or EOF
+                    }
+                }
+                if let Some(words) = dt.child("words") {
+                    let text = words.text.trim();
+                    // Treat "Intro:", "Verse", "Chorus", etc. as section markers
+                    if looks_like_section_marker(text) {
+                        if in_section {
+                            song.lines.push(Line::Empty);
+                        }
+                        let (section_dir, _) = map_section_label(text);
+                        emit_directive(&mut song.lines, section_dir, Some(text));
+                        in_section = true;
+                    }
+                }
+            }
+
+            // Bare <sound tempo="..."> inside <direction>
+            if let Some(sound) = direction.child("sound") {
+                if !tempo_emitted {
+                    if let Some(tempo) = sound.attr("tempo") {
+                        if !tempo.is_empty() {
+                            song.metadata.tempo = Some(tempo.to_string());
+                            tempo_emitted = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- collect chords and lyrics per measure --------------------------
+        let segments = collect_measure_segments(measure);
+        if segments.is_empty() {
+            continue;
+        }
+
+        // Build LyricsLine(s) from segments
+        // Each segment is (Option<chord_name>, lyric_text)
+        let mut line_segs: Vec<LyricsSegment> = Vec::new();
+        for (chord_name, lyric_text) in segments {
+            let chord = chord_name.map(Chord::new);
+            line_segs.push(LyricsSegment::new(chord, lyric_text));
+        }
+
+        if !line_segs.is_empty() {
+            let mut ll = LyricsLine::new();
+            ll.segments = line_segs;
+            song.lines.push(Line::Lyrics(ll));
+        }
+    }
+
+    // Close open section
+    if in_section {
+        song.lines.push(Line::Empty);
+    }
+
+    Ok(song)
+}
+
+/// Collect (chord_name, lyric_text) pairs from a measure.
+///
+/// Chords are matched to the lyric that immediately follows them. Notes
+/// without a lyric advance the "has chord available" state so the chord
+/// floats to the next lyric-bearing note.
+fn collect_measure_segments(measure: &Element) -> Vec<(Option<String>, String)> {
+    let mut result: Vec<(Option<String>, String)> = Vec::new();
+    let mut pending_chord: Option<String> = None;
+
+    for child in &measure.children {
+        match child.name.as_str() {
+            "harmony" => {
+                pending_chord = parse_harmony(child);
+            }
+            "note" => {
+                // Skip chord notes (notes that are part of a chord voicing)
+                if child.child("chord").is_some() {
+                    continue;
+                }
+
+                let lyric_text = collect_lyric_text(child);
+                if !lyric_text.is_empty() {
+                    result.push((pending_chord.take(), lyric_text));
+                } else {
+                    // Note has no lyric — keep the chord pending for the next lyric
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // If there's a leftover pending chord with no following lyric, add it
+    // as a chord-only segment so it isn't lost.
+    if let Some(chord) = pending_chord {
+        result.push((Some(chord), String::new()));
+    }
+
+    result
+}
+
+/// Extract the chord name from a `<harmony>` element.
+fn parse_harmony(harmony: &Element) -> Option<String> {
+    let root = harmony.child("root")?;
+    let step = root.text_at(&["root-step"])?;
+    if step.is_empty() {
+        return None;
+    }
+
+    let alter = root
+        .text_at(&["root-alter"])
+        .and_then(|s| {
+            let v: f64 = s.trim().parse().ok()?;
+            Some(v)
+        })
+        .unwrap_or(0.0);
+
+    let root_str = format!(
+        "{}{}",
+        step,
+        match alter as i32 {
+            1 => "#",
+            -1 => "b",
+            _ => "",
+        }
+    );
+
+    // Try the `text` attribute on <kind> first — it often has the display
+    // chord symbol (e.g., "m7", "maj7", "sus4").
+    let suffix = if let Some(kind_elem) = harmony.child("kind") {
+        if let Some(text_attr) = kind_elem.attr("text") {
+            // text="" means major, text="m" means minor, etc.
+            text_attr.to_string()
+        } else {
+            // Fall back to mapping the kind content
+            let kind_content = kind_elem.text.trim();
+            musicxml_kind_to_suffix(kind_content).to_string()
+        }
+    } else {
+        String::new()
+    };
+
+    // Bass note for slash chords
+    let bass_str = if let Some(bass) = harmony.child("bass") {
+        let bass_step = bass.text_at(&["bass-step"]).unwrap_or("");
+        if bass_step.is_empty() {
+            String::new()
+        } else {
+            let bass_alter = bass
+                .text_at(&["bass-alter"])
+                .and_then(|s| s.trim().parse::<f64>().ok())
+                .unwrap_or(0.0);
+            format!(
+                "/{}{}",
+                bass_step,
+                match bass_alter as i32 {
+                    1 => "#",
+                    -1 => "b",
+                    _ => "",
+                }
+            )
+        }
+    } else {
+        String::new()
+    };
+
+    Some(format!("{root_str}{suffix}{bass_str}"))
+}
+
+/// Map MusicXML `<kind>` content to a ChordPro chord suffix.
+fn musicxml_kind_to_suffix(kind: &str) -> &str {
+    match kind {
+        "major" | "none" | "" => "",
+        "minor" => "m",
+        "dominant" => "7",
+        "major-seventh" => "maj7",
+        "minor-seventh" => "m7",
+        "diminished" => "dim",
+        "augmented" => "aug",
+        "half-diminished" => "m7b5",
+        "diminished-seventh" => "dim7",
+        "major-sixth" => "6",
+        "minor-sixth" => "m6",
+        "dominant-ninth" => "9",
+        "major-ninth" => "maj9",
+        "minor-ninth" => "m9",
+        "suspended-fourth" => "sus4",
+        "suspended-second" => "sus2",
+        "dominant-11th" => "11",
+        "major-11th" => "maj11",
+        "dominant-13th" => "13",
+        "major-13th" => "maj13",
+        "power" => "5",
+        "major-minor" => "mM7",
+        "augmented-seventh" => "aug7",
+        "augmented-major-seventh" => "augM7",
+        _ => "",
+    }
+}
+
+/// Collect the lyric text from a `<note>` element.
+///
+/// Concatenates all `<lyric><text>` values (there may be multiple lyrics
+/// in different verses). Uses only the first lyric if multiple are present.
+fn collect_lyric_text(note: &Element) -> String {
+    // Use the first <lyric> element (lyric number="1")
+    for lyric in note.children_named("lyric") {
+        let text = lyric.text_at(&["text"]).unwrap_or("").trim();
+        if !text.is_empty() {
+            let syllabic = lyric.text_at(&["syllabic"]).unwrap_or("single");
+            return match syllabic {
+                "begin" | "middle" => format!("{text}-"),
+                _ => format!("{text} "),
+            };
+        }
+    }
+    String::new()
+}
+
+/// Map a key signature (circle-of-fifths value + mode) to a key name string.
+fn fifths_to_key(fifths: i32, mode: &str) -> String {
+    let major_keys = [
+        "Cb", "Gb", "Db", "Ab", "Eb", "Bb", "F", "C", "G", "D", "A", "E", "B", "F#", "C#",
+    ];
+    // Index 7 = C (fifths=0), offset by +7
+    let idx = (fifths + 7).clamp(0, 14) as usize;
+    let key = major_keys[idx];
+    if mode.eq_ignore_ascii_case("minor") {
+        format!("{key}m")
+    } else {
+        key.to_string()
+    }
+}
+
+/// Decide which section directive to emit for a rehearsal/words label.
+///
+/// Returns `(start_directive_name, end_directive_name)`.
+fn map_section_label(label: &str) -> (&'static str, &'static str) {
+    let lower = label.to_lowercase();
+    if lower.contains("chorus") || lower.contains("refrain") {
+        ("start_of_chorus", "end_of_chorus")
+    } else if lower.contains("bridge") {
+        ("start_of_bridge", "end_of_bridge")
+    } else if lower.contains("intro") || lower.contains("outro") {
+        ("start_of_verse", "end_of_verse")
+    } else {
+        // Default to verse
+        ("start_of_verse", "end_of_verse")
+    }
+}
+
+/// Heuristic: is this a words string likely to be a section label?
+fn looks_like_section_marker(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    matches!(
+        lower.as_str(),
+        "verse"
+            | "chorus"
+            | "bridge"
+            | "intro"
+            | "outro"
+            | "pre-chorus"
+            | "prechorus"
+            | "interlude"
+            | "coda"
+            | "tag"
+    ) || lower.starts_with("verse ")
+        || lower.starts_with("chorus ")
+}
+
+/// Push a directive line onto `lines`.
+fn emit_directive(lines: &mut Vec<Line>, name: &str, value: Option<&str>) {
+    let dir = match value {
+        Some(v) => Directive::with_value(name, v),
+        None => Directive::name_only(name),
+    };
+    lines.push(Line::Directive(dir));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fifths_to_key_major() {
+        assert_eq!(fifths_to_key(0, "major"), "C");
+        assert_eq!(fifths_to_key(1, "major"), "G");
+        assert_eq!(fifths_to_key(-1, "major"), "F");
+        assert_eq!(fifths_to_key(2, "major"), "D");
+        assert_eq!(fifths_to_key(-2, "major"), "Bb");
+        assert_eq!(fifths_to_key(4, "major"), "E");
+    }
+
+    #[test]
+    fn fifths_to_key_minor() {
+        assert_eq!(fifths_to_key(0, "minor"), "Cm");
+        assert_eq!(fifths_to_key(3, "minor"), "Am");
+    }
+
+    #[test]
+    fn musicxml_kind_suffix() {
+        assert_eq!(musicxml_kind_to_suffix("major"), "");
+        assert_eq!(musicxml_kind_to_suffix("minor"), "m");
+        assert_eq!(musicxml_kind_to_suffix("dominant"), "7");
+        assert_eq!(musicxml_kind_to_suffix("major-seventh"), "maj7");
+        assert_eq!(musicxml_kind_to_suffix("diminished"), "dim");
+        assert_eq!(musicxml_kind_to_suffix("suspended-fourth"), "sus4");
+    }
+
+    #[test]
+    fn simple_import() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <work><work-title>Test Song</work-title></work>
+  <identification>
+    <creator type="composer">Test Artist</creator>
+  </identification>
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <key><fifths>0</fifths><mode>major</mode></key>
+      </attributes>
+      <direction><sound tempo="120"/></direction>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <duration>1</duration>
+        <lyric><syllabic>single</syllabic><text>Hello</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <duration>1</duration>
+        <lyric><syllabic>single</syllabic><text>world</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>"#;
+        let song = from_musicxml(xml).unwrap();
+        assert_eq!(song.metadata.title.as_deref(), Some("Test Song"));
+        assert_eq!(
+            song.metadata.artists.first().map(String::as_str),
+            Some("Test Artist")
+        );
+        assert_eq!(song.metadata.key.as_deref(), Some("C"));
+        assert_eq!(song.metadata.tempo.as_deref(), Some("120"));
+
+        // Should have one lyrics line with two segments
+        let lyrics: Vec<&Line> = song
+            .lines
+            .iter()
+            .filter(|l| matches!(l, Line::Lyrics(_)))
+            .collect();
+        assert_eq!(lyrics.len(), 1);
+        if let Line::Lyrics(ll) = lyrics[0] {
+            assert_eq!(ll.segments.len(), 2);
+            assert_eq!(
+                ll.segments[0].chord.as_ref().map(|c| c.name.as_str()),
+                Some("C")
+            );
+            assert!(ll.segments[0].text.contains("Hello"));
+            assert_eq!(
+                ll.segments[1].chord.as_ref().map(|c| c.name.as_str()),
+                Some("G")
+            );
+            assert!(ll.segments[1].text.contains("world"));
+        }
+    }
+
+    #[test]
+    fn import_sharp_flat_chords() {
+        let xml = r#"<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name/></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <harmony>
+        <root><root-step>F</root-step><root-alter>1</root-alter></root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <note>
+        <duration>1</duration>
+        <lyric><syllabic>single</syllabic><text>hi</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>B</root-step><root-alter>-1</root-alter></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <duration>1</duration>
+        <lyric><syllabic>single</syllabic><text>there</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>"#;
+        let song = from_musicxml(xml).unwrap();
+        let lyrics: Vec<&Line> = song
+            .lines
+            .iter()
+            .filter(|l| matches!(l, Line::Lyrics(_)))
+            .collect();
+        assert_eq!(lyrics.len(), 1);
+        if let Line::Lyrics(ll) = lyrics[0] {
+            assert_eq!(
+                ll.segments[0].chord.as_ref().map(|c| c.name.as_str()),
+                Some("F#m")
+            );
+            assert_eq!(
+                ll.segments[1].chord.as_ref().map(|c| c.name.as_str()),
+                Some("Bb")
+            );
+        }
+    }
+}

--- a/crates/convert-musicxml/src/import.rs
+++ b/crates/convert-musicxml/src/import.rs
@@ -125,9 +125,14 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
             }
             if !capo_emitted {
                 if let Some(capo_text) = attrs.text_at(&["capo"]) {
-                    if !capo_text.is_empty() && capo_text != "0" {
-                        emit_directive(&mut song.lines, "capo", Some(capo_text));
-                        capo_emitted = true;
+                    // Validate: capo must be a non-negative integer in [1, 24].
+                    // Values outside this range are silently ignored — a capo
+                    // of 0 means "no capo" and > 24 is beyond any real guitar fret.
+                    if let Ok(capo_val) = capo_text.trim().parse::<u8>() {
+                        if (1..=24).contains(&capo_val) {
+                            emit_directive(&mut song.lines, "capo", Some(capo_text.trim()));
+                            capo_emitted = true;
+                        }
                     }
                 }
             }
@@ -145,13 +150,15 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
 
         // --- directions (tempo, rehearsal marks) ----------------------------
         for direction in measure.children_named("direction") {
-            // Tempo
+            // Tempo — validate that the value is a positive finite number before storing.
             if !tempo_emitted {
                 if let Some(sound) = direction.child("sound") {
                     if let Some(tempo) = sound.attr("tempo") {
-                        if !tempo.is_empty() {
-                            song.metadata.tempo = Some(tempo.to_string());
-                            tempo_emitted = true;
+                        if let Ok(bpm) = tempo.trim().parse::<f64>() {
+                            if bpm > 0.0 && bpm.is_finite() {
+                                song.metadata.tempo = Some(tempo.trim().to_string());
+                                tempo_emitted = true;
+                            }
                         }
                     }
                 }
@@ -187,13 +194,15 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
                 }
             }
 
-            // Bare <sound tempo="..."> inside <direction>
+            // Bare <sound tempo="..."> inside <direction> (second position)
             if let Some(sound) = direction.child("sound") {
                 if !tempo_emitted {
                     if let Some(tempo) = sound.attr("tempo") {
-                        if !tempo.is_empty() {
-                            song.metadata.tempo = Some(tempo.to_string());
-                            tempo_emitted = true;
+                        if let Ok(bpm) = tempo.trim().parse::<f64>() {
+                            if bpm > 0.0 && bpm.is_finite() {
+                                song.metadata.tempo = Some(tempo.trim().to_string());
+                                tempo_emitted = true;
+                            }
                         }
                     }
                 }

--- a/crates/convert-musicxml/src/lib.rs
+++ b/crates/convert-musicxml/src/lib.rs
@@ -1,0 +1,56 @@
+//! MusicXML ↔ ChordPro bidirectional converter.
+//!
+//! This crate provides:
+//!
+//! - [`from_musicxml`]: parse a MusicXML 4.0 document into a ChordSketch
+//!   [`Song`](chordsketch_core::ast::Song) AST
+//! - [`to_musicxml`]: serialize a [`Song`](chordsketch_core::ast::Song) to a
+//!   MusicXML 4.0 string
+//!
+//! # What is preserved across a round-trip
+//!
+//! - Song title and composer/artist metadata
+//! - Key signature and tempo
+//! - Chord symbols (root, accidental, quality, extension, bass note)
+//! - Lyrics text
+//! - Section structure (verse/chorus/bridge)
+//!
+//! # Limitations
+//!
+//! - Only the first `<part>` of a multi-part MusicXML file is imported.
+//! - Rhythmic values are not preserved: all exported notes are whole notes.
+//! - Staff notation (pitches, durations, articulations) is discarded on import.
+//! - Chord diagrams, PDF layout settings, and inline markup are not exported.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use chordsketch_convert_musicxml::{from_musicxml, to_musicxml};
+//! use chordsketch_core::ast::{Song, Chord, Line, LyricsLine, LyricsSegment};
+//!
+//! // Build a simple song
+//! let mut song = Song::new();
+//! song.metadata.title = Some("My Song".to_string());
+//! let mut ll = LyricsLine::new();
+//! ll.segments = vec![
+//!     LyricsSegment::new(Some(Chord::new("C")), "Hello "),
+//!     LyricsSegment::new(Some(Chord::new("G")), "world"),
+//! ];
+//! song.lines.push(Line::Lyrics(ll));
+//!
+//! // Export to MusicXML
+//! let xml = to_musicxml(&song);
+//! assert!(xml.contains("<root-step>C</root-step>"));
+//! assert!(xml.contains("<text>Hello</text>"));
+//!
+//! // Import back
+//! let reimported = from_musicxml(&xml).unwrap();
+//! assert_eq!(reimported.metadata.title.as_deref(), Some("My Song"));
+//! ```
+
+pub use export::to_musicxml;
+pub use import::{ImportError, from_musicxml};
+
+mod export;
+mod import;
+mod xml;

--- a/crates/convert-musicxml/src/xml.rs
+++ b/crates/convert-musicxml/src/xml.rs
@@ -1,0 +1,593 @@
+//! Minimal XML DOM builder for MusicXML files.
+//!
+//! This is a purpose-built parser that handles the subset of XML used by
+//! MusicXML 4.0 files. It is not a general-purpose XML parser and does not
+//! attempt to implement the full XML specification.
+//!
+//! # Supported features
+//!
+//! - XML declarations (`<?xml ...?>`)
+//! - DOCTYPE declarations (skipped)
+//! - Comments (`<!-- ... -->`) — skipped
+//! - Processing instructions (`<?...?>`) — skipped
+//! - Element start/end tags
+//! - Self-closing elements (`<tag/>`)
+//! - Attributes with single or double quoted values
+//! - Text content
+//! - CDATA sections (`<![CDATA[...]]>`) — treated as text
+//! - Standard entity references (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`)
+
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A parsed XML element.
+#[derive(Debug, Default)]
+pub(crate) struct Element {
+    /// The element's tag name (without namespace prefix).
+    pub name: String,
+    /// Attribute map (namespace prefixes stripped from attribute names).
+    pub attrs: HashMap<String, String>,
+    /// Concatenated text content of direct text nodes (trimmed).
+    pub text: String,
+    /// Child elements in document order.
+    pub children: Vec<Element>,
+}
+
+impl Element {
+    /// Returns the first child element with the given local name, if any.
+    pub fn child(&self, name: &str) -> Option<&Element> {
+        self.children.iter().find(|c| c.name == name)
+    }
+
+    /// Returns an iterator over all child elements with the given local name.
+    pub fn children_named<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a Element> + 'a {
+        self.children.iter().filter(move |c| c.name == name)
+    }
+
+    /// Navigates `path` from this element and returns the element at that
+    /// path, or `None` if any step is missing.
+    pub fn at_path(&self, path: &[&str]) -> Option<&Element> {
+        match path {
+            [] => Some(self),
+            [first, rest @ ..] => self.child(first)?.at_path(rest),
+        }
+    }
+
+    /// Returns the trimmed text content of the element at `path`.
+    pub fn text_at(&self, path: &[&str]) -> Option<&str> {
+        Some(self.at_path(path)?.text.trim())
+    }
+
+    /// Returns the value of the attribute with the given local name.
+    pub fn attr(&self, name: &str) -> Option<&str> {
+        self.attrs.get(name).map(String::as_str)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/// Parse an XML string into an element tree.
+///
+/// Returns the root element, or an error message if parsing fails.
+pub(crate) fn parse(xml: &str) -> Result<Element, String> {
+    let mut p = Parser {
+        src: xml.as_bytes(),
+        pos: 0,
+    };
+    p.skip_bom();
+    p.skip_prolog()?;
+    p.skip_whitespace_and_comments()?;
+    p.parse_element()
+}
+
+struct Parser<'a> {
+    src: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    // --- helpers -----------------------------------------------------------
+
+    fn remaining(&self) -> usize {
+        self.src.len().saturating_sub(self.pos)
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.src.get(self.pos).copied()
+    }
+
+    fn starts_with(&self, pat: &[u8]) -> bool {
+        self.src.get(self.pos..).is_some_and(|s| s.starts_with(pat))
+    }
+
+    fn advance(&mut self) {
+        if self.pos < self.src.len() {
+            self.pos += 1;
+        }
+    }
+
+    fn consume_char(&mut self) -> Option<u8> {
+        let b = self.src.get(self.pos).copied()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn expect(&mut self, pat: &[u8]) -> Result<(), String> {
+        if self.starts_with(pat) {
+            self.pos += pat.len();
+            Ok(())
+        } else {
+            let got = &self.src[self.pos..self.pos.min(self.src.len()).min(self.pos + 8)];
+            Err(format!(
+                "expected {:?} at offset {} but got {:?}",
+                std::str::from_utf8(pat).unwrap_or("?"),
+                self.pos,
+                std::str::from_utf8(got).unwrap_or("?")
+            ))
+        }
+    }
+
+    fn slice_str(&self, start: usize, end: usize) -> &'a str {
+        std::str::from_utf8(&self.src[start..end]).unwrap_or("")
+    }
+
+    // --- skip utilities ----------------------------------------------------
+
+    fn skip_bom(&mut self) {
+        // UTF-8 BOM: EF BB BF
+        if self.starts_with(&[0xEF, 0xBB, 0xBF]) {
+            self.pos += 3;
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while let Some(b) = self.peek() {
+            if b.is_ascii_whitespace() {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Skip whitespace and XML comments.
+    fn skip_whitespace_and_comments(&mut self) -> Result<(), String> {
+        loop {
+            self.skip_whitespace();
+            if self.starts_with(b"<!--") {
+                self.skip_comment()?;
+            } else {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn skip_comment(&mut self) -> Result<(), String> {
+        self.expect(b"<!--")?;
+        loop {
+            if self.remaining() < 3 {
+                return Err("unterminated comment".to_string());
+            }
+            if self.starts_with(b"-->") {
+                self.pos += 3;
+                return Ok(());
+            }
+            self.advance();
+        }
+    }
+
+    /// Skip the XML prolog: declaration, DOCTYPE, and leading comments/PIs.
+    fn skip_prolog(&mut self) -> Result<(), String> {
+        loop {
+            self.skip_whitespace();
+            if self.starts_with(b"<?") {
+                // Processing instruction or XML declaration — skip to ?>
+                self.pos += 2;
+                loop {
+                    if self.remaining() < 2 {
+                        return Err("unterminated processing instruction".to_string());
+                    }
+                    if self.starts_with(b"?>") {
+                        self.pos += 2;
+                        break;
+                    }
+                    self.advance();
+                }
+            } else if self.starts_with(b"<!--") {
+                self.skip_comment()?;
+            } else if self.starts_with(b"<!DOCTYPE") || self.starts_with(b"<!doctype") {
+                self.skip_doctype()?;
+            } else {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn skip_doctype(&mut self) -> Result<(), String> {
+        // Skip everything until the closing `>`, handling nested `[...]`.
+        while self.peek().is_some() && self.peek() != Some(b'<') {
+            self.advance();
+        }
+        // Advance past the initial `<!` if we haven't yet
+        if self.starts_with(b"<!") {
+            self.advance();
+            self.advance();
+        }
+        let mut depth = 1i32;
+        loop {
+            match self.consume_char() {
+                None => return Err("unterminated DOCTYPE".to_string()),
+                Some(b'[') => depth += 1,
+                Some(b']') => depth -= 1,
+                Some(b'>') if depth <= 1 => return Ok(()),
+                _ => {}
+            }
+        }
+    }
+
+    // --- main parser -------------------------------------------------------
+
+    /// Parse an element: `<name attrs> children </name>` or `<name attrs/>`.
+    fn parse_element(&mut self) -> Result<Element, String> {
+        self.skip_whitespace_and_comments()?;
+
+        // Consume `<`
+        if self.peek() != Some(b'<') {
+            return Err(format!(
+                "expected '<' at offset {} but got {:?}",
+                self.pos,
+                self.peek().map(char::from)
+            ));
+        }
+        self.advance();
+
+        // Read tag name (may contain `:` for namespaced elements — keep it)
+        let name_start = self.pos;
+        while let Some(b) = self.peek() {
+            if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b':' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        if self.pos == name_start {
+            return Err(format!("empty tag name at offset {}", self.pos));
+        }
+        let raw_name = self.slice_str(name_start, self.pos).to_string();
+        // Strip namespace prefix for usability (keep local name only)
+        let name = local_name(&raw_name).to_string();
+
+        // Read attributes
+        let attrs = self.parse_attrs()?;
+
+        self.skip_whitespace();
+
+        // Self-closing?
+        if self.starts_with(b"/>") {
+            self.pos += 2;
+            return Ok(Element {
+                name,
+                attrs,
+                text: String::new(),
+                children: Vec::new(),
+            });
+        }
+
+        self.expect(b">")?;
+
+        // Read children
+        let (text, children) = self.parse_children(&raw_name)?;
+
+        Ok(Element {
+            name,
+            attrs,
+            text,
+            children,
+        })
+    }
+
+    fn parse_attrs(&mut self) -> Result<HashMap<String, String>, String> {
+        let mut attrs = HashMap::new();
+        loop {
+            self.skip_whitespace();
+            // Stop at `>` or `/>`
+            if self.peek() == Some(b'>') || self.starts_with(b"/>") {
+                break;
+            }
+            if self.peek().is_none() {
+                return Err("unexpected EOF inside tag".to_string());
+            }
+            // Read attribute name
+            let aname_start = self.pos;
+            while let Some(b) = self.peek() {
+                if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b':' {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            if self.pos == aname_start {
+                // Skip any unexpected character
+                self.advance();
+                continue;
+            }
+            let raw_aname = self.slice_str(aname_start, self.pos).to_string();
+            let aname = local_name(&raw_aname).to_string();
+
+            self.skip_whitespace();
+            if self.peek() != Some(b'=') {
+                // Boolean attribute (no value) — store empty string
+                attrs.insert(aname, String::new());
+                continue;
+            }
+            self.advance(); // consume `=`
+            self.skip_whitespace();
+
+            // Read value
+            let quote = match self.peek() {
+                Some(q @ b'"') | Some(q @ b'\'') => {
+                    self.advance();
+                    q
+                }
+                _ => {
+                    return Err(format!(
+                        "expected quote for attribute value at offset {}",
+                        self.pos
+                    ));
+                }
+            };
+            let vstart = self.pos;
+            while let Some(b) = self.peek() {
+                if b == quote {
+                    break;
+                }
+                self.advance();
+            }
+            let raw_val = self.slice_str(vstart, self.pos).to_string();
+            if self.peek() == Some(quote) {
+                self.advance(); // consume closing quote
+            }
+            attrs.insert(aname, decode_entities(&raw_val));
+        }
+        Ok(attrs)
+    }
+
+    /// Parse children of an element with tag `parent_raw_name`.
+    ///
+    /// Returns `(text_content, child_elements)`.
+    fn parse_children(&mut self, parent_raw_name: &str) -> Result<(String, Vec<Element>), String> {
+        let parent_local = local_name(parent_raw_name);
+        let mut text = String::new();
+        let mut children = Vec::new();
+
+        loop {
+            // CDATA
+            if self.starts_with(b"<![CDATA[") {
+                self.pos += 9;
+                let tstart = self.pos;
+                loop {
+                    if self.remaining() < 3 {
+                        return Err("unterminated CDATA section".to_string());
+                    }
+                    if self.starts_with(b"]]>") {
+                        let t = self.slice_str(tstart, self.pos);
+                        text.push_str(t);
+                        self.pos += 3;
+                        break;
+                    }
+                    self.advance();
+                }
+                continue;
+            }
+
+            // Comment
+            if self.starts_with(b"<!--") {
+                self.skip_comment()?;
+                continue;
+            }
+
+            // Processing instruction
+            if self.starts_with(b"<?") {
+                self.pos += 2;
+                loop {
+                    if self.remaining() < 2 {
+                        return Err("unterminated PI in element body".to_string());
+                    }
+                    if self.starts_with(b"?>") {
+                        self.pos += 2;
+                        break;
+                    }
+                    self.advance();
+                }
+                continue;
+            }
+
+            // End tag
+            if self.starts_with(b"</") {
+                self.pos += 2;
+                self.skip_whitespace();
+                let tstart = self.pos;
+                while let Some(b) = self.peek() {
+                    if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b':'
+                    {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+                let closing_raw = self.slice_str(tstart, self.pos);
+                let closing_local = local_name(closing_raw);
+                self.skip_whitespace();
+                // Consume `>`
+                if self.peek() == Some(b'>') {
+                    self.advance();
+                }
+                if closing_local != parent_local {
+                    // Mismatched end tag — tolerate by ignoring (robustness)
+                }
+                break;
+            }
+
+            // Child element
+            if self.peek() == Some(b'<') {
+                let child = self.parse_element()?;
+                children.push(child);
+                continue;
+            }
+
+            // Text
+            if self.peek().is_none() {
+                break;
+            }
+            let tstart = self.pos;
+            while let Some(b) = self.peek() {
+                if b == b'<' {
+                    break;
+                }
+                self.advance();
+            }
+            let raw_text = self.slice_str(tstart, self.pos);
+            let decoded = decode_entities(raw_text);
+            text.push_str(&decoded);
+        }
+
+        Ok((text.trim().to_string(), children))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Strip the namespace prefix from a qualified name, returning the local name.
+///
+/// `"ns:foo"` → `"foo"`, `"foo"` → `"foo"`.
+fn local_name(name: &str) -> &str {
+    name.rfind(':').map_or(name, |i| &name[i + 1..])
+}
+
+/// Decode the five standard XML predefined entity references.
+fn decode_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '&' {
+            let rest: String = chars.as_str().to_string();
+            if let Some(semi) = rest.find(';') {
+                let entity = &rest[..semi];
+                let replacement = match entity {
+                    "amp" => "&",
+                    "lt" => "<",
+                    "gt" => ">",
+                    "quot" => "\"",
+                    "apos" => "'",
+                    _ => {
+                        out.push('&');
+                        continue;
+                    }
+                };
+                out.push_str(replacement);
+                // Advance past the entity + semicolon
+                for _ in 0..semi + 1 {
+                    chars.next();
+                }
+            } else {
+                out.push('&');
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_element() {
+        let doc = "<root><child>hello</child></root>";
+        let root = parse(doc).unwrap();
+        assert_eq!(root.name, "root");
+        assert_eq!(root.child("child").unwrap().text, "hello");
+    }
+
+    #[test]
+    fn parse_self_closing() {
+        let doc = "<root><br/><hr /></root>";
+        let root = parse(doc).unwrap();
+        assert_eq!(root.children.len(), 2);
+        assert_eq!(root.children[0].name, "br");
+        assert_eq!(root.children[1].name, "hr");
+    }
+
+    #[test]
+    fn parse_attributes() {
+        let doc = r#"<root id="42" name='hello'></root>"#;
+        let root = parse(doc).unwrap();
+        assert_eq!(root.attr("id"), Some("42"));
+        assert_eq!(root.attr("name"), Some("hello"));
+    }
+
+    #[test]
+    fn parse_entities() {
+        let doc = "<root>&amp;&lt;&gt;&quot;&apos;</root>";
+        let root = parse(doc).unwrap();
+        assert_eq!(root.text, "&<>\"'");
+    }
+
+    #[test]
+    fn parse_with_prolog() {
+        let doc = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root PUBLIC "-//Test//DTD//EN" "test.dtd">
+<!-- a comment -->
+<root><item>42</item></root>"#;
+        let root = parse(doc).unwrap();
+        assert_eq!(root.name, "root");
+        assert_eq!(root.child("item").unwrap().text, "42");
+    }
+
+    #[test]
+    fn parse_namespace_prefix() {
+        let doc = r#"<ns:root xmlns:ns="http://example.com"><ns:child>text</ns:child></ns:root>"#;
+        let root = parse(doc).unwrap();
+        assert_eq!(root.name, "root");
+        assert_eq!(root.child("child").unwrap().text, "text");
+    }
+
+    #[test]
+    fn parse_cdata() {
+        let doc = "<root><![CDATA[<not-a-tag>]]></root>";
+        let root = parse(doc).unwrap();
+        assert_eq!(root.text, "<not-a-tag>");
+    }
+
+    #[test]
+    fn at_path() {
+        let doc = "<a><b><c>deep</c></b></a>";
+        let root = parse(doc).unwrap();
+        assert_eq!(root.text_at(&["b", "c"]), Some("deep"));
+    }
+
+    #[test]
+    fn decode_entities_standalone() {
+        assert_eq!(decode_entities("a &amp; b"), "a & b");
+        assert_eq!(decode_entities("&lt;tag&gt;"), "<tag>");
+        assert_eq!(decode_entities("no entities"), "no entities");
+    }
+}

--- a/crates/convert-musicxml/tests/fixtures/metadata.xml
+++ b/crates/convert-musicxml/tests/fixtures/metadata.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Amazing Grace</work-title>
+  </work>
+  <identification>
+    <creator type="composer">John Newton</creator>
+    <creator type="lyricist">John Newton</creator>
+  </identification>
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>1</fifths><mode>major</mode></key>
+        <time><beats>3</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome><beat-unit>quarter</beat-unit><per-minute>72</per-minute></metronome>
+        </direction-type>
+        <sound tempo="72"/>
+      </direction>
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <lyric number="1"><syllabic>single</syllabic><text>A</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <lyric number="1"><syllabic>begin</syllabic><text>ma</text></lyric>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <lyric number="1"><syllabic>end</syllabic><text>zing</text></lyric>
+      </note>
+    </measure>
+    <measure number="2">
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>G</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <lyric number="1"><syllabic>single</syllabic><text>grace</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/crates/convert-musicxml/tests/fixtures/sections.xml
+++ b/crates/convert-musicxml/tests/fixtures/sections.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Section Demo</work-title>
+  </work>
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <!-- Verse section -->
+    <measure number="1">
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>Verse 1</rehearsal>
+        </direction-type>
+      </direction>
+      <harmony>
+        <root><root-step>A</root-step></root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>Verse</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>F</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>line</text></lyric>
+      </note>
+    </measure>
+    <!-- Chorus section -->
+    <measure number="2">
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>Chorus</rehearsal>
+        </direction-type>
+      </direction>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>Chorus</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>line</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/crates/convert-musicxml/tests/fixtures/simple.xml
+++ b/crates/convert-musicxml/tests/fixtures/simple.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>Hello</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>A</root-step></root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>world</text></lyric>
+      </note>
+    </measure>
+    <measure number="2">
+      <harmony>
+        <root><root-step>F</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>Good</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>bye</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/crates/convert-musicxml/tests/integration_test.rs
+++ b/crates/convert-musicxml/tests/integration_test.rs
@@ -309,6 +309,79 @@ fn round_trip_preserves_lyrics() {
 }
 
 // ---------------------------------------------------------------------------
+// Section end directives
+// ---------------------------------------------------------------------------
+
+/// Regression test: imported sections must have explicit `{end_of_*}` directives.
+///
+/// Previously `map_section_label` returned the end-directive name but it was
+/// always discarded with `let _ = section_end`, so the resulting ChordPro had
+/// `{start_of_verse}` / `{start_of_chorus}` without any closing directives.
+#[test]
+fn sections_have_end_directives() {
+    let xml = fixture("sections.xml");
+    let song = from_musicxml(&xml).expect("sections.xml should parse");
+
+    use chordsketch_core::ast::DirectiveKind;
+
+    let has_verse_end = song.lines.iter().any(|l| {
+        matches!(
+            l,
+            Line::Directive(d) if d.kind == DirectiveKind::EndOfVerse
+        )
+    });
+    let has_chorus_end = song.lines.iter().any(|l| {
+        matches!(
+            l,
+            Line::Directive(d) if d.kind == DirectiveKind::EndOfChorus
+        )
+    });
+
+    assert!(
+        has_verse_end,
+        "expected end_of_verse directive after verse section"
+    );
+    assert!(
+        has_chorus_end,
+        "expected end_of_chorus directive after chorus section"
+    );
+}
+
+/// Sections must be ordered correctly: start → content → end.
+#[test]
+fn section_end_follows_content() {
+    let xml = fixture("sections.xml");
+    let song = from_musicxml(&xml).expect("sections.xml should parse");
+
+    use chordsketch_core::ast::DirectiveKind;
+
+    // Collect line positions for start_of_verse, lyrics, and end_of_verse.
+    let verse_start = song
+        .lines
+        .iter()
+        .position(|l| matches!(l, Line::Directive(d) if d.kind == DirectiveKind::StartOfVerse));
+    let verse_end = song
+        .lines
+        .iter()
+        .position(|l| matches!(l, Line::Directive(d) if d.kind == DirectiveKind::EndOfVerse));
+    let first_lyrics = song.lines.iter().position(|l| matches!(l, Line::Lyrics(_)));
+
+    let (start, end, lyrics) = (
+        verse_start.expect("start_of_verse not found"),
+        verse_end.expect("end_of_verse not found"),
+        first_lyrics.expect("no lyrics found"),
+    );
+    assert!(
+        start < lyrics,
+        "start_of_verse must precede lyrics (start={start}, lyrics={lyrics})"
+    );
+    assert!(
+        lyrics < end,
+        "lyrics must precede end_of_verse (lyrics={lyrics}, end={end})"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Error cases
 // ---------------------------------------------------------------------------
 

--- a/crates/convert-musicxml/tests/integration_test.rs
+++ b/crates/convert-musicxml/tests/integration_test.rs
@@ -1,0 +1,327 @@
+//! Integration tests for the MusicXML ↔ ChordPro converter.
+//!
+//! Tests cover three fixture files plus a round-trip (ChordPro → MusicXML → ChordPro).
+
+use chordsketch_convert_musicxml::{from_musicxml, to_musicxml};
+use chordsketch_core::ast::Line;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn fixture(name: &str) -> String {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read fixture {name}: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: simple.xml
+// ---------------------------------------------------------------------------
+
+#[test]
+fn simple_import_chords() {
+    let xml = fixture("simple.xml");
+    let song = from_musicxml(&xml).expect("simple.xml should parse");
+
+    let lyrics: Vec<&Line> = song
+        .lines
+        .iter()
+        .filter(|l| matches!(l, Line::Lyrics(_)))
+        .collect();
+
+    // Two measures → two lyric lines
+    assert_eq!(lyrics.len(), 2, "expected 2 lyric lines");
+
+    // First line: [C]Hello [Am]world
+    if let Line::Lyrics(ll) = lyrics[0] {
+        assert_eq!(ll.segments.len(), 2);
+        assert_eq!(
+            ll.segments[0].chord.as_ref().map(|c| c.name.as_str()),
+            Some("C")
+        );
+        assert!(
+            ll.segments[0].text.contains("Hello"),
+            "expected 'Hello' in first segment"
+        );
+        assert_eq!(
+            ll.segments[1].chord.as_ref().map(|c| c.name.as_str()),
+            Some("Am")
+        );
+        assert!(
+            ll.segments[1].text.contains("world"),
+            "expected 'world' in second segment"
+        );
+    }
+
+    // Second line: [F]Good [G]bye
+    if let Line::Lyrics(ll) = lyrics[1] {
+        assert_eq!(ll.segments.len(), 2);
+        assert_eq!(
+            ll.segments[0].chord.as_ref().map(|c| c.name.as_str()),
+            Some("F")
+        );
+        assert_eq!(
+            ll.segments[1].chord.as_ref().map(|c| c.name.as_str()),
+            Some("G")
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: metadata.xml
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metadata_import() {
+    let xml = fixture("metadata.xml");
+    let song = from_musicxml(&xml).expect("metadata.xml should parse");
+
+    assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
+    assert!(
+        song.metadata.artists.iter().any(|a| a.contains("Newton"))
+            || song.metadata.lyricists.iter().any(|l| l.contains("Newton")),
+        "expected John Newton as composer or lyricist"
+    );
+    assert_eq!(
+        song.metadata.key.as_deref(),
+        Some("G"),
+        "key should be G major (1 sharp)"
+    );
+    assert_eq!(song.metadata.tempo.as_deref(), Some("72"));
+}
+
+#[test]
+fn metadata_import_lyrics_content() {
+    let xml = fixture("metadata.xml");
+    let song = from_musicxml(&xml).expect("metadata.xml should parse");
+
+    // Should have lyric content including the word "grace"
+    let all_text: String = song
+        .lines
+        .iter()
+        .filter_map(|l| {
+            if let Line::Lyrics(ll) = l {
+                Some(
+                    ll.segments
+                        .iter()
+                        .map(|s| s.text.as_str())
+                        .collect::<String>(),
+                )
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        all_text.to_lowercase().contains("grace"),
+        "lyrics should contain 'grace'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: sections.xml
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sections_import_structure() {
+    let xml = fixture("sections.xml");
+    let song = from_musicxml(&xml).expect("sections.xml should parse");
+
+    assert_eq!(song.metadata.title.as_deref(), Some("Section Demo"));
+
+    // Should have section directives
+    let has_section_start = song.lines.iter().any(|l| {
+        if let Line::Directive(d) = l {
+            use chordsketch_core::ast::DirectiveKind;
+            matches!(
+                d.kind,
+                DirectiveKind::StartOfVerse | DirectiveKind::StartOfChorus
+            )
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_section_start,
+        "expected at least one section start directive"
+    );
+}
+
+#[test]
+fn sections_import_chorus_label() {
+    let xml = fixture("sections.xml");
+    let song = from_musicxml(&xml).expect("sections.xml should parse");
+
+    // The Chorus rehearsal mark should produce a start_of_chorus directive
+    let has_chorus = song.lines.iter().any(|l| {
+        if let Line::Directive(d) = l {
+            use chordsketch_core::ast::DirectiveKind;
+            d.kind == DirectiveKind::StartOfChorus
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_chorus,
+        "expected start_of_chorus directive from 'Chorus' rehearsal mark"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: ChordPro → MusicXML → ChordPro
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_trip_preserves_title() {
+    let mut song = chordsketch_core::ast::Song::new();
+    song.metadata.title = Some("Round Trip Song".to_string());
+    song.metadata.artists = vec!["Test Artist".to_string()];
+    song.metadata.key = Some("Am".to_string());
+    song.metadata.tempo = Some("100".to_string());
+
+    let mut ll = chordsketch_core::ast::LyricsLine::new();
+    ll.segments = vec![
+        chordsketch_core::ast::LyricsSegment::new(
+            Some(chordsketch_core::ast::Chord::new("Am")),
+            "Hello ",
+        ),
+        chordsketch_core::ast::LyricsSegment::new(
+            Some(chordsketch_core::ast::Chord::new("Dm")),
+            "world ",
+        ),
+        chordsketch_core::ast::LyricsSegment::new(
+            Some(chordsketch_core::ast::Chord::new("E")),
+            "yeah",
+        ),
+    ];
+    song.lines.push(Line::Lyrics(ll));
+
+    // Export to MusicXML
+    let xml = to_musicxml(&song);
+
+    // Import back
+    let reimported = from_musicxml(&xml).expect("round-trip should succeed");
+
+    // Title preserved
+    assert_eq!(
+        reimported.metadata.title.as_deref(),
+        Some("Round Trip Song"),
+        "title not preserved in round-trip"
+    );
+
+    // Key preserved
+    assert_eq!(
+        reimported.metadata.key.as_deref(),
+        Some("Am"),
+        "key not preserved in round-trip"
+    );
+
+    // Tempo preserved
+    assert_eq!(
+        reimported.metadata.tempo.as_deref(),
+        Some("100"),
+        "tempo not preserved in round-trip"
+    );
+
+    // Chords preserved
+    let lyrics: Vec<&Line> = reimported
+        .lines
+        .iter()
+        .filter(|l| matches!(l, Line::Lyrics(_)))
+        .collect();
+    assert!(
+        !lyrics.is_empty(),
+        "expected at least one lyrics line after round-trip"
+    );
+
+    if let Line::Lyrics(ll) = lyrics[0] {
+        assert!(
+            ll.segments
+                .iter()
+                .any(|s| s.chord.as_ref().map(|c| c.name.as_str()) == Some("Am")),
+            "Am chord should survive round-trip"
+        );
+        assert!(
+            ll.segments
+                .iter()
+                .any(|s| s.chord.as_ref().map(|c| c.name.as_str()) == Some("Dm")),
+            "Dm chord should survive round-trip"
+        );
+        assert!(
+            ll.segments
+                .iter()
+                .any(|s| s.chord.as_ref().map(|c| c.name.as_str()) == Some("E")),
+            "E chord should survive round-trip"
+        );
+    }
+}
+
+#[test]
+fn round_trip_preserves_lyrics() {
+    let mut song = chordsketch_core::ast::Song::new();
+    let mut ll = chordsketch_core::ast::LyricsLine::new();
+    ll.segments = vec![
+        chordsketch_core::ast::LyricsSegment::new(
+            Some(chordsketch_core::ast::Chord::new("C")),
+            "Twinkle ",
+        ),
+        chordsketch_core::ast::LyricsSegment::new(None, "twinkle "),
+        chordsketch_core::ast::LyricsSegment::new(
+            Some(chordsketch_core::ast::Chord::new("G")),
+            "little ",
+        ),
+        chordsketch_core::ast::LyricsSegment::new(None, "star"),
+    ];
+    song.lines.push(Line::Lyrics(ll));
+
+    let xml = to_musicxml(&song);
+    let reimported = from_musicxml(&xml).expect("lyrics round-trip should succeed");
+
+    let all_text: String = reimported
+        .lines
+        .iter()
+        .filter_map(|l| {
+            if let Line::Lyrics(ll) = l {
+                Some(
+                    ll.segments
+                        .iter()
+                        .map(|s| s.text.as_str())
+                        .collect::<String>(),
+                )
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        all_text.contains("Twinkle"),
+        "lyrics 'Twinkle' should survive round-trip"
+    );
+    assert!(
+        all_text.contains("star"),
+        "lyrics 'star' should survive round-trip"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wrong_root_element_returns_error() {
+    let xml = r#"<?xml version="1.0"?><score-timewise></score-timewise>"#;
+    assert!(
+        from_musicxml(xml).is_err(),
+        "score-timewise should return an error (only score-partwise is supported)"
+    );
+}
+
+#[test]
+fn invalid_xml_returns_error() {
+    assert!(from_musicxml("<unclosed").is_err());
+}


### PR DESCRIPTION
## What

Adds a new zero-dependency `chordsketch-convert-musicxml` crate implementing bidirectional conversion between MusicXML 4.0 and ChordPro format, plus CLI integration.

## Why

MusicXML is the standard interchange format for notation software (MuseScore, Sibelius, Finale). This allows users to bring existing scores into ChordSketch and export ChordSketch songs to notation software. Closes #1143.

## New crate: `crates/convert-musicxml`

**Zero external dependencies.** Contains:

- `xml.rs` — minimal DOM builder (handles declarations, DOCTYPE, comments, CDATA, namespaced elements, the 5 predefined entities)
- `import.rs` — MusicXML → `Song` AST: extracts title, composer, key (circle-of-fifths → key name), tempo, capo, chord names (from `<harmony>` root/kind elements), lyrics (from `<note><lyric>`), section structure (rehearsal marks → `start_of_verse/chorus/bridge`)
- `export.rs` — `Song` AST → MusicXML 4.0 string: emits `<harmony>` from parsed `ChordDetail`, `<lyric>` per lyric segment, `<rehearsal>` for section markers; whole notes used throughout (no rhythm data in ChordPro)
- `lib.rs` — public API: `from_musicxml(xml: &str) -> Result<Song, ImportError>` and `to_musicxml(song: &Song) -> String`

## CLI changes

```bash
# Import: MusicXML → ChordPro (auto-detected by .xml extension)
chordsketch convert song.xml

# Import: force format
chordsketch convert song.xml --from musicxml

# Export: ChordPro → MusicXML
chordsketch convert song.cho --to musicxml
```

## Test results

- **22 unit tests** in xml/import/export modules
- **9 integration tests** against 3 fixture files (`simple.xml`, `metadata.xml`, `sections.xml`) plus 2 round-trip tests
- All 32 tests pass: `test result: ok. 32 passed`
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo doc --no-deps` with `RUSTDOCFLAGS="-D warnings"`: clean

## Review summary

New crate with no modifications to existing crates' logic. The only changes to existing files are:
- `Cargo.toml`: adds `crates/convert-musicxml` to workspace members
- `crates/cli/Cargo.toml`: adds `chordsketch-convert-musicxml` dependency
- `crates/cli/src/main.rs`: extends `ConvertFrom` enum and `run_convert` to support MusicXML

Closes #1143