### PR TITLE
fix(ci): remove tag ref from vscode-extension build/publish checkouts

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ inputs.tag || github.ref }}
+        # No `ref:` override — always check out main so package-lock.json
+        # is present for Node.js caching. Same pattern as #1521.
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -120,8 +120,8 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.tag != '')
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ inputs.tag || github.ref }}
+        # No `ref:` override — always check out main so scripts/ is present.
+        # Same pattern as #1521.
 
       - name: Check required secrets present
         # Fails fast when VSCE_PAT is missing so "environment missing → silent


### PR DESCRIPTION
## What

Remove `ref: ${{ inputs.tag || github.ref }}` from the `actions/checkout` steps in both the build and publish jobs of `vscode-extension.yml`.

## Why

Same root cause as #1520 (fixed for kotlin/napi in #1521). When triggered with `tag=v0.2.0`, the workflow checked out the 2026-04-08 commit which predates `packages/vscode-extension/package-lock.json`. The Node.js cache step fails immediately with "Some specified paths were not resolved" and the entire build is skipped.

Removing the `ref:` override means the workflow always checks out main where all required files are present.

## Review summary

1-line change per job (2 total). Same pattern as #1521.

Closes #1523