### PR TITLE
docs: add CocoaPods to release channels and Swift README

### DIFF
--- a/ci/release-channels.toml
+++ b/ci/release-channels.toml
@@ -178,6 +178,22 @@ token. The same .vsix artifact built by the `build` job is reused; no
 separate build step is needed. See #1604.
 """
 
+# ---------------------------------------------------------------- CocoaPods
+
+[[channels]]
+id = "cocoapods"
+display = "CocoaPods — ChordSketch"
+kind = "manual"
+expected_version = "skip"
+skip_reason = """
+CocoaPods trunk push requires COCOAPODS_TRUNK_TOKEN which has not been
+configured yet. The post-release.yml job exists but skips gracefully
+when the secret is absent. Once the token is added and the first
+`pod trunk push` succeeds, change expected_version to "tag".
+"""
+required_secrets = ["COCOAPODS_TRUNK_TOKEN"]
+notes = "Published by post-release.yml update-cocoapods job."
+
 # ---------------------------------------------------------------- language bindings
 
 [[channels]]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -188,6 +188,7 @@ When adding a new channel, update both.
 | PyPI | `chordsketch` | `python.yml` on tag push | none (OIDC trusted publisher) | `pypi` rollup entry |
 | RubyGems | `chordsketch` | `ruby.yml` on tag push | none (OIDC trusted publisher) | `rubygems` rollup entry |
 | Maven Central | `io.github.koedame:chordsketch` | `kotlin.yml` on tag push | `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD` | `maven-central` rollup entry |
+| CocoaPods | `ChordSketch` | `post-release.yml` on `release: published` | `COCOAPODS_TRUNK_TOKEN` | `cocoapods` rollup entry |
 | JetBrains Marketplace | `me.koeda.chordsketch` | manual `./gradlew publishPlugin` | `JETBRAINS_MARKETPLACE_TOKEN` | not yet automated |
 | from source | `git clone` + `cargo install --path crates/cli` | always available | none | `source-build` job |
 | Library Usage (Rust) | crates.io snippet from README | implicit via crates.io | none | `library-smoke` job |

--- a/packages/swift/README.md
+++ b/packages/swift/README.md
@@ -47,6 +47,20 @@ let package = Package(
 Or add via Xcode: **File → Add Package Dependencies**, enter
 `https://github.com/koedame/chordsketch`.
 
+### CocoaPods
+
+Add to your `Podfile`:
+
+```ruby
+pod 'ChordSketch'
+```
+
+Then run:
+
+```bash
+pod install
+```
+
 ## Quick Start
 
 ```swift


### PR DESCRIPTION
## What

Complete the remaining local work for CocoaPods distribution (#1614).

## Why

The podspec template and post-release.yml job were already created, but
the release-channels manifest, Distribution Channels table, and Swift
README were not updated to reflect CocoaPods as a channel.

## Changes

- `ci/release-channels.toml`: add `cocoapods` channel (skip until
  `COCOAPODS_TRUNK_TOKEN` is configured)
- `packages/swift/README.md`: add CocoaPods install snippet
- `docs/releasing.md`: add CocoaPods row to Distribution Channels table

## Remaining human steps for #1614

1. `pod trunk register` to create a CocoaPods account
2. `pod trunk push ChordSketch.podspec --allow-warnings` for first publish
3. Add `COCOAPODS_TRUNK_TOKEN` as a GitHub secret
4. Update `release-channels.toml` to change `expected_version` from
   `"skip"` to `"tag"`

## Test results

```
python3 scripts/check-version-consistency.py → OK (21 sources in sync)
```

Part of #1614

🤖 Generated with [Claude Code](https://claude.com/claude-code)