### PR TITLE
ci: add npm publish workflow for tree-sitter-chordpro

### DIFF
--- a/.github/workflows/npm-publish-tree-sitter.yml
+++ b/.github/workflows/npm-publish-tree-sitter.yml
@@ -1,0 +1,74 @@
+name: Publish tree-sitter-chordpro
+
+# Publishes the tree-sitter-chordpro grammar package to npm.
+# The generated parser files (src/parser.c, src/grammar.json) are already
+# committed, so no build step is needed — this is a pure publish job.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.0). Required for manual triggers.'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish tree-sitter-chordpro
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/tree-sitter-chordpro
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/tree-sitter-chordpro
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check required secrets present
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: python3 ../../scripts/check-env-secrets.py --channel npm-tree-sitter
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Derive version from git tag
+        if: github.event_name == 'release'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Set version from workflow input
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ inputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Check if version already published
+        id: check
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version 2>/dev/null; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/ci/release-channels.toml
+++ b/ci/release-channels.toml
@@ -102,6 +102,17 @@ expected_version = "tag"
 required_secrets = ["NPM_TOKEN"]
 notes = "Patch skew from workspace is allowed; see ci/version-skew-allowlist.toml."
 
+# ---------------------------------------------------------------- npm (tree-sitter)
+
+[[channels]]
+id = "npm-tree-sitter"
+display = "npm — tree-sitter-chordpro"
+kind = "npm"
+package = "tree-sitter-chordpro"
+expected_version = "tag"
+required_secrets = ["NPM_TOKEN"]
+notes = "Unscoped package; version tracks workspace releases."
+
 # ---------------------------------------------------------------- installers
 
 [[channels]]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -83,6 +83,7 @@ at post-release verification rather than before the tag is cut.
      publish has succeeded and its allowlist entry has been retired)
    - `crates/napi/package.json` — both the main package and the per-platform
      manifests under `crates/napi/npm/<triple>/package.json`
+   - `packages/tree-sitter-chordpro/package.json`
 
    Hardcoded pins in CI:
    - `.github/workflows/readme-smoke.yml` ~line 204:

--- a/packages/tree-sitter-chordpro/package.json
+++ b/packages/tree-sitter-chordpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-chordpro",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Tree-sitter grammar for ChordPro music notation files",
   "license": "MIT",
   "repository": {

--- a/packages/tree-sitter-chordpro/src/parser.c
+++ b/packages/tree-sitter-chordpro/src/parser.c
@@ -1188,7 +1188,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_chordpro(void) {
     .max_reserved_word_set_size = 0,
     .metadata = {
       .major_version = 0,
-      .minor_version = 1,
+      .minor_version = 2,
       .patch_version = 0,
     },
   };

--- a/packages/tree-sitter-chordpro/tree-sitter.json
+++ b/packages/tree-sitter-chordpro/tree-sitter.json
@@ -10,7 +10,7 @@
     }
   ],
   "metadata": {
-    "version": "0.1.0",
+    "version": "0.2.0",
     "license": "MIT",
     "description": "Tree-sitter grammar for ChordPro music notation files",
     "authors": [

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -16,6 +16,7 @@ Sources checked:
   2. `packages/npm/package.json` `version`
   3. `packages/vscode-extension/package.json` `version`
   4. `crates/napi/package.json` `version`
+  4b. `packages/tree-sitter-chordpro/package.json` `version`
   5. `.github/workflows/readme-smoke.yml` — the two hardcoded pins:
        a. L~204: `npm install '@chordsketch/wasm@<version>'`
        b. L~450–451: `chordsketch-core = "<caret>"` and
@@ -199,6 +200,11 @@ def load_all_sources(repo_root: Path) -> list[Source]:
         load_package_json_version(repo_root, "packages/vscode-extension/package.json")
     )
     sources.append(load_package_json_version(repo_root, "crates/napi/package.json"))
+    sources.append(
+        load_package_json_version(
+            repo_root, "packages/tree-sitter-chordpro/package.json"
+        )
+    )
     sources.extend(load_napi_platform_package_versions(repo_root))
     sources.extend(load_readme_smoke_pins(repo_root))
     return sources

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -49,6 +49,7 @@ def _build_repo(
     npm_version: str = "0.2.0",
     vscode_version: str = "0.2.0",
     napi_version: str = "0.2.0",
+    tree_sitter_version: str = "0.2.0",
     smoke_npm_pin: str = "0.2.0",
     smoke_caret: str = "0.2",
 ) -> None:
@@ -102,6 +103,14 @@ def _build_repo(
     npm_dir.mkdir(parents=True, exist_ok=True)
     (npm_dir / "package.json").write_text(
         f'{{\n  "name": "@chordsketch/wasm",\n  "version": "{npm_version}"\n}}\n',
+        encoding="utf-8",
+    )
+
+    # packages/tree-sitter-chordpro/package.json
+    ts_dir = root / "packages" / "tree-sitter-chordpro"
+    ts_dir.mkdir(parents=True, exist_ok=True)
+    (ts_dir / "package.json").write_text(
+        f'{{\n  "name": "tree-sitter-chordpro",\n  "version": "{tree_sitter_version}"\n}}\n',
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## What

Add automated npm publishing for the `tree-sitter-chordpro` grammar
package, enabling CI-driven releases.

## Why

The tree-sitter grammar is required for Neovim (#1606) and Helix (#1607)
editor integration. Publishing it to npm makes it installable by
nvim-treesitter, which is a prerequisite for submitting an upstream
parser entry. Currently there is no automated way to publish this
package.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/npm-publish-tree-sitter.yml` | New workflow: release + workflow_dispatch triggers, `npm` environment gate, duplicate-publish check |
| `ci/release-channels.toml` | Add `npm-tree-sitter` channel entry |
| `docs/releasing.md` | Add `packages/tree-sitter-chordpro/package.json` to version bump list |
| `scripts/check-version-consistency.py` | Include tree-sitter-chordpro in version tracking (21 sources, was 20) |
| `packages/tree-sitter-chordpro/package.json` | Bump 0.1.0 → 0.2.0 to match workspace |
| `packages/tree-sitter-chordpro/tree-sitter.json` | Bump 0.1.0 → 0.2.0 to match workspace |

## Pre-merge verification needed

The existing `NPM_TOKEN` must have permission to publish **unscoped**
packages (`tree-sitter-chordpro` is NOT under `@chordsketch/*`). If the
token is scope-restricted, a new token or token update will be needed.

## Test results

```
python3 scripts/check-version-consistency.py → OK (21 sources in sync)
cargo test --workspace → all pass
```

Closes #1744

🤖 Generated with [Claude Code](https://claude.com/claude-code)