### PR TITLE
fix: emit warning when {transpose} value cannot be parsed as i8

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -313,11 +313,17 @@ fn render_song_body(
                     continue;
                 }
                 if directive.kind == DirectiveKind::Transpose {
-                    let file_offset: i8 = directive
-                        .value
-                        .as_deref()
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(0);
+                    let raw_value = directive.value.as_deref().unwrap_or("");
+                    let file_offset: i8 = match raw_value.parse() {
+                        Ok(v) => v,
+                        Err(_) => {
+                            warnings.push(format!(
+                                "{{transpose}} value {raw_value:?} cannot be \
+                                 parsed as i8, ignored (using 0)"
+                            ));
+                            0
+                        }
+                    };
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
@@ -2129,6 +2135,23 @@ mod transpose_tests {
         let html = render_song_with_transpose(&song, 3, &Config::defaults());
         // 2 + 3 = 5, C+5=F
         assert!(html.contains("<span class=\"chord\">F</span>"));
+    }
+
+    #[test]
+    fn test_transpose_out_of_i8_range_emits_warning() {
+        // 999 cannot be represented as i8; should fall back to 0 with a warning
+        let input = "{transpose: 999}\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result.output.contains("<span class=\"chord\">G</span>"),
+            "chord should be untransposed"
+        );
+        assert!(
+            result.warnings.iter().any(|w| w.contains("\"999\"")),
+            "expected warning about out-of-range value, got: {:?}",
+            result.warnings
+        );
     }
 
     // --- Issue #109: {chorus} recall ---

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -525,8 +525,17 @@ fn render_song_into_doc(
                     continue;
                 }
                 if d.kind == DirectiveKind::Transpose {
-                    let file_offset: i8 =
-                        d.value.as_deref().and_then(|v| v.parse().ok()).unwrap_or(0);
+                    let raw_value = d.value.as_deref().unwrap_or("");
+                    let file_offset: i8 = match raw_value.parse() {
+                        Ok(v) => v,
+                        Err(_) => {
+                            warnings.push(format!(
+                                "{{transpose}} value {raw_value:?} cannot be \
+                                 parsed as i8, ignored (using 0)"
+                            ));
+                            0
+                        }
+                    };
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
@@ -3202,6 +3211,22 @@ mod transpose_tests {
         // 2+3=5, C+5=F
         let content = String::from_utf8_lossy(&bytes);
         assert!(content.contains("(F)"));
+    }
+
+    #[test]
+    fn test_transpose_out_of_i8_range_emits_warning() {
+        // 999 cannot be represented as i8; should fall back to 0 with a warning
+        let input = "{transpose: 999}\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        // G + 0 transposition = G
+        let content = String::from_utf8_lossy(&result.output);
+        assert!(content.contains("(G)"), "chord should be untransposed");
+        assert!(
+            result.warnings.iter().any(|w| w.contains("\"999\"")),
+            "expected warning about out-of-range value, got: {:?}",
+            result.warnings
+        );
     }
 }
 

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -138,11 +138,17 @@ fn render_song_impl(
                 }
                 if directive.kind == DirectiveKind::Transpose {
                     // {transpose: N} sets the in-file transposition amount.
-                    let file_offset: i8 = directive
-                        .value
-                        .as_deref()
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(0);
+                    let raw_value = directive.value.as_deref().unwrap_or("");
+                    let file_offset: i8 = match raw_value.parse() {
+                        Ok(v) => v,
+                        Err(_) => {
+                            warnings.push(format!(
+                                "{{transpose}} value {raw_value:?} cannot be \
+                                 parsed as i8, ignored (using 0)"
+                            ));
+                            0
+                        }
+                    };
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
@@ -954,18 +960,40 @@ mod transpose_tests {
     fn test_transpose_invalid_value_treated_as_zero() {
         let input = "{transpose: abc}\n[G]Hello";
         let song = chordsketch_core::parse(input).unwrap();
-        let output = render_song(&song);
+        let result =
+            render_song_with_warnings(&song, 0, &chordsketch_core::config::Config::defaults());
         // Invalid value -> treated as 0
-        assert!(output.contains("G\nHello"));
+        assert!(result.output.contains("G\nHello"));
+        assert!(
+            result.warnings.iter().any(|w| w.contains("\"abc\"")),
+            "expected warning about unparseable value, got: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_transpose_out_of_i8_range_emits_warning() {
+        // 999 cannot be represented as i8; should fall back to 0 with a warning
+        let input = "{transpose: 999}\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result =
+            render_song_with_warnings(&song, 0, &chordsketch_core::config::Config::defaults());
+        assert!(result.output.contains("G\nHello"), "chord should be untransposed");
+        assert!(
+            result.warnings.iter().any(|w| w.contains("\"999\"")),
+            "expected warning about out-of-range value, got: {:?}",
+            result.warnings
+        );
     }
 
     #[test]
     fn test_transpose_no_value_treated_as_zero() {
         let input = "{transpose}\n[G]Hello";
         let song = chordsketch_core::parse(input).unwrap();
-        let output = render_song(&song);
-        // No value -> treated as 0
-        assert!(output.contains("G\nHello"));
+        let result =
+            render_song_with_warnings(&song, 0, &chordsketch_core::config::Config::defaults());
+        // No value -> treated as 0, empty string emits a warning
+        assert!(result.output.contains("G\nHello"));
     }
 
     // --- Issue #109: {chorus} recall ---

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -978,7 +978,10 @@ mod transpose_tests {
         let song = chordsketch_core::parse(input).unwrap();
         let result =
             render_song_with_warnings(&song, 0, &chordsketch_core::config::Config::defaults());
-        assert!(result.output.contains("G\nHello"), "chord should be untransposed");
+        assert!(
+            result.output.contains("G\nHello"),
+            "chord should be untransposed"
+        );
         assert!(
             result.warnings.iter().any(|w| w.contains("\"999\"")),
             "expected warning about out-of-range value, got: {:?}",


### PR DESCRIPTION
## What

When a ChordPro file contains a `{transpose}` directive whose value cannot
be parsed as `i8` (e.g. `{transpose: 999}` or `{transpose: abc}`), all
three renderers now emit a warning instead of silently falling back to 0.

**Before**: silent fallback to 0 transposition, no diagnostic.

**After**: warning emitted via the render warnings vector:
```
{transpose} value "999" cannot be parsed as i8, ignored (using 0)
```

## Why

Silent fallback to incorrect transposition is confusing for users who have
a typo or out-of-range value in their file. This is the symmetric treatment
of the saturation warning that already exists for combined-offset overflow.

## Changes

- `crates/render-text/src/lib.rs`: parse failure → emit warning, use 0
- `crates/render-html/src/lib.rs`: same
- `crates/render-pdf/src/lib.rs`: same
- Tests added to all three renderers for `{transpose: 999}` case
- Existing `test_transpose_invalid_value_treated_as_zero` in render-text
  updated to also assert the warning is emitted

## Test results

All tests pass:
- `cargo test -p chordsketch-render-text -p chordsketch-render-html -p chordsketch-render-pdf` ✅
- `cargo clippy ... -D warnings` ✅

## Sister-site audit

All three renderers updated in the same PR. No equivalent issue in
bindings (FFI/WASM/NAPI) — they delegate to the renderer crates.

Closes #1592