### PR TITLE
docs: fix stale inline version comments for GitHub Actions SHA pins

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Log in to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3

--- a/.github/workflows/grammar.yml
+++ b/.github/workflows/grammar.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## What

Update two stale inline version comments in workflow YAML files that were left behind after dependabot bumped the pinned SHA references.

| File | Was | Now |
|------|-----|-----|
| `.github/workflows/docker.yml` | `docker/setup-qemu-action@... # v3` | `# v4.0.0` |
| `.github/workflows/grammar.yml` | `actions/setup-node@... # v4` | `# v6.3.0` |

## Why

The SHA pins themselves are correct and were already updated by dependabot PRs #1599 and #1602. However the human-readable version tag comments were not updated, causing confusion between the pinned hash and the declared version.

## Test results

No functional change — comments only. CI should pass unchanged.

## Review summary

Cosmetic documentation fix. No security impact. No behavior change.

Closes #1617