### PR TITLE
test(ci): strengthen transpose assertion to check chord values changed

### DIFF
--- a/.github/workflows/github-action-ci.yml
+++ b/.github/workflows/github-action-ci.yml
@@ -92,7 +92,14 @@ jobs:
           OUTPUT="${{ steps.render-transpose.outputs.output-path }}"
           echo "output-path: $OUTPUT"
           [ -s "$OUTPUT" ] || { echo "Output file is missing or empty"; exit 1; }
-          # G transposed +2 = A; assert A chord is present and G is absent
-          # (text renderer outputs chords inline, e.g. [A] or A  above the lyric)
-          grep -q "A" "$OUTPUT" || { echo "Expected A chord (G+2) not found in transposed output"; exit 1; }
+          # The text renderer puts chords on their own line above lyrics (no brackets).
+          # After G+2=A transpose: all standalone G chords become A.
+          # \bA\b matches standalone "A" (chord token) but NOT "Amazing" or "A7".
+          # \bG\b matches standalone "G" but NOT "Grace" (G followed by r) or "G7".
+          grep -qE '\bA\b' "$OUTPUT" || { echo "Expected standalone A chord (G+2) not found in transposed output"; exit 1; }
+          if grep -qE '\bG\b' "$OUTPUT"; then
+            echo "Standalone G chord found in transposed output — transposition was not applied"
+            cat "$OUTPUT"
+            exit 1
+          fi
           cat "$OUTPUT"


### PR DESCRIPTION
## What

Replaces the weak `grep -q "A"` check with word-boundary-aware assertions that precisely validate transposition:

```bash
# \bA\b matches standalone A chord token — NOT "Amazing" or "A7"
grep -qE '\bA\b' "$OUTPUT" || { echo "Expected standalone A chord..."; exit 1; }

# \bG\b matches standalone G chord — NOT "Grace" (G followed by letter)
if grep -qE '\bG\b' "$OUTPUT"; then
  echo "Standalone G chord found — transposition was not applied"; exit 1
fi
```

## Why

The previous `grep -q "A"` test was satisfied by the title "Amazing Grace" even if transposition had failed entirely. The new test uses `\b` (word boundary) to distinguish chord tokens from words.

The text renderer outputs chords on their own line above lyrics without brackets — verified locally:
```
A       A7         D         A
Amazing grace, how sweet the sound
```

Closes #1643

## Test plan

- [x] Verified locally that `chordsketch -f text --transpose 2 simple.cho` produces `A` chords (no `G`)
- [x] `\bA\b` matches standalone `A` but not `Amazing`, `A7`
- [x] `\bG\b` does not match `Grace` (G followed by r) or `G7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)