### PR TITLE
docs: add nixpkgs reference derivation and release channel entry

### DIFF
--- a/ci/release-channels.toml
+++ b/ci/release-channels.toml
@@ -135,6 +135,19 @@ required_secrets = []
 notes = "Updated by .github/workflows/post-release.yml via PR to koedame/scoop-bucket."
 
 [[channels]]
+id = "nixpkgs"
+display = "nixpkgs — pkgs.chordsketch"
+kind = "manual"
+expected_version = "skip"
+skip_reason = """
+nixpkgs PR has not been submitted yet. The reference derivation is at
+packaging/nix/package.nix. Once the PR is merged and the package is
+available in a nixpkgs release channel, change expected_version to "tag".
+"""
+required_secrets = []
+notes = "Manual PR to NixOS/nixpkgs. See packaging/nix/package.nix."
+
+[[channels]]
 id = "winget"
 display = "winget — microsoft/winget-pkgs"
 kind = "manual"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -183,6 +183,7 @@ When adding a new channel, update both.
 | npm (tree-sitter) | `tree-sitter-chordpro` | `npm-publish-tree-sitter.yml` on `release: published` | `NPM_TOKEN` | `npm-tree-sitter` rollup entry |
 | Homebrew tap | `koedame/tap/chordsketch` | `post-release.yml` on `release: published` | `TAP_GITHUB_TOKEN` | `homebrew` job |
 | Scoop bucket | `koedame/scoop-bucket/chordsketch` | `post-release.yml` on `release: published` | `TAP_GITHUB_TOKEN` | `scoop` job |
+| nixpkgs | `pkgs.chordsketch` | manual PR to `NixOS/nixpkgs` | none | `nixpkgs` rollup entry |
 | winget | `koedame.chordsketch` | manual PR to `microsoft/winget-pkgs` (Step 8) | none (uses your `gh` token to fork+push) | `winget` job |
 | VS Code Marketplace | `koedame.chordsketch` | `vscode-extension.yml` on `release: published` | `VSCE_PAT` (PAT, Marketplace Publish scope) | `vscode-marketplace` rollup entry |
 | PyPI | `chordsketch` | `python.yml` on tag push | none (OIDC trusted publisher) | `pypi` rollup entry |

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -1,0 +1,48 @@
+# Reference nixpkgs derivation for chordsketch.
+#
+# This file is a template for submitting a PR to NixOS/nixpkgs.
+# Place it at pkgs/by-name/ch/chordsketch/package.nix in a nixpkgs
+# checkout and submit a PR.
+#
+# Before submitting, update:
+#   - `version` to match the latest release tag
+#   - `hash` to match the source tarball (see instructions below)
+#   - `cargoHash` to match the vendored dependencies
+#
+# To compute the hashes:
+#   nix-prefetch-url --unpack \
+#     https://github.com/koedame/chordsketch/archive/refs/tags/v${version}.tar.gz
+#   # For cargoHash, set it to "" first, run `nix-build`, and copy the
+#   # hash from the error message.
+
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "chordsketch";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "koedame";
+    repo = "chordsketch";
+    tag = "v${version}";
+    hash = ""; # TODO: compute with nix-prefetch-url --unpack
+  };
+
+  cargoHash = ""; # TODO: set to "" and build to get the correct hash
+
+  cargoBuildFlags = [ "--package" "chordsketch" ];
+  cargoTestFlags = [ "--package" "chordsketch" ];
+
+  meta = {
+    description = "ChordPro file format parser and renderer (text, HTML, PDF)";
+    homepage = "https://github.com/koedame/chordsketch";
+    changelog = "https://github.com/koedame/chordsketch/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ ]; # TODO: add your nixpkgs maintainer handle
+    mainProgram = "chordsketch";
+  };
+}


### PR DESCRIPTION
## What

Complete the remaining local work for nixpkgs distribution (#1610).

## Why

The flake.nix and nix.yml CI were already created, but there was no
reference derivation for the nixpkgs PR submission, and the release
channels manifest did not track nixpkgs.

## Changes

- `packaging/nix/package.nix`: reference nixpkgs derivation template
  (uses `rustPlatform.buildRustPackage`, `fetchFromGitHub`, builds
  only the CLI crate). Has TODO markers for hashes that must be computed
  at submission time.
- `ci/release-channels.toml`: add `nixpkgs` channel (skip until PR
  merges in NixOS/nixpkgs)
- `docs/releasing.md`: add nixpkgs row to Distribution Channels table

## Remaining human steps for #1610

1. Fork `NixOS/nixpkgs`
2. Copy `packaging/nix/package.nix` to
   `pkgs/by-name/ch/chordsketch/package.nix`
3. Compute `hash` and `cargoHash` (instructions in the file)
4. Submit PR and respond to nixpkgs reviewer feedback

## Test results

```
python3 scripts/check-version-consistency.py → OK (21 sources in sync)
```

Part of #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)