### PR TITLE
ci(swift): add if-no-files-found: error to assemble-xcframework upload steps

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -258,6 +258,7 @@ jobs:
           name: xcframework
           path: chordsketch-xcframework.zip
           retention-days: 7
+          if-no-files-found: error
 
       - name: Upload Swift source
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -265,6 +266,7 @@ jobs:
           name: swift-source
           path: generated/chordsketch.swift
           retention-days: 7
+          if-no-files-found: error
 
   publish:
     name: Publish XCFramework


### PR DESCRIPTION
## What

Add `if-no-files-found: error` to the two `upload-artifact` steps in the
`assemble-xcframework` job of `swift.yml`:

- **Upload XCFramework** (`xcframework` artifact, `chordsketch-xcframework.zip`)
- **Upload Swift source** (`swift-source` artifact, `generated/chordsketch.swift`)

## Why

PR #1497 added the same guard to the `build-target` matrix cells. For
consistency and defence-in-depth, extending it to the `assemble-xcframework`
job makes the failure mode explicit if either output file is missing. Both
files are produced by earlier steps in the same job, so a missing file would
typically cause an earlier step to fail anyway — but an explicit guard makes
the error message immediately actionable rather than requiring tracing back
through the job log.

## Test results

Workflow-only change (no Rust code modified).

## Review summary

No blocking findings expected — two-line guard addition, follows the pattern
already established by #1497.

Closes #1498