### PR TITLE
fix(cli): add path assertion to missing-config-file test

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -481,7 +481,8 @@ fn test_no_default_configs_with_missing_config_file() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error:"));
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains(&nonexistent));
 }
 
 #[test]


### PR DESCRIPTION
## What

Add the missing file-path assertion to
`test_no_default_configs_with_missing_config_file`.

## Why

PR #1739 added path assertions to `test_nonexistent_file` and
`test_convert_nonexistent_file` but missed this third test. The
auto-review caught the inconsistency and filed #1740.

## Changes

One line: add `.stderr(predicate::str::contains(&nonexistent))` to
verify the error message includes the missing config file path.

## Test results

```
running 1 test ... ok (test_no_default_configs_with_missing_config_file)
cargo fmt --check ... ok
```

Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)