### PR TITLE
docs(render-pdf): update cid_glyphs field comment to reflect GID 0 inclusion rationale

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -18,9 +18,9 @@ use chordsketch_core::render_result::RenderResult;
 use chordsketch_core::resolve_diagrams_instrument;
 use chordsketch_core::transpose::transpose_chord;
 
-use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
+use flate2::Compression;
 use std::collections::BTreeMap;
 use std::io::{Read as IoRead, Write as IoWrite};
 
@@ -2165,6 +2165,14 @@ struct PdfDocument {
     /// Populated when CID-font segments are rendered (any character outside
     /// the WinAnsiEncoding range). Used in `build_pdf` to emit the ToUnicode
     /// CMap and the glyph-width `/W` array for the embedded CID font.
+    ///
+    /// **GID 0 (`.notdef`) entries may be present.** Characters absent from
+    /// the bundled font fall back to GID 0 in the content stream, and those
+    /// GID 0 entries are recorded here so that `cid_needed =
+    /// !self.cid_glyphs.is_empty()` stays `true` whenever `/F5` was
+    /// referenced — even when every non-Latin-1 character maps to `.notdef`.
+    /// GID 0 is excluded from the ToUnicode CMap in `build_to_unicode_cmap`
+    /// (PDF spec §9.10.3 forbids it as a source entry).
     cid_glyphs: BTreeMap<u16, char>,
 }
 
@@ -4828,7 +4836,7 @@ mod jpeg_tests {
         // Build a JPEG with valid SOI, then >64 KB of padding before the SOF.
         // The parser should bail out before reaching the SOF marker.
         let mut data = vec![0xFF, 0xD8]; // SOI
-        // Fill with non-marker bytes (not 0xFF) to force byte-by-byte scanning
+                                         // Fill with non-marker bytes (not 0xFF) to force byte-by-byte scanning
         data.resize(70_000, 0x00);
         // Append a valid SOF0 marker well past the 64 KB scan limit
         data.extend_from_slice(&[0xFF, 0xC0]);

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -18,9 +18,9 @@ use chordsketch_core::render_result::RenderResult;
 use chordsketch_core::resolve_diagrams_instrument;
 use chordsketch_core::transpose::transpose_chord;
 
+use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
-use flate2::Compression;
 use std::collections::BTreeMap;
 use std::io::{Read as IoRead, Write as IoWrite};
 
@@ -4836,7 +4836,7 @@ mod jpeg_tests {
         // Build a JPEG with valid SOI, then >64 KB of padding before the SOF.
         // The parser should bail out before reaching the SOF marker.
         let mut data = vec![0xFF, 0xD8]; // SOI
-                                         // Fill with non-marker bytes (not 0xFF) to force byte-by-byte scanning
+        // Fill with non-marker bytes (not 0xFF) to force byte-by-byte scanning
         data.resize(70_000, 0x00);
         // Append a valid SOF0 marker well past the 64 KB scan limit
         data.extend_from_slice(&[0xFF, 0xC0]);


### PR DESCRIPTION
## What

Update the `cid_glyphs` field doc comment in `crates/render-pdf/src/lib.rs` to reflect the design change introduced in #1679 (commit `acceede`).

## Why

Since `acceede`, GID 0 (`.notdef`) entries are intentionally stored in `cid_glyphs` so that `cid_needed = !self.cid_glyphs.is_empty()` remains `true` whenever `/F5` was referenced in a content stream — even when all non-Latin-1 characters fall back to `.notdef`. The old comment only mentioned "non-Latin-1 glyphs", implying only non-GID-0 entries were stored. This was stale and could mislead future contributors.

The inline comment at the filter site in `build_to_unicode_cmap` already explains the design, but the field-level doc comment is the canonical entry point for understanding the field's contract.

## Test results

No behavior change — docs only. CI format/clippy/test pass.

## Review summary

Docs-only change, no functional modification.

Closes #1680