### PR TITLE
ci(python): add $env:USERPROFILE\.rustup to Windows Defender exclusions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -114,6 +114,7 @@ jobs:
         run: |
           Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE
           Add-MpPreference -ExclusionPath "$env:USERPROFILE\.cargo"
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.rustup"
 
       - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         with:


### PR DESCRIPTION
## What

Add `$env:USERPROFILE\.rustup` to the Windows Defender exclusion list in the `build-wheels-windows` job.

## Why

The Rust toolchain (compiler, linker, standard library) lives in `$env:USERPROFILE\.rustup`. Windows Defender may scan these binaries each time they are invoked during Rust compilation, adding I/O overhead that the cargo (`$env:USERPROFILE\.cargo`) and workspace exclusions added in #1486 do not cover. Adding a third `Add-MpPreference` call is a standard mitigation.

## Before measurements (after #1486 — with cargo + workspace exclusions, without rustup)

| Run ID | Windows x64 build |
|--------|-------------------|
| 24280405808 | 422s |
| 24280548564 | 349s |

## After measurements

Will be reported in a comment on #1464 once CI for this PR completes.

## Test results

CI will run the full Python Package workflow. The `build-wheels-windows` duration from this run will serve as the "after" measurement.

## Review summary

Single-line CI change. The `Add-MpPreference` PowerShell cmdlet is a standard Windows API call that does not affect build correctness, only Defender scan scope.

Closes #1487
Part of #1464