### PR TITLE
feat(ci): add ubuntu-24.04-arm to github-action-ci matrix

### DIFF
--- a/.github/workflows/github-action-ci.yml
+++ b/.github/workflows/github-action-ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4


### PR DESCRIPTION
## What

Adds `ubuntu-24.04-arm` to the matrix in `.github/workflows/github-action-ci.yml`.

## Why

The `Linux-ARM64` platform detection branch in `action.yml` (resolves to the `aarch64-unknown-linux-musl` triple) was untested. GitHub-hosted `ubuntu-24.04-arm` runners are available for public repos and exercise this path end-to-end.

Closes #1645

## Test plan

- [x] CI matrix now runs on 4 platforms: ubuntu-latest (x86_64), ubuntu-24.04-arm (arm64), macos-latest (arm64), windows-latest (x86_64)
- [x] The `Linux-ARM64` case in the `case "${RUNNER_OS}-${RUNNER_ARCH}"` switch is now exercised

## Review summary

One-line change to the matrix. No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)