### PR TITLE
fix(playground): add validate() to wasm.d.ts type declarations

### DIFF
--- a/packages/playground/src/wasm.d.ts
+++ b/packages/playground/src/wasm.d.ts
@@ -14,6 +14,7 @@ declare module '@chordsketch/wasm' {
     input: string,
     options: { transpose?: number; config?: string },
   ): Uint8Array;
+  export function validate(input: string): string[];
   export function version(): string;
   export default function init(): Promise<void>;
 }


### PR DESCRIPTION
## What

Add validate(input: string): string[] to the playground's local wasm.d.ts.

## Why

PR #1713 added validate() to the WASM binding but the playground's local TypeScript type declarations were not updated. This prevents TypeScript-aware usage of validate() in the playground code.

## Changes

packages/playground/src/wasm.d.ts: add validate() declaration

Closes #1726

Generated with [Claude Code](https://claude.com/claude-code)