### PR TITLE
ci(python): exclude build dirs from Windows Defender to reduce wheel build time

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -105,6 +105,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Exclude build directories from Windows Defender
+        # Windows Defender real-time protection scans every file written to disk
+        # during compilation, adding significant overhead on I/O-heavy Rust builds.
+        # Excluding the workspace and Cargo home from scanning is a standard
+        # mitigation for GitHub-hosted Windows runners. See #1464.
+        shell: powershell
+        run: |
+          Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.cargo"
+
       - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         with:
           command: build


### PR DESCRIPTION
## What

Add a PowerShell step to the `build-wheels-windows` job that excludes `GITHUB_WORKSPACE` and the Cargo home directory from Windows Defender real-time protection, before the maturin build runs.

## Why

Investigation of #1464 found that maturin-action's sccache provides near-zero cache benefit on Windows (341–438s consistently, same as a cold build), while the Kotlin JNI build for the **same crate** using `Swatinem/rust-cache` takes 98s. The ~4× gap is consistent with Windows Defender I/O overhead, which scans every file written during Rust compilation.

## Before measurements

From 4 consecutive CI runs today (2026-04-11):

| Run | Windows x64 build | Ubuntu x86_64 build |
|-----|-------------------|---------------------|
| 24279952532 | 342s | 83s |
| 24279840955 | 384s | — |
| 24279811714 | 438s | — |
| 24279713744 | 341s | 73s |

## After measurements

Will be reported in the [#1464 comment](https://github.com/koedame/chordsketch/issues/1464#issuecomment-4229237170) once CI for this PR completes.

## Test results

CI will run the full Python Package workflow including the Windows wheel build. The build duration will serve as the "after" measurement.

## Review summary

N/A — CI-only change. The `Add-MpPreference` PowerShell cmdlet is a standard Windows API call that does not affect correctness, only scan scope.

Part of #1464