### PR TITLE
test(napi): add timeout and spawn-error guard to spawnSync in warning-routing test

### DIFF
--- a/crates/napi/__tests__/warning-routing.test.js
+++ b/crates/napi/__tests__/warning-routing.test.js
@@ -60,9 +60,12 @@ describe("NAPI warning routing", () => {
         process.stdout.write(out);
       `,
       ],
-      { encoding: "utf8" }
+      { encoding: "utf8", timeout: 10000 }
     );
 
+    // Guard against spawn failures (result.status is null when spawnSync
+    // itself fails, e.g., executable not found).
+    expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
     // The rendered output must be non-empty (no regression in output).
     expect(result.stdout.trim()).toBeTruthy();
@@ -83,9 +86,11 @@ describe("NAPI warning routing", () => {
         process.stdout.write(out);
       `,
       ],
-      { encoding: "utf8" }
+      { encoding: "utf8", timeout: 10000 }
     );
 
+    // Guard against spawn failures before checking exit status.
+    expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBeTruthy();
     expect(result.stderr).not.toMatch(/chordsketch:/);


### PR DESCRIPTION
## What

Add two defensive options to both `spawnSync` calls in `crates/napi/__tests__/warning-routing.test.js`:

1. **`timeout: 10_000`** — if the child process ever hangs, Jest fails immediately with `ETIMEDOUT` instead of blocking until the CI runner's overall timeout, making the cause obvious.

2. **`expect(result.error).toBeUndefined()`** before `expect(result.status).toBe(0)` — when `spawnSync` fails to spawn (e.g., executable not found), `result.status` is `null` and `result.error` carries the descriptive message. Without this guard, the assertion fails as `"Expected: 0, Received: null"` rather than reporting the actual error.

## Why

Flagged as a Nit finding during auto-review of PR #1632. Neither change affects the test's correctness in the happy path; both improve the diagnostic quality of failures.

## Test results

No Rust changes — all existing CI passes. The Jest test itself is exercised only in CI against a built `.node` artifact (see `napi.yml`).

## Sister-site audit

Only one Jest test file in this repo; no sibling sites.

Closes #1633