### PR TITLE
docs: add missing crate READMEs and editor section to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ into a structured AST and rendering to plain text, HTML, and PDF.
 **[ChordSketch Playground](https://koedame.github.io/chordsketch/)** — try
 ChordPro rendering directly in your browser, no installation required.
 
+## Editor Integration
+
+ChordSketch provides syntax highlighting and Language Server Protocol (LSP)
+support for multiple editors:
+
+- **VS Code / Cursor / Windsurf / VSCodium** — install the [ChordSketch extension](https://marketplace.visualstudio.com/items?itemName=koedame.chordsketch)
+- **JetBrains IDEs** (IntelliJ IDEA, PyCharm, WebStorm, etc.) — install the ChordPro plugin
+- **Zed** — install the ChordPro extension from the extensions panel
+- **Neovim** — manual tree-sitter + LSP configuration
+- **Helix** — manual grammar + LSP configuration
+
+See [docs/editors.md](docs/editors.md) for detailed setup instructions.
+
 ## Installation
 
 ### npm (WASM)
@@ -129,7 +142,9 @@ println!("{text}");
 | [`chordsketch-render-html`](crates/render-html) | HTML renderer |
 | [`chordsketch-render-pdf`](crates/render-pdf) | PDF renderer |
 | [`chordsketch`](crates/cli) | Command-line tool |
+| [`chordsketch-lsp`](crates/lsp) | Language Server Protocol server |
 | [`chordsketch-wasm`](crates/wasm) | WebAssembly bindings via wasm-bindgen |
+| [`chordsketch-convert-musicxml`](crates/convert-musicxml) | MusicXML ↔ ChordPro bidirectional converter |
 
 ### Packages
 

--- a/crates/convert-musicxml/README.md
+++ b/crates/convert-musicxml/README.md
@@ -1,0 +1,65 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/koedame/chordsketch/main/assets/logo.svg" alt="ChordSketch" width="80" height="80">
+</p>
+
+# chordsketch-convert-musicxml
+
+MusicXML 4.0 to ChordPro bidirectional converter.
+
+Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
+
+## Usage
+
+```rust
+use chordsketch_convert_musicxml::{from_musicxml, to_musicxml};
+use chordsketch_core::ast::{Song, Chord, Line, LyricsLine, LyricsSegment};
+
+// Build a simple song
+let mut song = Song::new();
+song.metadata.title = Some("My Song".to_string());
+let mut ll = LyricsLine::new();
+ll.segments = vec![
+    LyricsSegment::new(Some(Chord::new("C")), "Hello "),
+    LyricsSegment::new(Some(Chord::new("G")), "world"),
+];
+song.lines.push(Line::Lyrics(ll));
+
+// Export to MusicXML
+let xml = to_musicxml(&song);
+
+// Import back from MusicXML
+let reimported = from_musicxml(&xml).unwrap();
+assert_eq!(reimported.metadata.title.as_deref(), Some("My Song"));
+```
+
+## API
+
+| Function | Input | Output |
+|----------|-------|--------|
+| `from_musicxml(xml)` | MusicXML string | `Result<Song, ImportError>` |
+| `to_musicxml(song)` | `&Song` | MusicXML string |
+
+## What is preserved across a round-trip
+
+- Song title and composer/artist metadata
+- Key signature and tempo
+- Chord symbols (root, accidental, quality, extension, bass note)
+- Lyrics text
+- Section structure (verse/chorus/bridge)
+
+## Limitations
+
+- Only the first `<part>` of a multi-part MusicXML file is imported
+- Rhythmic values are not preserved: all exported notes are whole notes
+- Staff notation (pitches, durations, articulations) is discarded on import
+- Chord diagrams, PDF layout settings, and inline markup are not exported
+
+## Links
+
+- [ChordSketch repository](https://github.com/koedame/chordsketch)
+- [Playground](https://chordsketch.koeda.me)
+- [Issue tracker](https://github.com/koedame/chordsketch/issues)
+
+## License
+
+MIT

--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -1,0 +1,56 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/koedame/chordsketch/main/assets/logo.svg" alt="ChordSketch" width="80" height="80">
+</p>
+
+# chordsketch-lsp
+
+Language Server Protocol (LSP) server for
+[ChordPro](https://www.chordpro.org/) files. Provides diagnostics,
+completions, hover information, and formatting for `.cho`, `.chordpro`,
+and `.chopro` files in any editor that supports LSP.
+
+Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
+
+## Installation
+
+```bash
+cargo install chordsketch-lsp
+```
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| Diagnostics | Parse error reporting with line/column positions |
+| Completions | Directive names, chord names, metadata keys (triggered on `{` and `[`) |
+| Hover | Chord diagrams and directive documentation |
+| Formatting | Full document formatting |
+
+## Editor Setup
+
+See [docs/editors.md](../../docs/editors.md) for detailed setup instructions
+for VS Code, JetBrains IDEs, Zed, Neovim, and Helix.
+
+### Generic LSP configuration
+
+The server communicates over stdio:
+
+```json
+{
+  "command": "chordsketch-lsp",
+  "args": ["--stdio"],
+  "filetypes": ["chordpro"],
+  "root_markers": [".git"]
+}
+```
+
+## Links
+
+- [ChordSketch repository](https://github.com/koedame/chordsketch)
+- [Playground](https://chordsketch.koeda.me)
+- [Editor integration guide](../../docs/editors.md)
+- [Issue tracker](https://github.com/koedame/chordsketch/issues)
+
+## License
+
+MIT


### PR DESCRIPTION
## What

- Create README.md for the LSP crate (crates/lsp/)
- Create README.md for the convert-musicxml crate (crates/convert-musicxml/)
- Add Editor Integration section to the root README
- Add missing crates to root README workspace table

## Why

Per package-documentation.md, every published crate must have a README (L1 minimum). A documentation audit found two published crates without READMEs. The root README also had no mention of editor integrations despite five editors being supported.

## Changes

| File | Change |
|------|--------|
| crates/lsp/README.md | New — features table, install, LSP config, editor doc link |
| crates/convert-musicxml/README.md | New — API table, usage example, round-trip docs, limitations |
| README.md | Add Editor Integration section; add LSP and convert-musicxml to workspace table |

README snapshot verified unchanged (no install/usage commands modified).

Closes #1720

Generated with [Claude Code](https://claude.com/claude-code)