### PR TITLE
ci: extract Python smoke test to scripts/smoke-test-python.py

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -141,39 +141,7 @@ jobs:
         run: pip install chordsketch --find-links dist --no-index
 
       - name: Run smoke test
-        run: |
-          python -c "
-          import chordsketch
-
-          v = chordsketch.version()
-          assert v, 'version should not be empty'
-          print(f'Version: {v}')
-
-          text = chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', None, None)
-          assert 'Test' in text and 'Hello' in text
-          print('Text render: OK')
-
-          html = chordsketch.parse_and_render_html('{title: Test}\n[C]Hello', None, None)
-          assert 'Test' in html
-          print('HTML render: OK')
-
-          pdf = chordsketch.parse_and_render_pdf('{title: Test}\n[C]Hello', None, None)
-          assert pdf[:4] == b'%PDF'
-          print('PDF render: OK')
-
-          errors = chordsketch.validate('{title: Valid}\n[C]Hello')
-          assert isinstance(errors, list)
-          print('Validate: OK')
-
-          text = chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', 'guitar', None)
-          assert 'Test' in text
-          print('Config preset: OK')
-
-          chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', None, 2)
-          print('Transpose: OK')
-
-          print('All smoke tests passed!')
-          "
+        run: python scripts/smoke-test-python.py
 
   test-macos:
     name: Test Python bindings (macos-latest)
@@ -203,39 +171,7 @@ jobs:
         run: pip install chordsketch --find-links dist --no-index
 
       - name: Run smoke test
-        run: |
-          python -c "
-          import chordsketch
-
-          v = chordsketch.version()
-          assert v, 'version should not be empty'
-          print(f'Version: {v}')
-
-          text = chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', None, None)
-          assert 'Test' in text and 'Hello' in text
-          print('Text render: OK')
-
-          html = chordsketch.parse_and_render_html('{title: Test}\n[C]Hello', None, None)
-          assert 'Test' in html
-          print('HTML render: OK')
-
-          pdf = chordsketch.parse_and_render_pdf('{title: Test}\n[C]Hello', None, None)
-          assert pdf[:4] == b'%PDF'
-          print('PDF render: OK')
-
-          errors = chordsketch.validate('{title: Valid}\n[C]Hello')
-          assert isinstance(errors, list)
-          print('Validate: OK')
-
-          text = chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', 'guitar', None)
-          assert 'Test' in text
-          print('Config preset: OK')
-
-          chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', None, 2)
-          print('Transpose: OK')
-
-          print('All smoke tests passed!')
-          "
+        run: python scripts/smoke-test-python.py
 
   test-windows:
     name: Test Python bindings (windows-latest)
@@ -257,39 +193,7 @@ jobs:
         run: pip install chordsketch --find-links dist --no-index
 
       - name: Run smoke test
-        run: |
-          python -c "
-          import chordsketch
-
-          v = chordsketch.version()
-          assert v, 'version should not be empty'
-          print(f'Version: {v}')
-
-          text = chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', None, None)
-          assert 'Test' in text and 'Hello' in text
-          print('Text render: OK')
-
-          html = chordsketch.parse_and_render_html('{title: Test}\n[C]Hello', None, None)
-          assert 'Test' in html
-          print('HTML render: OK')
-
-          pdf = chordsketch.parse_and_render_pdf('{title: Test}\n[C]Hello', None, None)
-          assert pdf[:4] == b'%PDF'
-          print('PDF render: OK')
-
-          errors = chordsketch.validate('{title: Valid}\n[C]Hello')
-          assert isinstance(errors, list)
-          print('Validate: OK')
-
-          text = chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', 'guitar', None)
-          assert 'Test' in text
-          print('Config preset: OK')
-
-          chordsketch.parse_and_render_text('{title: Test}\n[C]Hello', None, 2)
-          print('Transpose: OK')
-
-          print('All smoke tests passed!')
-          "
+        run: python scripts/smoke-test-python.py
 
   publish:
     name: Publish to PyPI

--- a/scripts/smoke-test-python.py
+++ b/scripts/smoke-test-python.py
@@ -1,0 +1,38 @@
+"""
+Smoke test for the chordsketch Python package.
+
+Called from .github/workflows/python.yml by each per-OS test job
+(test-ubuntu, test-macos, test-windows) after the wheel has been
+installed, so that the test logic lives in a single place.
+"""
+
+import chordsketch
+
+v = chordsketch.version()
+assert v, "version should not be empty"
+print(f"Version: {v}")
+
+text = chordsketch.parse_and_render_text("{title: Test}\n[C]Hello", None, None)
+assert "Test" in text and "Hello" in text
+print("Text render: OK")
+
+html = chordsketch.parse_and_render_html("{title: Test}\n[C]Hello", None, None)
+assert "Test" in html
+print("HTML render: OK")
+
+pdf = chordsketch.parse_and_render_pdf("{title: Test}\n[C]Hello", None, None)
+assert pdf[:4] == b"%PDF"
+print("PDF render: OK")
+
+errors = chordsketch.validate("{title: Valid}\n[C]Hello")
+assert isinstance(errors, list)
+print("Validate: OK")
+
+text = chordsketch.parse_and_render_text("{title: Test}\n[C]Hello", "guitar", None)
+assert "Test" in text
+print("Config preset: OK")
+
+chordsketch.parse_and_render_text("{title: Test}\n[C]Hello", None, 2)
+print("Transpose: OK")
+
+print("All smoke tests passed!")


### PR DESCRIPTION
## What

Extract the Python smoke test script from the inline `python -c "..."` block in `python.yml` to `scripts/smoke-test-python.py`, and replace all three per-OS test jobs with `python scripts/smoke-test-python.py`.

## Why

The smoke test body was duplicated verbatim in `test-ubuntu`, `test-macos`, and `test-windows` (introduced in #1481). Any future assertion change required keeping three copies in sync manually. A shared script eliminates the maintenance burden.

## Test results

The script is called via `python scripts/smoke-test-python.py` from each job after `actions/checkout` runs, so the file is present in every runner environment. CI will exercise this on all three platforms.

## Review summary

Low-severity finding from the auto-review of #1481, filed as #1482.

Closes #1482