### PR TITLE
test: add golden fixtures for heuristic stop-word collision patterns

### DIFF
--- a/crates/core/tests/fixtures/heuristic-stop-word-lyrics/expected.cho
+++ b/crates/core/tests/fixtures/heuristic-stop-word-lyrics/expected.cho
@@ -1,3 +1,2 @@
-[Am]Amazing[F] grace h[C]ow sweet [G]the sound
-[Em]Empty rooms [B]broken windows
-[G]Green hills [D]and dark valleys
+[Am]Amazing [G]Grace
+[Em]Empty   [B]Beautiful

--- a/crates/core/tests/fixtures/heuristic-stop-word-lyrics/expected.cho
+++ b/crates/core/tests/fixtures/heuristic-stop-word-lyrics/expected.cho
@@ -1,0 +1,3 @@
+[Am]Amazing[F] grace h[C]ow sweet [G]the sound
+[Em]Empty rooms [B]broken windows
+[G]Green hills [D]and dark valleys

--- a/crates/core/tests/fixtures/heuristic-stop-word-lyrics/input.txt
+++ b/crates/core/tests/fixtures/heuristic-stop-word-lyrics/input.txt
@@ -1,6 +1,4 @@
-Am     F       C        G
-Amazing grace how sweet the sound
-Em          B
-Empty rooms broken windows
-G           D
-Green hills and dark valleys
+Am      G
+Amazing Grace
+Em      B
+Empty   Beautiful

--- a/crates/core/tests/fixtures/heuristic-stop-word-lyrics/input.txt
+++ b/crates/core/tests/fixtures/heuristic-stop-word-lyrics/input.txt
@@ -1,0 +1,6 @@
+Am     F       C        G
+Amazing grace how sweet the sound
+Em          B
+Empty rooms broken windows
+G           D
+Green hills and dark valleys

--- a/crates/core/tests/fixtures/heuristic-stop-word-sections/expected.cho
+++ b/crates/core/tests/fixtures/heuristic-stop-word-sections/expected.cho
@@ -1,0 +1,6 @@
+{start_of_chorus}
+[G]Green fi[D]elds and bright skies
+{end_of_chorus}
+{start_of_bridge}
+[Em]Empty ch[B]airs at empty tables
+{end_of_bridge}

--- a/crates/core/tests/fixtures/heuristic-stop-word-sections/input.txt
+++ b/crates/core/tests/fixtures/heuristic-stop-word-sections/input.txt
@@ -1,0 +1,6 @@
+Chorus:
+G       D
+Green fields and bright skies
+Bridge:
+Em      B
+Empty chairs at empty tables


### PR DESCRIPTION
## What

Two new golden test fixtures for the plain-text heuristic importer, as required by `.claude/rules/golden-tests.md`. Closes #1543.

### `heuristic-stop-word-lyrics`

A song with lyric lines containing words that begin with valid chord-root letters:

| Word | Chord-like prefix | Expected: NOT a chord |
|------|------------------|-----------------------|
| Amazing | Am | ✓ lyric word |
| Empty | Em | ✓ lyric word |
| Green | G | ✓ lyric word |
| Dark | D | ✓ lyric word |

### `heuristic-stop-word-sections`

Section labels starting with chord-root letters (`Chorus:` → C, `Bridge:` → B) that must be detected as section directives, not as chord lines.

## Why

The heuristic importer unit tests in `heuristic.rs` test `is_chord_token` at the token level. These golden fixtures cover the integration path: the full pipeline from plain-text input to ChordPro output. Both fixtures fail the golden test if stop-word rejection is broken, providing regression coverage against future changes to chord detection.

## Test results

```
cargo test -p chordsketch-core --test golden_heuristic
# 1 test passes (heuristic_golden_tests covers all 13 fixture directories)
```