### PR TITLE
fix(cli): replace hardcoded path in test_config_nonexistent_file

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -290,16 +290,17 @@ fn test_config_file() {
 
 #[test]
 fn test_config_nonexistent_file() {
+    let nonexistent = {
+        let f = NamedTempFile::new().unwrap();
+        f.path().to_string_lossy().to_string()
+    };
     Command::cargo_bin("chordsketch")
         .unwrap()
-        .args([
-            "--config",
-            "/nonexistent/chordpro-test-config.json",
-            &fixture("simple.cho"),
-        ])
+        .args(["--config", &nonexistent, &fixture("simple.cho")])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error:"));
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains(&nonexistent));
 }
 
 #[test]


### PR DESCRIPTION
## What

Replace the last hardcoded path in CLI tests and add path assertion.

## Why

`test_config_nonexistent_file` used `/nonexistent/chordpro-test-config.json`
— the same TOCTOU pattern fixed in #1736 and #1739 for other tests.
This was the only remaining instance.

## Changes

- Replace hardcoded path with `NamedTempFile` drop pattern
- Add `.stderr(predicate::str::contains(&nonexistent))` assertion

## Test results

```
running 1 test ... ok (test_config_nonexistent_file)
cargo fmt --check ... ok
```

Closes #1742

🤖 Generated with [Claude Code](https://claude.com/claude-code)