### PR TITLE
fix(ci): pass github.event_name through env var in all post-release jobs

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -25,8 +25,9 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="$RELEASE_TAG"
@@ -108,8 +109,9 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="$RELEASE_TAG"
@@ -171,8 +173,9 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="$RELEASE_TAG"
@@ -243,8 +246,9 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="$RELEASE_TAG"
@@ -306,8 +310,9 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="$RELEASE_TAG"
@@ -346,8 +351,9 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="$RELEASE_TAG"
@@ -462,8 +468,9 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="$RELEASE_TAG"


### PR DESCRIPTION
## What

Replace direct `${{ github.event_name }}` interpolation with `EVENT_NAME`
environment variable in all 7 remaining Determine version steps in
`post-release.yml`.

## Why

Direct expression interpolation in shell `run:` blocks is inconsistent with
how `INPUT_TAG` and `RELEASE_TAG` are already passed via `env:` in the same
steps. While `github.event_name` has a constrained value set (`release`,
`workflow_dispatch`) and is not user-controllable, following GitHub's
recommended practice of avoiding direct interpolation improves consistency
and defense-in-depth.

The `update-flatpak` job was already fixed in #1705. This PR applies the
same fix to the remaining 7 jobs:

- `update-homebrew`
- `update-scoop`
- `update-chocolatey`
- `update-snap`
- `update-cocoapods`
- `update-aur`
- `update-swift-package`

## Test results

- No Rust code changes
- The `run:` block logic is unchanged — only the source of the
  `event_name` value changes from direct interpolation to env var

## Review summary

Mechanical change: 7 identical substitutions, each adding
`EVENT_NAME: ${{ github.event_name }}` to the `env:` block and replacing
`"${{ github.event_name }}"` with `"$EVENT_NAME"` in the `run:` block.

Sister-site audit: all 8 Determine version steps in post-release.yml now
use `EVENT_NAME` consistently.

Closes #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)