### PR TITLE
fix(cli): replace last hardcoded /tmp path and restore path assertions

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -57,7 +57,8 @@ fn test_nonexistent_file() {
         .arg(&nonexistent)
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error:"));
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains(&nonexistent));
 }
 
 #[test]
@@ -466,12 +467,16 @@ fn test_define_value_containing_spaces() {
 fn test_no_default_configs_with_missing_config_file() {
     // --no-default-configs combined with --config pointing to a nonexistent file
     // should fail gracefully with an error message.
+    let nonexistent = {
+        let f = NamedTempFile::new().unwrap();
+        f.path().to_string_lossy().to_string()
+    };
     Command::cargo_bin("chordsketch")
         .unwrap()
         .args([
             "--no-default-configs",
             "--config",
-            "/tmp/nonexistent_chordpro_config_12345.json",
+            &nonexistent,
             &fixture("simple.cho"),
         ])
         .assert()
@@ -716,7 +721,8 @@ fn test_convert_nonexistent_file() {
         .args(["convert", &nonexistent])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error:"));
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains(&nonexistent));
 }
 
 #[test]


### PR DESCRIPTION
## What

Fix the last remaining hardcoded `/tmp/` path in CLI tests and restore
file-path error assertions that were lost in the PR #1736 refactor.

## Why

1. `test_no_default_configs_with_missing_config_file` still used a
   hardcoded `/tmp/nonexistent_chordpro_config_12345.json` path —
   the same TOCTOU risk fixed in #1736 for other tests.

2. When #1736 replaced hardcoded paths with `NamedTempFile`, the
   assertion that the error message includes the file path was lost.
   The path variable is available, so we can assert against it.

## Changes

- Replace hardcoded path in `test_no_default_configs_with_missing_config_file`
  with `NamedTempFile` drop pattern
- Add `.stderr(predicate::str::contains(&nonexistent))` to both
  `test_nonexistent_file` and `test_convert_nonexistent_file`

## Test results

```
running 55 tests ... ok. 55 passed; 0 failed
cargo fmt --check ... ok
```

Closes #1737
Closes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)