### PR TITLE
docs(ci): clarify library-smoke rust-cache saves empty workspace target/

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -416,8 +416,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       # Caches ~/.cargo/registry so crates.io dependency fetches are fast on
-      # re-runs. The scratch project builds in /tmp so target/ is not cached,
-      # but the registry cache alone is worthwhile given the daily + PR cadence.
+      # re-runs. The scratch project builds in /tmp/library-smoke so its target/
+      # is NOT in the workspace; rust-cache will attempt to save the workspace
+      # target/ but it will be empty for this job (harmless). The registry cache
+      # alone is worthwhile given the daily + PR cadence.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: readme-smoke-library


### PR DESCRIPTION
## What

Expand the `library-smoke` rust-cache comment in `readme-smoke.yml` to explicitly note that `Swatinem/rust-cache` will attempt to save the workspace `target/` on every run, but that it will be empty for this job.

## Why

The comment added in #1488 said "target/ is not cached" but didn't explain that rust-cache still attempts the save/restore cycle. A reader might wonder why the action is present if the target/ benefit is absent. The expanded comment removes that ambiguity.

## Test results

Comment-only change; no CI behavior is altered.

## Review summary

Documentation only. No logic changes.

Closes #1489