### PR TITLE
feat(ci): add MacPorts Portfile and document manual update process

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -269,7 +269,30 @@ After the release workflow completes and the GitHub Release is published:
       koedame.chordsketch` becomes available within minutes. The next
       `readme-smoke.yml` run will turn the `winget (Windows)` job green.
 
-5. **Automated channel rollup** — `.github/workflows/release-verify.yml`
+5. **MacPorts Portfile** — MacPorts does **not** have an automated update
+   mechanism. After each release, the Portfile must be updated manually and
+   submitted as a PR to `macports/macports-ports`:
+
+   1. A reference Portfile lives at `packaging/macports/Portfile`. Update
+      the `github.setup` version and the `checksums` block. To compute the
+      checksums, download the source tarball that GitHub auto-generates for
+      the tag:
+      ```bash
+      TAG=vX.Y.Z
+      curl -L -o chordsketch-${TAG}.tar.gz \
+        "https://github.com/koedame/chordsketch/archive/refs/tags/${TAG}.tar.gz"
+      openssl dgst -rmd160 chordsketch-${TAG}.tar.gz
+      openssl dgst -sha256 chordsketch-${TAG}.tar.gz
+      wc -c chordsketch-${TAG}.tar.gz
+      ```
+   2. If the `cargo.crates` block needs updating (dependency versions
+      changed), regenerate it using MacPorts' `cargo2port.py` tool from a
+      local MacPorts install.
+   3. Fork `macports/macports-ports` (or use the existing fork), place the
+      Portfile in `textproc/chordsketch/Portfile`, and open a PR.
+   4. Wait for MacPorts CI and maintainer review.
+
+6. **Automated channel rollup** — `.github/workflows/release-verify.yml`
    runs automatically on `release: published`, queries every registry
    listed in `ci/release-channels.toml`, and appends a
    `## Channel Verification` section to the release body. Wait for that
@@ -295,7 +318,7 @@ After the release workflow completes and the GitHub Release is published:
      -f tag=vX.Y.Z -f force_stale_channel=crates-io-cli
    ```
 
-6. **Manual verification** — confirm every documented install path works for
+7. **Manual verification** — confirm every documented install path works for
    end users. Easiest: trigger `readme-smoke.yml` via `workflow_dispatch` and
    confirm every job is green. `gh workflow run` does not print the run id,
    so resolve it from the workflow's most recent run before passing it to

--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        koedame chordsketch 0.2.0 v
+revision            0
+categories          textproc music
+license             MIT
+maintainers         {koeda.me:oss @koedame} openmaintainer
+description         ChordPro file format parser and renderer
+long_description    ChordSketch is a Rust implementation of the ChordPro file \
+                    format. It parses .cho files and renders them to plain text, \
+                    HTML, or PDF output. Full compatibility with the ChordPro \
+                    specification.
+
+checksums           rmd160  0 \
+                    sha256  0 \
+                    size    0
+
+# The CLI crate is at crates/cli within the workspace.
+# cargo.crates is populated by running:
+#   sudo port -v extract chordsketch && cd <workdir> && cargo2port.py
+# See the MacPorts Rust PortGroup documentation for details.
+
+build.dir           ${worksrcpath}
+cargo.bin           ${worksrcpath}/target/[cargo.rust_platform]/release/chordsketch
+
+destroot {
+    xinstall -m 0755 ${cargo.bin} ${destroot}${prefix}/bin/chordsketch
+}
+
+notes "
+ChordSketch has been installed. Run 'chordsketch --help' to get started.
+"

--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -1,5 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# Reference Portfile for MacPorts submission. Before submitting to
+# macports/macports-ports, you must:
+#   1. Replace the placeholder checksums with actual values
+#   2. Populate the cargo.crates block via cargo2port.py
+# See docs/releasing.md for the full procedure.
+
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
@@ -15,20 +21,30 @@ long_description    ChordSketch is a Rust implementation of the ChordPro file \
                     HTML, or PDF output. Full compatibility with the ChordPro \
                     specification.
 
+# TODO: Replace with actual checksums before submission.
+# Compute via:
+#   curl -L -o src.tar.gz https://github.com/koedame/chordsketch/archive/refs/tags/v0.2.0.tar.gz
+#   openssl dgst -rmd160 src.tar.gz
+#   openssl dgst -sha256 src.tar.gz
+#   wc -c src.tar.gz
 checksums           rmd160  0 \
                     sha256  0 \
                     size    0
 
-# The CLI crate is at crates/cli within the workspace.
-# cargo.crates is populated by running:
+# TODO: Populate cargo.crates before submission.
+# The cargo portgroup requires all crate dependencies to be listed here.
+# Generate this block by running:
 #   sudo port -v extract chordsketch && cd <workdir> && cargo2port.py
 # See the MacPorts Rust PortGroup documentation for details.
+# cargo.crates \
+#     crate_name version checksum \
+#     ...
 
 build.dir           ${worksrcpath}
-cargo.bin           ${worksrcpath}/target/[cargo.rust_platform]/release/chordsketch
 
 destroot {
-    xinstall -m 0755 ${cargo.bin} ${destroot}${prefix}/bin/chordsketch
+    xinstall -m 0755 ${worksrcpath}/target/[option cargo.rust_platform]/release/chordsketch \
+        ${destroot}${prefix}/bin/chordsketch
 }
 
 notes "


### PR DESCRIPTION
## What

- Add `packaging/macports/Portfile` reference Portfile for MacPorts
- Document the manual MacPorts update process in `docs/releasing.md`

## Why

MacPorts is used by macOS developers, particularly in academic and scientific
computing environments. A reference Portfile in the repo provides the basis
for the upstream `macports/macports-ports` PR and documents the build
configuration for future maintainers. Unlike Homebrew, MacPorts does not
have an automated update mechanism, so the manual process is documented.

## Changes

- **`packaging/macports/Portfile`** (new): Reference Portfile using the
  `github` and `cargo` portgroups. Builds from source via cargo (not
  pre-built binaries, following MacPorts convention). Categories:
  `textproc music`. Placeholder checksums to be computed at submission time.
- **`docs/releasing.md`**: New step 5 in Post-Release documenting the
  manual Portfile update and submission process, including checksum
  computation commands and `cargo2port.py` usage for dependency updates.

## Remaining manual steps (tracked by #1615)

- [ ] Compute actual checksums for the current release
- [ ] Populate `cargo.crates` block via `cargo2port.py`
- [ ] Test locally with `sudo port install` from the Portfile directory
- [ ] Submit PR to [macports/macports-ports](https://github.com/macports/macports-ports)
- [ ] Add `sudo port install chordsketch` snippet to README after acceptance

## Test results

- No Rust code changes
- Portfile follows MacPorts Rust portgroup conventions

## Review summary

Infrastructure-only change. Portfile follows established MacPorts patterns
for Rust workspace projects. No post-release automation needed (documented
manual process instead).

Sister-site audit: N/A — new packaging format, not a bug fix.

Part of #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)