### PR TITLE
security: add recursion depth limit to MusicXML XML parser

### DIFF
--- a/crates/convert-musicxml/src/xml.rs
+++ b/crates/convert-musicxml/src/xml.rs
@@ -73,9 +73,22 @@ impl Element {
 // Parser
 // ---------------------------------------------------------------------------
 
+/// Maximum XML element nesting depth accepted by the parser.
+///
+/// Deeply nested documents are rejected with an error rather than overflowing
+/// the Rust call stack. Legitimate MusicXML files are shallow (typically under
+/// 20 levels); 200 is a generous ceiling that still prevents unbounded recursion
+/// from adversarial input.
+const MAX_DEPTH: usize = 200;
+
 /// Parse an XML string into an element tree.
 ///
 /// Returns the root element, or an error message if parsing fails.
+///
+/// # Errors
+///
+/// Returns an error if the XML is malformed or if the element nesting depth
+/// exceeds [`MAX_DEPTH`].
 pub(crate) fn parse(xml: &str) -> Result<Element, String> {
     let mut p = Parser {
         src: xml.as_bytes(),
@@ -84,7 +97,7 @@ pub(crate) fn parse(xml: &str) -> Result<Element, String> {
     p.skip_bom();
     p.skip_prolog()?;
     p.skip_whitespace_and_comments()?;
-    p.parse_element()
+    p.parse_element(0)
 }
 
 struct Parser<'a> {
@@ -234,7 +247,13 @@ impl<'a> Parser<'a> {
     // --- main parser -------------------------------------------------------
 
     /// Parse an element: `<name attrs> children </name>` or `<name attrs/>`.
-    fn parse_element(&mut self) -> Result<Element, String> {
+    ///
+    /// `depth` is the current nesting level (0 for the root element).
+    /// Returns an error if `depth` reaches [`MAX_DEPTH`].
+    fn parse_element(&mut self, depth: usize) -> Result<Element, String> {
+        if depth >= MAX_DEPTH {
+            return Err(format!("XML nesting depth limit of {} exceeded", MAX_DEPTH));
+        }
         self.skip_whitespace_and_comments()?;
 
         // Consume `<`
@@ -282,7 +301,7 @@ impl<'a> Parser<'a> {
         self.expect(b">")?;
 
         // Read children
-        let (text, children) = self.parse_children(&raw_name)?;
+        let (text, children) = self.parse_children(&raw_name, depth)?;
 
         Ok(Element {
             name,
@@ -360,8 +379,15 @@ impl<'a> Parser<'a> {
 
     /// Parse children of an element with tag `parent_raw_name`.
     ///
+    /// `depth` is the nesting level of the *parent* element; child elements are
+    /// parsed at `depth + 1`.
+    ///
     /// Returns `(text_content, child_elements)`.
-    fn parse_children(&mut self, parent_raw_name: &str) -> Result<(String, Vec<Element>), String> {
+    fn parse_children(
+        &mut self,
+        parent_raw_name: &str,
+        depth: usize,
+    ) -> Result<(String, Vec<Element>), String> {
         let parent_local = local_name(parent_raw_name);
         let mut text = String::new();
         let mut children = Vec::new();
@@ -436,7 +462,7 @@ impl<'a> Parser<'a> {
 
             // Child element
             if self.peek() == Some(b'<') {
-                let child = self.parse_element()?;
+                let child = self.parse_element(depth + 1)?;
                 children.push(child);
                 continue;
             }
@@ -751,6 +777,39 @@ mod tests {
         let input = "&".repeat(1000);
         let output = decode_entities(&input);
         assert_eq!(output, input);
+    }
+
+    #[test]
+    fn parse_depth_limit_rejected() {
+        // Build an XML document with MAX_DEPTH + 1 levels of nesting.
+        // The parser must return an error rather than overflowing the call stack.
+        let open: String = (0..=MAX_DEPTH).map(|i| format!("<a{i}>")).collect();
+        let close: String = (0..=MAX_DEPTH).rev().map(|i| format!("</a{i}>")).collect();
+        let doc = format!("{open}{close}");
+        let result = parse(&doc);
+        assert!(
+            result.is_err(),
+            "expected depth-limit error but got Ok for {}-level nesting",
+            MAX_DEPTH + 1
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("depth limit"),
+            "error message should mention depth limit: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_depth_at_limit_accepted() {
+        // MAX_DEPTH - 1 levels of nesting (indices 0 .. MAX_DEPTH-1) must succeed.
+        let open: String = (0..MAX_DEPTH).map(|i| format!("<a{i}>")).collect();
+        let close: String = (0..MAX_DEPTH).rev().map(|i| format!("</a{i}>")).collect();
+        let doc = format!("{open}{close}");
+        assert!(
+            parse(&doc).is_ok(),
+            "expected Ok for {}-level nesting but got an error",
+            MAX_DEPTH
+        );
     }
 
     #[test]

--- a/crates/convert-musicxml/src/xml.rs
+++ b/crates/convert-musicxml/src/xml.rs
@@ -801,7 +801,7 @@ mod tests {
 
     #[test]
     fn parse_depth_at_limit_accepted() {
-        // MAX_DEPTH - 1 levels of nesting (indices 0 .. MAX_DEPTH-1) must succeed.
+        // MAX_DEPTH levels of nesting (indices 0..MAX_DEPTH-1 are depths 0 to 199) must succeed.
         let open: String = (0..MAX_DEPTH).map(|i| format!("<a{i}>")).collect();
         let close: String = (0..MAX_DEPTH).rev().map(|i| format!("</a{i}>")).collect();
         let doc = format!("{open}{close}");


### PR DESCRIPTION
## What

Add a `MAX_DEPTH` (200) guard to the `parse_element` method in the MusicXML XML parser. Mutual recursion between `parse_element` and `parse_children` had no depth limit, allowing adversarial input to overflow the Rust call stack (stack overflow / crash).

## Why

Closes #1539. User-supplied MusicXML files are parsed by this code path. An attacker could craft a file with deeply nested elements to crash any process that imports it.

Legitimate MusicXML files are very shallow (typically under 20 levels). A limit of 200 is generous enough for all valid content while still providing a hard bound.

## Changes

- Added `const MAX_DEPTH: usize = 200` constant with doc comment explaining rationale
- Updated `parse_element` to accept a `depth: usize` parameter and return `Err` when `depth >= MAX_DEPTH`
- Updated `parse_children` to accept and forward `depth`, passing `depth + 1` to recursive `parse_element` calls
- Updated the top-level `parse` entry point to call `parse_element(0)`
- Added two tests:
  - `parse_depth_limit_rejected`: verifies `MAX_DEPTH + 1` nesting is rejected with a descriptive error
  - `parse_depth_at_limit_accepted`: verifies `MAX_DEPTH` nesting succeeds

## Test results

```
test xml::tests::parse_depth_at_limit_accepted ... ok
test xml::tests::parse_depth_limit_rejected ... ok
```

All 36 crate tests pass.

## Sister-site audit

This XML parser (`crates/convert-musicxml/src/xml.rs`) is self-contained and only used by the MusicXML importer. There is no equivalent recursive XML/document parser elsewhere in the codebase that would require the same fix.