### PR TITLE
refactor: add #[must_use] to version() and parse_and_render_* in FFI/NAPI/WASM

### DIFF
--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -91,6 +91,7 @@ fn flush_warnings<T>(result: RenderResult<T>) -> T {
 ///   (`-128..=127`); musically meaningful values are typically `-24..=24`
 ///   (two octaves). If the combined offset (API value + in-file directive)
 ///   saturates the `i8` range, it is clamped and a warning is emitted.
+#[must_use = "callers must handle parse and render errors"]
 pub fn parse_and_render_text(
     input: String,
     config_json: Option<String>,
@@ -117,6 +118,7 @@ pub fn parse_and_render_text(
 /// forwarded to stderr via `flush_warnings`.
 ///
 /// See [`parse_and_render_text`] for `transpose` parameter documentation.
+#[must_use = "callers must handle parse and render errors"]
 pub fn parse_and_render_html(
     input: String,
     config_json: Option<String>,
@@ -143,6 +145,7 @@ pub fn parse_and_render_html(
 /// forwarded to stderr via `flush_warnings`.
 ///
 /// See [`parse_and_render_text`] for `transpose` parameter documentation.
+#[must_use = "callers must handle parse and render errors"]
 pub fn parse_and_render_pdf(
     input: String,
     config_json: Option<String>,
@@ -167,6 +170,7 @@ pub fn validate(input: String) -> Vec<String> {
 }
 
 /// Return the ChordSketch library version.
+#[must_use]
 pub fn version() -> String {
     chordsketch_core::version().to_string()
 }

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -219,6 +219,7 @@ pub fn validate(input: String) -> Vec<String> {
 }
 
 /// Return the ChordSketch library version.
+#[must_use]
 #[napi]
 pub fn version() -> String {
     chordsketch_core::version().to_string()

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -294,6 +294,7 @@ pub fn render_pdf_with_options(input: &str, options: JsValue) -> Result<Vec<u8>,
 }
 
 /// Returns the ChordSketch library version.
+#[must_use]
 #[wasm_bindgen]
 pub fn version() -> String {
     chordsketch_core::version().to_string()


### PR DESCRIPTION
## What

Follow-up to PR #1584. Adds missing `#[must_use]` annotations to public functions in the FFI, NAPI, and WASM bindings that were outside the explicit scope of #1547.

**Changes:**
- `crates/ffi/src/lib.rs`: `parse_and_render_text`, `parse_and_render_html`, `parse_and_render_pdf` get `#[must_use = "callers must handle parse and render errors"]`; `version()` gets plain `#[must_use]`
- `crates/napi/src/lib.rs`: `version()` gets plain `#[must_use]`
- `crates/wasm/src/lib.rs`: `version()` gets plain `#[must_use]`

Note: `render-text::try_render` was already annotated with `#[must_use = "parse errors should be handled"]` since PR #495 — issue #1585 was based on a stale reading of the PR #1584 diff.

## Why

`defensive-inputs.md` requires `#[must_use]` on functions whose return values should not be silently discarded. `version()` returns `String` (no implicit warning from the type system); `parse_and_render_*` return `Result` (implicit warning exists but adding a message improves diagnostics). Per the Clippy `double_must_use` lint, functions returning already-`#[must_use]` types need a string message.

## Test results

```
cargo clippy -p chordsketch-ffi -p chordsketch-napi -- -D warnings  # clean
cargo fmt --check                                                     # clean
```

## Sister-site audit

- All three bindings (FFI, NAPI, WASM) updated for `version()`.
- `parse_and_render_*` is FFI-specific; NAPI and WASM use differently-named `render_*` functions. Those functions can be addressed in a separate follow-up if desired.

Closes #1585
Closes #1586