### PR TITLE
refactor: add #[must_use] to public parse/render functions and document ast.rs unwrap_or

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -781,7 +781,13 @@ impl ChordDefinition {
     pub fn parse_value(value: &str) -> Self {
         let value = value.trim();
         let mut parts = value.splitn(2, char::is_whitespace);
-        let name = parts.next().unwrap_or("").to_string();
+        // splitn(2, ..) on any string always yields at least one element, so
+        // next() is infallible here. If value is empty or whitespace-only after
+        // trim(), name will be "" — the callers check def.display/format/raw
+        // before using def.name, so an empty name is a harmless no-op.
+        let name = parts.next().expect("splitn always yields at least one element").to_string();
+        // rest is None for single-word values (no whitespace); "" is the correct
+        // default (no rest tokens to process).
         let rest = parts.next().unwrap_or("").trim();
 
         let mut def = Self {

--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -785,7 +785,10 @@ impl ChordDefinition {
         // next() is infallible here. If value is empty or whitespace-only after
         // trim(), name will be "" — the callers check def.display/format/raw
         // before using def.name, so an empty name is a harmless no-op.
-        let name = parts.next().expect("splitn always yields at least one element").to_string();
+        let name = parts
+            .next()
+            .expect("splitn always yields at least one element")
+            .to_string();
         // rest is None for single-word values (no whitespace); "" is the correct
         // default (no rest tokens to process).
         let rest = parts.next().unwrap_or("").trim();

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -925,6 +925,7 @@ impl Parser {
 /// assert_eq!(song.metadata.title.as_deref(), Some("Hello World"));
 /// assert_eq!(song.lines.len(), 2);
 /// ```
+#[must_use = "callers must handle the parse error"]
 pub fn parse(input: &str) -> Result<Song, ParseError> {
     parse_with_options(input, &ParseOptions::default())
 }
@@ -965,6 +966,7 @@ impl Default for ParseOptions {
 ///
 /// Returns a [`ParseError`] if the input exceeds the configured size limit
 /// or contains structural problems.
+#[must_use = "callers must handle the parse error"]
 pub fn parse_with_options(input: &str, options: &ParseOptions) -> Result<Song, ParseError> {
     if options.max_input_size > 0 && input.len() > options.max_input_size {
         return Err(ParseError::new(
@@ -1001,6 +1003,7 @@ pub fn parse_with_options(input: &str, options: &ParseOptions) -> Result<Song, P
 /// // The valid lyrics line was still parsed.
 /// assert!(result.song.lines.len() >= 2);
 /// ```
+#[must_use]
 pub fn parse_lenient(input: &str) -> ParseResult {
     parse_lenient_with_options(input, &ParseOptions::default())
 }
@@ -1008,6 +1011,7 @@ pub fn parse_lenient(input: &str) -> ParseResult {
 /// Parses a ChordPro source string leniently with custom options.
 ///
 /// See [`parse_lenient`] for details.
+#[must_use]
 pub fn parse_lenient_with_options(input: &str, options: &ParseOptions) -> ParseResult {
     if options.max_input_size > 0 && input.len() > options.max_input_size {
         return ParseResult {
@@ -1158,6 +1162,7 @@ fn split_at_new_song(input: &str) -> Vec<&str> {
 /// assert_eq!(songs[0].metadata.title.as_deref(), Some("Song One"));
 /// assert_eq!(songs[1].metadata.title.as_deref(), Some("Song Two"));
 /// ```
+#[must_use = "callers must handle the parse error"]
 pub fn parse_multi(input: &str) -> Result<Vec<Song>, ParseError> {
     parse_multi_with_options(input, &ParseOptions::default())
 }
@@ -1172,6 +1177,7 @@ pub fn parse_multi(input: &str) -> Result<Vec<Song>, ParseError> {
 ///
 /// Returns a [`ParseError`] if the input exceeds the configured size limit
 /// or any song segment contains structural problems.
+#[must_use = "callers must handle the parse error"]
 pub fn parse_multi_with_options(
     input: &str,
     options: &ParseOptions,
@@ -1220,6 +1226,7 @@ pub fn parse_multi_with_options(
 /// assert!(result.results[0].has_errors()); // unclosed chord
 /// assert!(result.results[1].is_ok());
 /// ```
+#[must_use]
 pub fn parse_multi_lenient(input: &str) -> MultiParseResult {
     parse_multi_lenient_with_options(input, &ParseOptions::default())
 }
@@ -1227,6 +1234,7 @@ pub fn parse_multi_lenient(input: &str) -> MultiParseResult {
 /// Parses a multi-song ChordPro source string leniently with custom options.
 ///
 /// See [`parse_multi_lenient`] for details.
+#[must_use]
 pub fn parse_multi_lenient_with_options(input: &str, options: &ParseOptions) -> MultiParseResult {
     if options.max_input_size > 0 && input.len() > options.max_input_size {
         return MultiParseResult {

--- a/crates/core/src/render_result.rs
+++ b/crates/core/src/render_result.rs
@@ -30,6 +30,7 @@ impl<T> RenderResult<T> {
     }
 
     /// Returns `true` if there are no warnings.
+    #[must_use]
     pub fn has_warnings(&self) -> bool {
         !self.warnings.is_empty()
     }

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -144,6 +144,7 @@ pub fn parse_and_render_pdf(
 }
 
 /// Validate ChordPro input and return any parse errors as strings.
+#[must_use]
 pub fn validate(input: String) -> Vec<String> {
     let result = chordsketch_core::parse_multi_lenient(&input);
     result

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -207,6 +207,7 @@ pub fn render_pdf_with_options(input: String, options: RenderOptions) -> Result<
 
 /// Validate ChordPro input and return any parse errors as strings.
 /// Returns an empty array if the input is valid.
+#[must_use]
 #[napi]
 pub fn validate(input: String) -> Vec<String> {
     let result = chordsketch_core::parse_multi_lenient(&input);

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -153,6 +153,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
 /// This is the structured variant of [`render_song_with_transpose`]. Instead
 /// of printing warnings to stderr, they are collected into
 /// [`RenderResult::warnings`].
+#[must_use = "caller must check warnings in the returned RenderResult"]
 pub fn render_song_with_warnings(
     song: &Song,
     cli_transpose: i8,
@@ -621,6 +622,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
 /// This is the structured variant of [`render_songs_with_transpose`]. Instead
 /// of printing warnings to stderr, they are collected into
 /// [`RenderResult::warnings`].
+#[must_use = "caller must check warnings in the returned RenderResult"]
 pub fn render_songs_with_warnings(
     songs: &[Song],
     cli_transpose: i8,

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -279,6 +279,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
 /// This is the structured variant of [`render_song_with_transpose`]. Instead
 /// of printing warnings to stderr, they are collected into
 /// [`RenderResult::warnings`].
+#[must_use = "caller must check warnings in the returned RenderResult"]
 pub fn render_song_with_warnings(
     song: &Song,
     cli_transpose: i8,
@@ -337,6 +338,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
 /// This is the structured variant of [`render_songs_with_transpose`]. Instead
 /// of printing warnings to stderr, they are collected into
 /// [`RenderResult::warnings`].
+#[must_use = "caller must check warnings in the returned RenderResult"]
 pub fn render_songs_with_warnings(
     songs: &[Song],
     cli_transpose: i8,

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -54,6 +54,7 @@ pub fn render_song_with_transpose(song: &Song, cli_transpose: i8, config: &Confi
 /// This is the structured variant of [`render_song_with_transpose`]. Instead
 /// of printing warnings to stderr, they are collected into
 /// [`RenderResult::warnings`].
+#[must_use = "caller must check warnings in the returned RenderResult"]
 pub fn render_song_with_warnings(
     song: &Song,
     cli_transpose: i8,
@@ -309,6 +310,7 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
 /// This is the structured variant of [`render_songs_with_transpose`]. Instead
 /// of printing warnings to stderr, they are collected into
 /// [`RenderResult::warnings`].
+#[must_use = "caller must check warnings in the returned RenderResult"]
 pub fn render_songs_with_warnings(
     songs: &[Song],
     cli_transpose: i8,


### PR DESCRIPTION
## What

Two quality improvements batched together:

### #1547 — `#[must_use]` annotations

Add `#[must_use]` (with descriptive messages where the return type is already
`#[must_use]`) to every public function whose return value must not be silently
discarded:

| Crate | Function | Note |
|-------|----------|------|
| `chordsketch-core/parser` | `parse`, `parse_with_options`, `parse_multi`, `parse_multi_with_options` | Returns `Result`; message added to satisfy `double_must_use` lint |
| `chordsketch-core/parser` | `parse_lenient`, `parse_lenient_with_options`, `parse_multi_lenient`, `parse_multi_lenient_with_options` | Returns `ParseResult` / `MultiParseResult` |
| `chordsketch-render-{text,html,pdf}` | `render_song_with_warnings`, `render_songs_with_warnings` | Returns `RenderResult<T>`; message added |
| `chordsketch-core/render_result` | `RenderResult::has_warnings` | Returns `bool` |
| `chordsketch-ffi`, `chordsketch-napi` | `validate` | Returns `Vec<String>` |

### #1548 — `unwrap_or("")` in `ChordDefinition::parse_value`

- **`name` field**: replaced `unwrap_or("")` with `expect(...)` and a comment explaining
  the invariant (`splitn(2, ..)` always yields at least one element, so `next()` is
  infallible). Also documents that an empty name is a harmless no-op because all callers
  check `def.display`, `def.format`, or `def.raw` before acting on `def.name`.
- **`rest` field**: `unwrap_or("")` is semantically correct (`None` means no second token);
  added an inline comment justifying the default.

## Test results

```
cargo test -p chordsketch-core
test result: ok. 1047 passed; 0 failed; 8 ignored

cargo clippy -p chordsketch-core -p chordsketch-render-text -p chordsketch-render-html -p chordsketch-render-pdf -- -D warnings
Finished dev — 0 errors

cargo clippy -p chordsketch-ffi -- -D warnings
Finished dev — 0 errors
```

## Sister-site audit

All three renderers (text, HTML, PDF) updated consistently. Both bindings (FFI, NAPI)
updated consistently.

Closes #1547
Closes #1548