### PR TITLE
test(ci): add PDF render step and negative-path validation tests

### DIFF
--- a/.github/workflows/github-action-ci.yml
+++ b/.github/workflows/github-action-ci.yml
@@ -104,3 +104,72 @@ jobs:
             exit 1
           fi
           cat "$OUTPUT"
+
+      # ---- PDF output -----------------------------------------------------
+      - name: Render to PDF
+        id: render-pdf
+        uses: ./packages/github-action
+        with:
+          input: packages/github-action/fixtures/simple.cho
+          output: out/simple.pdf
+          format: pdf
+
+      - name: Verify PDF output
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT="${{ steps.render-pdf.outputs.output-path }}"
+          echo "output-path: $OUTPUT"
+          [ -s "$OUTPUT" ] || { echo "PDF output file is missing or empty"; exit 1; }
+          # PDF files begin with the %PDF- magic bytes. Use python3 (pre-installed on
+          # all GitHub-hosted runners) to read binary bytes without grep binary-mode issues.
+          python3 -c "
+          import sys
+          with open(sys.argv[1], 'rb') as f:
+              header = f.read(5)
+          assert header == b'%PDF-', f'Expected PDF magic bytes, got {header!r}'
+          print('PDF header verified:', header)
+          " "$OUTPUT"
+
+      # ---- validation: negative-path tests --------------------------------
+      # Verify that the action exits non-zero when given an invalid format or
+      # transpose value. 'continue-on-error: true' prevents the job from failing
+      # when the action under test exits 1; we then assert the outcome explicitly.
+
+      - name: Test invalid format (should fail)
+        id: test-invalid-format
+        uses: ./packages/github-action
+        continue-on-error: true
+        with:
+          input: packages/github-action/fixtures/simple.cho
+          output: out/should-not-exist.txt
+          format: xlsx
+
+      - name: Verify invalid format was rejected
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.test-invalid-format.outcome }}" != "failure" ]; then
+            echo "Expected action to fail with invalid format 'xlsx' but it succeeded"
+            exit 1
+          fi
+          echo "Correctly rejected invalid format 'xlsx'"
+
+      - name: Test invalid transpose (should fail)
+        id: test-invalid-transpose
+        uses: ./packages/github-action
+        continue-on-error: true
+        with:
+          input: packages/github-action/fixtures/simple.cho
+          output: out/should-not-exist-2.txt
+          transpose: abc
+
+      - name: Verify invalid transpose was rejected
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.test-invalid-transpose.outcome }}" != "failure" ]; then
+            echo "Expected action to fail with invalid transpose 'abc' but it succeeded"
+            exit 1
+          fi
+          echo "Correctly rejected invalid transpose 'abc'"


### PR DESCRIPTION
## What

Adds three new test cases to `github-action-ci.yml`:

1. **PDF render step** — renders the fixture as PDF and verifies the output starts with `%PDF-` magic bytes (python3-based header check for binary-safe comparison on all platforms)
2. **Invalid format negative test** — passes `format: xlsx`, asserts the action exits non-zero
3. **Invalid transpose negative test** — passes `transpose: abc`, asserts the action exits non-zero

## Why

- #1656: The `pdf` format was the only format not exercised by CI; a regression in PDF rendering would go undetected.
- #1662: The `format` and `transpose` validation added in PRs #1654 and #1661 had no negative-path coverage. The validation could have a regex typo without any CI failure.

## Test results

- All existing tests (text, html, transpose) continue to pass.
- The negative-path tests use `continue-on-error: true` + `outcome == 'failure'` assertion — a standard GitHub Actions pattern for expected-failure testing.
- The PDF header check uses `python3` (pre-installed on all GitHub-hosted runners) for portable binary file inspection.

## Review summary

Sister-site audit: N/A — this is a CI workflow addition, not a renderer change.

Closes #1656
Closes #1662