### PR TITLE
chore(versions): retire vscode-extension 0.1.0 skew after first Marketplace publish

### DIFF
--- a/ci/version-skew-allowlist.toml
+++ b/ci/version-skew-allowlist.toml
@@ -29,23 +29,3 @@
 #                    human-actionable)
 #   tracking_issue — GitHub issue number, as a string or integer
 
-# ----------------------------------------------------------------
-# VS Code extension lagging until first Marketplace publish
-# ----------------------------------------------------------------
-
-[[allowed_skews]]
-file = "packages/vscode-extension/package.json"
-field = "version"
-current_value = "0.1.0"
-reason = """
-The VS Code extension is pinned at 0.1.0 until the first successful
-Marketplace publish. The `vscode-marketplace` environment was never created,
-so the publish job has been silently skipped on every run since #1352 (see
-issue #1506 Background §1). Bumping the package version before the first
-publish would create a confusing "0.2.0 was never published" gap in the
-Marketplace history. This entry retires the moment the first publish
-succeeds.
-"""
-expires_at = "first successful Marketplace publish"
-tracking_issue = "1508"
-

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "chordsketch",
   "displayName": "ChordSketch",
   "description": "ChordPro language support with syntax highlighting, diagnostics, completions, and a live HTML preview panel.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "koedame",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## What

- Removes the `[[allowed_skews]]` entry for `packages/vscode-extension/package.json` from `ci/version-skew-allowlist.toml`
- Bumps the VS Code extension version from `0.1.0` to `0.2.0` to match the canonical workspace version

## Why

The allowlist entry's `expires_at` condition ("first successful Marketplace publish") is now met.
The first publish succeeded on 2026-04-11 via workflow run [24288149273](https://github.com/koedame/chordsketch/actions/runs/24288149273).

## Test results

Version consistency CI check will pass once the allowlist entry is removed and the version is bumped to match the workspace.

## Review summary

Mechanical cleanup: removes the allowlist entry and bumps the version to match.

Closes #1508