### PR TITLE
docs: remove completed phase roadmap and phase-specific workflow rules

### DIFF
--- a/.claude/rules/doc-maintenance.md
+++ b/.claude/rules/doc-maintenance.md
@@ -15,7 +15,6 @@ promptly.
 |---|---|
 | New crate added to workspace | `CLAUDE.md` Architecture table |
 | New rule or convention agreed upon | `.claude/rules/` — add new file |
-| Phase started or completed | `CLAUDE.md` Phase Roadmap |
 | Build commands or CI pipeline changed | `CLAUDE.md` Build Commands |
 | New workflow or process introduced | `.claude/rules/` — add new file |
 | Existing rule no longer applies | Remove or update the relevant `.claude/rules/` file |
@@ -27,12 +26,6 @@ promptly.
 `cargo doc --workspace --no-deps` is run in CI with `RUSTDOCFLAGS="-D warnings"`.
 Doc warnings (broken intra-doc links, missing `# Safety` sections, etc.) are treated
 as errors. Ensure all public items have valid doc comments before pushing.
-
-## Phase Completion Review
-
-When a phase's tracking issue is closed, perform a full review of all documentation
-files to ensure they accurately reflect the current state of the project. This is the
-one scheduled (non-event-driven) documentation checkpoint.
 
 ## Principles
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -7,7 +7,6 @@
 - Issue body must include:
   - **Goal**: What should be achieved
   - **Acceptance Criteria**: Checkboxes for done-ness
-  - **Phase**: Which roadmap phase this belongs to
 
 ## Duplicate Prevention
 
@@ -32,7 +31,6 @@ bug should close all linked issues.
 
 | Category | Labels |
 |---|---|
-| Phase | `phase:1` through `phase:6` (roadmap phases) |
 | Type | `type:feature`, `type:bug`, `type:docs`, `type:refactor`, `type:ci`, `type:tracking` |
 | Size | `size:small` (< 1 hour), `size:medium` (1-4 hours), `size:large` (4+ hours) |
 | Priority | `priority:high`, `priority:medium`, `priority:low` |
@@ -51,48 +49,31 @@ bug should close all linked issues.
 
 ## Tracking Issues & Sub-Issues
 
-- Each **Phase** has a single **tracking issue** labeled `type:tracking` and `phase:N`.
-- Tracking issue title format: `Phase N: <description>` (e.g., `Phase 2: Core Parser`).
-- Tracking issue body contains a high-level overview; GitHub displays sub-issue relationships automatically in the issue UI.
-- Individual tasks are created as **GitHub sub-issues** of the tracking issue.
-- Sub-issues follow the same rules as regular issues (imperative title, English only, Goal, Acceptance Criteria, labels).
-- Sub-issues inherit the `phase:N` label from their parent tracking issue.
-- A phase tracking issue may only be closed after the **Phase Completion Gate**
-  (see below).
+For large features or milestones, create a **tracking issue** labeled
+`type:tracking`. Individual tasks are created as GitHub sub-issues.
+Sub-issues follow the same rules as regular issues.
 
-### Phase Completion Gate
+A tracking issue may only be closed after a **milestone review**:
 
-Before closing a phase tracking issue:
-
-0. **Prerequisite** — all sub-issues of the tracking issue must be closed.
-   If any are open, complete them first.
-1. **Initial review** — run `/project:phase-review <tracking-issue-number>`. This
-   verifies the prerequisite, performs both code review and security review
-   on the full phase diff, classifies findings by severity (see
-   [Severity Definitions](pr-workflow.md#severity-definitions)), and creates
-   issues for all findings.
-2. **Blocking findings** (High, Medium) — create sub-issues, implement fixes
-   via normal PR workflow, and merge to `main`.
-3. **Non-blocking findings** (Low, Nit) — issues are created but do **not**
-   block phase closure.
-4. **Delta review** — run `/project:delta-review <base-commit>` where `<base-commit>`
-   is the last commit reviewed. This reviews only the fix commits, not the
-   entire phase. Only new blocking findings require further fixes.
-5. **Repeat steps 2–4** until a delta review produces no new blocking findings.
-6. **Close** the phase tracking issue.
+0. All sub-issues must be closed first.
+1. Run `/project:phase-review <tracking-issue-number>` to perform code and
+   security review, classify findings by severity, and create issues for all
+   findings.
+2. **Blocking findings** (High, Medium) — fix via normal PR workflow.
+3. **Non-blocking findings** (Low, Nit) — issues created, do not block closure.
+4. Run `/project:delta-review <base-commit>` to review only fix commits.
+5. Repeat steps 2–4 until no new blocking findings remain.
+6. Close the tracking issue.
 
 ### Review Finding Accountability
 
 All review findings must be:
 
-1. **Individually documented** in the review comment on the tracking issue or PR,
-   with a clear description and severity classification.
-2. **Resolved or tracked** before the phase or PR is closed:
+1. **Individually documented** with description and severity classification.
+2. **Resolved or tracked** before the issue is closed:
    - **Blocking** (High, Medium) — fixed in the current cycle.
    - **Non-blocking** (Low, Nit) — GitHub Issue created for future work.
-3. **Never silently dropped.** Aggregate counts like "14 Low findings" without
-   enumeration are not acceptable. Every finding must be enumerable and
-   traceable.
+3. **Never silently dropped.** Every finding must be enumerable and traceable.
 
 ### Creating Sub-Issue Relationships
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,32 +68,6 @@ Additionally, these non-Rust packages exist:
 - **GitHub Project**: https://github.com/orgs/koedame/projects/1/views/1
 - **Issues**: https://github.com/koedame/chordsketch/issues
 
-## Phase Roadmap
-
-High-level phases:
-
-1. **Phase 1** — Workspace setup, CI, project scaffolding ✅
-2. **Phase 2** — Core parser (ChordPro format lexer + AST) ✅
-3. **Phase 3** — Plain text renderer ✅
-4. **Phase 4** — CLI tool with file I/O ✅
-5. **Phase 5** — Extended directives, metadata, transposition ✅
-6. **Phase 6** — Additional renderers (HTML, PDF) ✅
-7. **Phase 7** — Missing metadata, `{meta}`, `{transpose}` directives ✅
-8. **Phase 8** — Additional section environments (grid, custom, chorus recall) ✅
-9. **Phase 9** — Inline markup parsing and rendering ✅
-10. **Phase 10** — Font, size, and color directives (legacy formatting) ✅
-11. **Phase 11** — Page control and multi-page PDF ✅
-12. **Phase 12** — Image directive ✅
-13. **Phase 13** — Configuration file system (chordsketch.json, RRJSON) ✅
-14. **Phase 14** — Chord diagram rendering and extended `{define}` ✅
-15. **Phase 15** — Delegate environments (ABC, Lilypond, SVG, textblock) ✅
-16. **Phase 16** — Conditional directive selectors ✅
-17. **Phase 17** — Multi-song files and `{new_song}` directive ✅
-18. **Phase 18** — Perl reference implementation compatibility testing ✅
-19. **Phase 19** — Production readiness and publishing ✅
-20. **Phase 20** — WASM build & web playground ✅
-21. **Phase 21** — Multi-language bindings & expanded distribution ✅
-
 ## Merge Policy
 
 PRs are automatically reviewed; **merging is always a human action**.


### PR DESCRIPTION
## What

Remove all stale phase-related content now that all 21 initial roadmap phases
are complete:

- **`CLAUDE.md`**: remove the entire Phase Roadmap section (phases 1–21, all ✅)
- **`.claude/rules/issue-workflow.md`**:
  - Remove "Phase" field from issue body template
  - Remove `phase:N` row from the Issue Labels table
  - Replace the phase-specific Tracking Issues / Phase Completion Gate language
    with a concise generic "milestone review" description that preserves the
    `/project:phase-review` and `/project:delta-review` tooling for future use
- **`.claude/rules/doc-maintenance.md`**:
  - Remove "Phase started or completed → CLAUDE.md Phase Roadmap" trigger
  - Remove the "Phase Completion Review" scheduled checkpoint section
- **GitHub labels**: delete `phase:1` through `phase:21` from the repo

## Why

The phase concept was used to track the zero-to-published build-out. Now that
all 21 phases are complete, keeping the roadmap and phase-specific rules
misleads new contributors into thinking phases are still the active work unit.
The quality-gate tooling (`/project:phase-review`, `/project:delta-review`)
is preserved and documented generically as a "milestone review" pattern.

## Test results

Documentation-only change (no Rust code modified). `cargo doc`, `cargo clippy`,
and `cargo test` are unaffected.

## Review summary

No blocking findings expected — purely a doc cleanup removing completed/stale
content.

Closes #1495