### PR TITLE
docs: fix sanitizer documentation inconsistencies

### DIFF
--- a/.claude/rules/sanitizer-security.md
+++ b/.claude/rules/sanitizer-security.md
@@ -63,8 +63,11 @@ Direct URI-bearing SVG/HTML attributes MUST include at minimum:
 SVG animation value attributes (`to`, `values`, `from`, `by`) are NOT URI-bearing
 in the conventional sense — they carry animation values. However, they MUST still be
 sanitized when the animated `attributeName` is a URI attribute (e.g.
-`<animate attributeName="href" to="javascript:alert(1)"/>`). Filter for animation
-elements that target URI attributes rather than blanket URI-checking these attributes.
+`<animate attributeName="href" to="javascript:alert(1)"/>`). The implementation uses
+a defense-in-depth approach: animation elements (`animate`, `set`, etc.) are stripped
+entirely via `DANGEROUS_TAGS`, and `to`/`values`/`from`/`by` are additionally included
+in `is_uri_attr` as a secondary defense on any surviving element. Both layers are
+intentional and must be preserved.
 
 ### Testing completeness
 

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1188,7 +1188,7 @@ fn has_dangerous_uri_scheme(value: &str) -> bool {
     //   data:               content injection
     //   file:/blob:         local file access when HTML is opened as a local file
     //   mhtml:              MIME HTML (IE-era; blocked by is_safe_image_src via allowlist)
-    // See WHATWG Fetch forbidden origins for further rationale.
+    // See OWASP XSS Prevention Cheat Sheet for further rationale.
     lower.starts_with("javascript:")
         || lower.starts_with("vbscript:")
         || lower.starts_with("data:")


### PR DESCRIPTION
## What

Fix two documentation inconsistencies in sanitizer-related code and rules, identified as Nit findings from PR #1593.

### Change 1 — `crates/render-html/src/lib.rs` (Closes #1594)

Update the inline comment in `has_dangerous_uri_scheme` from:
```rust
// See WHATWG Fetch forbidden origins for further rationale.
```
to:
```rust
// See OWASP XSS Prevention Cheat Sheet for further rationale.
```

The WHATWG Fetch spec does not define a URI scheme denylist for HTML sanitization purposes. The OWASP XSS Prevention Cheat Sheet is the correct reference, which is what `.claude/rules/sanitizer-security.md` was updated to reference in PR #1593. The inline implementation comment was missed in that PR.

### Change 2 — `.claude/rules/sanitizer-security.md` (Closes #1595)

Clarify the animation attribute guidance to accurately describe the actual defense-in-depth approach:

**Before**: "Filter for animation elements that target URI attributes rather than blanket URI-checking these attributes."

**After**: Describes that the implementation uses two layers — animation elements are stripped entirely via `DANGEROUS_TAGS`, and `to`/`values`/`from`/`by` are additionally included in `is_uri_attr` as a secondary defense.

The previous wording was inaccurate as a description of what the code actually does. The implementation is *more* conservative than the docs prescribed (defense-in-depth). The update preserves both layers as intentional.

## Why

Both are documentation consistency issues with no security impact. The implementation is correct in both cases.

## Test results

No functional changes — documentation and comments only. CI should pass unchanged.

## Sister-site audit

No sister sites for documentation changes.

Closes #1594
Closes #1595