### PR TITLE
docs: codify fix-propagation rule and strengthen sibling rules/review commands

### DIFF
--- a/.claude/commands/project/delta-review.md
+++ b/.claude/commands/project/delta-review.md
@@ -22,6 +22,17 @@ review. The argument is a base commit hash or PR number: `$ARGUMENTS`
      adjusted expected outputs that hide the real defect?
    - Any symptomatic fix is at minimum **Medium** severity (spec violation / incorrect behavior preserved).
 
+   **Additionally, run a fix-propagation audit** (per `.claude/rules/fix-propagation.md`):
+   - If the diff fixes a bug in one renderer, check the other two renderers for the same bug.
+   - If the diff fixes a bug in one binding (FFI/WASM/NAPI), check the other two bindings.
+   - If the diff changes validation or clamping logic in one renderer, verify parity in all three.
+   - If the diff adds/changes an entry in a URI scheme denylist, tag blocklist, or attribute
+     allowlist, verify all sibling lists are consistent (see `.claude/rules/sanitizer-security.md`).
+   - If the diff fixes a security or resource-management property in one external-tool
+     invocation (`invoke_abc2svg`, `invoke_lilypond`, `invoke_musescore`), check all three.
+   - An unfixed sister site carrying the same defect is at minimum **Medium** severity.
+   - The PR description MUST include a sentence confirming the sister-site audit was done.
+
 4. **Classify every finding by severity**:
 
    | Severity | Blocks | Definition |

--- a/.claude/commands/project/phase-review.md
+++ b/.claude/commands/project/phase-review.md
@@ -21,6 +21,10 @@ tracking issue number: `$ARGUMENTS`
      errors (`unwrap_or_default`, swallowed `Err`), bumped timeouts, or adjusted golden
      snapshots that hide rather than fix a defect. Any such pattern is at minimum
      **Medium** severity.
+   - **Check for fix-propagation gaps** (per `.claude/rules/fix-propagation.md`):
+     for each bug fix in the phase, verify that the fix was applied to all sibling sites
+     (all three renderers, all three bindings, all external-tool invocation functions,
+     all sibling sanitizer lists). An unfixed sibling is at minimum **Medium** severity.
 
 3. **Classify every finding by severity**:
 

--- a/.claude/rules/fix-propagation.md
+++ b/.claude/rules/fix-propagation.md
@@ -1,0 +1,81 @@
+# Fix Propagation
+
+**When a bug is fixed in one location, every equivalent location must receive the same fix
+in the same PR.**
+
+This is the single most common recurring defect pattern in this codebase: a fix is applied
+to the most visible code path while equivalent "sister sites" are overlooked. The result is
+an asymmetric codebase where one binding is secure, one renderer is correct, or one function
+is safe — while its siblings are not.
+
+## Sister-Site Groups
+
+Before closing any PR that fixes a bug, run a sister-site audit against the following
+known sibling groups:
+
+### Renderers (text / HTML / PDF)
+`crates/render-text/src/lib.rs`, `crates/render-html/src/lib.rs`, `crates/render-pdf/src/lib.rs`
+
+Any fix to one renderer MUST be audited across all three:
+- Input validation / clamping (e.g., `{columns}` upper bound)
+- Directive match arms and fallback behavior
+- Error handling and warning paths
+
+### Bindings (FFI / WASM / NAPI)
+`crates/ffi/src/lib.rs`, `crates/wasm/src/lib.rs`, `crates/napi/src/lib.rs`
+
+Any fix to one binding's public API surface MUST be audited across all three:
+- Warning routing (e.g., `render_songs_with_warnings` vs. `render_songs_with_transpose`)
+- Input validation and error return paths
+- API shape consistency (options structs, return types)
+
+### External tool invocations
+`invoke_abc2svg`, `invoke_lilypond`, `invoke_musescore` in `crates/core/src/external_tool.rs`
+
+Any security or resource-management fix applied to one invocation function MUST be
+applied to all (e.g., `O_EXCL` temp file creation, RAII cleanup, JavaScript/script
+stripping for user-supplied notation content).
+
+### Sanitizer functions and blocklists
+`has_dangerous_uri_scheme`, `is_uri_attr`, `DANGEROUS_TAGS`, `is_safe_image_src`
+in `crates/render-html/src/lib.rs`; `sanitize_directive_token` in `crates/core/`
+
+Any addition to one URI-scheme denylist, tag blocklist, or attribute allowlist MUST be
+cross-checked against all sibling lists for the same class of risk.
+
+## Audit Procedure
+
+For every PR that fixes a bug (not just a feature addition):
+
+1. **Identify the fix pattern** — what class of defect is being corrected?
+   (e.g., missing bounds check, wrong function used, incomplete blocklist, non-RAII cleanup)
+
+2. **Ask: where else does this pattern occur?** — Search the codebase for the same
+   construct (`grep`/`Glob` for the same function name, struct, or idiom).
+
+3. **Check each sister site** — does it have the same defect? If yes, fix it in the same PR.
+   If the sister site is intentionally different, document why with a comment.
+
+4. **PR description must state the audit was done**, e.g.:
+   > Sister-site audit: checked `invoke_lilypond` and `invoke_musescore` — both updated.
+   > No equivalent issue in the FFI and NAPI bindings (different code path).
+
+## Severity
+
+A PR that fixes a bug in one sister site but leaves an equivalent defect in another is:
+- **High** if the unfixed site has a security impact
+- **Medium** if it causes incorrect output or violates a spec
+- **Low** if it is a defense-in-depth or quality gap
+
+## Why
+
+6 of the 14 findings in the 2026-04-12 main-branch review were caused by fix locality bias:
+- WASM got `render_songs_with_warnings`; NAPI did not (#1541)
+- HTML renderer clamps `{columns}`; PDF did not (#1540)
+- `invoke_abc2svg` uses `O_EXCL`; `invoke_lilypond` did not (#1546)
+- `is_safe_image_src` blocks `file:`; `has_dangerous_uri_scheme` did not (#1538)
+- Some SVG URI attributes sanitized; others were not (#1545)
+- `%%javascript` stripped from ABC; `%%js` potentially not (#1551)
+
+In every case, an earlier fix was correct and complete for the code path that was changed,
+but the author did not check the equivalent code paths.

--- a/.claude/rules/renderer-parity.md
+++ b/.claude/rules/renderer-parity.md
@@ -17,6 +17,24 @@ renderer is a correctness bug.
   a fixture exercises a directive in the text renderer, an equivalent fixture
   must exist (or be explicitly tracked) for HTML and PDF.
 
+## Validation Parity
+
+Renderer parity extends beyond AST arms to **input validation and clamping logic**.
+If one renderer applies a bounds check, clamps a value, or validates a directive
+parameter, all renderers MUST apply the same check.
+
+Examples of validation that must be consistent across all three renderers:
+- `{columns}` value: clamped to `1..=MAX_COLUMNS` in all three renderers
+- `{capo}` value: validated against the valid fret range in all three renderers
+- Any directive whose value is parsed as a numeric type: same min/max in all renderers
+
+Inconsistent validation is a correctness bug: the same `.cho` file can produce
+different output (or panic) depending on which output format is used.
+
+When adding or changing validation in one renderer:
+1. Apply the same change to the other two renderers in the same PR.
+2. Add a golden test with an out-of-range value that exercises the clamping/rejection.
+
 ## Audit pattern
 
 Before closing a PR that touches any renderer:
@@ -24,9 +42,14 @@ Before closing a PR that touches any renderer:
 1. Search for all `match` arms on `Line`, `Directive`, or equivalent AST
    enums in the changed renderer.
 2. Verify every arm exists in the other renderers.
-3. If an arm is missing, either add it or file a sub-issue.
+3. For every directive that parses a numeric parameter, verify the valid range
+   and clamping logic is identical in all three renderers.
+4. If an arm or validation is missing, either add it or file a sub-issue.
 
 ## Why
 
 45 renderer parity issues were filed — the most common was a new directive
 handled in the text renderer but silently ignored or panicking in HTML/PDF.
+A 2026-04-12 audit found that the `{columns}` directive was clamped to 32 in
+the HTML renderer but unbounded in the PDF renderer (#1540), illustrating that
+parity must cover validation logic, not only match arms.

--- a/.claude/rules/sanitizer-security.md
+++ b/.claude/rules/sanitizer-security.md
@@ -29,8 +29,49 @@ property. Asymmetric treatment is a structural vulnerability.
 Example: if directive *values* are sanitized, directive *names* must be
 sanitized too — they appear in the same output context.
 
+## Blocklist and Allowlist Completeness
+
+When maintaining a URI scheme denylist, tag blocklist, or attribute allowlist,
+the list MUST be verified against the relevant specification for completeness.
+A partial list gives a false sense of security.
+
+### URI scheme denylists
+
+Every URI scheme denylist MUST block at minimum:
+`javascript:`, `vbscript:`, `data:`, `file:`, `blob:`
+
+Whenever an entry is added to any URI scheme list:
+1. Cross-check `has_dangerous_uri_scheme` and `is_safe_image_src` (and any future
+   sibling functions) to ensure they are consistent.
+2. Verify the list against the [WHATWG Fetch forbidden origins list](https://fetch.spec.whatwg.org/).
+
+### SVG tag blocklists
+
+Blocklisted SVG tags MUST include all tags that can load external resources:
+`script`, `use` (with external `href`), `feImage`, `image`, `iframe`, `embed`, `object`
+
+Whenever a tag is added to `DANGEROUS_TAGS`, check whether there is an equivalent
+filter primitive or presentation element that can load the same resource class.
+
+### Attribute allowlists / URI attribute lists
+
+URI-bearing SVG/HTML attributes MUST include at minimum:
+`href`, `xlink:href`, `src`, `action`, `formaction`, `poster`, `background`, `ping`, `to`, `values`, `from`, `by`
+
+### Testing completeness
+
+When a new entry is added to any blocklist or allowlist:
+- Add a test that exercises the new entry with a malicious value.
+- Add a comment citing the relevant spec section or CVE that motivated the entry.
+
 ## Why
 
 53 sanitizer bypass issues and 18 security asymmetry issues were filed.
 The most common pattern was sanitizing only one field of a multi-field
 record, leaving the other fields exploitable.
+
+A 2026-04-12 audit found two blocklist completeness gaps: `file:` URI not blocked
+in `has_dangerous_uri_scheme` despite being blocked in `is_safe_image_src` (#1538),
+and `feImage` absent from `DANGEROUS_TAGS` despite being a known resource-loading
+SVG primitive (#1545). Both were caused by partial lists copied from one context
+without auditing the full specification.


### PR DESCRIPTION
## What

Adds a new rule and strengthens two existing rules to prevent the most common recurring
defect pattern found in the 2026-04-12 main-branch review: **fix locality bias** — a fix
is applied to one location but not propagated to all equivalent locations.

6 of 14 review findings (#1538, #1540, #1541, #1545, #1546, #1551) shared this root cause.

### New: `.claude/rules/fix-propagation.md`

Defines the **sister-site audit** requirement:

> When a bug is fixed in one location, every equivalent location must receive the same fix
> in the same PR.

Lists the known sibling groups in this codebase:
- Renderers (text / HTML / PDF)
- Bindings (FFI / WASM / NAPI)
- External-tool invocations (`invoke_abc2svg`, `invoke_lilypond`, `invoke_musescore`)
- Sanitizer lists (`has_dangerous_uri_scheme`, `is_uri_attr`, `DANGEROUS_TAGS`, `is_safe_image_src`)

### Updated: `.claude/rules/renderer-parity.md`

Adds a **Validation Parity** section: parity covers not only match arms but also input
validation and clamping logic. If one renderer clamps `{columns}` to 32, all must.

### Updated: `.claude/rules/sanitizer-security.md`

Adds a **Blocklist and Allowlist Completeness** section with:
- Minimum required URI schemes in every denylist (`javascript:`, `vbscript:`, `data:`, `file:`, `blob:`)
- Minimum required SVG tags in every blocklist
- Minimum required URI-bearing attributes in every attribute list
- Requirement to cite the spec section or CVE when adding an entry

### Updated: `/project:delta-review` and `/project:phase-review`

Both review commands now include an explicit **fix-propagation audit** step that flags
unfixed sister sites as at minimum **Medium** severity.

## Why

All 6 fix-locality issues had a previous correct fix applied to one sibling that was not
carried to the others. The new rule and review-command checks create a mandatory checkpoint
so this class of omission is caught before merge rather than in a later audit.

## Test results

Documentation-only change; no code or tests affected.

## Review summary

No code changes — purely `.claude/` rule and command files.

Closes #1552