### PR TITLE
chore(nix): commit flake.lock for reproducible builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,9 @@
   # nixpkgs unstable supports Rust 1.85+ and the 2024 edition used by this
   # workspace, so no rust-overlay or similar overlay is required.
   #
-  # The input is pinned to a specific nixpkgs commit so the derivation is
-  # reproducible without requiring a committed flake.lock.  Update this SHA
-  # (and re-verify the build) when bumping nixpkgs.
+  # The input is pinned to a specific nixpkgs commit and the resolved
+  # metadata is recorded in flake.lock for fully reproducible builds.
+  # When bumping nixpkgs, update this SHA and run `nix flake update`.
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa"; # nixos-unstable 2026-04-09
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
## What

Commit the `flake.lock` file generated by `nix flake update` and update the
`flake.nix` comment to reflect that the lock file now exists.

## Why

The `flake.nix` added in #1683 pinned nixpkgs to a specific commit but did not
include a `flake.lock`. Without the lock file, Nix must resolve input metadata
(narHash) on every evaluation, making builds non-deterministic across machines.
The lock file records the exact resolved metadata for fully reproducible builds.

## Changes

- **`flake.lock`** (new): Generated by `nix flake update`, locks `nixpkgs` to
  commit `4c1018dae…` with its narHash.
- **`flake.nix`**: Updated comment to reflect that `flake.lock` now provides
  reproducibility (previously stated "reproducible without requiring a committed
  flake.lock").

## Test results

- `nix flake update` completed successfully (run via `nixos/nix` Docker image)
- Lock file pins to the same commit already specified in `flake.nix`
- CI (`nix.yml`) will pick up the lock file automatically — no workflow changes needed

## Review summary

Minimal change: one new generated file + a 3-line comment update. No code logic
changes.

Closes #1684

🤖 Generated with [Claude Code](https://claude.com/claude-code)