### PR TITLE
test(cli): add regression test for --transpose -2 space form

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -135,6 +135,21 @@ fn test_transpose_down() {
 }
 
 #[test]
+fn test_transpose_down_space_form() {
+    // Regression test for #1669: --transpose -2 (space-separated) was previously
+    // rejected by clap 4 as an unknown short flag. Fixed by adding
+    // allow_negative_numbers = true to the --transpose arg definition.
+    // This test would fail if that attribute were removed.
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args([&fixture("simple.cho"), "--transpose", "-2"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("F     A#"))
+        .stdout(predicate::str::contains("Hello world"));
+}
+
+#[test]
 fn test_transpose_zero_is_noop() {
     Command::cargo_bin("chordsketch")
         .unwrap()


### PR DESCRIPTION
## What

Adds `test_transpose_down_space_form` to `crates/cli/tests/cli.rs`. This test uses `["--transpose", "-2"]` (two separate args, space form) rather than `["--transpose=-2"]` (equals form).

## Why

The existing `test_transpose_down` used the equals form, which worked even **before** PR #1670's fix. Without a test for the space form, removing `allow_negative_numbers = true` from the `--transpose` arg definition would still allow all existing tests to pass — making the fix silently regressable. The new test would fail if `allow_negative_numbers = true` were removed.

## Test results

Both `test_transpose_down` and `test_transpose_down_space_form` pass.

Closes #1671