### PR TITLE
docs: enforce root-cause-fix discipline in rules and review commands

### DIFF
--- a/.claude/commands/project/delta-review.md
+++ b/.claude/commands/project/delta-review.md
@@ -16,6 +16,12 @@ review. The argument is a base commit hash or PR number: `$ARGUMENTS`
 
 3. **Perform both code review and security review** on the diff.
 
+   **Additionally, check for symptomatic / band-aid fixes** (per `.claude/rules/root-cause-fixes.md`):
+   - Does the fix address the root cause, or does it only mask the symptom?
+   - Are there `#[allow(...)]`, deleted tests, silenced errors, bumped timeouts, or
+     adjusted expected outputs that hide the real defect?
+   - Any symptomatic fix is at minimum **Medium** severity (spec violation / incorrect behavior preserved).
+
 4. **Classify every finding by severity**:
 
    | Severity | Blocks | Definition |

--- a/.claude/commands/project/phase-review.md
+++ b/.claude/commands/project/phase-review.md
@@ -16,6 +16,11 @@ tracking issue number: `$ARGUMENTS`
    - Perform a thorough code review: correctness, quality, consistency, test coverage.
    - Perform a security review: input validation, injection, trust boundaries,
      data exposure.
+   - **Check for symptomatic / band-aid fixes** (per `.claude/rules/root-cause-fixes.md`):
+     look for `#[allow(...)]` suppressions, deleted or `#[ignore]`-d tests, silenced
+     errors (`unwrap_or_default`, swallowed `Err`), bumped timeouts, or adjusted golden
+     snapshots that hide rather than fix a defect. Any such pattern is at minimum
+     **Medium** severity.
 
 3. **Classify every finding by severity**:
 

--- a/.claude/rules/root-cause-fixes.md
+++ b/.claude/rules/root-cause-fixes.md
@@ -1,14 +1,19 @@
 # Root Cause Fixes
 
+**Symptomatic / band-aid fixes are prohibited in this project.**
+
 When encountering a problem — whether a bug, test failure, build error, or unexpected
-behavior — always investigate and fix the **root cause**, not the symptom.
+behavior — stop, investigate, and fix the **root cause**. Patching the symptom while
+leaving the underlying defect intact is not acceptable.
 
 ## Rules
 
 - **No workarounds without justification.** Do not suppress warnings, skip tests, add
-  special-case patches, or apply band-aid fixes. If a workaround is truly necessary
-  (e.g., upstream bug outside our control), document the reason and link to a tracking
-  issue for the proper fix.
+  special-case patches, or apply band-aid fixes. If a workaround is truly unavoidable
+  (e.g., upstream bug with no released fix), you MUST:
+  1. Add a `// WORKAROUND: <reason>` comment at every affected site.
+  2. Open a GitHub Issue for the proper fix and link it from the comment.
+  3. Keep the workaround isolated — do not let it spread across the codebase.
 - **Diagnose before fixing.** Read the error, trace the cause, and understand *why* the
   problem occurs before writing any fix. A fix you don't understand is not a fix.
 - **Fix at the right layer.** If the bug is in the parser, fix the parser — don't add
@@ -19,3 +24,34 @@ behavior — always investigate and fix the **root cause**, not the symptom.
 - **Tests must validate the root cause.** When adding a regression test, ensure it
   covers the actual root cause, not just the surface-level symptom. The test should fail
   if the root cause is reintroduced.
+- **Do not change the test to match broken behavior.** If a test fails, the test is
+  probably right. Fix the code, not the test (unless the spec itself changed).
+
+## Symptomatic Fix Patterns to Reject
+
+The following patterns are symptomatic fixes and MUST NOT be merged:
+
+| Pattern | Root-cause alternative |
+|---------|----------------------|
+| `unwrap_or_default()` / `unwrap_or("")` to silence a missing-value error | Fix the upstream code that should always produce the value |
+| Catching a panic with `catch_unwind` instead of eliminating the panic | Remove the condition that causes the panic |
+| `#[allow(clippy::...)]` / `#[allow(unused_...)]` on legitimate warnings | Fix the code the lint is flagging |
+| Returning early with `Ok(())` to skip a failing step | Handle the failure correctly |
+| Deleting or `#[ignore]`-ing a failing test | Fix the code so the test passes |
+| Adding a special-case `if` to avoid triggering a known bug | Fix the known bug |
+| Bumping a timeout / retry count to mask intermittent failures | Eliminate the source of intermittency |
+| Adjusting expected output in a golden test to hide a regression | Fix the regression |
+
+## Process When Root Cause Is Unknown
+
+If you cannot identify the root cause within the current scope:
+
+1. State this explicitly — do not silently apply a workaround.
+2. Open a GitHub Issue describing the unresolved root cause.
+3. Discuss with the maintainer before landing any interim patch.
+
+## Why
+
+Symptomatic fixes compound over time. Each one hides a defect, increases the
+distance between code and spec, and makes the next bug harder to diagnose.
+This project enforces root-cause discipline to keep the codebase tractable.


### PR DESCRIPTION
## What

Strengthens \`.claude/rules/root-cause-fixes.md\` and wires the prohibition into both review commands.

**\`root-cause-fixes.md\`:**
- Explicit prohibition statement at the top: *"Symptomatic / band-aid fixes are prohibited in this project."*
- Banned-pattern reference table (pattern → root-cause alternative)
- Documented procedure for the rare unavoidable workaround: \`// WORKAROUND:\` comment + linked issue + keep isolated
- New rule: do not change a test to match broken behavior
- "Process when root cause is unknown" section

**\`/project:delta-review\` and \`/project:phase-review\`:**
- Added a symptomatic-fix check step listing the specific anti-patterns to look for
- Any symptomatic fix is classified as at minimum **Medium** severity

## Why

The maintainer explicitly codified this as a hard project rule. Capturing it in the rules file and in the review commands ensures it is enforced consistently across both human and automated reviews.

## Test results

Documentation-only change; no code or tests affected.

## Review summary

No code changes — purely \`.claude/\` rule and command files.

Closes #1536