### PR TITLE
fix(ci): remove tag ref from publish-job checkouts

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -198,8 +198,11 @@ jobs:
       url: https://repo1.maven.org/maven2/io/github/koedame/chordsketch/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ inputs.tag || github.ref }}
+        # No `ref:` override — always check out the default branch (main) so
+        # scripts/check-env-secrets.py is present. The publish step uses
+        # pre-built artifacts downloaded from the build jobs; the Gradle source
+        # in packages/kotlin/ is identical in substance between main and any
+        # recent release tag, with version 0.2.0 specified in both.
 
       - name: Check required secrets present
         # Fails fast when any Maven Central credential is missing so

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -200,8 +200,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ inputs.tag || github.ref }}
+        # No `ref:` override — always check out the default branch (main) so
+        # scripts/check-env-secrets.py is present. The publish step uses
+        # pre-built .node artifacts downloaded from the build jobs; version
+        # is determined by the tag input, not by checked-out source.
 
       - name: Check required secrets present
         # Fails fast when NPM_TOKEN is missing so "environment missing →


### PR DESCRIPTION
## What

Remove `ref: ${{ inputs.tag || github.ref }}` from the `actions/checkout` step in the publish jobs of `kotlin.yml` and `napi.yml`.

## Why

When triggered via `workflow_dispatch` with `tag=v0.2.0`, these jobs checked out the v0.2.0 tag (commit from 2026-04-08) which predates `scripts/check-env-secrets.py`. The check step failed immediately with "No such file or directory", blocking Maven Central and napi npm publish entirely.

Publish jobs use pre-built artifacts downloaded from the build jobs — they do not need the source at the exact tag commit. Always checking out main ensures `scripts/` is present.

## Test results

CI pass on the branch. Maven Central and napi will be re-triggered after merge.

## Review summary

2-line CI fix per workflow. No logic changes to publish commands.

Closes #1520