### PR TITLE
docs(adr): record Kotlin Maven Central credential decision (closes #1124, #1501)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ println!("{text}");
 - [ChordPro file format specification](https://www.chordpro.org/chordpro/)
 - [Configuration guide](docs/configuration.md)
 - [Versioning and release process](docs/releasing.md)
+- [Architecture decision records](docs/adr/README.md)
 - [SECURITY.md](SECURITY.md)
 - [CHANGELOG.md](CHANGELOG.md)
 

--- a/docs/adr/0001-kotlin-maven-central-publishing-credentials.md
+++ b/docs/adr/0001-kotlin-maven-central-publishing-credentials.md
@@ -1,0 +1,176 @@
+# 0001. Kotlin Maven Central publishing credentials
+
+- **Status**: Accepted
+- **Date**: 2026-04-11
+
+## Context
+
+ChordSketch publishes binding packages to multiple language registries from
+GitHub Actions. The security goal across all of these channels is to
+eliminate long-lived publishing credentials in favour of GitHub OIDC
+trusted publishing, where each release run obtains a short-lived token
+scoped to a specific repository, workflow, and environment.
+
+This goal has already been achieved for two of the three current channels:
+
+- **PyPI** — `python.yml` uses `pypa/gh-action-pypi-publish` with OIDC
+  trusted publishing.
+- **RubyGems** — `ruby.yml` uses `rubygems/configure-rubygems-credentials`
+  with OIDC trusted publishing (see lines 247–328).
+
+The third channel, **Maven Central** (Kotlin), still authenticates with
+long-lived `CENTRAL_PORTAL_USERNAME` / `CENTRAL_PORTAL_PASSWORD` user
+tokens stored in the `maven-central` GitHub environment, as configured in
+`.github/workflows/kotlin.yml` lines 173–245.
+
+#1124 proposed migrating Kotlin to OIDC to bring it in line with the other
+two channels and remove the last long-lived publishing credentials from
+the repository.
+
+A research pass on **2026-04-11** confirmed the migration is **blocked
+upstream**:
+
+1. **Sonatype Central Portal exposes no OIDC token-exchange endpoint.**
+   The URL `https://central.sonatype.com/publishing/trusted-publishers`
+   resolves but serves only an empty single-page-application shell — the
+   route exists but no feature is wired behind it. Sonatype's documented
+   OIDC support applies to Nexus Repository Cloud / Pro 3.86+, not the
+   Central Portal that publishes to Maven Central.
+2. **The vanniktech `gradle-maven-publish-plugin` has no OIDC code path.**
+   Latest release 0.36.0 (2025-01-18) still requires
+   `mavenCentralUsername` / `mavenCentralPassword`. Release notes through
+   0.33–0.36 cover the OSSRH sunset and Central Portal migration but
+   contain zero mentions of OIDC, trusted publishing, or `id-token`.
+3. **No official Sonatype GitHub Action exists** for Central Portal
+   publishing. The `sonatype/actions` organisation publishes only
+   Lifecycle / IQ Server tooling (Evaluate, Fetch SBOM, Setup Sonatype
+   CLI, Run Sonatype CLI), none of which authenticate to Maven Central.
+4. **No community GitHub Action implements OIDC ↔ Central Portal token
+   exchange.** Searches surface only guides that use long-lived user
+   tokens (`teamlead/java-maven-sonatype-starter`, `davidcarboni/releaser`,
+   sbt-ci-release, etc.).
+
+The migration cannot be implemented today without writing a custom OIDC
+bridge whose counter-party (the Sonatype OIDC endpoint) does not exist.
+
+## Decision
+
+Continue to authenticate the Kotlin Maven Central publish job with the
+long-lived `CENTRAL_PORTAL_USERNAME` / `CENTRAL_PORTAL_PASSWORD` secrets
+held in the `maven-central` GitHub environment. Do not introduce a custom
+OIDC bridge or speculative tooling. Re-evaluate when **any** of the watch
+signals listed in [References](#references) flips.
+
+## Rationale
+
+The four upstream gaps above are joint blockers — fixing any one of them
+on our side would still leave the migration non-functional because the
+others are missing. Specifically:
+
+- Adding `id-token: write` permission to the publish job is harmless but
+  meaningless without an action that consumes the resulting token.
+- Forking the vanniktech plugin to add an OIDC code path would still need
+  a Sonatype-side endpoint to exchange the token against.
+- Writing a custom token-exchange action has no Sonatype URL to POST to.
+
+The honest engineering answer is to wait. A workaround built today would
+have to be ripped out the moment Sonatype ships the real feature, and
+maintaining the workaround would consume the engineering attention that
+should instead go toward monitoring the watch signals.
+
+The empty SPA shell at `central.sonatype.com/publishing/trusted-publishers`
+is the only weak signal that Sonatype is building this feature — it is
+not yet usable but is worth checking periodically.
+
+## Consequences
+
+**Positive**
+
+- No engineering time is spent building a bridge that would have to be
+  removed later.
+- The Kotlin publish flow stays simple and matches the patterns documented
+  for the vanniktech plugin and Central Portal.
+- The repository carries an honest, discoverable record of *why* one
+  channel is asymmetric with the others, so a future contributor (or
+  Claude session) does not re-propose the migration without the upstream
+  context.
+
+**Negative**
+
+- Long-lived `CENTRAL_PORTAL_*` secrets remain in the `maven-central`
+  environment. They require manual rotation per Sonatype's user-token
+  policy and represent an exfiltration window the other channels do not
+  have.
+- Incident response for a credential leak must remember that Maven
+  Central is the asymmetric channel and follow the user-token revocation
+  flow at https://central.sonatype.com/account.
+
+**Mitigations**
+
+- The secrets are scoped to the `maven-central` environment, not the
+  repository (see `kotlin.yml` lines 196–198), so they are not exposed to
+  pull-request workflow runs or to unrelated jobs.
+- The `maven-central` environment can have required reviewers added if
+  the threat model demands it; this ADR does not mandate that change but
+  notes it as an available lever.
+
+## Alternatives considered
+
+- **Build a custom OIDC bridge action** — rejected. There is no Sonatype
+  endpoint to exchange the GitHub token against, so the action would be
+  a no-op shell. Implementation cost: small. Value delivered: zero until
+  Sonatype ships an endpoint, at which point the official path will
+  presumably work better.
+- **Fork the vanniktech plugin to add OIDC support** — rejected for the
+  same reason. An OIDC code path in the plugin still needs a server-side
+  counterpart.
+- **Move to a different Maven Central client (e.g. JReleaser)** — not
+  pursued. JReleaser also targets the existing Central Portal API and
+  would face the same upstream block. Switching clients is a much larger
+  change than the OIDC migration would have been.
+- **Close #1124 silently without an ADR** — rejected. The rationale would
+  be buried in issue history and the decision would be invisible to
+  anyone scanning the repository for "why is Kotlin asymmetric?". An ADR
+  is the lowest-cost way to make the reasoning permanent and
+  discoverable.
+- **Leave #1124 open as a passive reminder** — rejected by the
+  maintainer. The issue cannot be acted on, has no clear deadline, and
+  fragments the work-in-progress signal in the issue tracker. A watch
+  signal in an ADR is a better fit than a perpetually-open issue.
+
+## References
+
+**GitHub**
+
+- Issue: koedame/chordsketch#1124 (closed by this ADR)
+- Tracking issue for this ADR: koedame/chordsketch#1501
+
+**Sibling implementations to mirror once unblocked**
+
+- `.github/workflows/ruby.yml` lines 247–328 — RubyGems OIDC pattern
+  using `rubygems/configure-rubygems-credentials` and an
+  `ACTIONS_ID_TOKEN_REQUEST_URL` availability probe.
+- `.github/workflows/python.yml` — PyPI OIDC pattern using
+  `pypa/gh-action-pypi-publish`.
+
+**Current Kotlin publish job**
+
+- `.github/workflows/kotlin.yml` lines 173–245 — the publish job that
+  this ADR governs.
+
+**Watch signals — re-open the migration when any of these flip**
+
+1. The vanniktech `gradle-maven-publish-plugin`
+   ([releases](https://github.com/vanniktech/gradle-maven-publish-plugin/releases))
+   ships a release whose notes mention `oidc`, `trusted publish`, or
+   `id-token`.
+2. `https://central.sonatype.com/publishing/trusted-publishers` returns
+   substantive content rather than an empty SPA shell.
+3. An official `sonatype/*` GitHub Action for Central Portal publishing
+   appears in the [sonatype organisation](https://github.com/sonatype).
+4. `https://central.sonatype.org/publish/publish-portal-gradle/`
+   documents an OIDC-based authentication flow.
+
+When any of these flips, file a fresh issue referencing this ADR and the
+specific signal that changed, and follow the normal PR workflow for the
+migration.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,81 @@
+# Architecture Decision Records
+
+This directory contains the architecture decision records (ADRs) for
+ChordSketch. An ADR captures a single, significant architectural or
+operational decision together with the context that produced it, the
+alternatives considered, and the consequences accepted.
+
+ADRs exist to preserve **why** a decision was made, not just **what** was
+decided. The codebase, git history, and issue tracker already record the
+**what**; an ADR exists when the **why** would otherwise be lost.
+
+## When to write an ADR
+
+Write an ADR when any of the following are true:
+
+- A decision intentionally **declines** to do work that an open issue
+  proposes (e.g. an upstream-blocked migration), and that decision should
+  outlive the issue's closure.
+- A decision rules out an alternative whose case is non-obvious enough that
+  a future contributor might re-propose it without the historical context.
+- A decision establishes a project-wide convention that the rules in
+  `.claude/rules/` do not already cover.
+
+Routine code changes do **not** need an ADR. The bar is "would a reasonable
+future contributor reach the wrong conclusion if this rationale were
+missing?"
+
+## File naming
+
+ADR files are named `NNNN-kebab-case-title.md`, where `NNNN` is a
+zero-padded sequence number assigned in creation order. Numbers are
+**never reused**, even if an ADR is later superseded.
+
+## Template
+
+Each ADR follows this structure:
+
+```markdown
+# NNNN. Short title in sentence case
+
+- **Status**: Accepted | Superseded by ADR-NNNN | Deprecated
+- **Date**: YYYY-MM-DD
+
+## Context
+
+What problem prompted this decision? What constraints, prior art, or
+upstream limits define the space of possible answers?
+
+## Decision
+
+The chosen course of action, stated unambiguously.
+
+## Rationale
+
+Why this option, given the context. Cite evidence (URLs, commit hashes,
+issue numbers) so the reasoning can be re-verified later.
+
+## Consequences
+
+The trade-offs accepted by the decision — both positive and negative.
+Mitigations for the negatives, if any.
+
+## Alternatives considered
+
+Other options that were on the table and why they were rejected.
+
+## References
+
+Issues, PRs, external documentation, and any "watch signals" that should
+prompt revisiting the decision.
+```
+
+Once the ADR is committed, its **Status** is locked. If the decision later
+changes, write a new ADR that supersedes the old one and update the old
+ADR's Status line to `Superseded by ADR-NNNN`.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-kotlin-maven-central-publishing-credentials.md) | Kotlin Maven Central publishing credentials | Accepted (2026-04-11) |


### PR DESCRIPTION
## Summary

- Establishes `docs/adr/` as the location for architecture decision records, with a short README explaining the convention, file-naming scheme (`NNNN-kebab-case-title.md`), and template structure.
- Adds **ADR 0001 — Kotlin Maven Central publishing credentials**, recording the decision to keep long-lived `CENTRAL_PORTAL_USERNAME` / `CENTRAL_PORTAL_PASSWORD` secrets in the `maven-central` GitHub environment until upstream OIDC support exists.
- Links the new directory from `README.md`'s docs list.
- Closes #1124 and #1501.

## Why

#1124 asked to migrate Kotlin Maven Central publishing from long-lived secrets to GitHub OIDC trusted publishing, matching the pattern already used by `ruby.yml` and `python.yml`. A research pass on **2026-04-11** confirmed the migration is still blocked upstream:

1. Sonatype Central Portal exposes no OIDC token-exchange endpoint. `https://central.sonatype.com/publishing/trusted-publishers` returns only an empty SPA shell — feature appears to be in development, not shipped.
2. The vanniktech `gradle-maven-publish-plugin` 0.36.0 (2025-01-18) still requires `mavenCentralUsername` / `mavenCentralPassword`. No OIDC code path.
3. No official `sonatype/*` GitHub Action exists for Central Portal publishing — the `sonatype/actions` org publishes only Lifecycle / IQ Server tooling.
4. No community action implements OIDC ↔ Central Portal token exchange.

The migration cannot be implemented today without writing a custom bridge whose Sonatype-side counterpart does not exist. Rather than leave #1124 open as a passive reminder, the decision is recorded as an ADR — including the four watch signals that should prompt revisiting — and the issue is closed. A fresh issue will be filed when any of the watch signals flips.

This is also the first ADR in the repository, so the PR establishes the ADR convention along the way.

## Test plan

This is a docs-only change. Verification is manual:

- [ ] `docs/adr/README.md` and `docs/adr/0001-kotlin-maven-central-publishing-credentials.md` render correctly in the GitHub PR preview.
- [ ] Internal links resolve: `README.md` → `docs/adr/README.md`, ADR 0001 → its sibling files in `.github/workflows/`.
- [ ] CI green (no Rust source changes, so `cargo doc --workspace --no-deps` and other gates should pass unchanged).
- [ ] **Reviewer pre-merge sanity check** — re-fetch the four upstream sources listed under "Watch signals" in ADR 0001 to confirm none of them have flipped between PR open and merge time. If any has flipped, this ADR is wrong on arrival and the PR should pivot to actually doing the migration:
  - [ ] [vanniktech plugin releases](https://github.com/vanniktech/gradle-maven-publish-plugin/releases) — newest release notes do not mention `oidc` / `trusted publish` / `id-token`
  - [ ] `https://central.sonatype.com/publishing/trusted-publishers` — still serves an empty SPA shell
  - [ ] [github.com/sonatype](https://github.com/sonatype) — no Central Portal publishing action present
  - [ ] `https://central.sonatype.org/publish/publish-portal-gradle/` — does not document an OIDC flow

## Review summary

No code changes; no Rust crate modifications; no workflow modifications. Only `README.md` (one-line additive edit) and two new markdown files under `docs/adr/`.