### PR TITLE
fix(metadata): add missing readme and categories to crate Cargo.toml

### DIFF
--- a/crates/convert-musicxml/Cargo.toml
+++ b/crates/convert-musicxml/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 keywords = ["musicxml", "chordpro", "music", "converter"]
 categories = ["parser-implementations", "text-processing"]
+readme = "README.md"
 description = "MusicXML ↔ ChordPro bidirectional converter"
 
 [dependencies]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -8,6 +8,8 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
+categories = ["development-tools", "text-processing"]
+readme = "README.md"
 description = "Language Server Protocol server for ChordPro files"
 
 [[bin]]


### PR DESCRIPTION
## What

Add missing Cargo.toml metadata fields for crates.io discoverability.

## Why

Per package-documentation.md, every published crate must have readme and categories in Cargo.toml. These fields were omitted when the READMEs were created in #1720.

## Changes

- crates/lsp/Cargo.toml: add readme and categories
- crates/convert-musicxml/Cargo.toml: add readme

Closes #1722

Generated with [Claude Code](https://claude.com/claude-code)