### PR TITLE
fix(core): add missing #[must_use] to public Result-returning functions

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -179,6 +179,7 @@ impl Config {
     /// # Errors
     ///
     /// Returns a [`rrjson::ParseError`] if the input is malformed.
+    #[must_use = "parse errors should not be silently discarded"]
     pub fn parse(input: &str) -> Result<Self, rrjson::ParseError> {
         let root = rrjson::parse_rrjson(input)?;
         Ok(Self { root })
@@ -259,6 +260,7 @@ impl Config {
     /// Returns [`ConfigError::Io`] if the file cannot be read, or
     /// [`ConfigError::Parse`] if the content is malformed.
     #[cfg(not(target_arch = "wasm32"))]
+    #[must_use = "config resolution errors should not be silently discarded"]
     pub fn resolve(name: &str) -> Result<ConfigResolveResult, ConfigError> {
         // Try preset first
         if let Some(preset) = Self::preset(name) {
@@ -297,6 +299,7 @@ impl Config {
     ///
     /// Returns [`DefineError`] if the input has no `=`, the key is empty,
     /// or the dotted key exceeds the maximum nesting depth.
+    #[must_use = "define errors should not be silently discarded"]
     pub fn with_define(mut self, define: &str) -> Result<Self, DefineError> {
         self.apply_define(define)?;
         Ok(self)
@@ -313,6 +316,7 @@ impl Config {
     /// Returns [`DefineError`] if the input has no `=`, the key is empty,
     /// or the dotted key exceeds the maximum nesting depth. On error,
     /// `self` is not modified.
+    #[must_use = "define errors should not be silently discarded"]
     pub fn apply_define(&mut self, define: &str) -> Result<(), DefineError> {
         let Some(eq_pos) = define.find('=') else {
             return Err(DefineError::MissingEquals);

--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -154,6 +154,7 @@ impl Drop for TempDirGuard {
 /// - The temporary file cannot be written
 /// - `abc2svg` is not available or fails to execute
 /// - The output does not contain a recognizable `<body>` section
+#[must_use = "invocation errors should not be silently discarded"]
 pub fn invoke_abc2svg(abc_content: &str) -> Result<String, String> {
     let sanitized = sanitize_abc_content(abc_content);
 
@@ -346,6 +347,7 @@ fn extract_body_content(html: &str) -> Option<String> {
 /// - The temporary directory or file cannot be created
 /// - `lilypond` is not available or fails to execute
 /// - The output SVG file cannot be read
+#[must_use = "invocation errors should not be silently discarded"]
 pub fn invoke_lilypond(ly_content: &str) -> Result<String, String> {
     let sanitized = sanitize_lilypond_content(ly_content);
 
@@ -548,6 +550,7 @@ fn collect_musescore_pages(tmp_dir: &std::path::Path) -> Result<String, String> 
 /// - The temporary file cannot be written
 /// - Neither `mscore` nor `musescore` is available or they fail to execute
 /// - No SVG output file can be found after a successful run
+#[must_use = "invocation errors should not be silently discarded"]
 pub fn invoke_musescore(musicxml_content: &str) -> Result<String, String> {
     // Check tool availability before creating any temp files so that a missing
     // tool never leaves an orphaned directory behind.

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -181,6 +181,7 @@ impl Parser {
     /// Returns a [`ParseError`] on the first structural problem encountered
     /// (e.g., unclosed directives or chords). Use [`parse_lenient`] to
     /// collect all errors and obtain a partial AST.
+    #[must_use = "callers must handle the parse result"]
     pub fn parse(mut self) -> Result<Song, ParseError> {
         let mut song = Song::new();
 
@@ -210,12 +211,14 @@ impl Parser {
     /// skips to the next line to continue. The returned [`ParseResult`]
     /// contains the partial AST (all successfully parsed lines) and a
     /// list of all errors encountered.
+    #[must_use = "callers must handle the parse result"]
     pub fn parse_lenient(self) -> ParseResult {
         self.parse_lenient_limited(0)
     }
 
     /// Like [`parse_lenient`](Self::parse_lenient), but stops collecting errors
     /// after `max_errors` have been recorded. Set to `0` to disable the limit.
+    #[must_use = "callers must handle the parse result"]
     pub fn parse_lenient_limited(mut self, max_errors: usize) -> ParseResult {
         let mut song = Song::new();
         let mut errors = Vec::new();

--- a/crates/core/src/rrjson.rs
+++ b/crates/core/src/rrjson.rs
@@ -268,6 +268,7 @@ pub struct ParseResult {
 /// # Errors
 ///
 /// Returns a [`ParseError`] if the input is malformed.
+#[must_use = "parse errors should not be silently discarded"]
 pub fn parse_rrjson(input: &str) -> Result<Value, ParseError> {
     parse_rrjson_with_warnings(input).map(|r| r.value)
 }
@@ -278,6 +279,7 @@ pub fn parse_rrjson(input: &str) -> Result<Value, ParseError> {
 /// # Errors
 ///
 /// Returns a [`ParseError`] if the input is malformed.
+#[must_use = "parse errors should not be silently discarded"]
 pub fn parse_rrjson_with_warnings(input: &str) -> Result<ParseResult, ParseError> {
     let mut parser = Parser::new(input);
     parser.skip_ws_and_comments()?;


### PR DESCRIPTION
## What

Add `#[must_use]` attributes to 12 public functions that return `Result` or `ParseResult`.

## Why

Per `.claude/rules/code-style.md`: "Use `#[must_use]` on functions whose return values should not be silently discarded." A code quality audit found 12 public functions in `chordsketch-core` that return `Result` without `#[must_use]`, allowing callers to silently discard errors.

## Changes

| File | Functions |
|------|-----------|
| `config.rs` | `Config::parse`, `Config::resolve`, `Config::with_define`, `Config::apply_define` |
| `external_tool.rs` | `invoke_abc2svg`, `invoke_lilypond`, `invoke_musescore` |
| `parser.rs` | `Parser::parse`, `Parser::parse_lenient`, `Parser::parse_lenient_limited` |
| `rrjson.rs` | `parse_rrjson`, `parse_rrjson_with_warnings` |

## Test results

```
cargo clippy --workspace -- -D warnings  # clean
cargo test --workspace                    # all passing
```

No logic changes — attribute-only additions.

Closes #1716

🤖 Generated with [Claude Code](https://claude.com/claude-code)