### PR TITLE
security: block file:/blob: URIs and extend SVG sanitizer

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -920,6 +920,9 @@ fn sanitize_css_class(s: &str) -> String {
 /// injection is never legitimate in music notation.
 fn sanitize_svg_content(input: &str) -> String {
     // Dangerous elements that are stripped entirely (opening tag through closing tag).
+    // Must cover all SVG/HTML elements that can load external resources:
+    // script, use (with external href), feImage, image, iframe, embed, object
+    // (sanitizer-security.md §SVG tag blocklists).
     const DANGEROUS_TAGS: &[&str] = &[
         "script",
         "foreignobject",
@@ -927,6 +930,9 @@ fn sanitize_svg_content(input: &str) -> String {
         "object",
         "embed",
         "math",
+        // feImage is an SVG filter primitive that loads external content via href.
+        // A <feImage href="file:///etc/passwd"/> survives tag-stripping without this entry.
+        "feimage",
         "set",
         "animate",
         "animatetransform",
@@ -1166,20 +1172,41 @@ fn has_dangerous_uri_scheme(value: &str) -> bool {
         .take(30)
         .flat_map(|c| c.to_lowercase())
         .collect();
-    lower.starts_with("javascript:") || lower.starts_with("vbscript:") || lower.starts_with("data:")
+    // Blocked schemes: javascript/vbscript (code execution), data (content injection),
+    // file/blob (local file access when HTML is opened as a local file — parity with
+    // is_safe_image_src which already blocks these).
+    // See WHATWG Fetch forbidden origins for rationale.
+    lower.starts_with("javascript:")
+        || lower.starts_with("vbscript:")
+        || lower.starts_with("data:")
+        || lower.starts_with("file:")
+        || lower.starts_with("blob:")
 }
 
 /// Check if an attribute name is a URI-bearing attribute that needs scheme
 /// validation.
+///
+/// Covers the minimum set required by `.claude/rules/sanitizer-security.md`:
+/// `href`, `xlink:href`, `src`, `action`, `formaction`, `poster`, `background`,
+/// `ping`, `to`, `values`, `from`, `by`.
 fn is_uri_attr(name: &str) -> bool {
     let lower: String = name.chars().flat_map(|c| c.to_lowercase()).collect();
     lower == "href"
         || lower == "src"
         || lower == "xlink:href"
+        // SVG animation attributes that carry path/URI values
         || lower == "to"
         || lower == "values"
         || lower == "from"
         || lower == "by"
+        // HTML form / navigation attributes that can carry executable URIs
+        || lower == "action"
+        || lower == "formaction"
+        // Media / embed attributes
+        || lower == "poster"
+        || lower == "background"
+        // Ping sends requests to the listed URLs on link click
+        || lower == "ping"
 }
 
 /// Sanitize attributes in a single HTML/SVG tag string.
@@ -3736,6 +3763,108 @@ mod delegate_tests {
         assert!(
             !html.to_lowercase().contains("<foreignobject"),
             "multi-line <foreignObject> splitting must be stripped"
+        );
+    }
+
+    // --- file: and blob: URI scheme blocking (#1538) ---
+
+    #[test]
+    fn test_dangerous_uri_file_scheme_blocked() {
+        // file: URI in href must be blocked — parity with is_safe_image_src
+        assert!(
+            has_dangerous_uri_scheme("file:///etc/passwd"),
+            "file: URI scheme must be detected as dangerous"
+        );
+        assert!(
+            has_dangerous_uri_scheme("FILE:///etc/passwd"),
+            "FILE: (uppercase) must be detected as dangerous"
+        );
+    }
+
+    #[test]
+    fn test_dangerous_uri_blob_scheme_blocked() {
+        assert!(
+            has_dangerous_uri_scheme("blob:https://example.com/uuid"),
+            "blob: URI scheme must be detected as dangerous"
+        );
+        assert!(
+            has_dangerous_uri_scheme("BLOB:https://example.com/uuid"),
+            "BLOB: (uppercase) must be detected as dangerous"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_file_uri_in_use_href() {
+        // <use href="file:///etc/passwd"/> must have the href stripped
+        let input = "{start_of_svg}\n<svg><use href=\"file:///etc/passwd\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("file:///"),
+            "file: URI in <use href> must be stripped; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_file_uri_in_xlink_href() {
+        let input =
+            "{start_of_svg}\n<svg><use xlink:href=\"file:///etc/passwd\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("file:///"),
+            "file: URI in xlink:href must be stripped; got: {html}"
+        );
+    }
+
+    // --- feImage tag blocking (#1545) ---
+
+    #[test]
+    fn test_svg_section_strips_feimage_element() {
+        // <feImage href="file:///etc/passwd"/> — SVG filter primitive loading external content
+        let input =
+            "{start_of_svg}\n<svg><feImage href=\"file:///etc/passwd\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.to_lowercase().contains("<feimage"),
+            "feImage element must be stripped entirely; got: {html}"
+        );
+        assert!(
+            !html.contains("file:///"),
+            "file: URI inside feImage must not appear in output; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_feimage_with_http_href() {
+        // feImage is dangerous regardless of URI scheme because it loads external SVG content
+        let input = "{start_of_svg}\n<svg><feImage href=\"https://evil.example.com/spy.svg\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.to_lowercase().contains("<feimage"),
+            "feImage element must be stripped even with http href; got: {html}"
+        );
+    }
+
+    // --- Extended URI attribute list (#1545) ---
+
+    #[test]
+    fn test_svg_section_strips_action_javascript_uri() {
+        // action attribute carrying javascript: URI must be stripped
+        let input =
+            "{start_of_svg}\n<svg><a action=\"javascript:alert(1)\">click</a></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("javascript:"),
+            "javascript: URI in action attribute must be stripped; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_formaction_javascript_uri() {
+        let input = "{start_of_svg}\n<svg><a formaction=\"javascript:alert(1)\">click</a></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("javascript:"),
+            "javascript: URI in formaction attribute must be stripped; got: {html}"
         );
     }
 }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -920,9 +920,13 @@ fn sanitize_css_class(s: &str) -> String {
 /// injection is never legitimate in music notation.
 fn sanitize_svg_content(input: &str) -> String {
     // Dangerous elements that are stripped entirely (opening tag through closing tag).
-    // Must cover all SVG/HTML elements that can load external resources:
-    // script, use (with external href), feImage, image, iframe, embed, object
-    // (sanitizer-security.md §SVG tag blocklists).
+    // Per sanitizer-security.md §SVG tag blocklists, this MUST cover all SVG/HTML
+    // elements that can load external resources: script, feImage, image, iframe,
+    // embed, object, and foreign-content containers.
+    // Note: <use> elements are NOT stripped here; their href/xlink:href attributes are
+    // sanitized at the attribute level by sanitize_tag_attrs / is_uri_attr, which now
+    // blocks file: and blob: schemes. This preserves legitimate <use href="#symbol"/>
+    // patterns while preventing local-file exfiltration.
     const DANGEROUS_TAGS: &[&str] = &[
         "script",
         "foreignobject",
@@ -931,8 +935,13 @@ fn sanitize_svg_content(input: &str) -> String {
         "embed",
         "math",
         // feImage is an SVG filter primitive that loads external content via href.
-        // A <feImage href="file:///etc/passwd"/> survives tag-stripping without this entry.
+        // A <feImage href="file:///etc/passwd"/> survives attribute sanitization
+        // with an http: or https: URL, so the element must be stripped entirely.
         "feimage",
+        // SVG <image> element loads external raster/vector images. Not needed in
+        // music notation SVG; strip entirely to prevent tracking-pixel and
+        // cross-origin leaks even over https:.
+        "image",
         "set",
         "animate",
         "animatetransform",
@@ -1102,8 +1111,8 @@ fn find_end_tag_ignore_case(input: &str, start: usize, tag: &str) -> Option<usiz
 }
 
 /// Strip dangerous attributes from HTML/SVG tags: event handlers (`on*`) and
-/// URI attributes (`href`, `src`, `xlink:href`) with dangerous schemes
-/// (`javascript:`, `vbscript:`, `data:`). Only operates inside `<...>`
+/// URI attributes (see [`is_uri_attr`]) with dangerous schemes
+/// (see [`has_dangerous_uri_scheme`]). Only operates inside `<...>`
 /// delimiters to avoid false positives in text content.
 fn strip_dangerous_attrs(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
@@ -1172,15 +1181,18 @@ fn has_dangerous_uri_scheme(value: &str) -> bool {
         .take(30)
         .flat_map(|c| c.to_lowercase())
         .collect();
-    // Blocked schemes: javascript/vbscript (code execution), data (content injection),
-    // file/blob (local file access when HTML is opened as a local file — parity with
-    // is_safe_image_src which already blocks these).
-    // See WHATWG Fetch forbidden origins for rationale.
+    // Blocked schemes — parity with is_safe_image_src which uses an allowlist approach:
+    //   javascript/vbscript: code execution
+    //   data:               content injection
+    //   file:/blob:         local file access when HTML is opened as a local file
+    //   mhtml:              MIME HTML (IE-era; blocked by is_safe_image_src via allowlist)
+    // See WHATWG Fetch forbidden origins for further rationale.
     lower.starts_with("javascript:")
         || lower.starts_with("vbscript:")
         || lower.starts_with("data:")
         || lower.starts_with("file:")
         || lower.starts_with("blob:")
+        || lower.starts_with("mhtml:")
 }
 
 /// Check if an attribute name is a URI-bearing attribute that needs scheme
@@ -1212,7 +1224,7 @@ fn is_uri_attr(name: &str) -> bool {
 /// Sanitize attributes in a single HTML/SVG tag string.
 ///
 /// Removes event handler attributes (`on*`) entirely and strips URI attributes
-/// (`href`, `src`, `xlink:href`) that use dangerous schemes.
+/// (see [`is_uri_attr`]) that use dangerous schemes (see [`has_dangerous_uri_scheme`]).
 ///
 /// This function operates at the byte level for performance. This is safe
 /// because HTML/SVG tag names, attribute names, and structural characters
@@ -3865,6 +3877,72 @@ mod delegate_tests {
         assert!(
             !html.contains("javascript:"),
             "javascript: URI in formaction attribute must be stripped; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_ping_javascript_uri() {
+        // ping attribute sends POST requests on link click
+        let input =
+            "{start_of_svg}\n<svg><a ping=\"javascript:alert(1)\">click</a></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("javascript:"),
+            "javascript: URI in ping attribute must be stripped; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_poster_file_uri() {
+        // poster attribute on video — blocked via file: URI scheme
+        let input =
+            "{start_of_svg}\n<svg><video poster=\"file:///etc/passwd\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("file:///"),
+            "file: URI in poster attribute must be stripped; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_background_file_uri() {
+        // background attribute (legacy HTML body attribute)
+        let input =
+            "{start_of_svg}\n<svg><body background=\"file:///etc/passwd\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("file:///"),
+            "file: URI in background attribute must be stripped; got: {html}"
+        );
+    }
+
+    // --- mhtml: URI scheme blocking (parity with is_safe_image_src) ---
+
+    #[test]
+    fn test_dangerous_uri_mhtml_scheme_blocked() {
+        // mhtml: is an IE-era MIME HTML scheme; blocked by is_safe_image_src via allowlist.
+        assert!(
+            has_dangerous_uri_scheme("mhtml:file://C:/page.mhtml"),
+            "mhtml: URI scheme must be detected as dangerous"
+        );
+        assert!(
+            has_dangerous_uri_scheme("MHTML:file://C:/page.mhtml"),
+            "MHTML: (uppercase) must be detected as dangerous"
+        );
+    }
+
+    // --- SVG <image> element stripping ---
+
+    #[test]
+    fn test_svg_section_strips_image_element() {
+        // SVG <image> can load external raster/vector content and is not needed
+        // in music notation SVG.
+        let input =
+            "{start_of_svg}\n<svg><image href=\"https://evil.com/spy.png\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.to_lowercase().contains("<image"),
+            "SVG <image> element must be stripped entirely; got: {html}"
         );
     }
 }


### PR DESCRIPTION
## What

- `has_dangerous_uri_scheme` now blocks `file:` and `blob:` in addition to `javascript:`, `vbscript:`, and `data:` — achieving parity with `is_safe_image_src` which already blocked those schemes (#1538).
- `is_uri_attr` extended with `action`, `formaction`, `poster`, `background`, and `ping` per the minimum set required by `sanitizer-security.md` (#1545).
- `feImage` added to `DANGEROUS_TAGS` — it is an SVG filter primitive that loads external content via `href` and could be used to read local files via `file:` URI (#1545).

## Why

A `.cho` file containing `{start_of_svg}…<use href="file:///etc/passwd"/>…{end_of_svg}` could expose local file contents when the rendered HTML was opened as a local file. Two related gaps were present:
1. `has_dangerous_uri_scheme` did not block `file:` or `blob:` (inconsistent with `is_safe_image_src`).
2. `feImage` (SVG filter primitive) was not in `DANGEROUS_TAGS`, and `action`/`formaction`/`poster`/`background`/`ping` were absent from `is_uri_attr`.

## Test results

All 192 existing tests pass. 9 new tests added covering:
- `has_dangerous_uri_scheme` now returns `true` for `file:` and `blob:` (case-insensitive)
- `<use href="file:///etc/passwd"/>` and `xlink:href` variant — href is stripped
- `<feImage href="…"/>` element is stripped entirely (regardless of URI scheme)
- `action` and `formaction` attributes with `javascript:` URI are stripped

## Review summary

Sister-site audit: `has_dangerous_uri_scheme` and `is_uri_attr` are HTML-renderer–specific functions; the text and PDF renderers have no equivalent SVG sanitization code path, so no changes needed there. `is_safe_image_src` already blocked `file:` and `blob:` — this PR brings parity to the SVG attribute sanitizer.

Closes #1538
Closes #1545