### PR TITLE
fix: reject MusicXML inputs larger than 50 MiB to prevent memory exhaustion

### DIFF
--- a/crates/convert-musicxml/src/xml.rs
+++ b/crates/convert-musicxml/src/xml.rs
@@ -81,15 +81,38 @@ impl Element {
 /// from adversarial input.
 const MAX_DEPTH: usize = 200;
 
+/// Maximum input size accepted by the parser (50 MiB).
+///
+/// Inputs larger than this limit are rejected at the `parse()` entry point to
+/// prevent memory exhaustion from flat-wide adversarial documents — e.g., a
+/// document with millions of siblings, enormous text nodes, or millions of
+/// attributes that bypass the depth limit by operating horizontally within a
+/// single level. Real MusicXML files are typically well under 10 MB; 50 MiB is
+/// a generous ceiling. See #1565.
+///
+/// This limit also makes the `i32` bracket-depth counter in `skip_doctype`
+/// overflow-safe: even if the entire input consists of `[` characters, 50 MiB
+/// is well below `i32::MAX` (≈ 2 GiB).
+const MAX_INPUT_BYTES: usize = 50 * 1024 * 1024; // 50 MiB
+
 /// Parse an XML string into an element tree.
 ///
 /// Returns the root element, or an error message if parsing fails.
 ///
 /// # Errors
 ///
-/// Returns an error if the XML is malformed or if the element nesting depth
-/// exceeds [`MAX_DEPTH`].
+/// Returns an error if:
+/// - The input exceeds [`MAX_INPUT_BYTES`] (50 MiB)
+/// - The XML is malformed
+/// - The element nesting depth exceeds [`MAX_DEPTH`]
 pub(crate) fn parse(xml: &str) -> Result<Element, String> {
+    if xml.len() > MAX_INPUT_BYTES {
+        return Err(format!(
+            "MusicXML input too large: {} bytes (limit is {} bytes)",
+            xml.len(),
+            MAX_INPUT_BYTES
+        ));
+    }
     let mut p = Parser {
         src: xml.as_bytes(),
         pos: 0,
@@ -828,5 +851,37 @@ mod tests {
         // Also verify a valid named entity after multi-byte text still works.
         let input2 = "café &amp; more";
         assert_eq!(decode_entities(input2), "café & more");
+    }
+
+    #[test]
+    fn parse_rejects_oversized_input() {
+        // An input larger than MAX_INPUT_BYTES must be rejected at the entry
+        // point before any allocation, preventing memory exhaustion from
+        // flat-wide adversarial documents (see #1565).
+        let oversized = "A".repeat(MAX_INPUT_BYTES + 1);
+        let result = parse(&oversized);
+        assert!(result.is_err(), "expected error for oversized input");
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("too large"),
+            "error message should mention 'too large': {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_accepts_input_at_limit() {
+        // An input of exactly MAX_INPUT_BYTES must not be rejected by the size
+        // check (it may still fail for other reasons — malformed XML — but the
+        // size guard must not trigger).
+        let at_limit = "A".repeat(MAX_INPUT_BYTES);
+        let result = parse(&at_limit);
+        // The input is not valid XML, so it will fail, but the error must NOT
+        // mention "too large" (the size guard should not fire).
+        if let Err(msg) = result {
+            assert!(
+                !msg.contains("too large"),
+                "size guard should not fire at exactly MAX_INPUT_BYTES, got: {msg}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

Add `MAX_INPUT_BYTES = 50 * 1024 * 1024` (50 MiB) constant and check it at the `parse()` entry point in `crates/convert-musicxml/src/xml.rs`, returning an error before any allocation for inputs that exceed the limit. Closes #1565.

## Why

PR #1564 fixed the recursion depth (vertical nesting limit). However, the parser still had three unbounded memory allocation paths that bypass the depth limit by operating horizontally:

1. **Sibling count** — `parse_children` pushes children into an unbounded `Vec<Element>` with no cap. A document with millions of siblings at depth 0 allocates proportionally.
2. **Text accumulation** — The `text` `String` in `parse_children` is unbounded.
3. **Attribute accumulation** — `parse_attrs` pushes into an unbounded `HashMap`.

A flat-wide adversarial MusicXML document could exhaust process memory without triggering the depth limit. The simplest and most comprehensive fix is to reject inputs at the entry point before any allocation occurs.

**50 MiB** is chosen as a generous ceiling: real MusicXML files are typically well under 10 MB. This also makes the `i32` bracket-depth counter in `skip_doctype` overflow-safe (50 M characters is well below `i32::MAX` ≈ 2 GiB).

## Test results

```
cargo test -p chordsketch-convert-musicxml
# 13 tests pass (including 2 new: parse_rejects_oversized_input, parse_accepts_input_at_limit)
cargo clippy -p chordsketch-convert-musicxml -- -D warnings
# clean
```

## Sister-site audit

The XML parser at `crates/convert-musicxml/src/xml.rs` is only called by `crates/convert-musicxml/src/lib.rs` which is called from the CLI `--from musicxml` path. No other crate uses this parser. The NAPI/WASM/FFI bindings do not expose MusicXML import directly. ✓