### PR TITLE
refactor(cli): add descriptive #[must_use] to read_file_clamped and read_stdin_clamped

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,6 +21,7 @@ const MAX_INPUT_BYTES: u64 = 52_428_800;
 ///
 /// [`fs::metadata`] is used for an early, cheap size check that avoids
 /// loading oversized files into memory at all.
+#[must_use = "I/O errors from reading the file must be handled"]
 fn read_file_clamped(path: &str) -> Result<String, String> {
     match fs::metadata(path) {
         Ok(meta) if meta.len() > MAX_INPUT_BYTES => {
@@ -41,6 +42,7 @@ fn read_file_clamped(path: &str) -> Result<String, String> {
 /// Uses [`Read::take`] to avoid buffering more than `MAX_INPUT_BYTES + 1`
 /// bytes; if the read fills the cap the stream is rejected without consuming
 /// the remainder.
+#[must_use = "I/O errors from reading stdin must be handled"]
 fn read_stdin_clamped() -> Result<String, String> {
     let mut buf = String::new();
     io::stdin()


### PR DESCRIPTION
## What

Add `#[must_use = "..."]` to the two private helpers added in PR #1630:

- `read_file_clamped` — `#[must_use = "I/O errors from reading the file must be handled"]`
- `read_stdin_clamped` — `#[must_use = "I/O errors from reading stdin must be handled"]`

## Why

Both functions return `Result<String, String>`. Per the project's `defensive-inputs.md` rule:

> **`#[must_use]`**: Functions returning `Result` or `Option` must have `#[must_use]` so callers cannot silently discard errors.

`Result` itself already carries `#[must_use]`, so bare `#[must_use]` triggers Clippy's `double_must_use` lint (`"either add some descriptive message or remove the attribute"`). The message form satisfies both the project rule and Clippy: callers that discard the return value see a descriptive diagnostic rather than the generic one from `Result`.

## Test results

`cargo clippy -p chordsketch -- -D warnings` and `cargo fmt --check` pass locally. No logic changes.

## Sister-site audit

Only the CLI crate is affected; there are no sibling functions in other crates.

Closes #1631