### PR TITLE
test: add {transpose:   } whitespace-only value test in all three renderers

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -2175,6 +2175,25 @@ mod transpose_tests {
         );
     }
 
+    #[test]
+    fn test_transpose_whitespace_value_treated_as_zero() {
+        // {transpose:   } with whitespace-only value should silently reset to 0,
+        // no warning emitted. The parser trims whitespace → Some(""), which the
+        // Some("") arm converts to 0.
+        let input = "{transpose:   }\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result.output.contains("<span class=\"chord\">G</span>"),
+            "chord should be untransposed"
+        );
+        assert!(
+            result.warnings.is_empty(),
+            "whitespace-only {{transpose}} value should not emit a warning; got: {:?}",
+            result.warnings
+        );
+    }
+
     // --- Issue #109: {chorus} recall ---
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -3247,6 +3247,23 @@ mod transpose_tests {
             result.warnings
         );
     }
+
+    #[test]
+    fn test_transpose_whitespace_value_treated_as_zero() {
+        // {transpose:   } with whitespace-only value should silently reset to 0,
+        // no warning emitted. The parser trims whitespace → Some(""), which the
+        // Some("") arm converts to 0.
+        let input = "{transpose:   }\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        let content = String::from_utf8_lossy(&result.output);
+        assert!(content.contains("(G)"), "chord should be untransposed");
+        assert!(
+            result.warnings.is_empty(),
+            "whitespace-only {{transpose}} value should not emit a warning; got: {:?}",
+            result.warnings
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -1008,6 +1008,26 @@ mod transpose_tests {
         );
     }
 
+    #[test]
+    fn test_transpose_whitespace_value_treated_as_zero() {
+        // {transpose:   } with whitespace-only value should silently reset to 0,
+        // no warning emitted. The parser trims whitespace → Some(""), which the
+        // Some("") arm converts to 0.
+        let input = "{transpose:   }\n[G]Hello";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result =
+            render_song_with_warnings(&song, 0, &chordsketch_core::config::Config::defaults());
+        assert!(
+            result.output.contains("G\nHello"),
+            "chord should be untransposed"
+        );
+        assert!(
+            result.warnings.is_empty(),
+            "whitespace-only {{transpose}} value should not emit a warning; got: {:?}",
+            result.warnings
+        );
+    }
+
     // --- Issue #109: {chorus} recall ---
 
     #[test]


### PR DESCRIPTION
## What

Adds `test_transpose_whitespace_value_treated_as_zero` to render-text, render-html, and render-pdf.

## Why

PR #1625 introduced a `Some("") => 0` arm to handle `{transpose:   }` (whitespace-only value) silently. The existing `test_transpose_no_value_treated_as_zero` tests exercise the `None` arm (bare `{transpose}` with no colon), but no test was exercising the `Some("")` path specifically. This PR closes that coverage gap.

The parser trims whitespace before storing the directive value, so `{transpose:   }` yields `Some("")` (not `None`), which the `Some("") => 0` arm converts to 0 without emitting a warning.

## Test results

```
test transpose_tests::test_transpose_whitespace_value_treated_as_zero ... ok  (render-text)
test transpose_tests::test_transpose_whitespace_value_treated_as_zero ... ok  (render-html)
test transpose_tests::test_transpose_whitespace_value_treated_as_zero ... ok  (render-pdf)
```

## Review summary

Sister-site audit: fix applied to all three renderers in the same PR.

Closes #1626