### PR TITLE
fix: suppress warning for {transpose} with absent or empty value

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -313,16 +313,20 @@ fn render_song_body(
                     continue;
                 }
                 if directive.kind == DirectiveKind::Transpose {
-                    let raw_value = directive.value.as_deref().unwrap_or("");
-                    let file_offset: i8 = match raw_value.parse() {
-                        Ok(v) => v,
-                        Err(_) => {
-                            warnings.push(format!(
-                                "{{transpose}} value {raw_value:?} cannot be \
-                                 parsed as i8, ignored (using 0)"
-                            ));
-                            0
-                        }
+                    // A missing or empty value silently resets to 0; only a
+                    // non-empty value that cannot be parsed as i8 emits a warning.
+                    let file_offset: i8 = match directive.value.as_deref() {
+                        None | Some("") => 0,
+                        Some(raw) => match raw.parse() {
+                            Ok(v) => v,
+                            Err(_) => {
+                                warnings.push(format!(
+                                    "{{transpose}} value {raw:?} cannot be \
+                                     parsed as i8, ignored (using 0)"
+                                ));
+                                0
+                            }
+                        },
                     };
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
@@ -2150,6 +2154,23 @@ mod transpose_tests {
         assert!(
             result.warnings.iter().any(|w| w.contains("\"999\"")),
             "expected warning about out-of-range value, got: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_transpose_no_value_treated_as_zero() {
+        // {transpose} with no value should silently reset to 0, no warning.
+        let input = "{transpose}\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result.output.contains("<span class=\"chord\">G</span>"),
+            "chord should be untransposed"
+        );
+        assert!(
+            result.warnings.is_empty(),
+            "missing {{transpose}} value should not emit a warning; got: {:?}",
             result.warnings
         );
     }

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -525,16 +525,20 @@ fn render_song_into_doc(
                     continue;
                 }
                 if d.kind == DirectiveKind::Transpose {
-                    let raw_value = d.value.as_deref().unwrap_or("");
-                    let file_offset: i8 = match raw_value.parse() {
-                        Ok(v) => v,
-                        Err(_) => {
-                            warnings.push(format!(
-                                "{{transpose}} value {raw_value:?} cannot be \
-                                 parsed as i8, ignored (using 0)"
-                            ));
-                            0
-                        }
+                    // A missing or empty value silently resets to 0; only a
+                    // non-empty value that cannot be parsed as i8 emits a warning.
+                    let file_offset: i8 = match d.value.as_deref() {
+                        None | Some("") => 0,
+                        Some(raw) => match raw.parse() {
+                            Ok(v) => v,
+                            Err(_) => {
+                                warnings.push(format!(
+                                    "{{transpose}} value {raw:?} cannot be \
+                                     parsed as i8, ignored (using 0)"
+                                ));
+                                0
+                            }
+                        },
                     };
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
@@ -3225,6 +3229,21 @@ mod transpose_tests {
         assert!(
             result.warnings.iter().any(|w| w.contains("\"999\"")),
             "expected warning about out-of-range value, got: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_transpose_no_value_treated_as_zero() {
+        // {transpose} with no value should silently reset to 0, no warning.
+        let input = "{transpose}\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        let content = String::from_utf8_lossy(&result.output);
+        assert!(content.contains("(G)"), "chord should be untransposed");
+        assert!(
+            result.warnings.is_empty(),
+            "missing {{transpose}} value should not emit a warning; got: {:?}",
             result.warnings
         );
     }

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -138,16 +138,20 @@ fn render_song_impl(
                 }
                 if directive.kind == DirectiveKind::Transpose {
                     // {transpose: N} sets the in-file transposition amount.
-                    let raw_value = directive.value.as_deref().unwrap_or("");
-                    let file_offset: i8 = match raw_value.parse() {
-                        Ok(v) => v,
-                        Err(_) => {
-                            warnings.push(format!(
-                                "{{transpose}} value {raw_value:?} cannot be \
-                                 parsed as i8, ignored (using 0)"
-                            ));
-                            0
-                        }
+                    // A missing or empty value silently resets to 0; only a
+                    // non-empty value that cannot be parsed as i8 emits a warning.
+                    let file_offset: i8 = match directive.value.as_deref() {
+                        None | Some("") => 0,
+                        Some(raw) => match raw.parse() {
+                            Ok(v) => v,
+                            Err(_) => {
+                                warnings.push(format!(
+                                    "{{transpose}} value {raw:?} cannot be \
+                                     parsed as i8, ignored (using 0)"
+                                ));
+                                0
+                            }
+                        },
                     };
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
@@ -995,8 +999,13 @@ mod transpose_tests {
         let song = chordsketch_core::parse(input).unwrap();
         let result =
             render_song_with_warnings(&song, 0, &chordsketch_core::config::Config::defaults());
-        // No value -> treated as 0, empty string emits a warning
+        // No value -> silently treated as 0, no warning emitted.
         assert!(result.output.contains("G\nHello"));
+        assert!(
+            result.warnings.is_empty(),
+            "missing {{transpose}} value should not emit a warning; got: {:?}",
+            result.warnings
+        );
     }
 
     // --- Issue #109: {chorus} recall ---


### PR DESCRIPTION
## What

Refine `{transpose}` parse handling in all three renderers: a missing or empty value (bare `{transpose}` with no colon/value) now silently resets the transpose offset to 0 without emitting a warning. Only a non-empty, non-parseable value triggers the warning.

## Why

Previously the code used `directive.value.as_deref().unwrap_or("")`, which produced an empty string that failed `i8::parse`, causing a spurious warning for what is semantically a valid "reset to zero" usage. A user writing `{transpose}` in their `.cho` file should not see a parse warning.

## Test results

```
cargo test -p chordsketch-render-text -p chordsketch-render-html -p chordsketch-render-pdf
# 199 + 185 + 77 passed, 0 failed
cargo clippy -- -D warnings  # clean
cargo fmt --check             # clean
```

## Sister-site audit

Fix applied identically to all three renderers: `render-text`, `render-html`, `render-pdf`. No equivalent issue in FFI/WASM/NAPI bindings (they delegate to the renderers, not their own parse logic).

New `test_transpose_no_value_treated_as_zero` tests added to render-html and render-pdf; existing test in render-text updated to assert no warning is emitted.

Closes #1621