### PR TITLE
test(cli): add integration tests for convert subcommand

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -624,7 +624,9 @@ fn test_convert_abc() {
         .args(["convert", &fixture("simple.abc"), "--from", "abc"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("{title: Simple ABC Tune}"));
+        .stdout(predicate::str::contains("{title: Simple ABC Tune}"))
+        .stdout(predicate::str::contains("[C]"))
+        .stdout(predicate::str::contains("[G]"));
 }
 
 #[test]
@@ -701,6 +703,20 @@ fn test_convert_nonexistent_file() {
     Command::cargo_bin("chordsketch")
         .unwrap()
         .args(["convert", "/tmp/nonexistent-chordpro-convert-test.txt"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains(
+            "nonexistent-chordpro-convert-test",
+        ));
+}
+
+#[test]
+fn test_convert_musicxml_import_wrong_format() {
+    // Feeding a plaintext file with --from musicxml should fail.
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("plain.txt"), "--from", "musicxml"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("error:"));

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -578,3 +578,159 @@ fn test_completions_powershell() {
         .success()
         .stdout(predicate::str::contains("Register-ArgumentCompleter"));
 }
+
+// --- convert subcommand ---
+
+#[test]
+fn test_convert_plaintext_from_file() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("plain.txt"), "--from", "plaintext"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[G]Hello"))
+        .stdout(predicate::str::contains("[C]"))
+        .stdout(predicate::str::contains("[Am]Goodbye"));
+}
+
+#[test]
+fn test_convert_plaintext_from_stdin() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", "-", "--from", "plaintext"])
+        .write_stdin("G         C\nHello world\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[G]Hello"))
+        .stdout(predicate::str::contains("[C]"));
+}
+
+#[test]
+fn test_convert_plaintext_auto_detect() {
+    // Auto-detection should recognise plain chord+lyrics from content.
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("plain.txt")])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[G]Hello"))
+        .stdout(predicate::str::contains("[Am]Goodbye"));
+}
+
+#[test]
+fn test_convert_abc() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("simple.abc"), "--from", "abc"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("{title: Simple ABC Tune}"));
+}
+
+#[test]
+fn test_convert_musicxml_import() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("simple.xml")])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[C]"))
+        .stdout(predicate::str::contains("[Am]"))
+        .stdout(predicate::str::contains("Hello"));
+}
+
+#[test]
+fn test_convert_musicxml_import_forced() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("simple.xml"), "--from", "musicxml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[C]"))
+        .stdout(predicate::str::contains("Hello"));
+}
+
+#[test]
+fn test_convert_musicxml_export() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("simple.cho"), "--to", "musicxml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<score-partwise"))
+        .stdout(predicate::str::contains("<root-step>G</root-step>"));
+}
+
+#[test]
+fn test_convert_musicxml_export_to_file() {
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_string_lossy().to_string();
+
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args([
+            "convert",
+            &fixture("simple.cho"),
+            "--to",
+            "musicxml",
+            "-o",
+            &output_path,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    assert!(content.contains("<score-partwise"));
+}
+
+#[test]
+fn test_convert_chordpro_passthrough() {
+    // A .cho file with auto-detection should pass through unchanged.
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", &fixture("simple.cho")])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("{title: Simple Song}"))
+        .stdout(predicate::str::contains("[G]Hello [C]world"));
+}
+
+#[test]
+fn test_convert_nonexistent_file() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", "/tmp/nonexistent-chordpro-convert-test.txt"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error:"));
+}
+
+#[test]
+fn test_convert_export_multiple_files_rejected() {
+    // --to musicxml with multiple files should fail.
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args([
+            "convert",
+            &fixture("simple.cho"),
+            &fixture("second.cho"),
+            "--to",
+            "musicxml",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("single input file"));
+}
+
+#[test]
+fn test_convert_help() {
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args(["convert", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--from"))
+        .stdout(predicate::str::contains("--to"))
+        .stdout(predicate::str::contains("musicxml"));
+}

--- a/crates/cli/tests/fixtures/plain.txt
+++ b/crates/cli/tests/fixtures/plain.txt
@@ -1,0 +1,4 @@
+G         C
+Hello world
+Am        D
+Goodbye now

--- a/crates/cli/tests/fixtures/simple.abc
+++ b/crates/cli/tests/fixtures/simple.abc
@@ -1,0 +1,5 @@
+X:1
+T:Simple ABC Tune
+M:4/4
+K:C
+"C"CDEF|"G"GABc|

--- a/crates/cli/tests/fixtures/simple.xml
+++ b/crates/cli/tests/fixtures/simple.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>Hello</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>A</root-step></root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>world</text></lyric>
+      </note>
+    </measure>
+    <measure number="2">
+      <harmony>
+        <root><root-step>F</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>Good</text></lyric>
+      </note>
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>bye</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## What

Add 12 integration tests for the CLI `convert` subcommand, which
previously had zero test coverage.

## Why

The `convert` subcommand supports 4 input formats (plaintext, ABC,
MusicXML, ChordPro passthrough) and MusicXML export, but none of
these code paths were tested at the CLI level. The existing 40 tests
covered render mode, `fmt`, completions, and config handling only.

## Changes

**New test fixtures** (`crates/cli/tests/fixtures/`):
- `plain.txt` — plain chord+lyrics input
- `simple.abc` — ABC notation input
- `simple.xml` — MusicXML input (copied from convert-musicxml fixtures)

**New tests** (12 total):
| Test | Code path |
|------|-----------|
| `test_convert_plaintext_from_file` | `--from plaintext` with file |
| `test_convert_plaintext_from_stdin` | `--from plaintext` with stdin |
| `test_convert_plaintext_auto_detect` | Auto-detect plaintext format |
| `test_convert_abc` | `--from abc` |
| `test_convert_musicxml_import` | Auto-detect `.xml` extension |
| `test_convert_musicxml_import_forced` | `--from musicxml` |
| `test_convert_musicxml_export` | `--to musicxml` to stdout |
| `test_convert_musicxml_export_to_file` | `--to musicxml -o file` |
| `test_convert_chordpro_passthrough` | `.cho` auto-detected as passthrough |
| `test_convert_nonexistent_file` | Error path: missing file |
| `test_convert_export_multiple_files_rejected` | Error: multi-file export |
| `test_convert_help` | `convert --help` output |

## Test results

```
running 12 tests ... ok. 12 passed; 0 failed
cargo test --workspace ... ok (all tests pass)
cargo clippy --workspace ... ok
cargo fmt --check ... ok
```

Closes #1732

🤖 Generated with [Claude Code](https://claude.com/claude-code)