### PR TITLE
refactor: add #[must_use] to NAPI and WASM render_* functions

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -112,6 +112,7 @@ fn do_render_bytes(
 ///
 /// Use [`render_text_with_options`] to pass a config preset, inline RRJSON,
 /// or transposition.
+#[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_text(input: String) -> Result<String> {
     do_render_string(
@@ -126,6 +127,7 @@ pub fn render_text(input: String) -> Result<String> {
 ///
 /// Use [`render_html_with_options`] to pass a config preset, inline RRJSON,
 /// or transposition.
+#[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_html(input: String) -> Result<String> {
     do_render_string(
@@ -141,6 +143,7 @@ pub fn render_html(input: String) -> Result<String> {
 ///
 /// Use [`render_pdf_with_options`] to pass a config preset, inline RRJSON,
 /// or transposition.
+#[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_pdf(input: String) -> Result<Buffer> {
     let bytes = do_render_bytes(
@@ -166,6 +169,7 @@ fn parse_transpose(raw: i32) -> i8 {
 }
 
 /// Render ChordPro input as plain text with options.
+#[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_text_with_options(input: String, options: RenderOptions) -> Result<String> {
     let config = resolve_config(options.config)?;
@@ -179,6 +183,7 @@ pub fn render_text_with_options(input: String, options: RenderOptions) -> Result
 }
 
 /// Render ChordPro input as an HTML document with options.
+#[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_html_with_options(input: String, options: RenderOptions) -> Result<String> {
     let config = resolve_config(options.config)?;
@@ -192,6 +197,7 @@ pub fn render_html_with_options(input: String, options: RenderOptions) -> Result
 }
 
 /// Render ChordPro input as a PDF document with options (returned as a Buffer).
+#[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_pdf_with_options(input: String, options: RenderOptions) -> Result<Buffer> {
     let config = resolve_config(options.config)?;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -192,6 +192,7 @@ fn render_bytes_inner(
 /// the `*_with_options` variant — this function itself never errors
 /// because the lenient parser always produces at least one song and
 /// the default config never fails to resolve.
+#[must_use = "callers must handle render errors"]
 #[wasm_bindgen]
 pub fn render_html(input: &str) -> Result<String, JsValue> {
     render_string_inner(
@@ -210,6 +211,7 @@ pub fn render_html(input: &str) -> Result<String, JsValue> {
 /// the `*_with_options` variant — this function itself never errors
 /// because the lenient parser always produces at least one song and
 /// the default config never fails to resolve.
+#[must_use = "callers must handle render errors"]
 #[wasm_bindgen]
 pub fn render_text(input: &str) -> Result<String, JsValue> {
     render_string_inner(
@@ -228,6 +230,7 @@ pub fn render_text(input: &str) -> Result<String, JsValue> {
 /// the `*_with_options` variant — this function itself never errors
 /// because the lenient parser always produces at least one song and
 /// the default config never fails to resolve.
+#[must_use = "callers must handle render errors"]
 #[wasm_bindgen]
 pub fn render_pdf(input: &str) -> Result<Vec<u8>, JsValue> {
     render_bytes_inner(
@@ -250,6 +253,7 @@ pub fn render_pdf(input: &str) -> Result<Vec<u8>, JsValue> {
 /// # Errors
 ///
 /// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
 #[wasm_bindgen]
 pub fn render_html_with_options(input: &str, options: JsValue) -> Result<String, JsValue> {
     render_string_inner(
@@ -266,6 +270,7 @@ pub fn render_html_with_options(input: &str, options: JsValue) -> Result<String,
 /// # Errors
 ///
 /// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
 #[wasm_bindgen]
 pub fn render_text_with_options(input: &str, options: JsValue) -> Result<String, JsValue> {
     render_string_inner(
@@ -284,6 +289,7 @@ pub fn render_text_with_options(input: &str, options: JsValue) -> Result<String,
 /// # Errors
 ///
 /// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
 #[wasm_bindgen]
 pub fn render_pdf_with_options(input: &str, options: JsValue) -> Result<Vec<u8>, JsValue> {
     render_bytes_inner(


### PR DESCRIPTION
## What

Adds `#[must_use = "callers must handle render errors"]` to the 6 NAPI and 6 WASM public render functions that were missing it: `render_text`, `render_html`, `render_pdf`, and their `*_with_options` variants.

## Why

Follow-up to PR #1588, which added `#[must_use]` to `version()` and FFI `parse_and_render_*`. The NAPI and WASM `render_*` functions return `Result` and were explicitly deferred from that PR.

Per `defensive-inputs.md`: functions returning `Result` or `Option` must have `#[must_use]` so callers cannot silently discard errors. These functions return `napi::Result<T>` (NAPI) and `Result<T, JsValue>` (WASM), both are `std::Result`-based.

Using the `#[must_use = "message"]` string form avoids the Clippy `double_must_use` lint (since `Result` is already `#[must_use]` at the type level), consistent with how PR #1584 and #1588 handled this.

## Notes

- `#[must_use]` only affects Rust-side callers; JavaScript/TypeScript consumers are not affected.
- Attribute ordering (`#[must_use]` before `#[napi]`/`#[wasm_bindgen]`) is consistent with existing conventions in the codebase.

## Test results

```
cargo clippy -p chordsketch-napi -- -D warnings  # clean
cargo fmt --check                                  # clean
```

## Sister-site audit

All three bindings now have complete `#[must_use]` coverage on their public `render_*` functions:
- FFI: `parse_and_render_*` annotated in PR #1588
- NAPI: annotated here
- WASM: annotated here

Closes #1589