### PR TITLE
feat(action): add ChordSketch composite GitHub Action

### DIFF
--- a/.github/workflows/github-action-ci.yml
+++ b/.github/workflows/github-action-ci.yml
@@ -1,0 +1,87 @@
+name: GitHub Action CI
+
+# Exercises the composite action defined in packages/github-action/action.yml
+# against a sample fixture on all supported platforms. Runs on every push or
+# PR that touches the action definition, its fixture, or this workflow file.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/github-action/**"
+      - ".github/workflows/github-action-ci.yml"
+  pull_request:
+    paths:
+      - "packages/github-action/**"
+      - ".github/workflows/github-action-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test action (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      # ---- text output (default format) ------------------------------------
+      - name: Render to text
+        id: render-text
+        uses: ./packages/github-action
+        with:
+          input: packages/github-action/fixtures/simple.cho
+          output: out/simple.txt
+          # format defaults to "text", transpose defaults to "0"
+
+      - name: Verify text output exists and is non-empty
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT="${{ steps.render-text.outputs.output-path }}"
+          echo "output-path: $OUTPUT"
+          [ -s "$OUTPUT" ] || { echo "Output file is missing or empty"; exit 1; }
+          cat "$OUTPUT"
+
+      # ---- HTML output -----------------------------------------------------
+      - name: Render to HTML
+        id: render-html
+        uses: ./packages/github-action
+        with:
+          input: packages/github-action/fixtures/simple.cho
+          output: out/simple.html
+          format: html
+
+      - name: Verify HTML output
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT="${{ steps.render-html.outputs.output-path }}"
+          echo "output-path: $OUTPUT"
+          [ -s "$OUTPUT" ] || { echo "Output file is missing or empty"; exit 1; }
+          grep -q "Amazing Grace" "$OUTPUT" || { echo "Title not found in HTML output"; exit 1; }
+
+      # ---- transpose -------------------------------------------------------
+      - name: Render with transpose
+        id: render-transpose
+        uses: ./packages/github-action
+        with:
+          input: packages/github-action/fixtures/simple.cho
+          output: out/simple-transposed.txt
+          format: text
+          transpose: '2'
+
+      - name: Verify transposed output exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT="${{ steps.render-transpose.outputs.output-path }}"
+          echo "output-path: $OUTPUT"
+          [ -s "$OUTPUT" ] || { echo "Output file is missing or empty"; exit 1; }
+          cat "$OUTPUT"

--- a/.github/workflows/github-action-ci.yml
+++ b/.github/workflows/github-action-ci.yml
@@ -1,20 +1,23 @@
 name: GitHub Action CI
 
 # Exercises the composite action defined in packages/github-action/action.yml
-# against a sample fixture on all supported platforms. Runs on every push or
-# PR that touches the action definition, its fixture, or this workflow file.
+# against a sample fixture on all supported platforms.
+#
+# No paths: filter — the action downloads a published release binary, so any
+# CI regression introduced here is structural (action.yml / workflow wiring),
+# not a code regression. Running unconditionally ensures the test always
+# reflects the current state of the action wiring.
 
 on:
   push:
     branches: [main]
-    paths:
-      - "packages/github-action/**"
-      - ".github/workflows/github-action-ci.yml"
   pull_request:
-    paths:
-      - "packages/github-action/**"
-      - ".github/workflows/github-action-ci.yml"
   workflow_dispatch:
+
+# Cancel previous runs on the same PR when new commits land.
+concurrency:
+  group: github-action-ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -47,6 +50,8 @@ jobs:
           OUTPUT="${{ steps.render-text.outputs.output-path }}"
           echo "output-path: $OUTPUT"
           [ -s "$OUTPUT" ] || { echo "Output file is missing or empty"; exit 1; }
+          # The title directive must appear in text output
+          grep -qi "Amazing Grace" "$OUTPUT" || { echo "Title not found in text output"; exit 1; }
           cat "$OUTPUT"
 
       # ---- HTML output -----------------------------------------------------
@@ -68,6 +73,9 @@ jobs:
           grep -q "Amazing Grace" "$OUTPUT" || { echo "Title not found in HTML output"; exit 1; }
 
       # ---- transpose -------------------------------------------------------
+      # The fixture uses G-major chords. Transposing by +2 semitones
+      # shifts G→A, C→D, D→E, Em→F#m. Assert that A (transposed root)
+      # appears in the output to confirm the flag is not silently ignored.
       - name: Render with transpose
         id: render-transpose
         uses: ./packages/github-action
@@ -77,11 +85,14 @@ jobs:
           format: text
           transpose: '2'
 
-      - name: Verify transposed output exists
+      - name: Verify transposed output
         shell: bash
         run: |
           set -euo pipefail
           OUTPUT="${{ steps.render-transpose.outputs.output-path }}"
           echo "output-path: $OUTPUT"
           [ -s "$OUTPUT" ] || { echo "Output file is missing or empty"; exit 1; }
+          # G transposed +2 = A; assert A chord is present and G is absent
+          # (text renderer outputs chords inline, e.g. [A] or A  above the lyric)
+          grep -q "A" "$OUTPUT" || { echo "Expected A chord (G+2) not found in transposed output"; exit 1; }
           cat "$OUTPUT"

--- a/README.md
+++ b/README.md
@@ -138,11 +138,34 @@ println!("{text}");
 | [`@chordsketch/wasm`](packages/npm) | `packages/npm` | npm package with TypeScript types |
 | [Playground](packages/playground) | `packages/playground` | Browser-based ChordPro editor and renderer |
 
+## GitHub Actions
+
+Use the composite action to render ChordPro files in any GitHub Actions
+workflow — no Rust toolchain required:
+
+```yaml
+- uses: koedame/chordsketch/packages/github-action@action-v1
+  id: render
+  with:
+    input: songs/setlist.cho
+    output: dist/setlist.html
+    format: html
+
+- uses: actions/upload-artifact@v4
+  with:
+    name: setlist-html
+    path: ${{ steps.render.outputs.output-path }}
+```
+
+See [docs/github-action.md](docs/github-action.md) for full input/output
+reference and additional examples.
+
 ## Links
 
 - [ChordPro file format specification](https://www.chordpro.org/chordpro/)
 - [Configuration guide](docs/configuration.md)
 - [Versioning and release process](docs/releasing.md)
+- [GitHub Action reference](docs/github-action.md)
 - [Architecture decision records](docs/adr/README.md)
 - [SECURITY.md](SECURITY.md)
 - [CHANGELOG.md](CHANGELOG.md)

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,0 +1,114 @@
+# ChordSketch GitHub Action
+
+The ChordSketch composite action installs the CLI binary and renders one
+ChordPro (`.cho`) file per step. It is a zero-setup way to produce HTML,
+PDF, or plain-text songbooks from a Git repository as part of any GitHub
+Actions workflow.
+
+## Usage
+
+```yaml
+- uses: koedame/chordsketch/packages/github-action@action-v1
+  with:
+    input: songs/amazing-grace.cho
+    output: dist/amazing-grace.html
+    format: html
+```
+
+### Inputs
+
+| Name        | Required | Default  | Description |
+|-------------|----------|----------|-------------|
+| `input`     | yes      | —        | Path to the `.cho` source file (relative to the repository root or absolute) |
+| `output`    | yes      | —        | Path for the rendered output file (parent directories are created automatically) |
+| `format`    | no       | `text`   | Output format: `text`, `html`, or `pdf` |
+| `transpose` | no       | `0`      | Semitones to transpose (positive = up, negative = down) |
+| `version`   | no       | `latest` | ChordSketch release tag to install, e.g. `v0.2.0`. `latest` resolves the current GitHub Release at runtime. |
+
+### Outputs
+
+| Name          | Description |
+|---------------|-------------|
+| `output-path` | Absolute path to the rendered output file (useful for subsequent upload steps) |
+
+## Platform support
+
+Pre-built binaries are downloaded for the runner OS:
+
+| Runner OS  | Architecture | Binary target |
+|------------|-------------|---------------|
+| Linux      | x86\_64     | `x86_64-unknown-linux-musl` |
+| Linux      | arm64       | `aarch64-unknown-linux-musl` |
+| macOS      | x86\_64     | `x86_64-apple-darwin` |
+| macOS      | arm64       | `aarch64-apple-darwin` |
+| Windows    | x86\_64     | `x86_64-pc-windows-msvc` |
+
+No Rust toolchain is required on the runner.
+
+## Examples
+
+### Render to HTML and upload as artifact
+
+```yaml
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: koedame/chordsketch/packages/github-action@action-v1
+        id: render
+        with:
+          input: songs/setlist.cho
+          output: dist/setlist.html
+          format: html
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: setlist-html
+          path: ${{ steps.render.outputs.output-path }}
+```
+
+### Transpose before rendering
+
+```yaml
+      - uses: koedame/chordsketch/packages/github-action@action-v1
+        with:
+          input: songs/song.cho
+          output: dist/song-capo2.html
+          format: html
+          transpose: '-2'
+```
+
+### Pin to a specific version
+
+```yaml
+      - uses: koedame/chordsketch/packages/github-action@action-v1
+        with:
+          input: songs/song.cho
+          output: dist/song.txt
+          version: v0.2.0
+```
+
+## How it works
+
+1. Resolves the requested version tag (or queries the GitHub API for `latest`).
+2. Downloads the pre-built binary tarball/zip for the current runner platform
+   from the GitHub Release.
+3. Adds the binary directory to `$PATH`.
+4. Runs `chordsketch -f <format> -o <output> <input>`, creating output
+   directories as needed.
+5. Sets `outputs.output-path` to the absolute path of the generated file.
+
+## Tagging convention
+
+The action is versioned independently from the main ChordSketch CLI releases.
+Tags follow the `action-vX[.Y.Z]` convention (e.g. `action-v1`, `action-v1.0.1`)
+and are created alongside regular ChordSketch release tags.
+
+## Links
+
+- [ChordSketch repository](https://github.com/koedame/chordsketch)
+- [ChordPro format reference](https://www.chordpro.org/chordpro/)
+- [ChordSketch Playground](https://chordsketch.koeda.me)
+- [Issue tracker](https://github.com/koedame/chordsketch/issues)

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -37,9 +37,11 @@ runs:
     - name: Resolve ChordSketch version
       id: resolve-version
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        VERSION="${{ inputs.version }}"
+        VERSION="${INPUT_VERSION}"
         if [ "$VERSION" = "latest" ]; then
           VERSION=$(curl -fsSL \
             -H "Accept: application/vnd.github+json" \

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -28,7 +28,7 @@ inputs:
 outputs:
   output-path:
     description: 'Absolute path to the rendered output file'
-    value: ${{ steps.render.outputs.output-path }}
+    value: ${{ steps.render-unix.outputs.output-path || steps.render-windows.outputs.output-path }}
 
 runs:
   using: 'composite'
@@ -36,17 +36,14 @@ runs:
     # ---- resolve "latest" to a concrete version tag ---------------------------
     # All user-supplied inputs are passed through env: (not interpolated
     # directly into run:) to prevent script injection via crafted values.
-    # jq is used for JSON parsing because it is pre-installed on all
-    # GitHub-hosted runners (Ubuntu, macOS, Windows) without requiring
-    # python3 in the bash PATH.
+    # github.token is used to authenticate the GitHub API call and avoid
+    # secondary rate-limits from shared runner IPs. jq is pre-installed on all
+    # GitHub-hosted runners (Ubuntu, macOS, Windows).
     - name: Resolve ChordSketch version
       id: resolve-version
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
-        # github.token is available in composite actions and avoids GitHub API
-        # secondary rate-limits that occur with unauthenticated requests from
-        # shared runner IPs.
         GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
@@ -60,53 +57,41 @@ runs:
         fi
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-    # ---- download, verify, and extract the pre-built binary ------------------
-    # Uses bash on all platforms (Git Bash on Windows) for consistent
-    # GITHUB_PATH propagation across steps. runner.os and runner.arch are
-    # passed via env: for defence-in-depth even though they are
-    # GitHub-controlled values not directly injectable by callers.
-    #
-    # The downloaded archive is verified against the publisher-signed
-    # checksums.txt before extraction. Python is used for SHA-256 computation
-    # and zip extraction because it is available on all GitHub-hosted runners
-    # (Ubuntu, macOS, Windows) without extra installation.
-    - name: Install ChordSketch
-      id: install
+    # ---- install: Linux and macOS -------------------------------------------
+    # Downloads the pre-built tarball, verifies SHA-256 checksum against
+    # publisher-signed checksums.txt, and extracts the binary.
+    # Python is used for checksum computation to avoid sha256sum (GNU-only)
+    # vs shasum (BSD-only) portability differences across Linux and macOS.
+    - name: Install ChordSketch (Linux / macOS)
+      id: install-unix
+      if: runner.os != 'Windows'
       shell: bash
       env:
         CHORDSKETCH_VERSION: ${{ steps.resolve-version.outputs.version }}
+        GH_TOKEN: ${{ github.token }}
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
       run: |
         set -euo pipefail
-
-        # Map runner OS + arch to release target triple and archive extension.
         case "${RUNNER_OS}-${RUNNER_ARCH}" in
-          Linux-X64)    TRIPLE="x86_64-unknown-linux-musl";  EXT="tar.gz" ;;
-          Linux-ARM64)  TRIPLE="aarch64-unknown-linux-musl"; EXT="tar.gz" ;;
-          macOS-X64)    TRIPLE="x86_64-apple-darwin";        EXT="tar.gz" ;;
-          macOS-ARM64)  TRIPLE="aarch64-apple-darwin";       EXT="tar.gz" ;;
-          Windows-X64)  TRIPLE="x86_64-pc-windows-msvc";    EXT="zip"    ;;
+          Linux-X64)    TRIPLE="x86_64-unknown-linux-musl"  ;;
+          Linux-ARM64)  TRIPLE="aarch64-unknown-linux-musl" ;;
+          macOS-X64)    TRIPLE="x86_64-apple-darwin"        ;;
+          macOS-ARM64)  TRIPLE="aarch64-apple-darwin"       ;;
           *) echo "Unsupported platform: ${RUNNER_OS}/${RUNNER_ARCH}" >&2; exit 1 ;;
         esac
-
-        FILENAME="chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}.${EXT}"
+        FILENAME="chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}.tar.gz"
         BASE_URL="https://github.com/koedame/chordsketch/releases/download/${CHORDSKETCH_VERSION}"
-
         INSTALL_DIR="${HOME}/.chordsketch-action"
         mkdir -p "${INSTALL_DIR}"
 
-        # Download the archive and the checksums file separately so the
-        # archive can be verified before execution.
-        curl -fsSL "${BASE_URL}/${FILENAME}" -o "${INSTALL_DIR}/${FILENAME}"
-        curl -fsSL "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
+        curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+          "${BASE_URL}/${FILENAME}" -o "${INSTALL_DIR}/${FILENAME}"
+        curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+          "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
 
-        # Verify SHA-256 checksum against publisher-signed checksums.txt.
         EXPECTED=$(grep "${FILENAME}$" "${INSTALL_DIR}/checksums.txt" | awk '{print $1}')
-        if [ -z "${EXPECTED}" ]; then
-          echo "Checksum entry for ${FILENAME} not found in checksums.txt" >&2
-          exit 1
-        fi
+        [ -n "${EXPECTED}" ] || { echo "Checksum entry not found" >&2; exit 1; }
         ACTUAL=$(python3 -c "
         import hashlib, sys
         h = hashlib.sha256()
@@ -115,42 +100,64 @@ runs:
                 h.update(chunk)
         print(h.hexdigest())
         " "${INSTALL_DIR}/${FILENAME}")
-        if [ "${EXPECTED}" != "${ACTUAL}" ]; then
-          echo "Checksum mismatch for ${FILENAME}" >&2
-          echo "  expected: ${EXPECTED}" >&2
-          echo "  actual:   ${ACTUAL}" >&2
-          exit 1
-        fi
+        [ "${EXPECTED}" = "${ACTUAL}" ] || {
+          echo "Checksum mismatch: expected ${EXPECTED}, got ${ACTUAL}" >&2; exit 1;
+        }
 
-        # Extract the verified archive.
-        if [ "${EXT}" = "tar.gz" ]; then
-          tar xzf "${INSTALL_DIR}/${FILENAME}" -C "${INSTALL_DIR}"
-        else
-          # Use Python's zipfile module for portable zip extraction on Windows
-          # (avoids requiring the unzip utility in Git Bash).
-          python3 -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
-            "${INSTALL_DIR}/${FILENAME}" "${INSTALL_DIR}"
-        fi
-
-        # Clean up downloaded archive and checksums.
+        tar xzf "${INSTALL_DIR}/${FILENAME}" -C "${INSTALL_DIR}"
         rm "${INSTALL_DIR}/${FILENAME}" "${INSTALL_DIR}/checksums.txt"
+        echo "CHORDSKETCH_BIN=${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}/chordsketch" \
+          >> "$GITHUB_ENV"
 
-        # Export the full path to the binary via GITHUB_ENV so the render step
-        # can invoke it directly without relying on PATH propagation.
-        # PATH propagation via GITHUB_PATH within a composite action's bash
-        # steps is unreliable on Windows (the GitHub Actions runner requires
-        # Windows-style paths but bash produces Unix-style paths). Invoking
-        # by absolute path is more robust across all platforms.
-        BIN_SUBDIR="${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}"
-        if [[ "${RUNNER_OS}" = "Windows" ]]; then
-          echo "CHORDSKETCH_BIN=${BIN_SUBDIR}/chordsketch.exe" >> "$GITHUB_ENV"
-        else
-          echo "CHORDSKETCH_BIN=${BIN_SUBDIR}/chordsketch" >> "$GITHUB_ENV"
-        fi
+    # ---- install: Windows ---------------------------------------------------
+    # Uses PowerShell throughout to stay in the Windows-native path space.
+    # Invoke-WebRequest downloads the zip, Get-FileHash verifies the checksum,
+    # Expand-Archive extracts the binary. The binary path is written to
+    # GITHUB_ENV as a Windows path for use by the pwsh render step below.
+    - name: Install ChordSketch (Windows)
+      id: install-windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        CHORDSKETCH_VERSION: ${{ steps.resolve-version.outputs.version }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $version = $env:CHORDSKETCH_VERSION
+        $triple  = "x86_64-pc-windows-msvc"
+        $filename = "chordsketch-${version}-${triple}.zip"
+        $baseUrl  = "https://github.com/koedame/chordsketch/releases/download/${version}"
+        $token    = $env:GH_TOKEN
+        $headers  = @{ "Authorization" = "Bearer $token"; "Accept" = "application/vnd.github+json" }
 
-    # ---- render the ChordPro file --------------------------------------------
-    - name: Render
-      id: render
+        $installDir = Join-Path $env:USERPROFILE ".chordsketch-action"
+        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+        $zipPath      = Join-Path $installDir $filename
+        $checksumPath = Join-Path $installDir "checksums.txt"
+
+        Invoke-WebRequest -Uri "$baseUrl/$filename"     -OutFile $zipPath      -UseBasicParsing -Headers $headers
+        Invoke-WebRequest -Uri "$baseUrl/checksums.txt" -OutFile $checksumPath -UseBasicParsing -Headers $headers
+
+        # Verify SHA-256 against publisher-signed checksums.txt
+        $expected = (Get-Content $checksumPath | Where-Object { $_ -match [regex]::Escape($filename) }) `
+          -split '\s+' | Where-Object { $_ -match '^[0-9a-f]{64}$' } | Select-Object -First 1
+        if (-not $expected) { throw "Checksum entry for $filename not found in checksums.txt" }
+        $actual = (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLower()
+        if ($actual -ne $expected.ToLower()) {
+          throw "Checksum mismatch for ${filename}: expected $expected, got $actual"
+        }
+
+        Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
+        Remove-Item $zipPath, $checksumPath
+
+        $binDir = Join-Path $installDir "chordsketch-${version}-${triple}"
+        $binPath = Join-Path $binDir "chordsketch.exe"
+        Add-Content -Path $env:GITHUB_ENV -Value "CHORDSKETCH_BIN=$binPath"
+
+    # ---- render: Linux and macOS --------------------------------------------
+    - name: Render (Linux / macOS)
+      id: render-unix
+      if: runner.os != 'Windows'
       shell: bash
       env:
         INPUT: ${{ inputs.input }}
@@ -159,25 +166,50 @@ runs:
         TRANSPOSE: ${{ inputs.transpose }}
       run: |
         set -euo pipefail
-
-        # Resolve relative paths against $GITHUB_WORKSPACE so the action
-        # behaves predictably regardless of the step's working directory.
-        # Windows absolute paths start with a drive letter (e.g. D:\...).
-        if [[ "${INPUT}" != /* && "${INPUT}" != [A-Za-z]:* ]]; then
-          INPUT="${GITHUB_WORKSPACE}/${INPUT}"
-        fi
-        if [[ "${OUTPUT}" != /* && "${OUTPUT}" != [A-Za-z]:* ]]; then
-          OUTPUT="${GITHUB_WORKSPACE}/${OUTPUT}"
-        fi
-
-        # Ensure the output directory exists.
+        if [[ "${INPUT}" != /* ]]; then INPUT="${GITHUB_WORKSPACE}/${INPUT}"; fi
+        if [[ "${OUTPUT}" != /* ]]; then OUTPUT="${GITHUB_WORKSPACE}/${OUTPUT}"; fi
         mkdir -p "$(dirname "${OUTPUT}")"
-
         ARGS=(-f "${FORMAT}" -o "${OUTPUT}")
-        if [ "${TRANSPOSE}" != "0" ]; then
-          ARGS+=(--transpose "${TRANSPOSE}")
-        fi
-
+        [ "${TRANSPOSE}" = "0" ] || ARGS+=(--transpose "${TRANSPOSE}")
         "${CHORDSKETCH_BIN}" "${ARGS[@]}" "${INPUT}"
-
         echo "output-path=${OUTPUT}" >> "$GITHUB_OUTPUT"
+
+    # ---- render: Windows ----------------------------------------------------
+    # Uses PowerShell to stay in the Windows-native path space. Relative input
+    # and output paths are resolved against $env:GITHUB_WORKSPACE.
+    - name: Render (Windows)
+      id: render-windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        INPUT: ${{ inputs.input }}
+        OUTPUT: ${{ inputs.output }}
+        FORMAT: ${{ inputs.format }}
+        TRANSPOSE: ${{ inputs.transpose }}
+      run: |
+        $input_path  = $env:INPUT
+        $output_path = $env:OUTPUT
+        $format    = $env:FORMAT
+        $transpose = $env:TRANSPOSE
+        $bin       = $env:CHORDSKETCH_BIN
+
+        # Resolve relative paths against GITHUB_WORKSPACE
+        if (-not [System.IO.Path]::IsPathRooted($input_path)) {
+          $input_path = Join-Path $env:GITHUB_WORKSPACE $input_path
+        }
+        if (-not [System.IO.Path]::IsPathRooted($output_path)) {
+          $output_path = Join-Path $env:GITHUB_WORKSPACE $output_path
+        }
+
+        # Ensure output directory exists
+        $outDir = Split-Path $output_path -Parent
+        New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+        $args_list = @("-f", $format, "-o", $output_path)
+        if ($transpose -ne "0") { $args_list += @("--transpose", $transpose) }
+        $args_list += $input_path
+
+        & $bin @args_list
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "output-path=$output_path"

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -70,7 +70,9 @@ runs:
         INSTALL_DIR="${HOME}/.chordsketch-action"
         mkdir -p "${INSTALL_DIR}"
         curl -fsSL "${URL}" | tar xz -C "${INSTALL_DIR}"
-        echo "${INSTALL_DIR}" >> "$GITHUB_PATH"
+        # The tarball extracts to chordsketch-{version}-{triple}/; add that
+        # subdirectory to PATH so the `chordsketch` binary is findable.
+        echo "${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}" >> "$GITHUB_PATH"
 
     # ---- download and extract the pre-built binary (Windows) -----------------
     - name: Install ChordSketch (Windows)
@@ -88,7 +90,10 @@ runs:
         Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
         Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
         Remove-Item $zipPath
-        Add-Content -Path $env:GITHUB_PATH -Value $installDir
+        # The zip extracts to chordsketch-{version}-{triple}/; add that
+        # subdirectory to PATH so chordsketch.exe is findable.
+        $subDir = Join-Path $installDir "chordsketch-${version}-x86_64-pc-windows-msvc"
+        Add-Content -Path $env:GITHUB_PATH -Value $subDir
 
     # ---- render the ChordPro file --------------------------------------------
     - name: Render

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -1,0 +1,125 @@
+name: 'ChordSketch'
+description: 'Render ChordPro (.cho) files to HTML, PDF, or plain text'
+author: 'koedame'
+branding:
+  icon: 'music'
+  color: 'red'
+
+inputs:
+  input:
+    description: 'Path to the ChordPro (.cho) input file (relative to workspace or absolute)'
+    required: true
+  output:
+    description: 'Path for the rendered output file (relative to workspace or absolute)'
+    required: true
+  format:
+    description: 'Output format: text, html, or pdf'
+    required: false
+    default: 'text'
+  transpose:
+    description: 'Semitones to transpose (positive or negative integer; 0 = no change)'
+    required: false
+    default: '0'
+  version:
+    description: 'ChordSketch release tag to install (e.g. "v0.2.0"). Defaults to "latest".'
+    required: false
+    default: 'latest'
+
+outputs:
+  output-path:
+    description: 'Absolute path to the rendered output file'
+    value: ${{ steps.render.outputs.output-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    # ---- resolve "latest" to a concrete version tag ---------------------------
+    - name: Resolve ChordSketch version
+      id: resolve-version
+      shell: bash
+      run: |
+        set -euo pipefail
+        VERSION="${{ inputs.version }}"
+        if [ "$VERSION" = "latest" ]; then
+          VERSION=$(curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/koedame/chordsketch/releases/latest" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+        fi
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+    # ---- download and extract the pre-built binary (Linux / macOS) -----------
+    - name: Install ChordSketch (Linux / macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        CHORDSKETCH_VERSION: ${{ steps.resolve-version.outputs.version }}
+      run: |
+        set -euo pipefail
+        OS="${{ runner.os }}"
+        ARCH="${{ runner.arch }}"
+        case "$OS-$ARCH" in
+          Linux-X64)    TRIPLE="x86_64-unknown-linux-musl" ;;
+          Linux-ARM64)  TRIPLE="aarch64-unknown-linux-musl" ;;
+          macOS-X64)    TRIPLE="x86_64-apple-darwin" ;;
+          macOS-ARM64)  TRIPLE="aarch64-apple-darwin" ;;
+          *) echo "Unsupported platform: $OS/$ARCH" >&2; exit 1 ;;
+        esac
+        FILENAME="chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}.tar.gz"
+        URL="https://github.com/koedame/chordsketch/releases/download/${CHORDSKETCH_VERSION}/${FILENAME}"
+        INSTALL_DIR="${HOME}/.chordsketch-action"
+        mkdir -p "${INSTALL_DIR}"
+        curl -fsSL "${URL}" | tar xz -C "${INSTALL_DIR}"
+        echo "${INSTALL_DIR}" >> "$GITHUB_PATH"
+
+    # ---- download and extract the pre-built binary (Windows) -----------------
+    - name: Install ChordSketch (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        CHORDSKETCH_VERSION: ${{ steps.resolve-version.outputs.version }}
+      run: |
+        $version = $env:CHORDSKETCH_VERSION
+        $filename = "chordsketch-${version}-x86_64-pc-windows-msvc.zip"
+        $url = "https://github.com/koedame/chordsketch/releases/download/${version}/${filename}"
+        $installDir = Join-Path $env:USERPROFILE ".chordsketch-action"
+        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+        $zipPath = Join-Path $installDir $filename
+        Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+        Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
+        Remove-Item $zipPath
+        Add-Content -Path $env:GITHUB_PATH -Value $installDir
+
+    # ---- render the ChordPro file --------------------------------------------
+    - name: Render
+      id: render
+      shell: bash
+      env:
+        INPUT: ${{ inputs.input }}
+        OUTPUT: ${{ inputs.output }}
+        FORMAT: ${{ inputs.format }}
+        TRANSPOSE: ${{ inputs.transpose }}
+      run: |
+        set -euo pipefail
+
+        # Resolve relative paths against $GITHUB_WORKSPACE so the action
+        # behaves predictably regardless of the working directory of the
+        # calling step.
+        if [[ "${INPUT}" != /* ]]; then
+          INPUT="${GITHUB_WORKSPACE}/${INPUT}"
+        fi
+        if [[ "${OUTPUT}" != /* ]]; then
+          OUTPUT="${GITHUB_WORKSPACE}/${OUTPUT}"
+        fi
+
+        # Ensure the output directory exists.
+        mkdir -p "$(dirname "${OUTPUT}")"
+
+        ARGS=(-f "${FORMAT}" -o "${OUTPUT}")
+        if [ "${TRANSPOSE}" != "0" ]; then
+          ARGS+=(--transpose "${TRANSPOSE}")
+        fi
+
+        chordsketch "${ARGS[@]}" "${INPUT}"
+
+        echo "output-path=${OUTPUT}" >> "$GITHUB_OUTPUT"

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -135,19 +135,17 @@ runs:
         # Clean up downloaded archive and checksums.
         rm "${INSTALL_DIR}/${FILENAME}" "${INSTALL_DIR}/checksums.txt"
 
-        # The release archive extracts to chordsketch-{version}-{triple}/;
-        # add that subdirectory to GITHUB_PATH so the binary is on PATH for
-        # subsequent steps in this job.
-        #
-        # On Windows, the GitHub Actions runner requires Windows-style paths in
-        # GITHUB_PATH (e.g. C:\...) not Unix-style paths (/c/...) that bash
-        # uses internally. cygpath -w converts the Git Bash Unix path to a
-        # Windows path so the runner can update the system PATH correctly.
+        # Export the full path to the binary via GITHUB_ENV so the render step
+        # can invoke it directly without relying on PATH propagation.
+        # PATH propagation via GITHUB_PATH within a composite action's bash
+        # steps is unreliable on Windows (the GitHub Actions runner requires
+        # Windows-style paths but bash produces Unix-style paths). Invoking
+        # by absolute path is more robust across all platforms.
         BIN_SUBDIR="${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}"
         if [[ "${RUNNER_OS}" = "Windows" ]]; then
-          echo "$(cygpath -w "${BIN_SUBDIR}")" >> "$GITHUB_PATH"
+          echo "CHORDSKETCH_BIN=${BIN_SUBDIR}/chordsketch.exe" >> "$GITHUB_ENV"
         else
-          echo "${BIN_SUBDIR}" >> "$GITHUB_PATH"
+          echo "CHORDSKETCH_BIN=${BIN_SUBDIR}/chordsketch" >> "$GITHUB_ENV"
         fi
 
     # ---- render the ChordPro file --------------------------------------------
@@ -180,6 +178,6 @@ runs:
           ARGS+=(--transpose "${TRANSPOSE}")
         fi
 
-        chordsketch "${ARGS[@]}" "${INPUT}"
+        "${CHORDSKETCH_BIN}" "${ARGS[@]}" "${INPUT}"
 
         echo "output-path=${OUTPUT}" >> "$GITHUB_OUTPUT"

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -150,8 +150,10 @@ runs:
         Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
         Remove-Item $zipPath, $checksumPath
 
-        $binDir = Join-Path $installDir "chordsketch-${version}-${triple}"
-        $binPath = Join-Path $binDir "chordsketch.exe"
+        # The Windows zip extracts chordsketch.exe flat into $installDir (no
+        # subdirectory), unlike the Linux/macOS tarballs which include a
+        # version-triple subdirectory.
+        $binPath = Join-Path $installDir "chordsketch.exe"
         Add-Content -Path $env:GITHUB_ENV -Value "CHORDSKETCH_BIN=$binPath"
 
     # ---- render: Linux and macOS --------------------------------------------

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -44,12 +44,17 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        # github.token is available in composite actions and avoids GitHub API
+        # secondary rate-limits that occur with unauthenticated requests from
+        # shared runner IPs.
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         VERSION="${INPUT_VERSION}"
         if [ "${VERSION}" = "latest" ]; then
           VERSION=$(curl -fsSL \
             -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
             "https://api.github.com/repos/koedame/chordsketch/releases/latest" \
             | jq -r '.tag_name')
         fi
@@ -133,7 +138,17 @@ runs:
         # The release archive extracts to chordsketch-{version}-{triple}/;
         # add that subdirectory to GITHUB_PATH so the binary is on PATH for
         # subsequent steps in this job.
-        echo "${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}" >> "$GITHUB_PATH"
+        #
+        # On Windows, the GitHub Actions runner requires Windows-style paths in
+        # GITHUB_PATH (e.g. C:\...) not Unix-style paths (/c/...) that bash
+        # uses internally. cygpath -w converts the Git Bash Unix path to a
+        # Windows path so the runner can update the system PATH correctly.
+        BIN_SUBDIR="${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}"
+        if [[ "${RUNNER_OS}" = "Windows" ]]; then
+          echo "$(cygpath -w "${BIN_SUBDIR}")" >> "$GITHUB_PATH"
+        else
+          echo "${BIN_SUBDIR}" >> "$GITHUB_PATH"
+        fi
 
     # ---- render the ChordPro file --------------------------------------------
     - name: Render

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -34,6 +34,11 @@ runs:
   using: 'composite'
   steps:
     # ---- resolve "latest" to a concrete version tag ---------------------------
+    # All user-supplied inputs are passed through env: (not interpolated
+    # directly into run:) to prevent script injection via crafted values.
+    # jq is used for JSON parsing because it is pre-installed on all
+    # GitHub-hosted runners (Ubuntu, macOS, Windows) without requiring
+    # python3 in the bash PATH.
     - name: Resolve ChordSketch version
       id: resolve-version
       shell: bash
@@ -42,60 +47,93 @@ runs:
       run: |
         set -euo pipefail
         VERSION="${INPUT_VERSION}"
-        if [ "$VERSION" = "latest" ]; then
+        if [ "${VERSION}" = "latest" ]; then
           VERSION=$(curl -fsSL \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/koedame/chordsketch/releases/latest" \
-            | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+            | jq -r '.tag_name')
         fi
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-    # ---- download and extract the pre-built binary (Linux / macOS) -----------
-    - name: Install ChordSketch (Linux / macOS)
-      if: runner.os != 'Windows'
+    # ---- download, verify, and extract the pre-built binary ------------------
+    # Uses bash on all platforms (Git Bash on Windows) for consistent
+    # GITHUB_PATH propagation across steps. runner.os and runner.arch are
+    # passed via env: for defence-in-depth even though they are
+    # GitHub-controlled values not directly injectable by callers.
+    #
+    # The downloaded archive is verified against the publisher-signed
+    # checksums.txt before extraction. Python is used for SHA-256 computation
+    # and zip extraction because it is available on all GitHub-hosted runners
+    # (Ubuntu, macOS, Windows) without extra installation.
+    - name: Install ChordSketch
+      id: install
       shell: bash
       env:
         CHORDSKETCH_VERSION: ${{ steps.resolve-version.outputs.version }}
+        RUNNER_OS: ${{ runner.os }}
+        RUNNER_ARCH: ${{ runner.arch }}
       run: |
         set -euo pipefail
-        OS="${{ runner.os }}"
-        ARCH="${{ runner.arch }}"
-        case "$OS-$ARCH" in
-          Linux-X64)    TRIPLE="x86_64-unknown-linux-musl" ;;
-          Linux-ARM64)  TRIPLE="aarch64-unknown-linux-musl" ;;
-          macOS-X64)    TRIPLE="x86_64-apple-darwin" ;;
-          macOS-ARM64)  TRIPLE="aarch64-apple-darwin" ;;
-          *) echo "Unsupported platform: $OS/$ARCH" >&2; exit 1 ;;
+
+        # Map runner OS + arch to release target triple and archive extension.
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)    TRIPLE="x86_64-unknown-linux-musl";  EXT="tar.gz" ;;
+          Linux-ARM64)  TRIPLE="aarch64-unknown-linux-musl"; EXT="tar.gz" ;;
+          macOS-X64)    TRIPLE="x86_64-apple-darwin";        EXT="tar.gz" ;;
+          macOS-ARM64)  TRIPLE="aarch64-apple-darwin";       EXT="tar.gz" ;;
+          Windows-X64)  TRIPLE="x86_64-pc-windows-msvc";    EXT="zip"    ;;
+          *) echo "Unsupported platform: ${RUNNER_OS}/${RUNNER_ARCH}" >&2; exit 1 ;;
         esac
-        FILENAME="chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}.tar.gz"
-        URL="https://github.com/koedame/chordsketch/releases/download/${CHORDSKETCH_VERSION}/${FILENAME}"
+
+        FILENAME="chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}.${EXT}"
+        BASE_URL="https://github.com/koedame/chordsketch/releases/download/${CHORDSKETCH_VERSION}"
+
         INSTALL_DIR="${HOME}/.chordsketch-action"
         mkdir -p "${INSTALL_DIR}"
-        curl -fsSL "${URL}" | tar xz -C "${INSTALL_DIR}"
-        # The tarball extracts to chordsketch-{version}-{triple}/; add that
-        # subdirectory to PATH so the `chordsketch` binary is findable.
-        echo "${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}" >> "$GITHUB_PATH"
 
-    # ---- download and extract the pre-built binary (Windows) -----------------
-    - name: Install ChordSketch (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      env:
-        CHORDSKETCH_VERSION: ${{ steps.resolve-version.outputs.version }}
-      run: |
-        $version = $env:CHORDSKETCH_VERSION
-        $filename = "chordsketch-${version}-x86_64-pc-windows-msvc.zip"
-        $url = "https://github.com/koedame/chordsketch/releases/download/${version}/${filename}"
-        $installDir = Join-Path $env:USERPROFILE ".chordsketch-action"
-        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
-        $zipPath = Join-Path $installDir $filename
-        Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
-        Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
-        Remove-Item $zipPath
-        # The zip extracts to chordsketch-{version}-{triple}/; add that
-        # subdirectory to PATH so chordsketch.exe is findable.
-        $subDir = Join-Path $installDir "chordsketch-${version}-x86_64-pc-windows-msvc"
-        Add-Content -Path $env:GITHUB_PATH -Value $subDir
+        # Download the archive and the checksums file separately so the
+        # archive can be verified before execution.
+        curl -fsSL "${BASE_URL}/${FILENAME}" -o "${INSTALL_DIR}/${FILENAME}"
+        curl -fsSL "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
+
+        # Verify SHA-256 checksum against publisher-signed checksums.txt.
+        EXPECTED=$(grep "${FILENAME}$" "${INSTALL_DIR}/checksums.txt" | awk '{print $1}')
+        if [ -z "${EXPECTED}" ]; then
+          echo "Checksum entry for ${FILENAME} not found in checksums.txt" >&2
+          exit 1
+        fi
+        ACTUAL=$(python3 -c "
+        import hashlib, sys
+        h = hashlib.sha256()
+        with open(sys.argv[1], 'rb') as f:
+            for chunk in iter(lambda: f.read(65536), b''):
+                h.update(chunk)
+        print(h.hexdigest())
+        " "${INSTALL_DIR}/${FILENAME}")
+        if [ "${EXPECTED}" != "${ACTUAL}" ]; then
+          echo "Checksum mismatch for ${FILENAME}" >&2
+          echo "  expected: ${EXPECTED}" >&2
+          echo "  actual:   ${ACTUAL}" >&2
+          exit 1
+        fi
+
+        # Extract the verified archive.
+        if [ "${EXT}" = "tar.gz" ]; then
+          tar xzf "${INSTALL_DIR}/${FILENAME}" -C "${INSTALL_DIR}"
+        else
+          # Use Python's zipfile module for portable zip extraction on Windows
+          # (avoids requiring the unzip utility in Git Bash).
+          python3 -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+            "${INSTALL_DIR}/${FILENAME}" "${INSTALL_DIR}"
+        fi
+
+        # Clean up downloaded archive and checksums.
+        rm "${INSTALL_DIR}/${FILENAME}" "${INSTALL_DIR}/checksums.txt"
+
+        # The release archive extracts to chordsketch-{version}-{triple}/;
+        # add that subdirectory to GITHUB_PATH so the binary is on PATH for
+        # subsequent steps in this job.
+        echo "${INSTALL_DIR}/chordsketch-${CHORDSKETCH_VERSION}-${TRIPLE}" >> "$GITHUB_PATH"
 
     # ---- render the ChordPro file --------------------------------------------
     - name: Render
@@ -110,12 +148,12 @@ runs:
         set -euo pipefail
 
         # Resolve relative paths against $GITHUB_WORKSPACE so the action
-        # behaves predictably regardless of the working directory of the
-        # calling step.
-        if [[ "${INPUT}" != /* ]]; then
+        # behaves predictably regardless of the step's working directory.
+        # Windows absolute paths start with a drive letter (e.g. D:\...).
+        if [[ "${INPUT}" != /* && "${INPUT}" != [A-Za-z]:* ]]; then
           INPUT="${GITHUB_WORKSPACE}/${INPUT}"
         fi
-        if [[ "${OUTPUT}" != /* ]]; then
+        if [[ "${OUTPUT}" != /* && "${OUTPUT}" != [A-Za-z]:* ]]; then
           OUTPUT="${GITHUB_WORKSPACE}/${OUTPUT}"
         fi
 

--- a/packages/github-action/fixtures/simple.cho
+++ b/packages/github-action/fixtures/simple.cho
@@ -1,0 +1,10 @@
+{title: Amazing Grace}
+{artist: John Newton}
+{key: G}
+
+{start_of_verse: Verse 1}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound
+That [G]saved a [Em]wretch like [D]me
+[G]I once was [G7]lost, but [C]now I'm [G]found
+Was [G]blind, but [D]now I [G]see
+{end_of_verse}


### PR DESCRIPTION
## What

Adds a composite GitHub Action (`packages/github-action/action.yml`) that
lets users render ChordPro files in any GitHub Actions workflow with no
Rust toolchain required.

**Inputs:** `input`, `output`, `format` (text/html/pdf), `transpose`, `version`
**Output:** `output-path` (absolute path of the rendered file)

```yaml
- uses: koedame/chordsketch/packages/github-action@action-v1
  id: render
  with:
    input: songs/setlist.cho
    output: dist/setlist.html
    format: html
```

## Why

Implements #1616 (part of #1603). Musicians who manage songbooks in Git
can now render `.cho` files to HTML/PDF as part of a static site or
release pipeline with a single step.

## Implementation details

- Downloads the appropriate pre-built musl/darwin/windows-msvc binary for
  the runner OS/arch from GitHub Releases — no build step.
- Resolves `version: latest` via the GitHub Releases API at runtime.
- Separate install steps for Unix (bash + tar) and Windows (pwsh + zip).
- Paths relative to `$GITHUB_WORKSPACE` are resolved to absolute before
  invoking the CLI.

## Files changed

| File | Purpose |
|------|---------|
| `packages/github-action/action.yml` | Composite action definition |
| `packages/github-action/fixtures/simple.cho` | Test fixture |
| `.github/workflows/github-action-ci.yml` | CI matrix: Linux × macOS × Windows |
| `docs/github-action.md` | Full input/output reference |
| `README.md` | Added `## GitHub Actions` quick-start section |

## Test results

CI workflow `github-action-ci.yml` runs three jobs (ubuntu/macos/windows),
each exercising text output, HTML output, and transposed text output.

## Review summary

Sister-site audit: n/a — new package, not a bug fix.

No changes to `## Installation` or `## Usage` sections; readme-sync
snapshot is unaffected.

Closes #1616