### PR TITLE
docs: add JetBrains Marketplace to releasing.md and editors link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ reference and additional examples.
 ## Links
 
 - [ChordPro file format specification](https://www.chordpro.org/chordpro/)
+- [Editor integration guide](docs/editors.md)
 - [Configuration guide](docs/configuration.md)
 - [Versioning and release process](docs/releasing.md)
 - [GitHub Action reference](docs/github-action.md)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -186,6 +186,7 @@ When adding a new channel, update both.
 | PyPI | `chordsketch` | `python.yml` on tag push | none (OIDC trusted publisher) | `pypi` rollup entry |
 | RubyGems | `chordsketch` | `ruby.yml` on tag push | none (OIDC trusted publisher) | `rubygems` rollup entry |
 | Maven Central | `io.github.koedame:chordsketch` | `kotlin.yml` on tag push | `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD` | `maven-central` rollup entry |
+| JetBrains Marketplace | `me.koeda.chordsketch` | manual `./gradlew publishPlugin` | `JETBRAINS_MARKETPLACE_TOKEN` | not yet automated |
 | from source | `git clone` + `cargo install --path crates/cli` | always available | none | `source-build` job |
 | Library Usage (Rust) | crates.io snippet from README | implicit via crates.io | none | `library-smoke` job |
 


### PR DESCRIPTION
## What

Two small documentation updates after the JetBrains plugin was added in #1711.

## Changes

- docs/releasing.md: Add JetBrains Marketplace to the distribution channels table
- README.md: Add docs/editors.md to the Links section

Closes #1724

Generated with [Claude Code](https://claude.com/claude-code)