### PR TITLE
docs: fix review findings in releasing.md and version-consistency script

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -180,6 +180,7 @@ When adding a new channel, update both.
 | Docker Hub | `docker.io/koedame/chordsketch` | `docker.yml` on `release: published` | `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` | `docker-hub` job |
 | npm (wasm) | `@chordsketch/wasm` | `npm-publish.yml` `workflow_dispatch` (Step 7) | `NPM_TOKEN` (Granular Token, see quirks) | `npm-wasm` job |
 | npm (napi) | `@chordsketch/node` + 5 prebuilt platform packages | `napi.yml` on `release: published` | `NPM_TOKEN` | `napi-node` job |
+| npm (tree-sitter) | `tree-sitter-chordpro` | `npm-publish-tree-sitter.yml` on `release: published` | `NPM_TOKEN` | `npm-tree-sitter` rollup entry |
 | Homebrew tap | `koedame/tap/chordsketch` | `post-release.yml` on `release: published` | `TAP_GITHUB_TOKEN` | `homebrew` job |
 | Scoop bucket | `koedame/scoop-bucket/chordsketch` | `post-release.yml` on `release: published` | `TAP_GITHUB_TOKEN` | `scoop` job |
 | winget | `koedame.chordsketch` | manual PR to `microsoft/winget-pkgs` (Step 8) | none (uses your `gh` token to fork+push) | `winget` job |
@@ -718,7 +719,9 @@ package.
    - If no build step is needed (e.g., pre-committed generated files),
      omit the build steps
 
-2. **Add a channel entry** to `ci/release-channels.toml`:
+2. **Add a channel entry** to `ci/release-channels.toml` **and** a
+   matching row to the Distribution Channels table in `docs/releasing.md`
+   (both must stay in sync):
    ```toml
    [[channels]]
    id = "npm-<short-name>"
@@ -739,8 +742,9 @@ package.
      `_build_repo()` fixture builder so unit tests create the file in
      their temp directories
 
-5. **Sync the package version** with the workspace version (currently
-   0.2.0), or add an entry to `ci/version-skew-allowlist.toml` if the
+5. **Sync the package version** with the workspace version (run
+   `python3 scripts/check-version-consistency.py` to find the canonical
+   version), or add an entry to `ci/version-skew-allowlist.toml` if the
    skew is intentional.
 
 6. **Regenerate any derived files** if the version is embedded in them

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -16,8 +16,8 @@ Sources checked:
   2. `packages/npm/package.json` `version`
   3. `packages/vscode-extension/package.json` `version`
   4. `crates/napi/package.json` `version`
-  4b. `packages/tree-sitter-chordpro/package.json` `version`
-  5. `.github/workflows/readme-smoke.yml` — the two hardcoded pins:
+  5. `packages/tree-sitter-chordpro/package.json` `version`
+  6. `.github/workflows/readme-smoke.yml` — the two hardcoded pins:
        a. L~204: `npm install '@chordsketch/wasm@<version>'`
        b. L~450–451: `chordsketch-core = "<caret>"` and
           `chordsketch-render-text = "<caret>"` (matched by both)

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -177,6 +177,13 @@ class CheckRunTests(unittest.TestCase):
             rc = check_version_consistency.run(root, root / "nonexistent.toml")
             self.assertEqual(rc, 1)
 
+    def test_tree_sitter_drift_detected(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _build_repo(root, tree_sitter_version="0.1.0")
+            rc = check_version_consistency.run(root, root / "nonexistent.toml")
+            self.assertEqual(rc, 1)
+
     def test_allowlisted_drift_passes(self) -> None:
         with TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## What

Batch fix four review findings from the auto-review of #1745 and #1748.

## Why

These were all filed as non-blocking Nit issues during automated review.
They are small, closely related documentation and test fixes that belong
in a single PR.

## Changes

| Issue | Fix |
|-------|-----|
| #1746 | Fix docstring numbering (4b→5, 5→6) in `check-version-consistency.py`; add `test_tree_sitter_drift_detected` test |
| #1749 | Add `tree-sitter-chordpro` row to Distribution Channels table in `releasing.md` |
| #1750 | Add note in Step 2 of "Adding a New npm Package" that the Distribution Channels table must also be updated |
| #1751 | Replace hardcoded `(currently 0.2.0)` with pointer to `check-version-consistency.py` |

## Test results

```
Ran 11 tests in 0.017s — OK (including new test_tree_sitter_drift_detected)
```

Closes #1746
Closes #1749
Closes #1750
Closes #1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)