### PR TITLE
chore: gitignore napi prebuilt binaries and package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ packages/npm/node/
 node_modules/
 packages/playground/dist/
 
+# napi-rs prebuilt binaries and lock files (local build/publish artifacts)
+crates/napi/**/*.node
+crates/napi/package-lock.json
+crates/napi/npm/*/package-lock.json
+
 # Tools
 .serena/
 


### PR DESCRIPTION
## What

Adds `.gitignore` entries for `crates/napi/**/*.node` and `crates/napi/package-lock.json`.

## Why

During the v0.2.0 manual napi publish, these local build/publish artifacts appeared as untracked files in the main checkout. They should never be committed.

## Test results

`git status` in a clean checkout no longer shows these files after the napi publish procedure.

## Review summary

Two-line `.gitignore` addition. No code changes.

Closes #1527