### PR TITLE
docs: add missing packages to CLAUDE.md Architecture table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Additionally, these non-Rust packages exist:
 | Kotlin (`chordsketch`) | `packages/kotlin` | Kotlin/JVM package via JNI |
 | Ruby (`chordsketch`) | `packages/ruby` | Ruby gem via UniFFI |
 | `@chordsketch/syntaxes` | `syntaxes/` | TextMate grammar and language configuration for ChordPro files (private, not published) |
+| VS Code extension | `packages/vscode-extension` | VS Code / Open VSX extension with TextMate highlighting, live preview, and LSP integration |
+| GitHub Action | `packages/github-action` | Composite GitHub Action for rendering ChordPro files in CI |
+| `tree-sitter-chordpro` | `packages/tree-sitter-chordpro` | Tree-sitter grammar for ChordPro syntax highlighting |
+| ChordPro (Zed extension) | `packages/zed-extension` | Zed editor extension with tree-sitter highlighting and LSP integration (not in workspace; targets wasm32-wasi) |
 
 ### Dependency Policy
 


### PR DESCRIPTION
## What

Add four missing packages to the non-Rust packages table in CLAUDE.md:

- `tree-sitter-chordpro` (`packages/tree-sitter-chordpro`) — added in #1694
- ChordPro Zed extension (`packages/zed-extension`) — added in #1694
- VS Code extension (`packages/vscode-extension`) — pre-existing gap
- GitHub Action (`packages/github-action`) — pre-existing gap

## Why

Per `doc-maintenance.md`, the Architecture table must be updated when new packages are added. #1694 added two new packages; this dedicated documentation PR fulfills that requirement. The VS Code extension and GitHub Action entries are also added to close a pre-existing gap in the table.

## Test results

Documentation-only change. No code modified.

- `cargo fmt --check` — N/A (no Rust changes)
- `cargo clippy` — N/A
- `cargo test` — N/A

Closes #1696