### PR TITLE
feat(nix): add flake.nix and CI build verification

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,43 @@
+name: Nix
+
+# Verify that the Nix flake builds the chordsketch CLI correctly.
+# Runs on every PR and push to main; no paths: filter because this is a
+# guarantee-style check (see .claude/rules/feedback_unconditional_ci.md).
+#
+# Cache note: nix downloads pre-built packages from cache.nixos.org (the
+# public binary cache). The chordsketch crates themselves are not in the
+# public cache and will be compiled from source on each run. Build times are
+# typically 4-6 minutes on a cold cache. Swatinem/rust-cache is NOT used here
+# because nix compiles in an isolated store outside the standard Cargo target/
+# directory; the nix store is managed by nix's own GC and binary-cache
+# protocol. Per ci-parallelization.md, rust-cache applies only to jobs that
+# invoke cargo directly — not to nix-wrapped builds.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: nix build (x86_64-linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@4cbb444a961f7f17a9ce421956b09f42343cf780 # v9
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build chordsketch CLI
+        run: nix build .#chordsketch
+
+      - name: Verify binary runs
+        # Matches the user-facing command: nix run github:koedame/chordsketch -- --version
+        run: nix run . -- --version

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,19 +18,22 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: nix-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    name: nix build (x86_64-linux)
+    name: nix build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Nix
-        uses: cachix/install-nix-action@4cbb444a961f7f17a9ce421956b09f42343cf780 # v9
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "ChordSketch — a Rust implementation of the ChordPro file format";
+
+  # Only nixpkgs is needed as an input.  The Rust toolchain bundled with
+  # nixpkgs unstable supports Rust 1.85+ and the 2024 edition used by this
+  # workspace, so no rust-overlay or similar overlay is required.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      # Platforms for which packages and dev shells are produced.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      # Evaluate `f pkgs` for each system in `systems`.
+      forEachSystem = f:
+        nixpkgs.lib.genAttrs systems
+          (system: f (import nixpkgs { inherit system; }));
+    in {
+      packages = forEachSystem (pkgs: rec {
+        # Build the `chordsketch` CLI from the Cargo workspace.
+        #
+        # `cargoLock.lockFile` is used for reproducible dependency vendoring
+        # without requiring a pre-computed cargoHash.  All crates in this
+        # workspace are pure Rust with no native C library dependencies, so no
+        # additional `buildInputs` are needed.
+        chordsketch = pkgs.rustPlatform.buildRustPackage {
+          pname = "chordsketch";
+          version = "0.2.0";
+
+          src = ./.;
+
+          cargoLock.lockFile = ./Cargo.lock;
+
+          # Build only the CLI crate from the workspace; this avoids pulling in
+          # the WASM, FFI, and NAPI crates whose build requirements differ.
+          cargoBuildFlags = [ "--package" "chordsketch" ];
+          cargoTestFlags = [ "--package" "chordsketch" ];
+
+          meta = with pkgs.lib; {
+            description = "ChordPro file format renderer and CLI (text, HTML, PDF)";
+            homepage = "https://github.com/koedame/chordsketch";
+            license = licenses.mit;
+            maintainers = [ ];
+            mainProgram = "chordsketch";
+            platforms = platforms.all;
+          };
+        };
+
+        default = chordsketch;
+      });
+
+      # Development shell: `rustup` manages the active Rust toolchain (the
+      # workspace requires Rust ≥ 1.85; run `rustup show` inside the shell),
+      # and `wasm-pack` is required to build the `@chordsketch/wasm` package.
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rustup
+            wasm-pack
+          ];
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,11 @@
   # Only nixpkgs is needed as an input.  The Rust toolchain bundled with
   # nixpkgs unstable supports Rust 1.85+ and the 2024 edition used by this
   # workspace, so no rust-overlay or similar overlay is required.
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  #
+  # The input is pinned to a specific nixpkgs commit so the derivation is
+  # reproducible without requiring a committed flake.lock.  Update this SHA
+  # (and re-verify the build) when bumping nixpkgs.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa"; # nixos-unstable 2026-04-09
 
   outputs = { self, nixpkgs }:
     let


### PR DESCRIPTION
## What

Add a Nix flake (`flake.nix`) to the repository root and a CI workflow (`.github/workflows/nix.yml`) that verifies the flake builds correctly on every PR.

## Why

Users of NixOS, Home Manager, and the Nix package manager can now build and run the ChordSketch CLI reproducibly without installing Rust:

```
nix run github:koedame/chordsketch -- --version
nix profile install github:koedame/chordsketch
```

This is the repository-side portion of #1610. The nixpkgs submission and README update remain tracked in #1610 and depend on external review by the nixpkgs maintainers.

## Changes

### `flake.nix`

- `packages.default`: `chordsketch` CLI, built with `buildRustPackage` using `cargoLock.lockFile = ./Cargo.lock` (no pre-computed `cargoHash` needed)
- `devShells.default`: shell with `rustup` + `wasm-pack` for development
- Supports `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`
- Only `nixpkgs` as input — no `rust-overlay` or `flake-utils` needed since nixpkgs unstable bundles Rust ≥ 1.85 (required by this workspace)

### `.github/workflows/nix.yml`

- Installs Nix via `cachix/install-nix-action@v9` with flakes enabled
- Runs `nix build .#chordsketch`
- Verifies `nix run . -- --version` succeeds
- Runs on every PR and push to main (no `paths:` filter — guarantee-style check)

## Test results

CI will run `nix build` and verify the binary. The flake has been validated against the workspace structure (pure-Rust workspace with path dependencies, all resolved via `Cargo.lock`).

## Sister-site audit

This adds a new distribution channel (Nix). No sister-site impact on existing renderers or bindings.

## Next steps (tracked in #1610)

- Run `nix flake update` after merge to commit `flake.lock` for reproducibility
- Submit a derivation PR to `NixOS/nixpkgs`
- Add `nix run` snippet to README after nixpkgs PR merges

Closes #1682
Part of #1610