### PR TITLE
docs(npm): add validate() to @chordsketch/wasm API documentation

### DIFF
--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -36,6 +36,7 @@ import init, {
   render_html,
   render_text,
   render_pdf,
+  validate,
   version,
 } from '@chordsketch/wasm';
 
@@ -47,6 +48,7 @@ const chordpro = `{title: Amazing Grace}
 
 [G]Amazing [G7]grace, how [C]sweet the [G]sound`;
 
+const errors = validate(chordpro); // [] if valid
 const html = render_html(chordpro);
 const text = render_text(chordpro);
 const pdfBytes = render_pdf(chordpro); // Uint8Array
@@ -62,6 +64,7 @@ import {
   render_html,
   render_text,
   render_pdf,
+  validate,
   version,
 } from '@chordsketch/wasm';
 
@@ -70,6 +73,7 @@ const chordpro = `{title: Amazing Grace}
 
 [G]Amazing [G7]grace, how [C]sweet the [G]sound`;
 
+const errors = validate(chordpro); // [] if valid
 const html = render_html(chordpro);
 const text = render_text(chordpro);
 const pdfBytes = render_pdf(chordpro); // Uint8Array
@@ -118,6 +122,12 @@ interface RenderOptions {
   config?: string;     // Preset name ("guitar", "ukulele") or inline RRJSON
 }
 ```
+
+### Validation
+
+| Function | Input | Output |
+|----------|-------|--------|
+| `validate(input)` | ChordPro string | `string[]` — parse errors (empty if valid) |
 
 ### Utility
 


### PR DESCRIPTION
## What

Document the validate() function in the @chordsketch/wasm npm package README.

## Why

PR #1713 added validate() to the WASM binding but the npm package documentation was not updated. Users looking at the README cannot discover this function.

Note: The TypeScript .d.ts files are auto-generated by wasm-pack and gitignored. They will automatically include validate() on the next wasm-pack build. Only the hand-maintained README needs updating.

## Changes

- Add validate import to browser and Node.js quick-start examples
- Add validate(chordpro) usage line in both examples
- Add Validation section to the API table

Closes #1718

Generated with [Claude Code](https://claude.com/claude-code)