### PR TITLE
fix: install TempFileGuard before write in invoke_abc2svg

### DIFF
--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -158,11 +158,15 @@ pub fn invoke_abc2svg(abc_content: &str) -> Result<String, String> {
     let sanitized = sanitize_abc_content(abc_content);
 
     let tmp_path = unique_temp_path("chordsketch_abc", "abc");
-    write_temp_file_exclusive(&tmp_path, &sanitized)?;
-    // Guard ensures the temp file is removed on any exit path.
+    // Guard is created before the write so that if write_temp_file_exclusive
+    // creates the file with O_EXCL but then fails on write_all, the guard's
+    // Drop still runs and removes the partially-created file. The `let _ =`
+    // in Drop silently handles the case where the file was never created
+    // (e.g. if O_EXCL open fails before any bytes are written).
     let _guard = TempFileGuard {
         path: tmp_path.clone(),
     };
+    write_temp_file_exclusive(&tmp_path, &sanitized)?;
 
     let output = Command::new("abc2svg")
         .arg("tosvg.js")


### PR DESCRIPTION
## What

Move `TempFileGuard` creation to before `write_temp_file_exclusive` in `invoke_abc2svg`, matching the ordering already used by `invoke_lilypond` and `invoke_musescore`.

## Why

If `OpenOptions::open` succeeds (file created with `O_EXCL`) but `write_all` subsequently fails, the early `?` return fires before the guard was created — leaving an orphaned temp file. Placing the guard first means `Drop` runs unconditionally on every exit path, including partial-write failures.

The guard's `Drop` calls `let _ = fs::remove_file(...)`, which silently handles the case where the file was never created (i.e., if `open()` itself failed).

## Test results

```
cargo test -p chordsketch-core   # 1050+ passed, 0 failed
cargo clippy -- -D warnings      # clean
cargo fmt --check                 # clean
```

## Sister-site audit

`invoke_lilypond` and `invoke_musescore` already install their `TempDirGuard` before `write_temp_file_exclusive`. This PR makes `invoke_abc2svg` consistent with them.

Closes #1623