### PR TITLE
test: use TempFileGuard for cleanup in write_temp_file_exclusive_prevents_overwrite

### DIFF
--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -640,10 +640,11 @@ mod tests {
         let path = super::unique_temp_path("test_excl", "tmp");
         // First write succeeds.
         super::write_temp_file_exclusive(&path, "hello").unwrap();
+        // Hold a guard so the file is cleaned up even if the assertion panics.
+        let _guard = super::TempFileGuard { path: path.clone() };
         // Second write to same path must fail (O_EXCL semantics).
         let result = super::write_temp_file_exclusive(&path, "world");
         assert!(result.is_err());
-        let _ = std::fs::remove_file(&path);
     }
 
     #[test]


### PR DESCRIPTION
## What

Replaces the manual `let _ = std::fs::remove_file(&path)` cleanup in
`write_temp_file_exclusive_prevents_overwrite` with a `TempFileGuard`, making it
consistent with the rest of the module.

## Why

Now that `TempFileGuard` exists in the same file, keeping the manual
`fs::remove_file` call is inconsistent. More importantly, the guard
ensures cleanup happens even if the `assert!(result.is_err())` assertion
panics — the manual call at the end of the function would be skipped in
that case.

## Changes

- `crates/core/src/external_tool.rs`: Replace `let _ = std::fs::remove_file(&path)` with `TempFileGuard` in the test.

Note: `TempFileGuard` and `TempDirGuard` guard drop behavior tests were already
present (added in #1622); this PR closes the remaining cleanup-consistency gap.

## Test results

```
test external_tool::tests::write_temp_file_exclusive_prevents_overwrite ... ok
```

Closes #1624