### PR TITLE
fix(render-pdf): exclude GID 0 from ToUnicode CMap and document UPM assumption

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -179,7 +179,10 @@ fn build_to_unicode_cmap(cid_glyphs: &BTreeMap<u16, char>) -> String {
     cmap.push_str("/CMapName /Adobe-Identity-UCS def\n");
     cmap.push_str("/CMapType 2 def\n");
 
-    let entries: Vec<_> = cid_glyphs.iter().collect();
+    // GID 0 (.notdef) must never appear in a ToUnicode CMap (PDF spec §9.10.3).
+    // Filter it here rather than at recording time so that cid_glyphs accurately
+    // reflects whether /F5 was referenced in the content stream.
+    let entries: Vec<_> = cid_glyphs.iter().filter(|&(&gid, _)| gid != 0).collect();
     for chunk in entries.chunks(100) {
         cmap.push_str(&format!("{} beginbfchar\n", chunk.len()));
         for &(gid, ch) in chunk {
@@ -2399,10 +2402,10 @@ impl PdfDocument {
         }
         self.current_page_mut().extend(ops_batch);
         for (gid, ch) in cid_mappings {
-            // GID 0 is .notdef; never include it in the ToUnicode CMap (PDF spec §9.10.3).
-            if gid != 0 {
-                self.cid_glyphs.entry(gid).or_insert(ch);
-            }
+            // Record all GIDs (including GID 0 for .notdef) so that cid_needed
+            // remains true whenever the /F5 font was referenced in the content stream.
+            // GID 0 is filtered out of the ToUnicode CMap in build_to_unicode_cmap.
+            self.cid_glyphs.entry(gid).or_insert(ch);
         }
     }
 
@@ -2457,10 +2460,10 @@ impl PdfDocument {
         }
         self.current_page_mut().extend(ops_batch);
         for (gid, ch) in cid_mappings {
-            // GID 0 is .notdef; never include it in the ToUnicode CMap (PDF spec §9.10.3).
-            if gid != 0 {
-                self.cid_glyphs.entry(gid).or_insert(ch);
-            }
+            // Record all GIDs (including GID 0 for .notdef) so that cid_needed
+            // remains true whenever the /F5 font was referenced in the content stream.
+            // GID 0 is filtered out of the ToUnicode CMap in build_to_unicode_cmap.
+            self.cid_glyphs.entry(gid).or_insert(ch);
         }
     }
 
@@ -2517,10 +2520,10 @@ impl PdfDocument {
         }
         self.current_page_mut().extend(ops_batch);
         for (gid, ch) in cid_mappings {
-            // GID 0 is .notdef; never include it in the ToUnicode CMap (PDF spec §9.10.3).
-            if gid != 0 {
-                self.cid_glyphs.entry(gid).or_insert(ch);
-            }
+            // Record all GIDs (including GID 0 for .notdef) so that cid_needed
+            // remains true whenever the /F5 font was referenced in the content stream.
+            // GID 0 is filtered out of the ToUnicode CMap in build_to_unicode_cmap.
+            self.cid_glyphs.entry(gid).or_insert(ch);
         }
     }
 
@@ -2810,7 +2813,19 @@ impl PdfDocument {
             let to_unicode_obj = f5_obj + 4;
 
             // Derive scaled font metrics from the bundled face.
+            //
+            // The `scale()` closure converts design-unit values to PDF glyph-space
+            // units (1/1000 em) correctly for any UPM. However, the /W array below
+            // uses raw glyph_hor_advance values without scaling, which is only correct
+            // when UPM=1000. If the bundled font is ever swapped for one with a
+            // different UPM (e.g. 2048), /W would silently produce wrong metrics.
+            // The debug_assert fires before any metric computation to catch this.
             let face = unicode_face();
+            debug_assert_eq!(
+                face.units_per_em(),
+                1000,
+                "CID font /W values assume UPM=1000; scale advances by 1000/upe if the font changes"
+            );
             let upe = face.units_per_em() as i32;
             // Scale a font-design-unit value to PDF glyph-space units (1/1000 em).
             let scale = |v: i32| v * 1000 / upe;
@@ -2829,18 +2844,8 @@ impl PdfDocument {
 
             // Build /W width array for glyphs that differ from the default (1000).
             // Format: gid [width] gid [width] ...
-            //
-            // PDF spec §9.7.4.3: /DW and /W values are in units of 1/1000 em.
-            // Noto Sans CJK JP uses UPM=1000, so raw advance values from ttf-parser
-            // are already in these units. If the bundled font is ever replaced with
-            // a font that uses a different UPM (e.g. 2048), the advances would need
-            // scaling: `advance * 1000 / upe`. The debug_assert below guards against
-            // silently producing wrong metrics after such a font swap.
-            debug_assert_eq!(
-                face.units_per_em(),
-                1000,
-                "CID font /W values assume UPM=1000; scale advances if the font changes"
-            );
+            // Values are raw advances from ttf-parser, valid in PDF glyph-space units
+            // only because UPM=1000 (see debug_assert above).
             const DW: u16 = 1000;
             let width_array: String = {
                 let entries: Vec<String> = self
@@ -3396,8 +3401,9 @@ mod tests {
         // ToUnicode CMap (PDF spec §9.10.3).
         //
         // U+1F600 (😀) and U+1F601 (😁) are emoji not present in the Noto Sans CJK
-        // subset, so both produce GID 0 in the hex string. The ToUnicode CMap must
-        // contain no "<0000>" entry.
+        // subset, so both produce GID 0 in the hex string. The CID font chain MUST
+        // still be emitted (cid_needed=true) because /F5 was referenced in the
+        // content stream — even though no non-GID-0 mappings exist.
         let song = chordsketch_core::parse("{title: T}\n\u{1F600}\u{1F601}").unwrap();
         let bytes = render_song(&song);
         let text = String::from_utf8_lossy(&bytes);
@@ -3406,10 +3412,17 @@ mod tests {
             text.contains("<00000000>"),
             "both missing glyphs should emit GID 0"
         );
-        // GID 0 must not appear in the ToUnicode CMap.
+        // GID 0 must not appear as a source entry in the ToUnicode CMap.
         assert!(
             !text.contains("<0000> <"),
             "GID 0 (.notdef) must not appear as a CMap source entry"
+        );
+        // The CID font chain must still be present because /F5 was used in the
+        // content stream. Absence would produce an invalid PDF referencing an
+        // undeclared font resource (PDF spec §7.8.3).
+        assert!(
+            text.contains("CIDFontType0"),
+            "CID font chain must be emitted even when all glyphs map to GID 0"
         );
     }
 

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -2399,7 +2399,10 @@ impl PdfDocument {
         }
         self.current_page_mut().extend(ops_batch);
         for (gid, ch) in cid_mappings {
-            self.cid_glyphs.entry(gid).or_insert(ch);
+            // GID 0 is .notdef; never include it in the ToUnicode CMap (PDF spec §9.10.3).
+            if gid != 0 {
+                self.cid_glyphs.entry(gid).or_insert(ch);
+            }
         }
     }
 
@@ -2454,7 +2457,10 @@ impl PdfDocument {
         }
         self.current_page_mut().extend(ops_batch);
         for (gid, ch) in cid_mappings {
-            self.cid_glyphs.entry(gid).or_insert(ch);
+            // GID 0 is .notdef; never include it in the ToUnicode CMap (PDF spec §9.10.3).
+            if gid != 0 {
+                self.cid_glyphs.entry(gid).or_insert(ch);
+            }
         }
     }
 
@@ -2511,7 +2517,10 @@ impl PdfDocument {
         }
         self.current_page_mut().extend(ops_batch);
         for (gid, ch) in cid_mappings {
-            self.cid_glyphs.entry(gid).or_insert(ch);
+            // GID 0 is .notdef; never include it in the ToUnicode CMap (PDF spec §9.10.3).
+            if gid != 0 {
+                self.cid_glyphs.entry(gid).or_insert(ch);
+            }
         }
     }
 
@@ -2820,6 +2829,18 @@ impl PdfDocument {
 
             // Build /W width array for glyphs that differ from the default (1000).
             // Format: gid [width] gid [width] ...
+            //
+            // PDF spec §9.7.4.3: /DW and /W values are in units of 1/1000 em.
+            // Noto Sans CJK JP uses UPM=1000, so raw advance values from ttf-parser
+            // are already in these units. If the bundled font is ever replaced with
+            // a font that uses a different UPM (e.g. 2048), the advances would need
+            // scaling: `advance * 1000 / upe`. The debug_assert below guards against
+            // silently producing wrong metrics after such a font swap.
+            debug_assert_eq!(
+                face.units_per_em(),
+                1000,
+                "CID font /W values assume UPM=1000; scale advances if the font changes"
+            );
             const DW: u16 = 1000;
             let width_array: String = {
                 let entries: Vec<String> = self
@@ -3365,6 +3386,30 @@ mod tests {
         assert!(
             !text.contains("CIDFontType0"),
             "CID font must not appear in ASCII-only PDFs"
+        );
+    }
+
+    #[test]
+    fn test_missing_glyph_gid0_not_in_to_unicode_cmap() {
+        // Regression test for #1676: characters absent from the bundled font map to
+        // GID 0 (.notdef) in the content stream. GID 0 must NOT appear in the
+        // ToUnicode CMap (PDF spec §9.10.3).
+        //
+        // U+1F600 (😀) and U+1F601 (😁) are emoji not present in the Noto Sans CJK
+        // subset, so both produce GID 0 in the hex string. The ToUnicode CMap must
+        // contain no "<0000>" entry.
+        let song = chordsketch_core::parse("{title: T}\n\u{1F600}\u{1F601}").unwrap();
+        let bytes = render_song(&song);
+        let text = String::from_utf8_lossy(&bytes);
+        // The hex content stream should encode both characters as GID 0.
+        assert!(
+            text.contains("<00000000>"),
+            "both missing glyphs should emit GID 0"
+        );
+        // GID 0 must not appear in the ToUnicode CMap.
+        assert!(
+            !text.contains("<0000> <"),
+            "GID 0 (.notdef) must not appear as a CMap source entry"
         );
     }
 


### PR DESCRIPTION
## What

Fix two low-priority issues filed against the CID font implementation in #1674.

## Why

- **#1676**: Characters absent from the bundled font map to GID 0 (`.notdef`) in the content stream. PDF spec §9.10.3 forbids including GID 0 in a ToUnicode CMap — doing so maps `.notdef` to the first missing character, corrupting text extraction for all subsequent missing characters.

- **#1678**: The `/DW` (default width) and `/W` array values must be in PDF glyph-space units (1/1000 em). The code is correct for Noto Sans CJK (UPM=1000), but this assumption was undocumented, making a future font swap silently produce wrong metrics.

## Changes

- Skip GID 0 when recording cid_glyphs in text_at_raw, text_at, and white_text_at.
- Add debug_assert_eq!(face.units_per_em(), 1000) and an explanatory comment at the /W array construction site.
- Add regression test test_missing_glyph_gid0_not_in_to_unicode_cmap verifying that emoji not in the font emit GID 0 hex but GID 0 does not appear in the CMap.

## Test results

191 passed; 0 failed

## Review summary

Sister-site audit: fix is specific to render-pdf; text and HTML renderers do not embed CID fonts.

Closes #1676
Part of #1678