### PR TITLE
feat(ci): add aarch64 architecture support to Flatpak manifest

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -694,16 +694,21 @@ jobs:
             exit 1
           fi
 
-          SHA_LINUX=$(grep "x86_64-unknown-linux-gnu" checksums.txt | awk '{print $1}')
+          SHA_X86_64=$(grep "x86_64-unknown-linux-gnu" checksums.txt | awk '{print $1}')
+          SHA_AARCH64=$(grep "aarch64-unknown-linux-gnu" checksums.txt | awk '{print $1}')
 
-          if [[ ! "$SHA_LINUX" =~ ^[0-9a-fA-F]{64}$ ]]; then
-            echo "ERROR: missing or invalid SHA256 for x86_64-unknown-linux-gnu: '${SHA_LINUX}'" >&2
-            exit 1
-          fi
+          for var_name in SHA_X86_64 SHA_AARCH64; do
+            val="${!var_name}"
+            if [[ ! "$val" =~ ^[0-9a-fA-F]{64}$ ]]; then
+              echo "ERROR: missing or invalid SHA256 for ${var_name}: '${val}'" >&2
+              exit 1
+            fi
+          done
 
           sed \
             -e "s/{{VERSION}}/${VERSION}/g" \
-            -e "s/{{SHA256_X86_64_UNKNOWN_LINUX_GNU}}/${SHA_LINUX}/g" \
+            -e "s/{{SHA256_X86_64_UNKNOWN_LINUX_GNU}}/${SHA_X86_64}/g" \
+            -e "s/{{SHA256_AARCH64_UNKNOWN_LINUX_GNU}}/${SHA_AARCH64}/g" \
             packaging/flatpak/me.koeda.chordsketch.yml.template > me.koeda.chordsketch.yml
 
           cat me.koeda.chordsketch.yml
@@ -755,7 +760,8 @@ jobs:
 ## Update chordsketch to ${VERSION}
 
 - **Version**: ${VERSION}
-- **Source**: Pre-built x86_64-linux-gnu binary from [GitHub Release](https://github.com/koedame/chordsketch/releases/tag/v${VERSION})
+- **Architectures**: x86_64, aarch64
+- **Source**: Pre-built binaries from [GitHub Release](https://github.com/koedame/chordsketch/releases/tag/v${VERSION})
 
 Automated update from the [chordsketch post-release workflow](https://github.com/koedame/chordsketch/blob/main/.github/workflows/post-release.yml).
 PR_BODY

--- a/packaging/flatpak/me.koeda.chordsketch.yml.template
+++ b/packaging/flatpak/me.koeda.chordsketch.yml.template
@@ -26,3 +26,11 @@ modules:
         url: https://github.com/koedame/chordsketch/releases/download/v{{VERSION}}/chordsketch-v{{VERSION}}-x86_64-unknown-linux-gnu.tar.gz
         sha256: {{SHA256_X86_64_UNKNOWN_LINUX_GNU}}
         strip-components: 1
+        only-arches:
+          - x86_64
+      - type: archive
+        url: https://github.com/koedame/chordsketch/releases/download/v{{VERSION}}/chordsketch-v{{VERSION}}-aarch64-unknown-linux-gnu.tar.gz
+        sha256: {{SHA256_AARCH64_UNKNOWN_LINUX_GNU}}
+        strip-components: 1
+        only-arches:
+          - aarch64


### PR DESCRIPTION
## What

Add aarch64 (ARM64) Linux binary support to the Flatpak manifest template
and update the post-release automation to handle both architectures.

## Why

Flathub strongly prefers multi-architecture support. GitHub Releases already
include `aarch64-unknown-linux-gnu` binaries, so adding aarch64 to the
Flatpak manifest is straightforward and broadens the install base to ARM64
Linux devices (Raspberry Pi, ARM servers, Apple Silicon Linux VMs, etc.).

## Changes

- **`packaging/flatpak/me.koeda.chordsketch.yml.template`**: Add second
  archive source for aarch64 with `only-arches` filters on both entries
  so Flatpak selects the correct binary per architecture.
- **`.github/workflows/post-release.yml`** (`update-flatpak` job):
  - Extract and validate aarch64 SHA256 from `checksums.txt`
  - Use loop-based validation (matching the `update-homebrew` pattern)
  - Pass `{{SHA256_AARCH64_UNKNOWN_LINUX_GNU}}` to sed substitution
  - Update Flathub PR body to mention both architectures

## Test results

- No Rust code changes
- Template syntax verified manually
- SHA256 validation uses the same loop pattern as `update-homebrew`

## Review summary

Small follow-up to #1705 (Flatpak infrastructure). Adds aarch64 support
using Flatpak's `only-arches` mechanism.

Sister-site audit: N/A — this is Flatpak-specific, no sibling renderers
or bindings affected.

Closes #1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)