### PR TITLE
fix(nix): read version from Cargo.toml, narrow platforms, fix stale comment

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,8 +1,7 @@
 name: Nix
 
 # Verify that the Nix flake builds the chordsketch CLI correctly.
-# Runs on every PR and push to main; no paths: filter because this is a
-# guarantee-style check (see .claude/rules/feedback_unconditional_ci.md).
+# Runs on every PR and push to main; no paths: filter (guarantee-style check).
 #
 # Cache note: nix downloads pre-built packages from cache.nixos.org (the
 # public binary cache). The chordsketch crates themselves are not in the

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,9 @@
       forEachSystem = f:
         nixpkgs.lib.genAttrs systems
           (system: f (import nixpkgs { inherit system; }));
+
+      # Read version from the CLI crate so it stays in sync automatically.
+      cliCargoToml = builtins.fromTOML (builtins.readFile ./crates/cli/Cargo.toml);
     in {
       packages = forEachSystem (pkgs: rec {
         # Build the `chordsketch` CLI from the Cargo workspace.
@@ -34,7 +37,7 @@
         # additional `buildInputs` are needed.
         chordsketch = pkgs.rustPlatform.buildRustPackage {
           pname = "chordsketch";
-          version = "0.2.0";
+          version = cliCargoToml.package.version;
 
           src = ./.;
 
@@ -51,7 +54,7 @@
             license = licenses.mit;
             maintainers = [ ];
             mainProgram = "chordsketch";
-            platforms = platforms.all;
+            platforms = systems;
           };
         };
 


### PR DESCRIPTION
## What

Fix three non-blocking review findings from #1683 (Nix flake PR):

1. **Version sync** (#1685): Read `version` from `crates/cli/Cargo.toml` via `builtins.fromTOML` instead of hardcoding `"0.2.0"`. Eliminates version drift.
2. **Platform accuracy** (#1686): Change `meta.platforms` from `platforms.all` to the `systems` list (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`). Prevents `nix search` / Hydra from advertising unsupported platforms.
3. **Stale reference** (#1687): Remove reference to non-existent `.claude/rules/feedback_unconditional_ci.md` in `nix.yml` comment.

## Why

These were filed as non-blocking review findings during #1683 review. Fixing them improves correctness and maintainability of the Nix integration.

## Test results

CI will run `nix build` and `nix run . -- --version` to verify the flake still builds correctly with the dynamic version reading.

## Sister-site audit

No sister-site impact — changes are limited to `flake.nix` and `.github/workflows/nix.yml`.

Closes #1685
Closes #1686
Closes #1687