### PR TITLE
docs: fix review findings in nix derivation, CocoaPods channel, and Swift README

### DIFF
--- a/ci/release-channels.toml
+++ b/ci/release-channels.toml
@@ -197,12 +197,15 @@ separate build step is needed. See #1604.
 id = "cocoapods"
 display = "CocoaPods — ChordSketch"
 kind = "manual"
+package = "ChordSketch"
 expected_version = "skip"
 skip_reason = """
 CocoaPods trunk push requires COCOAPODS_TRUNK_TOKEN which has not been
 configured yet. The post-release.yml job exists but skips gracefully
 when the secret is absent. Once the token is added and the first
-`pod trunk push` succeeds, change expected_version to "tag".
+`pod trunk push` succeeds, change expected_version to "tag" and kind
+to "cocoapods" (once a _check_cocoapods verifier is implemented) or
+keep kind = "manual" for paper-trail-only verification.
 """
 required_secrets = ["COCOAPODS_TRUNK_TOKEN"]
 notes = "Published by post-release.yml update-cocoapods job."

--- a/packages/swift/README.md
+++ b/packages/swift/README.md
@@ -49,6 +49,8 @@ Or add via Xcode: **File → Add Package Dependencies**, enter
 
 ### CocoaPods
 
+[![CocoaPods](https://img.shields.io/cocoapods/v/ChordSketch)](https://cocoapods.org/pods/ChordSketch)
+
 Add to your `Podfile`:
 
 ```ruby

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -6,14 +6,9 @@
 #
 # Before submitting, update:
 #   - `version` to match the latest release tag
-#   - `hash` to match the source tarball (see instructions below)
-#   - `cargoHash` to match the vendored dependencies
-#
-# To compute the hashes:
-#   nix-prefetch-url --unpack \
-#     https://github.com/koedame/chordsketch/archive/refs/tags/v${version}.tar.gz
-#   # For cargoHash, set it to "" first, run `nix-build`, and copy the
-#   # hash from the error message.
+#   - `hash` and `cargoHash` — leave both as "" initially, run
+#     `nix-build`, and copy the SRI hashes from the error messages.
+#   - `maintainers` — add your nixpkgs maintainer handle
 
 {
   lib,
@@ -29,20 +24,26 @@ rustPlatform.buildRustPackage rec {
     owner = "koedame";
     repo = "chordsketch";
     tag = "v${version}";
-    hash = ""; # TODO: compute with nix-prefetch-url --unpack
+    hash = ""; # leave empty; build once and copy the SRI hash from the error
   };
 
-  cargoHash = ""; # TODO: set to "" and build to get the correct hash
+  cargoHash = ""; # leave empty; build once and copy the SRI hash from the error
 
   cargoBuildFlags = [ "--package" "chordsketch" ];
   cargoTestFlags = [ "--package" "chordsketch" ];
 
   meta = {
-    description = "ChordPro file format parser and renderer (text, HTML, PDF)";
+    description = "ChordPro file format renderer and CLI (text, HTML, PDF)";
     homepage = "https://github.com/koedame/chordsketch";
     changelog = "https://github.com/koedame/chordsketch/blob/main/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ]; # TODO: add your nixpkgs maintainer handle
     mainProgram = "chordsketch";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 }


### PR DESCRIPTION
## What

Batch fix six review findings from auto-review of #1753 and #1756.

## Changes

| Issue | Fix |
|-------|-----|
| #1758 | Align `meta.description` in `package.nix` with `flake.nix` |
| #1760 | Add `meta.platforms` to `package.nix` (4 platforms, matching flake) |
| #1757 | Clarify `cargoHash` TODO comment |
| #1759 | Replace `nix-prefetch-url` instruction with SRI hash workflow |
| #1754 | Add missing `package` field to cocoapods channel; document activation steps |
| #1755 | Add CocoaPods badge to Swift README |

## Test results

```
python3 scripts/check-version-consistency.py → OK (21 sources)
```

Closes #1754 #1755 #1757 #1758 #1759 #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)