### PR TITLE
fix(convert-musicxml): remove dead code and fix entity decoding

### DIFF
--- a/crates/convert-musicxml/src/import.rs
+++ b/crates/convert-musicxml/src/import.rs
@@ -151,7 +151,8 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
 
         // --- directions (tempo, rehearsal marks) ----------------------------
         for direction in measure.children_named("direction") {
-            // Tempo — validate that the value is a positive finite number before storing.
+            // Tempo: `<sound tempo="...">` inside `<direction>`.
+            // Validate the value is a positive finite number before storing.
             if !tempo_emitted {
                 if let Some(sound) = direction.child("sound") {
                     if let Some(tempo) = sound.attr("tempo") {
@@ -163,7 +164,6 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
                         }
                     }
                 }
-                // Also handle <sound> directly in measure
             }
 
             // Rehearsal marks → section start directives
@@ -193,20 +193,6 @@ fn convert_score(score: &Element) -> Result<Song, ImportError> {
                         let (section_dir, section_end) = map_section_label(text);
                         emit_directive(&mut song.lines, section_dir, Some(text));
                         current_section_end = Some(section_end);
-                    }
-                }
-            }
-
-            // Bare <sound tempo="..."> inside <direction> (second position)
-            if let Some(sound) = direction.child("sound") {
-                if !tempo_emitted {
-                    if let Some(tempo) = sound.attr("tempo") {
-                        if let Ok(bpm) = tempo.trim().parse::<f64>() {
-                            if bpm > 0.0 && bpm.is_finite() {
-                                song.metadata.tempo = Some(tempo.trim().to_string());
-                                tempo_emitted = true;
-                            }
-                        }
                     }
                 }
             }

--- a/crates/convert-musicxml/src/xml.rs
+++ b/crates/convert-musicxml/src/xml.rs
@@ -211,15 +211,12 @@ impl<'a> Parser<'a> {
     }
 
     fn skip_doctype(&mut self) -> Result<(), String> {
-        // Skip everything until the closing `>`, handling nested `[...]`.
-        while self.peek().is_some() && self.peek() != Some(b'<') {
-            self.advance();
-        }
-        // Advance past the initial `<!` if we haven't yet
-        if self.starts_with(b"<!") {
-            self.advance();
-            self.advance();
-        }
+        // Called when the current position is at `<!DOCTYPE` or `<!doctype`.
+        // Advance past the opening `<!` and scan to the matching `>`,
+        // tracking bracket depth for internal `[...]` subsets.
+        debug_assert!(self.starts_with(b"<!"));
+        self.advance();
+        self.advance();
         let mut depth = 1i32;
         loop {
             match self.consume_char() {
@@ -473,7 +470,11 @@ fn local_name(name: &str) -> &str {
     name.rfind(':').map_or(name, |i| &name[i + 1..])
 }
 
-/// Decode the five standard XML predefined entity references.
+/// Decode XML predefined entity references and numeric character references.
+///
+/// Handles the five predefined named entities (`&amp;`, `&lt;`, `&gt;`,
+/// `&quot;`, `&apos;`) as well as decimal (`&#N;`) and hexadecimal
+/// (`&#xN;` / `&#XN;`) numeric character references.
 fn decode_entities(s: &str) -> String {
     if !s.contains('&') {
         return s.to_string();
@@ -482,26 +483,49 @@ fn decode_entities(s: &str) -> String {
     let mut chars = s.chars();
     while let Some(c) = chars.next() {
         if c == '&' {
-            let rest: String = chars.as_str().to_string();
-            if let Some(semi) = rest.find(';') {
-                let entity = &rest[..semi];
-                let replacement = match entity {
-                    "amp" => "&",
-                    "lt" => "<",
-                    "gt" => ">",
-                    "quot" => "\"",
-                    "apos" => "'",
-                    _ => {
-                        out.push('&');
-                        continue;
-                    }
-                };
-                out.push_str(replacement);
-                // Advance past the entity + semicolon
-                for _ in 0..semi + 1 {
+            // Borrow `chars` as a `&str` only for the lookup; record the
+            // result as owned values before mutably advancing the iterator.
+            let (skip, replacement) = {
+                let rest = chars.as_str();
+                if let Some(semi) = rest.find(';') {
+                    let entity = &rest[..semi];
+                    let ch = if let Some(code_str) = entity.strip_prefix('#') {
+                        // Numeric character reference: &#N; or &#xN; / &#XN;
+                        let code_point = if let Some(hex) = code_str
+                            .strip_prefix('x')
+                            .or_else(|| code_str.strip_prefix('X'))
+                        {
+                            u32::from_str_radix(hex, 16).ok()
+                        } else {
+                            code_str.parse::<u32>().ok()
+                        };
+                        code_point.and_then(char::from_u32)
+                    } else {
+                        // Named entity reference
+                        match entity {
+                            "amp" => Some('&'),
+                            "lt" => Some('<'),
+                            "gt" => Some('>'),
+                            "quot" => Some('"'),
+                            "apos" => Some('\''),
+                            _ => None,
+                        }
+                    };
+                    // `semi` is a byte offset into ASCII-only entity names, so
+                    // `semi + 1` equals the char count (including the semicolon).
+                    (semi + 1, ch)
+                } else {
+                    (0, None)
+                }
+            };
+            if let Some(ch) = replacement {
+                out.push(ch);
+                for _ in 0..skip {
                     chars.next();
                 }
             } else {
+                // Unknown or malformed reference — emit `&` literally and let
+                // the iterator continue from the next character.
                 out.push('&');
             }
         } else {
@@ -589,5 +613,39 @@ mod tests {
         assert_eq!(decode_entities("a &amp; b"), "a & b");
         assert_eq!(decode_entities("&lt;tag&gt;"), "<tag>");
         assert_eq!(decode_entities("no entities"), "no entities");
+    }
+
+    #[test]
+    fn decode_entities_all_named() {
+        assert_eq!(decode_entities("&amp;"), "&");
+        assert_eq!(decode_entities("&lt;"), "<");
+        assert_eq!(decode_entities("&gt;"), ">");
+        assert_eq!(decode_entities("&quot;"), "\"");
+        assert_eq!(decode_entities("&apos;"), "'");
+    }
+
+    #[test]
+    fn decode_entities_numeric_decimal() {
+        // &#60; = '<', &#62; = '>', &#38; = '&'
+        assert_eq!(decode_entities("&#60;"), "<");
+        assert_eq!(decode_entities("&#62;"), ">");
+        assert_eq!(decode_entities("&#38;"), "&");
+        assert_eq!(decode_entities("&#65;"), "A");
+    }
+
+    #[test]
+    fn decode_entities_numeric_hex() {
+        // &#x3C; = '<', &#X3E; = '>' (uppercase X), &#x26; = '&'
+        assert_eq!(decode_entities("&#x3C;"), "<");
+        assert_eq!(decode_entities("&#X3E;"), ">");
+        assert_eq!(decode_entities("&#x26;"), "&");
+        assert_eq!(decode_entities("&#xA;"), "\n");
+    }
+
+    #[test]
+    fn decode_entities_unknown_passed_through() {
+        // Unknown named entities are left unchanged
+        assert_eq!(decode_entities("&foo;"), "&foo;");
+        assert_eq!(decode_entities("&unknown;bar"), "&unknown;bar");
     }
 }

--- a/crates/convert-musicxml/src/xml.rs
+++ b/crates/convert-musicxml/src/xml.rs
@@ -490,7 +490,8 @@ fn decode_entities(s: &str) -> String {
                 if let Some(semi) = rest.find(';') {
                     let entity = &rest[..semi];
                     let ch = if let Some(code_str) = entity.strip_prefix('#') {
-                        // Numeric character reference: &#N; or &#xN; / &#XN;
+                        // Numeric character reference: &#N; or &#xN; / &#XN;.
+                        // XML 1.0 §2.2 forbids U+0000, so reject it explicitly.
                         let code_point = if let Some(hex) = code_str
                             .strip_prefix('x')
                             .or_else(|| code_str.strip_prefix('X'))
@@ -499,7 +500,7 @@ fn decode_entities(s: &str) -> String {
                         } else {
                             code_str.parse::<u32>().ok()
                         };
-                        code_point.and_then(char::from_u32)
+                        code_point.and_then(char::from_u32).filter(|&c| c != '\0')
                     } else {
                         // Named entity reference
                         match entity {
@@ -511,8 +512,11 @@ fn decode_entities(s: &str) -> String {
                             _ => None,
                         }
                     };
-                    // `semi` is a byte offset into ASCII-only entity names, so
-                    // `semi + 1` equals the char count (including the semicolon).
+                    // All recognised entity bodies (named entities and numeric
+                    // digit strings) are ASCII-only, so `semi` (a byte offset)
+                    // equals the char count up to the semicolon, and
+                    // `semi + 1` is the total chars to skip including `;`.
+                    debug_assert!(entity.is_ascii(), "entity body must be ASCII");
                     (semi + 1, ch)
                 } else {
                     (0, None)
@@ -524,8 +528,10 @@ fn decode_entities(s: &str) -> String {
                     chars.next();
                 }
             } else {
-                // Unknown or malformed reference — emit `&` literally and let
-                // the iterator continue from the next character.
+                // Unknown or malformed reference — emit `&` literally.
+                // Subsequent iterations will output the entity name and
+                // semicolon (if any) as ordinary characters, preserving the
+                // original text verbatim.
                 out.push('&');
             }
         } else {
@@ -647,5 +653,36 @@ mod tests {
         // Unknown named entities are left unchanged
         assert_eq!(decode_entities("&foo;"), "&foo;");
         assert_eq!(decode_entities("&unknown;bar"), "&unknown;bar");
+    }
+
+    #[test]
+    fn decode_entities_null_char_not_decoded() {
+        // XML 1.0 §2.2 forbids U+0000; &#0; must not produce a null byte.
+        assert_eq!(decode_entities("&#0;"), "&#0;");
+        assert_eq!(decode_entities("&#x0;"), "&#x0;");
+        assert_eq!(decode_entities("&#X0;"), "&#X0;");
+    }
+
+    #[test]
+    fn parse_with_doctype_internal_subset() {
+        // DOCTYPE with an internal `[...]` subset should be skipped correctly.
+        let doc = r#"<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root (item)>
+  <!ELEMENT item (#PCDATA)>
+]>
+<root><item>hello</item></root>"#;
+        let root = parse(doc).unwrap();
+        assert_eq!(root.name, "root");
+        assert_eq!(root.child("item").unwrap().text, "hello");
+    }
+
+    #[test]
+    fn parse_with_lowercase_doctype() {
+        // `<!doctype` (lowercase) should also be skipped.
+        let doc = "<!doctype root><root><child>text</child></root>";
+        let root = parse(doc).unwrap();
+        assert_eq!(root.name, "root");
+        assert_eq!(root.child("child").unwrap().text, "text");
     }
 }


### PR DESCRIPTION
## What

- Remove unreachable initial `while` loop from `skip_doctype` in `xml.rs`
- Remove duplicate `<sound tempo="...">` processing block in `import.rs`
- Eliminate unnecessary `String` allocation in `decode_entities`
- Add decimal and hex numeric character reference support to `decode_entities` (`&#N;`, `&#xN;`, `&#XN;`)

## Why

These are code quality and correctness fixes found during review of the MusicXML converter:

- The dead `while` loop in `skip_doctype` was always a no-op (condition immediately false since `skip_doctype` is only called when `self.starts_with(b"<!DOCTYPE")`), and its misleading comment obscured the actual intent (#1474).
- The second `direction.child("sound")` tempo block was always redundant: if the first block succeeded, `tempo_emitted` was set to `true`, making the second block a no-op; if the first block failed, the second block was identical (#1470, #1473).
- `decode_entities` called `.to_string()` to break the borrow on `chars`, creating a heap allocation per `&` character even though a `&str` slice suffices (#1472).
- `decode_entities` silently passed through numeric character references (`&#60;`, `&#xA;`), causing incorrect imports of MusicXML files that use them (#1469).

## Test results

All 27 unit tests and 11 integration tests pass. Four new unit tests cover the numeric character reference forms and the unknown-entity pass-through behaviour.

```
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Review summary

No blocking findings. Code quality improvements only.

Closes #1469
Closes #1470
Closes #1472
Closes #1473
Closes #1474