### PR TITLE
fix(ci): add set -euo pipefail to snap smoke install step

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -435,6 +435,7 @@ jobs:
 
       - name: Install via Snap
         run: |
+          set -euo pipefail
           sudo snap install chordsketch
           chordsketch --version
 


### PR DESCRIPTION
## What

Add `set -euo pipefail` to the snap install step in readme-smoke.yml.

## Why

Without it, a failure in `sudo snap install` would not stop the step
from continuing to `chordsketch --version`, masking the real error.

Closes #1777

🤖 Generated with [Claude Code](https://claude.com/claude-code)