### PR TITLE
ci: add Open VSX Registry publish job for VS Code extension

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -155,3 +155,58 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: ./node_modules/.bin/vsce publish --packagePath *.vsix
         working-directory: packages/vscode-extension
+
+  publish-openvsx:
+    name: Publish to Open VSX Registry
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Publish only on GitHub Release (published) events or when workflow_dispatch supplies a tag.
+    #
+    # Prerequisites (one-time human setup before this job can succeed):
+    #   1. Create an account on https://open-vsx.org/ (GitHub login)
+    #   2. Generate a personal access token at https://open-vsx.org/user-settings/tokens
+    #   3. Create the "open-vsx" environment at
+    #      https://github.com/koedame/chordsketch/settings/environments
+    #      and add the token as the OPEN_VSX_TOKEN environment secret.
+    #
+    # If the "open-vsx" environment does not exist (fork, fresh instance),
+    # GitHub cannot start this job. continue-on-error keeps the overall workflow
+    # green when publishing infrastructure is absent. See #1604.
+    continue-on-error: true
+    environment:
+      name: open-vsx
+      url: https://open-vsx.org/extension/koedame/chordsketch
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        # No `ref:` override — always check out main so scripts/ is present.
+
+      - name: Check required secrets present
+        env:
+          OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: python3 scripts/check-env-secrets.py --channel open-vsx
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: packages/vscode-extension/package-lock.json
+
+      - name: Install dependencies (for ovsx)
+        run: npm ci
+        working-directory: packages/vscode-extension
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: chordsketch-vsix
+          path: packages/vscode-extension/
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: npx ovsx publish *.vsix --pat "$OVSX_PAT"
+        working-directory: packages/vscode-extension

--- a/ci/release-channels.toml
+++ b/ci/release-channels.toml
@@ -152,6 +152,21 @@ manually by a human after registering the publisher at
 https://marketplace.visualstudio.com/manage (see #1428).
 """
 
+[[channels]]
+id = "open-vsx"
+display = "Open VSX Registry — koedame.chordsketch"
+kind = "open-vsx"
+package = "koedame.chordsketch"
+expected_version = "tag"
+required_secrets = ["OPEN_VSX_TOKEN"]
+notes = """
+Gated on the `open-vsx` GitHub environment in
+.github/workflows/vscode-extension.yml. First publish requires creating a
+namespace on open-vsx.org (GitHub login) and generating a personal access
+token. The same .vsix artifact built by the `build` job is reused; no
+separate build step is needed. See #1604.
+"""
+
 # ---------------------------------------------------------------- language bindings
 
 [[channels]]

--- a/scripts/_release_channels.py
+++ b/scripts/_release_channels.py
@@ -31,6 +31,7 @@ KNOWN_KINDS = frozenset(
         "ghcr",
         "docker-hub",
         "vscode-marketplace",
+        "open-vsx",
         "pypi",
         "rubygems",
         "maven-central",

--- a/scripts/check-release-channels.py
+++ b/scripts/check-release-channels.py
@@ -215,6 +215,23 @@ def _check_vscode_marketplace(channel: Channel, version: str) -> CheckResult:
     return _compare(channel, version, observed)
 
 
+def _check_open_vsx(channel: Channel, version: str) -> CheckResult:
+    # channel.package is "namespace.extension" (e.g. "koedame.chordsketch").
+    # The Open VSX REST API returns the latest published version at:
+    #   GET https://open-vsx.org/api/{namespace}/{name}
+    try:
+        namespace, name = channel.package.split(".", 1)
+    except ValueError:
+        return _error(channel, version, f"open-vsx package must be 'namespace.name', got {channel.package!r}")
+    url = f"https://open-vsx.org/api/{namespace}/{name}"
+    try:
+        payload = _http_get_json(url)
+    except Exception as exc:  # noqa: BLE001
+        return _error(channel, version, f"Open VSX API error: {exc}")
+    observed = str(payload.get("version") or "<missing>")
+    return _compare(channel, version, observed)
+
+
 def _check_pypi(channel: Channel, version: str) -> CheckResult:
     url = f"https://pypi.org/pypi/{channel.package}/json"
     try:
@@ -332,6 +349,7 @@ _DISPATCH: dict[str, Callable[[Channel, str], CheckResult]] = {
     "ghcr": _check_ghcr,
     "docker-hub": _check_docker_hub,
     "vscode-marketplace": _check_vscode_marketplace,
+    "open-vsx": _check_open_vsx,
     "pypi": _check_pypi,
     "rubygems": _check_rubygems,
     "maven-central": _check_maven_central,


### PR DESCRIPTION
## What

Adds CI infrastructure to publish the ChordSketch VS Code extension to the [Open VSX Registry](https://open-vsx.org/), making it installable in VS Code forks (Cursor, Windsurf, VSCodium) that cannot access the Microsoft VS Code Marketplace.

**Files changed:**
- `.github/workflows/vscode-extension.yml` — new `publish-openvsx` job after `publish`, reusing the same VSIX artifact
- `ci/release-channels.toml` — new `open-vsx` channel entry
- `scripts/_release_channels.py` — `open-vsx` added to `KNOWN_KINDS`
- `scripts/check-release-channels.py` — `_check_open_vsx` function using the Open VSX REST API

## Why

VS Code forks (Cursor, Windsurf, VSCodium) cannot access the Microsoft VS Code Marketplace due to ToS restrictions. They use Open VSX as their extension source. Publishing there makes ChordSketch discoverable and installable without user-side workarounds.

## Design

The `publish-openvsx` job follows the same pattern as the existing `publish` (VS Code Marketplace) job:
- `needs: [build]` — reuses the VSIX from the build job, no duplicate compilation
- `continue-on-error: true` — missing environment keeps the overall workflow green
- `environment: open-vsx` — gated on GitHub environment with `OPEN_VSX_TOKEN` secret
- `check-env-secrets.py --channel open-vsx` — fail-fast guard for missing credentials

The `_check_open_vsx` verifier queries `GET https://open-vsx.org/api/{namespace}/{name}` and compares the returned `version` field against the release tag.

## One-time human setup required

Before publishing works (see issue #1604):
1. Create a namespace on open-vsx.org (GitHub login)
2. Generate a personal access token at open-vsx.org/user-settings/tokens
3. Create the `open-vsx` GitHub environment and add `OPEN_VSX_TOKEN` as a secret

The job will silently skip until the environment is set up (`continue-on-error: true`).

## Test results

- `python3 scripts/_release_channels.py` — loads 22 channels, `open-vsx` present
- `python3 scripts/check-env-secrets.py --channel open-vsx` — correctly fails with `OPEN_VSX_TOKEN missing` (expected before setup)
- `python3 scripts/check-release-channels.py --tag v0.2.0 --channel open-vsx` — correctly returns HTTP 404 (expected before first publish)

## Sister-site audit

This is a CI/publish-infrastructure change. The VS Code Marketplace publish job was the only sibling — checked that both jobs are now symmetric in structure.

Closes #1604