### PR TITLE
ci(python): add Swatinem/rust-cache to Windows wheel build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -116,6 +116,23 @@ jobs:
           Add-MpPreference -ExclusionPath "$env:USERPROFILE\.cargo"
           Add-MpPreference -ExclusionPath "$env:USERPROFILE\.rustup"
 
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      # Cache the workspace target/ directory between runs. Unlike sccache (which
+      # caches individual compilation-unit outputs and is still invoked via
+      # RUSTC_WRAPPER), Swatinem/rust-cache allows cargo to skip the rustc
+      # invocation entirely for unchanged crates on a warm cache hit.
+      #
+      # Investigation (#1464) found that 30 compilation units consistently miss
+      # sccache on every Windows run — including documentation-only commits —
+      # because those units depend on UniFFI build.rs generated code with
+      # environment-specific paths that differ between runner instances.
+      # Those 30 misses account for ~390 of the ~420s build time.
+      # Caching target/ avoids recompiling those 30 units on warm runs.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: python-x86_64-pc-windows-msvc
+
       - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         with:
           command: build


### PR DESCRIPTION
## What

Add `Swatinem/rust-cache` and `dtolnay/rust-toolchain@stable` to the `build-wheels-windows` job in `python.yml`.

## Why

Investigation for #1464 found:

1. **sccache is working** (86% hit rate, 191 hits) — but 30 units **consistently miss on every run**, including documentation-only commits.
2. **Root cause**: `crates/ffi/build.rs` generates UniFFI scaffolding code. The generated code's compilation inputs include environment-specific absolute paths that differ between runner instances. This breaks sccache's deterministic hashing, causing the same 30 units to miss on every run.
3. **These 30 misses cost ~390s** of the ~420s total Windows build time.
4. **Windows Defender exclusions** (added in #1486/#1492) did not reduce build time — the bottleneck is the sccache misses, not I/O scanning overhead.

### How this fixes it

`Swatinem/rust-cache` caches the **entire workspace `target/` directory** at the GitHub Actions Cache level. Unlike sccache, which still invokes `rustc` (even on hits), `Swatinem/rust-cache` lets **cargo skip the `rustc` invocation entirely** for unchanged crates on warm runs. For a documentation-only PR (no Rust changes), all 221 compilation units would be skipped, leaving only the final link step (~10–30s).

### Step ordering

The new steps are placed **after** the Defender exclusion step so that the rust-cache restore I/O is protected from antivirus scanning.

## Before measurements

| Run ID | Windows x64 build |
|--------|-------------------|
| 24279713744 | 341s |
| 24279952532 | 342s |
| 24280405808 | 422s |
| 24280548564 | 349s |
| 24280676143 | 414s |

## After measurements

Will be reported in a comment on #1464 once CI for this PR completes. First run will be cold (cache populates), so the warm-cache improvement will be visible on the second run.

## Test results

CI will run the full Python Package workflow. The `build-wheels-windows` duration serves as the "after" measurement for this PR.

## Review summary

- Added `dtolnay/rust-toolchain@stable` (pinned hash matching all other uses in this repo).
- Added `Swatinem/rust-cache` (pinned hash matching all other uses in this repo).
- `shared-key: python-x86_64-pc-windows-msvc` to avoid cache thrashing with other workflows.
- The existing sccache configuration is unchanged — both caches coexist (rust-cache for target/, sccache for compilation units on cache misses).

Part of #1464