### PR TITLE
docs: add chordsketch-convert-musicxml to CLAUDE.md Architecture table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ This is a Cargo workspace with the following crates:
 | `chordsketch-render-text` | `crates/render-text` | lib | `chordsketch-core` |
 | `chordsketch-render-html` | `crates/render-html` | lib | `chordsketch-core` |
 | `chordsketch-render-pdf` | `crates/render-pdf` | lib | `chordsketch-core` |
-| `chordsketch` (CLI) | `crates/cli` | bin | `chordsketch-core`, `chordsketch-render-text`, `chordsketch-render-html`, `chordsketch-render-pdf` |
+| `chordsketch-convert-musicxml` | `crates/convert-musicxml` | lib | `chordsketch-core` |
+| `chordsketch` (CLI) | `crates/cli` | bin | `chordsketch-core`, `chordsketch-render-text`, `chordsketch-render-html`, `chordsketch-render-pdf`, `chordsketch-convert-musicxml` |
 | `chordsketch-lsp` | `crates/lsp` | bin | `chordsketch-core`, `tower-lsp`, `tokio` |
 | `chordsketch-wasm` | `crates/wasm` | cdylib | `chordsketch-core`, all renderers, `wasm-bindgen`, `serde` |
 | `chordsketch-ffi` | `crates/ffi` | cdylib/staticlib/lib | `chordsketch-core`, all renderers, `uniffi`, `thiserror` |


### PR DESCRIPTION
## What

Add the missing `chordsketch-convert-musicxml` crate to the Architecture table in
`CLAUDE.md` and update the CLI crate's dependency column to include it.

## Why

The `chordsketch-convert-musicxml` crate (`crates/convert-musicxml`) is a workspace
member and a dependency of the CLI crate, but was never added to the Architecture
table. This gap violates the doc-maintenance rule: "New crate added to workspace →
update CLAUDE.md Architecture table."

## Changes

- Added `chordsketch-convert-musicxml` row to the Rust crates table (lib, depends on
  `chordsketch-core`)
- Updated the CLI row to list `chordsketch-convert-musicxml` in its Dependencies column

Closes #1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)