### PR TITLE
docs(action): add actions/checkout step to README quick-start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Use the composite action to render ChordPro files in any GitHub Actions
 workflow — no Rust toolchain required:
 
 ```yaml
+- uses: actions/checkout@v4
+
 - uses: koedame/chordsketch/packages/github-action@action-v1
   id: render
   with:


### PR DESCRIPTION
## What

Adds the mandatory `actions/checkout` step to the `## GitHub Actions` quick-start snippet in `README.md`. Without it, users copying the example verbatim would get a failure because no repository content would be available when the render action runs.

## Why

Closes #1647

## Test plan

- [x] No snapshot changes needed — the extractor only covers `## Installation` and `## Usage` sections
- [x] README snapshot check (`Verify README install/usage snapshot`) passes unchanged

## Review summary

No logic changes. One step added to a YAML code example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)