### PR TITLE
chore(versions): re-sync @chordsketch/wasm to workspace 0.2.0

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -207,10 +207,10 @@ jobs:
         # error. Paired with the post-release rollup in release-verify.yml
         # which catches the silent environment-gate case. See #1506.
         env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
         run: python3 scripts/check-env-secrets.py --channel maven-central
 
       - name: Download generated Kotlin bindings

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -201,7 +201,7 @@ jobs:
           # 0.1.0 → 0.1.1 fix, in the publish PR itself). The README sync
           # check (.github/workflows/readme-sync.yml) does not catch this
           # automatically because the version string lives only here.
-          npm install '@chordsketch/wasm@0.2.0'
+          npm install '@chordsketch/wasm@0.1.1'
 
       - name: Smoke test text + HTML + PDF render
         run: |

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -201,7 +201,7 @@ jobs:
           # 0.1.0 → 0.1.1 fix, in the publish PR itself). The README sync
           # check (.github/workflows/readme-sync.yml) does not catch this
           # automatically because the version string lives only here.
-          npm install '@chordsketch/wasm@0.1.1'
+          npm install '@chordsketch/wasm@0.2.0'
 
       - name: Smoke test text + HTML + PDF render
         run: |

--- a/ci/release-channels.toml
+++ b/ci/release-channels.toml
@@ -179,10 +179,10 @@ kind = "maven-central"
 package = "io.github.koedame:chordsketch"
 expected_version = "tag"
 required_secrets = [
-    "MAVEN_CENTRAL_USERNAME",
-    "MAVEN_CENTRAL_PASSWORD",
-    "SIGNING_KEY",
-    "SIGNING_PASSWORD",
+    "CENTRAL_PORTAL_USERNAME",
+    "CENTRAL_PORTAL_PASSWORD",
+    "GPG_SIGNING_KEY",
+    "GPG_SIGNING_PASSWORD",
 ]
 notes = "OIDC migration tracked in #1124."
 

--- a/ci/version-skew-allowlist.toml
+++ b/ci/version-skew-allowlist.toml
@@ -50,6 +50,25 @@ expires_at = "first successful Marketplace publish"
 tracking_issue = "1508"
 
 # ----------------------------------------------------------------
+# readme-smoke.yml hardcoded npm pin
+# ----------------------------------------------------------------
+
+[[allowed_skews]]
+file = ".github/workflows/readme-smoke.yml"
+field = "npm install @chordsketch/wasm pin"
+current_value = "0.1.1"
+reason = """
+The smoke-test job installs @chordsketch/wasm@0.1.1 by literal pin. The npm
+package version was bumped to 0.2.0 in packages/npm/package.json in the
+same PR (#1518), but the pin in readme-smoke.yml can only advance once
+0.2.0 is actually published to npm (which happens when the v0.2.0 tag is
+cut and the publish workflow runs). This entry retires in the post-release
+PR that flips the pin to 0.2.0.
+"""
+expires_at = "first @chordsketch/wasm@0.2.0 npm publish"
+tracking_issue = "1509"
+
+# ----------------------------------------------------------------
 # readme-smoke.yml library-smoke caret constraint
 # ----------------------------------------------------------------
 

--- a/ci/version-skew-allowlist.toml
+++ b/ci/version-skew-allowlist.toml
@@ -30,25 +30,6 @@
 #   tracking_issue — GitHub issue number, as a string or integer
 
 # ----------------------------------------------------------------
-# npm @chordsketch/wasm patch-skew from workspace
-# ----------------------------------------------------------------
-
-[[allowed_skews]]
-file = "packages/npm/package.json"
-field = "version"
-current_value = "0.1.1"
-reason = """
-@chordsketch/wasm is allowed to patch-skew from the workspace version for
-packaging-only fixes, per docs/releasing.md §Version Skew. The dual-package
-(web/node) fix shipped as 0.1.1 while the crate stayed at 0.1.0; at the next
-workspace release this re-syncs. The WASM `version()` function returns the
-Rust crate version (compiled into the .wasm binary), not the npm wrapper
-version, so consumers that inspect `version()` still see a coherent value.
-"""
-expires_at = "next workspace-wide release (re-sync target)"
-tracking_issue = "1507"
-
-# ----------------------------------------------------------------
 # VS Code extension lagging until first Marketplace publish
 # ----------------------------------------------------------------
 
@@ -67,25 +48,6 @@ succeeds.
 """
 expires_at = "first successful Marketplace publish"
 tracking_issue = "1508"
-
-# ----------------------------------------------------------------
-# readme-smoke.yml hardcoded npm pin
-# ----------------------------------------------------------------
-
-[[allowed_skews]]
-file = ".github/workflows/readme-smoke.yml"
-field = "npm install @chordsketch/wasm pin"
-current_value = "0.1.1"
-reason = """
-The smoke-test job at lines ~195-204 of readme-smoke.yml installs
-@chordsketch/wasm@0.1.1 by literal pin. This tracks the npm package version
-above, which is itself patch-skewed. The README sync check
-(readme-sync.yml) does not catch drift here because the version string lives
-only inside this shell heredoc. When the npm allowlist entry above is
-retired, this one retires in the same PR.
-"""
-expires_at = "npm allowlist entry is retired"
-tracking_issue = "1509"
 
 # ----------------------------------------------------------------
 # readme-smoke.yml library-smoke caret constraint

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/wasm",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "ChordPro parser and renderer compiled to WebAssembly",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## What

- Bump `packages/npm/package.json` version: `0.1.1` → `0.2.0`
- Fix `ci/release-channels.toml` and `kotlin.yml` check step: align maven-central secret names with actual repo secrets (`CENTRAL_PORTAL_*` / `GPG_SIGNING_*`)
- Restore `readme-smoke.yml` wasm pin at `0.1.1` with updated allowlist entry (pin advances to `0.2.0` in the post-release PR after npm publish)

## Why

Pre-release version bump for v0.2.0. The `@chordsketch/wasm` npm package re-syncs with the workspace per the policy in `docs/releasing.md §Version Skew`. The readme-smoke pin stays at 0.1.1 until the publish workflow actually publishes 0.2.0 to npm.

## Test results

```
python3 scripts/check-version-consistency.py
# → OK: all sources are in sync (or covered by the allowlist)
```

## Review summary

Pre-release version bump and CI fix. No logic changes.

Closes #1507