### PR TITLE
ci(swift): add if-no-files-found: error to upload-artifact steps

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -71,6 +71,7 @@ jobs:
           name: swift-lib-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/libchordsketch_ffi.a
           retention-days: 1
+          if-no-files-found: error
 
       # The dylib is only produced for the macOS target and is only needed in
       # the assemble job to let uniffi-bindgen extract the library metadata.
@@ -81,6 +82,7 @@ jobs:
           name: swift-dylib-aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release/libchordsketch_ffi.dylib
           retention-days: 1
+          if-no-files-found: error
 
   # Download the 5 static libraries and dylib built in parallel above, then
   # assemble the XCFramework, generate Swift bindings, and run swift test.


### PR DESCRIPTION
## What

Add `if-no-files-found: error` to the two `upload-artifact` steps in the
`build-target` matrix job of `swift.yml`:

- `swift-lib-<target>` (static library, all 5 cells)
- `swift-dylib-aarch64-apple-darwin` (dylib, macOS cell only)

## Why

Without this guard the default behaviour is `warn`, meaning if `cargo build`
produces a library at an unexpected path (e.g. after a Cargo or target-triple
naming change), the upload step silently reports success. The downstream
`assemble-xcframework` job then fails with an opaque "no artifact found"
message instead of a clear "expected file was missing" error at the source.
Setting `if-no-files-found: error` surfaces the problem immediately, at the
right step.

## Test results

Workflow-only change (no Rust code modified). CI runs the Swift workflow on
`.github/workflows/swift.yml` path triggers.

## Review summary

No blocking findings expected — this is a two-line guard addition to an
existing workflow.

Closes #1496