### PR TITLE
docs(rules): add ADR discipline rule for proactive decision recording

### DIFF
--- a/.claude/rules/adr-discipline.md
+++ b/.claude/rules/adr-discipline.md
@@ -55,10 +55,44 @@ the action that locks in the decision:
    action. Do not wait for the user to ask.
 2. **Find the next sequence number** by listing existing ADRs in
    `docs/adr/` and incrementing the highest. Sequence numbers are
-   never reused, even when an ADR is later superseded.
-3. **Write the ADR** following the template in `docs/adr/README.md`
-   (Status, Date, Context, Decision, Rationale, Consequences,
-   Alternatives considered, References).
+   never reused, even when an ADR is later superseded. If `docs/adr/`
+   does not yet exist, start at `0001` and create the directory in the
+   same PR (along with a `docs/adr/README.md` index page using the
+   convention documented in this rule).
+3. **Write the ADR** using the template below as the source of truth.
+   Once `docs/adr/README.md` exists in `main`, treat it as a richer
+   secondary reference, but the field list in this rule is always
+   authoritative:
+
+   ```markdown
+   # NNNN. Short title in sentence case
+
+   - **Status**: Accepted | Superseded by ADR-NNNN | Deprecated
+   - **Date**: YYYY-MM-DD
+
+   ## Context
+   Why is this decision being made now? What constraints define the
+   space of possible answers?
+
+   ## Decision
+   The chosen course of action, stated unambiguously.
+
+   ## Rationale
+   Why this option, given the context. Cite evidence so the reasoning
+   can be re-verified later.
+
+   ## Consequences
+   Trade-offs accepted by the decision — both positive and negative,
+   plus mitigations for the negatives.
+
+   ## Alternatives considered
+   Other options on the table and why they were rejected.
+
+   ## References
+   Issues, PRs, external documentation, and any "watch signals" that
+   should prompt revisiting the decision.
+   ```
+
 4. **Open a dedicated PR** for the ADR (per the shared-files policy in
    `parallel-work.md` and `doc-maintenance.md`). Update the ADR index
    table in `docs/adr/README.md` in the same PR.

--- a/.claude/rules/adr-discipline.md
+++ b/.claude/rules/adr-discipline.md
@@ -1,0 +1,100 @@
+# ADR Discipline
+
+Significant decisions in this project — especially ones that intentionally
+**decline** to do work, lock in a non-obvious tradeoff, or establish a
+project-wide convention — MUST be recorded as Architecture Decision
+Records (ADRs) under `docs/adr/`.
+
+ADRs exist to preserve the **why** of a decision, so the rationale
+survives after the issue tracker, chat history, or commit message moves
+on. The bar for writing one is: *would a reasonable future contributor
+(or AI assistant session) reach the wrong conclusion if this rationale
+were missing?* If yes, write the ADR.
+
+## When to write an ADR (proactively, without being asked)
+
+Open an ADR PR whenever any of the following occur, **before** taking
+the action that locks in the decision:
+
+- **Closing an issue without implementing it.** If the work is being
+  declined because it is upstream-blocked, no longer wanted, superseded,
+  or rejected on its merits, the rationale belongs in an ADR. The
+  issue's closing comment then links to the ADR. (Canonical example:
+  ADR 0001, which captured why #1124 was closed without migrating
+  Kotlin Maven Central to OIDC.)
+- **Choosing one technical approach over another with non-obvious
+  tradeoffs.** If a future contributor might reasonably re-propose the
+  rejected option, the rejection needs to be durable.
+- **Establishing a project-wide convention not yet captured in
+  `.claude/rules/`.** Files in `.claude/rules/` are operational rules;
+  ADRs are the *decisions* that produced those rules. When a rule is
+  itself novel or contested, write the ADR first and link it from the
+  rule.
+- **Declining a known bug fix or improvement** because the cost
+  outweighs the benefit, or because the fix lives upstream and is
+  blocked there.
+- **Locking in a security trade-off** (e.g. accepting a long-lived
+  credential because the alternative is unavailable, or allowing a
+  particular permission scope).
+- **Reversing or superseding a previous ADR.** Write a new ADR
+  explaining the reversal; do not silently edit the old one.
+
+## When an ADR is NOT needed
+
+- Routine code changes that any maintainer would make the same way.
+- Bug fixes whose root cause is fully captured in the commit message.
+- Decisions already covered by an existing rule in `.claude/rules/` or
+  by an existing accepted ADR.
+- Minor stylistic, naming, or formatting choices.
+- Reversible experiments that can be rolled back without consequence.
+
+## Process
+
+1. **Recognize the trigger.** When you encounter one of the situations
+   above, pause and propose writing an ADR before executing the related
+   action. Do not wait for the user to ask.
+2. **Find the next sequence number** by listing existing ADRs in
+   `docs/adr/` and incrementing the highest. Sequence numbers are
+   never reused, even when an ADR is later superseded.
+3. **Write the ADR** following the template in `docs/adr/README.md`
+   (Status, Date, Context, Decision, Rationale, Consequences,
+   Alternatives considered, References).
+4. **Open a dedicated PR** for the ADR (per the shared-files policy in
+   `parallel-work.md` and `doc-maintenance.md`). Update the ADR index
+   table in `docs/adr/README.md` in the same PR.
+5. **Link the ADR** from any issue, PR, or rule the decision touches.
+   When closing an issue that the ADR governs, the closing comment must
+   include the ADR link.
+6. **Lock the Status** once the ADR PR merges. To change the decision
+   later, write a new ADR that supersedes the old one and update the
+   old ADR's Status line to `Superseded by ADR-NNNN`. Do not rewrite
+   accepted ADRs in place.
+
+## Proactive recognition (for AI assistants)
+
+When the user instructs you to **close an issue without implementing
+it**, **decline a proposal**, **choose between approaches with
+significant tradeoffs**, or **establish a new project-wide convention**,
+first check whether an ADR is warranted using the triggers above. If
+yes, propose writing the ADR (and the next sequence number) BEFORE
+executing the close/decline/convention action. The user should not have
+to ask "should we record this as an ADR?" — the rule fires
+automatically.
+
+If you are uncertain whether an ADR is warranted, err on the side of
+proposing one. A short ADR is cheap to write; a lost rationale is
+expensive to reconstruct.
+
+## Why
+
+Issues, comments, and chat history decay. Rationale that lives only in
+those places becomes invisible to future contributors and to future AI
+assistant sessions, who can then re-propose work that was already
+considered and declined — burning time on the same upstream check, the
+same alternatives analysis, and the same conclusion.
+
+ADR 0001 (Kotlin Maven Central credentials) is the canonical case: the
+OIDC migration cannot work today, the reasoning involved checking four
+upstream sources, and the issue would have been closed with that
+rationale buried in a comment if the maintainer had not asked for an
+ADR. This rule exists so that ask is no longer necessary.

--- a/.claude/rules/doc-maintenance.md
+++ b/.claude/rules/doc-maintenance.md
@@ -20,7 +20,7 @@ promptly.
 | Existing rule no longer applies | Remove or update the relevant `.claude/rules/` file |
 | Dependency policy changed | `CLAUDE.md` Dependency Policy section |
 | Public API contract changes | Doc comment on the affected function/struct |
-| Significant decision warranting an ADR (see [`adr-discipline.md`](adr-discipline.md)) | `docs/adr/` — add new ADR file and update the index in `docs/adr/README.md` |
+| Decision warranting an ADR (see [`adr-discipline.md`](adr-discipline.md)) | `docs/adr/` — add ADR file and update index |
 
 ## CI Doc Check
 

--- a/.claude/rules/doc-maintenance.md
+++ b/.claude/rules/doc-maintenance.md
@@ -20,6 +20,7 @@ promptly.
 | Existing rule no longer applies | Remove or update the relevant `.claude/rules/` file |
 | Dependency policy changed | `CLAUDE.md` Dependency Policy section |
 | Public API contract changes | Doc comment on the affected function/struct |
+| Significant decision warranting an ADR (see [`adr-discipline.md`](adr-discipline.md)) | `docs/adr/` — add new ADR file and update the index in `docs/adr/README.md` |
 
 ## CI Doc Check
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -53,8 +53,13 @@ When closing an issue because the work is being declined (upstream-blocked,
 no longer wanted, superseded, or rejected on its merits) rather than because
 a PR implemented it, **first check whether an ADR is warranted** per
 [`adr-discipline.md`](adr-discipline.md). If yes, write the ADR and link it
-from the closing comment so the rationale outlives the issue tracker. The
-ADR should be opened as its own dedicated PR before the close action runs.
+from the closing comment so the rationale outlives the issue tracker.
+
+The ADR PR must be **merged to `main`** before the issue is closed — opening
+the PR is not sufficient. If the close happens first, the closing comment
+will link to a path that does not yet exist on `main`, and the rationale
+will be invisible to anyone reading the issue between the close and the
+ADR merge.
 
 ## Tracking Issues & Sub-Issues
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -47,6 +47,15 @@ bug should close all linked issues.
    this repo; a human inspects the check rollup and performs the squash merge.
 6. Cleanup worktree.
 
+## Closing an Issue Without Implementing It
+
+When closing an issue because the work is being declined (upstream-blocked,
+no longer wanted, superseded, or rejected on its merits) rather than because
+a PR implemented it, **first check whether an ADR is warranted** per
+[`adr-discipline.md`](adr-discipline.md). If yes, write the ADR and link it
+from the closing comment so the rationale outlives the issue tracker. The
+ADR should be opened as its own dedicated PR before the close action runs.
+
 ## Tracking Issues & Sub-Issues
 
 For large features or milestones, create a **tracking issue** labeled


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/adr-discipline.md` — explicit triggers, process, and a "Proactive recognition" section directing AI assistants to propose an ADR **before** executing the related action.
- Adds an ADR row to the Update Triggers table in `.claude/rules/doc-maintenance.md`.
- Adds a "Closing an Issue Without Implementing It" section to `.claude/rules/issue-workflow.md` that points at the new rule.
- Closes #1503.

## Why

#1502 introduced the ADR convention and ADR 0001 (Kotlin Maven Central credentials), but only because the maintainer asked. The maintainer's follow-up: *"このような意思決定は積極的に今後ADRとして残すようにルールやスキルにまとめてほしい。私から言わなくても適切に運用されてほしい"* — make it automatic. This PR encodes the practice as a project rule so future sessions reach for an ADR by default whenever a decision intentionally declines work, locks in a non-obvious tradeoff, or establishes a project-wide convention.

The rule defines the **five trigger situations** that warrant an ADR:

1. Closing an issue without implementing it.
2. Choosing one technical approach over another with non-obvious tradeoffs.
3. Establishing a project-wide convention not yet captured in `.claude/rules/`.
4. Declining a known bug fix or improvement.
5. Locking in a security trade-off.

…and the inverse "when an ADR is NOT needed" guidance to keep the bar from drifting too low. The "Proactive recognition" section explicitly addresses AI assistants: *"propose the ADR (and the next sequence number) BEFORE executing the close/decline/convention action. The user should not have to ask 'should we record this as an ADR?' — the rule fires automatically."*

## Test plan

This is a docs-only change. Verification:

- [ ] `.claude/rules/adr-discipline.md`, `doc-maintenance.md`, and `issue-workflow.md` render correctly in the GitHub PR preview.
- [ ] Internal cross-links between the three files resolve.
- [ ] CI green (no Rust source changes).
- [ ] **Future verification (out of band)**: the next time this repo encounters an issue closure-without-implementation or a decline-an-approach moment, the active session should reach for an ADR without being asked. The maintainer can verify by watching how the next applicable situation is handled.

## Review summary

No code changes, no workflow modifications. Three `.claude/rules/` markdown files (one new, two amended). All cross-references kept in lockstep.

Note: Soft dependency on #1502 — the new rule references `docs/adr/` and ADR 0001. The rule is prescriptive, so it works regardless of merge order, but reading it is most useful when ADR 0001 is also visible on `main`.