### PR TITLE
docs: clarify sanitizer rules, fix-propagation wording, and feImage comment

### DIFF
--- a/.claude/commands/project/delta-review.md
+++ b/.claude/commands/project/delta-review.md
@@ -23,8 +23,8 @@ review. The argument is a base commit hash or PR number: `$ARGUMENTS`
    - Any symptomatic fix is at minimum **Medium** severity (spec violation / incorrect behavior preserved).
 
    **Additionally, run a fix-propagation audit** (per `.claude/rules/fix-propagation.md`):
-   - If the diff fixes a bug in one renderer, check the other two renderers for the same bug.
-   - If the diff fixes a bug in one binding (FFI/WASM/NAPI), check the other two bindings.
+   - If the diff fixes a bug in one renderer, check all other renderers for the same bug.
+   - If the diff fixes a bug in one binding (FFI/WASM/NAPI), check all other bindings.
    - If the diff changes validation or clamping logic in one renderer, verify parity in all three.
    - If the diff adds/changes an entry in a URI scheme denylist, tag blocklist, or attribute
      allowlist, verify all sibling lists are consistent (see `.claude/rules/sanitizer-security.md`).

--- a/.claude/rules/fix-propagation.md
+++ b/.claude/rules/fix-propagation.md
@@ -25,7 +25,8 @@ Any fix to one renderer MUST be audited across all three:
 `crates/ffi/src/lib.rs`, `crates/wasm/src/lib.rs`, `crates/napi/src/lib.rs`
 
 Any fix to one binding's public API surface MUST be audited across all three:
-- Warning routing (e.g., `render_songs_with_warnings` vs. `render_songs_with_transpose`)
+- Warning routing (e.g., WASM had `render_songs_with_warnings` while NAPI only had
+  `render_songs_with_transpose`, leaving NAPI without structured warning capture; see #1541)
 - Input validation and error return paths
 - API shape consistency (options structs, return types)
 

--- a/.claude/rules/renderer-parity.md
+++ b/.claude/rules/renderer-parity.md
@@ -32,7 +32,7 @@ Inconsistent validation is a correctness bug: the same `.cho` file can produce
 different output (or panic) depending on which output format is used.
 
 When adding or changing validation in one renderer:
-1. Apply the same change to the other two renderers in the same PR.
+1. Apply the same change to all other renderers in the same PR.
 2. Add a golden test with an out-of-range value that exercises the clamping/rejection.
 
 ## Audit pattern

--- a/.claude/rules/sanitizer-security.md
+++ b/.claude/rules/sanitizer-security.md
@@ -43,20 +43,28 @@ Every URI scheme denylist MUST block at minimum:
 Whenever an entry is added to any URI scheme list:
 1. Cross-check `has_dangerous_uri_scheme` and `is_safe_image_src` (and any future
    sibling functions) to ensure they are consistent.
-2. Verify the list against the [WHATWG Fetch forbidden origins list](https://fetch.spec.whatwg.org/).
+2. Verify the list against the [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+   for completeness. (The WHATWG Fetch spec does not define a URI scheme denylist
+   for HTML sanitization purposes.)
 
 ### SVG tag blocklists
 
 Blocklisted SVG tags MUST include all tags that can load external resources:
-`script`, `use` (with external `href`), `feImage`, `image`, `iframe`, `embed`, `object`
+`script`, `foreignObject`, `use` (with external `href`), `feImage`, `image`, `iframe`, `embed`, `object`
 
 Whenever a tag is added to `DANGEROUS_TAGS`, check whether there is an equivalent
 filter primitive or presentation element that can load the same resource class.
 
 ### Attribute allowlists / URI attribute lists
 
-URI-bearing SVG/HTML attributes MUST include at minimum:
-`href`, `xlink:href`, `src`, `action`, `formaction`, `poster`, `background`, `ping`, `to`, `values`, `from`, `by`
+Direct URI-bearing SVG/HTML attributes MUST include at minimum:
+`href`, `xlink:href`, `src`, `action`, `formaction`, `poster`, `background`, `ping`
+
+SVG animation value attributes (`to`, `values`, `from`, `by`) are NOT URI-bearing
+in the conventional sense — they carry animation values. However, they MUST still be
+sanitized when the animated `attributeName` is a URI attribute (e.g.
+`<animate attributeName="href" to="javascript:alert(1)"/>`). Filter for animation
+elements that target URI attributes rather than blanket URI-checking these attributes.
 
 ### Testing completeness
 

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -937,8 +937,8 @@ fn sanitize_svg_content(input: &str) -> String {
         "embed",
         "math",
         // feImage is an SVG filter primitive that loads external content via href.
-        // A <feImage href="file:///etc/passwd"/> survives attribute sanitization
-        // with an http: or https: URL, so the element must be stripped entirely.
+        // Stripping by URI scheme alone is insufficient: <feImage href="https://attacker.com/"/>
+        // would survive since https: is allowed. The element must be stripped entirely.
         "feimage",
         // SVG <image> element loads external raster/vector images. Not needed in
         // music notation SVG; strip entirely to prevent tracking-pixel and


### PR DESCRIPTION
## What

Four documentation/comment improvements to rules files and one code comment fix:

1. **`sanitizer-security.md`** (#1554, #1555, #1556):
   - Added `foreignObject` to the SVG tag blocklist minimum list — it was absent
     despite being a resource-loading element (and already in the implementation)
   - Rewrote the attribute allowlist section to separate *direct URI-bearing* attributes
     (`href`, `xlink:href`, `src`, `action`, `formaction`, `poster`, `background`, `ping`)
     from *SVG animation value* attributes (`to`, `values`, `from`, `by`), which are not
     directly URI-bearing but must be sanitized when their `attributeName` targets a URI attr
   - Replaced incorrect "WHATWG Fetch forbidden origins list" reference (which does not
     define a URI scheme denylist for sanitization) with the correct OWASP XSS Prevention
     Cheat Sheet reference

2. **`fix-propagation.md`** (#1556): Rewrote the warning-routing example from a confusing
   `vs.` comparison to a clear before/after description explaining the actual asymmetry

3. **`renderer-parity.md`** (#1556): Changed "the other two renderers" to "all other
   renderers" — the phrasing "other two" incorrectly implies there are only three

4. **`delta-review.md`** (#1556): Same phrasing fix for renderers and bindings

5. **`crates/render-html/src/lib.rs`** (#1562): Replaced confusing `feImage` comment.
   The old comment said "`file:///etc/passwd` survives with http: or https: URL", which
   was backwards. The new comment explains the actual risk: even `https:` URLs pass
   URI-scheme filtering, so the element must be stripped entirely.

## Why

All four issues were identified in the 2026-04-12 main-branch audit. These are
documentation/comment accuracy issues — the underlying implementation is already
correct.

## Test results

Only documentation and a code comment changed; no behavioral changes. CI passes
with no modifications to logic.

## Sister-site audit

Changes are limited to `.claude/rules/` docs and a single code comment in
`render-html`. No sister-site audit needed.

Closes #1554
Closes #1555
Closes #1556
Closes #1562