### PR TITLE
docs(action): use SHA-pinned action refs in documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Use the composite action to render ChordPro files in any GitHub Actions
 workflow — no Rust toolchain required:
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
 - uses: koedame/chordsketch/packages/github-action@action-v1
   id: render
@@ -153,7 +153,7 @@ workflow — no Rust toolchain required:
     output: dist/setlist.html
     format: html
 
-- uses: actions/upload-artifact@v4
+- uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
   with:
     name: setlist-html
     path: ${{ steps.render.outputs.output-path }}

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -54,7 +54,7 @@ jobs:
   render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
       - uses: koedame/chordsketch/packages/github-action@action-v1
         id: render
@@ -63,7 +63,7 @@ jobs:
           output: dist/setlist.html
           format: html
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: setlist-html
           path: ${{ steps.render.outputs.output-path }}


### PR DESCRIPTION
## What

Replace floating `@v4` tags with commit-SHA-pinned refs in `README.md` and `docs/github-action.md`. The SHAs used match what is already present in `.github/workflows/*.yml` files:

| Action | SHA | Tag |
|--------|-----|-----|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v4 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |

## Why

Documentation examples should model the same security best practices as the live workflow files. Floating tags (`@v4`) can silently change behavior if the upstream action is updated or compromised.

Closes #1646

## Test plan

- [x] `Verify all action refs are SHA-pinned` CI check covers `.github/workflows/*.yml` — docs files are not checked by that script, but the change brings them in line with the same standard
- [x] No snapshot changes needed (GitHub Actions yaml blocks are not under `## Installation` or `## Usage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)