### PR TITLE
ci(docs): add readme-smoke.yml to rust-cache Required list

### DIFF
--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -42,7 +42,7 @@ YAML noise.
 
 **Required (workflows that run at least weekly):**
 `ci.yml`, `wasm.yml`, `python.yml`, `ruby.yml`, `kotlin.yml`, `swift.yml`,
-`napi.yml`, `ffi.yml`, `deploy-playground.yml`
+`napi.yml`, `ffi.yml`, `deploy-playground.yml`, `readme-smoke.yml`
 
 **Intentionally omitted (infrequent — cache expires before next run):**
 - `release.yml` — ~every 10 days on version tags

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -257,6 +257,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      # rust-cache intentionally omitted: this job installs from crates.io into a
+      # custom CARGO_HOME (/tmp/cargo-smoke) outside the workspace. Both the registry
+      # and build artifacts land under /tmp, not under ~/.cargo or the workspace
+      # target/, so Swatinem/rust-cache would cache nothing useful.
+
       - name: Install from crates.io into scratch CARGO_HOME
         env:
           CARGO_HOME: /tmp/cargo-smoke
@@ -277,6 +282,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      # rust-cache intentionally omitted: compilation happens inside a fresh clone at
+      # /tmp/chordsketch-src with CARGO_HOME=/tmp/cargo-source — both are outside the
+      # workspace and ~/.cargo, so Swatinem/rust-cache has nothing to cache.
 
       - name: Clone, install, and run
         env:
@@ -406,6 +415,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      # Caches ~/.cargo/registry so crates.io dependency fetches are fast on
+      # re-runs. The scratch project builds in /tmp so target/ is not cached,
+      # but the registry cache alone is worthwhile given the daily + PR cadence.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: readme-smoke-library
+
       - name: Build and run README Library Usage snippet
         run: |
           set -euo pipefail
@@ -474,6 +490,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      # Caches the workspace target/ directory. Although CARGO_HOME is redirected to
+      # /tmp/cargo-usage, cargo install --path still compiles into the workspace
+      # target/, so subsequent runs skip recompiling unchanged crates.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: readme-smoke-usage
 
       - name: Install CLI from workspace
         env:


### PR DESCRIPTION
## What

- Add `readme-smoke.yml` to the **Required** list in section 2 of `.claude/rules/ci-parallelization.md`.
- Add `Swatinem/rust-cache` steps to the two jobs in the workflow that genuinely benefit from caching.
- Add explanatory comments to the two jobs where rust-cache is intentionally omitted.

## Why

`readme-smoke.yml` runs daily (cron `0 6 * * *`) and on every PR — it comfortably meets the at-least-weekly threshold defined by the ci-parallelization rule. It was absent from both the Required and Intentionally omitted lists, which would cause a contributor following the rule's enumeration to miss it during a cache-coverage audit.

## Changes

### `readme-smoke.yml`

| Job | Treatment | Rationale |
|---|---|---|
| `library-smoke` | **Added** rust-cache (`shared-key: readme-smoke-library`) | Uses default CARGO_HOME (`~/.cargo`); caching the registry index/sources reduces crates.io fetch time on daily + PR runs. |
| `usage-smoke` | **Added** rust-cache (`shared-key: readme-smoke-usage`) | Compiles via `cargo install --path crates/cli` from the workspace root; the workspace `target/` is cached, avoiding full recompilation on re-runs. |
| `cargo-install` | Comment added — rust-cache **omitted** | Installs from crates.io into `CARGO_HOME=/tmp/cargo-smoke`; build artifacts land under `/tmp`, not in `~/.cargo` or the workspace `target/`. Nothing to cache. |
| `source-build` | Comment added — rust-cache **omitted** | Clones to `/tmp/chordsketch-src` and sets `CARGO_HOME=/tmp/cargo-source`; all compilation happens outside the workspace. Nothing to cache. |

### `.claude/rules/ci-parallelization.md`

Added `readme-smoke.yml` to the Required workflow list.

## Test results

No functional code changes; all existing tests continue to pass. The added rust-cache steps are no-ops on first run (cold cache) and accelerate subsequent runs.

## Review summary

Documentation and CI configuration change only. No logic changes.

Closes #1485