### PR TITLE
docs: add missing crates and packages to README workspace tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ println!("{text}");
 | [`chordsketch-render-html`](crates/render-html) | HTML renderer |
 | [`chordsketch-render-pdf`](crates/render-pdf) | PDF renderer |
 | [`chordsketch-convert-musicxml`](crates/convert-musicxml) | MusicXML ↔ ChordPro bidirectional converter |
-| [`chordsketch`](crates/cli) | Command-line tool |
-| [`chordsketch-lsp`](crates/lsp) | Language Server Protocol server |
 | [`chordsketch-wasm`](crates/wasm) | WebAssembly bindings via wasm-bindgen |
 | [`chordsketch-ffi`](crates/ffi) | UniFFI bindings for Python, Ruby, Swift, and Kotlin |
 | [`chordsketch-napi`](crates/napi) | Native Node.js addon via napi-rs |
+| [`chordsketch`](crates/cli) | Command-line tool |
+| [`chordsketch-lsp`](crates/lsp) | Language Server Protocol server |
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -141,16 +141,28 @@ println!("{text}");
 | [`chordsketch-render-text`](crates/render-text) | Plain text renderer |
 | [`chordsketch-render-html`](crates/render-html) | HTML renderer |
 | [`chordsketch-render-pdf`](crates/render-pdf) | PDF renderer |
+| [`chordsketch-convert-musicxml`](crates/convert-musicxml) | MusicXML ↔ ChordPro bidirectional converter |
 | [`chordsketch`](crates/cli) | Command-line tool |
 | [`chordsketch-lsp`](crates/lsp) | Language Server Protocol server |
 | [`chordsketch-wasm`](crates/wasm) | WebAssembly bindings via wasm-bindgen |
-| [`chordsketch-convert-musicxml`](crates/convert-musicxml) | MusicXML ↔ ChordPro bidirectional converter |
+| [`chordsketch-ffi`](crates/ffi) | UniFFI bindings for Python, Ruby, Swift, and Kotlin |
+| [`chordsketch-napi`](crates/napi) | Native Node.js addon via napi-rs |
 
 ### Packages
 
 | Package | Path | Description |
 |---|---|---|
-| [`@chordsketch/wasm`](packages/npm) | `packages/npm` | npm package with TypeScript types |
+| [`@chordsketch/wasm`](packages/npm) | `packages/npm` | npm WASM package with TypeScript types |
+| [`@chordsketch/node`](crates/napi) | `crates/napi` | Native Node.js addon (prebuilt binaries, no Rust required) |
+| [Python `chordsketch`](crates/ffi) | `crates/ffi` | Python package via UniFFI + maturin |
+| [Swift `ChordSketch`](packages/swift) | `packages/swift` | Swift package with XCFramework |
+| [Kotlin `chordsketch`](packages/kotlin) | `packages/kotlin` | Kotlin/JVM package via JNI |
+| [Ruby `chordsketch`](packages/ruby) | `packages/ruby` | Ruby gem via UniFFI |
+| [VS Code extension](packages/vscode-extension) | `packages/vscode-extension` | Syntax highlighting, live preview, and LSP integration |
+| [JetBrains plugin](packages/jetbrains-plugin) | `packages/jetbrains-plugin` | TextMate syntax highlighting for JetBrains IDEs |
+| [Zed extension](packages/zed-extension) | `packages/zed-extension` | Tree-sitter highlighting and LSP for Zed |
+| [`tree-sitter-chordpro`](packages/tree-sitter-chordpro) | `packages/tree-sitter-chordpro` | Tree-sitter grammar for ChordPro |
+| [GitHub Action](packages/github-action) | `packages/github-action` | Composite action for rendering ChordPro in CI |
 | [Playground](packages/playground) | `packages/playground` | Browser-based ChordPro editor and renderer |
 
 ## GitHub Actions


### PR DESCRIPTION
## What

Add missing crates and packages to the README's Workspace Structure and
Packages tables so users can discover the full ChordSketch ecosystem.

## Why

The README listed only 8 of 10 Rust crates and 2 of 12 packages. Users
browsing the README had no visibility into the language bindings (Python,
Swift, Kotlin, Ruby, @chordsketch/node), editor extensions (VS Code,
JetBrains, Zed), tree-sitter grammar, or GitHub Action.

## Changes

**Workspace Structure table:**
- Add `chordsketch-ffi` (UniFFI bindings)
- Add `chordsketch-napi` (native Node.js addon)
- Reorder: group library crates before binary crates; move
  `convert-musicxml` next to the renderers

**Packages table:**
- Add `@chordsketch/node`, Python, Swift, Kotlin, Ruby bindings
- Add VS Code extension, JetBrains plugin, Zed extension
- Add `tree-sitter-chordpro` grammar
- Add GitHub Action
- Clarify `@chordsketch/wasm` as "WASM package"

## Test results

- `python3 scripts/extract-readme-commands.py --check` passes (no
  Installation/Usage commands changed)
- No code changes — documentation only

Closes #1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)