### PR TITLE
test: add Jest integration test for NAPI warning routing

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -144,6 +144,21 @@ jobs:
             console.log("All smoke tests passed!");
           '
 
+      - name: Jest warning-routing test (host target only)
+        # Exercises the full Rust flush_warnings → eprintln! → stderr path.
+        # Must run after the .node artifact is built and on the same host
+        # targets as the smoke test (cross-compiled artifacts cannot be
+        # required on the build host).  See #1568.
+        if: |
+          (matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu') ||
+          (matrix.os == 'macos-latest' && matrix.target == 'aarch64-apple-darwin') ||
+          (matrix.os == 'windows-latest' && matrix.target == 'x86_64-pc-windows-msvc')
+        working-directory: crates/napi
+        shell: bash
+        run: |
+          npm install --ignore-scripts
+          npx jest --no-coverage
+
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/crates/napi/__tests__/warning-routing.test.js
+++ b/crates/napi/__tests__/warning-routing.test.js
@@ -1,0 +1,93 @@
+"use strict";
+
+// Integration test for NAPI warning routing (issue #1568).
+//
+// The `flush_warnings` helper in the Rust NAPI binding writes each render
+// warning to stderr via `eprintln!("chordsketch: {w}")`.  Because
+// `eprintln!` writes directly to the process's file descriptor 2, the only
+// way to observe it in Node.js is to spawn a child process and capture its
+// stderr.
+//
+// Input that reliably triggers a warning:
+//   {transpose: 100} in the source + transpose option 100 on the JS side
+//   → combine_transpose(100, 100) = 200 which saturates to i8::MAX (127)
+//   → the renderer emits a "transpose … clamped" warning.
+//
+// This mirrors the Rust unit test
+// `test_render_songs_with_warnings_captures_saturation_warning` in
+// `crates/napi/src/lib.rs`, but exercises the full NAPI → eprintln! path
+// rather than just the underlying renderer.
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// Locate the compiled .node artifact built by the CI step that precedes this
+// test.  The file name encodes the target triple, so we scan for any .node
+// file in the package root rather than hard-coding a name.
+function findNodeFile() {
+  const dir = path.join(__dirname, "..");
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith(".node"));
+  if (files.length !== 1) {
+    throw new Error(
+      `Expected exactly 1 .node file in ${dir}, found ${files.length}: ${files.join(", ")}`
+    );
+  }
+  return path.join(dir, files[0]);
+}
+
+describe("NAPI warning routing", () => {
+  let nodeFile;
+
+  beforeAll(() => {
+    nodeFile = findNodeFile();
+  });
+
+  test("renderTextWithOptions emits chordsketch:-prefixed warning to stderr on saturating transpose", () => {
+    // Spawn a child process so we can capture stderr written by eprintln!.
+    // A saturating transpose (source {transpose:100} + option transpose:100
+    // = 200 > i8::MAX) reliably produces a "transpose ... clamped" warning.
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        `
+        const m = require(${JSON.stringify(nodeFile)});
+        const out = m.renderTextWithOptions(
+          "{title: T}\\n{transpose: 100}\\n[C]Hello",
+          { transpose: 100 }
+        );
+        process.stdout.write(out);
+      `,
+      ],
+      { encoding: "utf8" }
+    );
+
+    expect(result.status).toBe(0);
+    // The rendered output must be non-empty (no regression in output).
+    expect(result.stdout.trim()).toBeTruthy();
+    // At least one warning must have been forwarded to stderr with the
+    // "chordsketch:" prefix applied by flush_warnings.
+    expect(result.stderr).toMatch(/chordsketch:/);
+  });
+
+  test("renderText with non-saturating input produces no chordsketch: warning", () => {
+    // Sanity check: normal input must not produce spurious warnings.
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        `
+        const m = require(${JSON.stringify(nodeFile)});
+        const out = m.renderText("{title: T}\\n[C]Hello");
+        process.stdout.write(out);
+      `,
+      ],
+      { encoding: "utf8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBeTruthy();
+    expect(result.stderr).not.toMatch(/chordsketch:/);
+  });
+});

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -48,10 +48,18 @@
     ]
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.4.0"
+    "@napi-rs/cli": "^3.4.0",
+    "jest": "^29.7.0"
   },
   "scripts": {
     "build": "napi build --release --manifest-path Cargo.toml",
-    "build:debug": "napi build --manifest-path Cargo.toml"
+    "build:debug": "napi build --manifest-path Cargo.toml",
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/__tests__/**/*.test.js"
+    ]
   }
 }


### PR DESCRIPTION
## What

Adds a Jest integration test (`__tests__/warning-routing.test.js`) to the `@chordsketch/node` package that verifies the full `flush_warnings → eprintln! → stderr` path.

## Why

PR #1567 added `flush_warnings` to route render warnings through `eprintln!`. The existing Rust unit test (`test_render_songs_with_warnings_captures_saturation_warning`) only verifies that the renderer produces warnings — it does NOT verify that the NAPI binding actually writes them to stderr. This PR closes that gap.

## How

The test spawns a child process (via `spawnSync`) to call `renderTextWithOptions` with saturating-transpose input. Since `eprintln!` writes to the process's stderr file descriptor, a child process is the only way to capture it from Node.js.

**Saturating input:** `{transpose: 100}` in source + `transpose: 100` option = combined 200, which exceeds `i8::MAX` (127) and reliably triggers a "transpose … clamped" warning from the renderer.

**Assertions:**
1. `stderr` contains at least one `"chordsketch:"` prefix (from `flush_warnings`)
2. `stdout` is non-empty (rendered output not regressed)
3. Non-saturating input produces no spurious `"chordsketch:"` warnings

## CI changes

`napi.yml` gains a "Jest warning-routing test" step that:
- Runs `npm install --ignore-scripts && npx jest --no-coverage`
- Gated to the same host-native targets as the existing smoke test (cross-compiled artifacts cannot be `require()`-d on the build host)

Closes #1568