### PR TITLE
Release v0.2.1

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -201,7 +201,7 @@ jobs:
           # 0.1.0 → 0.1.1 fix, in the publish PR itself). The README sync
           # check (.github/workflows/readme-sync.yml) does not catch this
           # automatically because the version string lives only here.
-          npm install '@chordsketch/wasm@0.2.0'
+          npm install '@chordsketch/wasm@0.2.1'
 
       - name: Smoke test text + HTML + PDF render
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-16
+
+### Added
+
+- Publish `tree-sitter-chordpro` grammar to npm with CI workflow (#1745)
+- Publish chordsketch to AUR (`yay -S chordsketch`) (#1609)
+- Publish chordsketch to Snap Store (`sudo snap install chordsketch`) (#1613)
+- Publish ChordSketch podspec to CocoaPods (#1614)
+- Register chordsketch on Chocolatey (auto-publish on next release) (#1611)
+- Add nixpkgs reference derivation with verified hashes (#1762)
+- Submit nixpkgs PR (NixOS/nixpkgs#510263) (#1610)
+- Add CLI `convert` subcommand integration tests (13 tests) (#1732)
+- Add Chocolatey, AUR, Snap install sections to README (#1773)
+
+### Fixed
+
+- Replace hardcoded `/tmp` paths in CLI tests with `NamedTempFile` (#1736, #1739, #1741, #1743)
+- Switch Snap base from core22 to core24 for glibc 2.39 compatibility (#1774)
+
+### Changed
+
+- Add missing crates and packages to README workspace tables (#1731)
+- Document npm new-package publish procedure in releasing.md (#1748)
+- Document AUR, Snap, CocoaPods first-time setup procedures (#1766)
+
 ## [0.2.0] - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chordsketch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "chordsketch-convert-musicxml",
@@ -274,21 +274,21 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-convert-musicxml"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
 ]
 
 [[package]]
 name = "chordsketch-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "chordsketch-ffi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
  "chordsketch-render-html",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-lsp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
  "tokio",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-napi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
  "chordsketch-render-html",
@@ -323,14 +323,14 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-render-html"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
 ]
 
 [[package]]
 name = "chordsketch-render-pdf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
  "flate2",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-render-text"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
  "unicode-width",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chordsketch-core",
  "chordsketch-render-html",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -17,11 +17,11 @@ name = "chordsketch"
 path = "src/main.rs"
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
-chordsketch-render-text = { version = "0.2.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.0", path = "../render-pdf" }
-chordsketch-convert-musicxml = { version = "0.2.0", path = "../convert-musicxml" }
+chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
+chordsketch-convert-musicxml = { version = "0.2.1", path = "../convert-musicxml" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tempfile = "3"

--- a/crates/convert-musicxml/Cargo.toml
+++ b/crates/convert-musicxml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-convert-musicxml"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,4 +13,4 @@ readme = "README.md"
 description = "MusicXML ↔ ChordPro bidirectional converter"
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
+chordsketch-core = { version = "0.2.1", path = "../core" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-core"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-ffi"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,10 +15,10 @@ description = "UniFFI bindings for ChordPro parsing and rendering"
 crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
-chordsketch-render-text = { version = "0.2.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.0", path = "../render-pdf" }
+chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
 # `uniffi` is pinned to an exact patch version because the .udl + scaffolding
 # generated layout is part of the FFI surface — Python/Swift/Kotlin/Ruby
 # bindings depend on the binary being byte-compatible with the bindgen output.

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-lsp"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ name = "chordsketch-lsp"
 path = "src/main.rs"
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
+chordsketch-core = { version = "0.2.1", path = "../core" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["rt", "macros", "io-std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-napi"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,10 +15,10 @@ description = "Native Node.js addon for ChordPro parsing and rendering via napi-
 crate-type = ["cdylib"]
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
-chordsketch-render-text = { version = "0.2.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.0", path = "../render-pdf" }
+chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
 # `napi` and `napi-derive` are pinned to exact patch versions because the
 # `#[napi]` macro emits ABI-sensitive C glue against the Node-API ABI.
 # Caret ranges (`"3"`) would let a 3.5 release land via a casual `cargo

--- a/crates/napi/npm/darwin-arm64/package.json
+++ b/crates/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-darwin-arm64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Prebuilt @chordsketch/node binary for macOS aarch64 (Apple Silicon).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/darwin-x64/package.json
+++ b/crates/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-darwin-x64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Prebuilt @chordsketch/node binary for macOS x86_64.",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/crates/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-linux-arm64-gnu",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Prebuilt @chordsketch/node binary for Linux aarch64 (glibc).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/linux-x64-gnu/package.json
+++ b/crates/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-linux-x64-gnu",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Prebuilt @chordsketch/node binary for Linux x86_64 (glibc).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/win32-x64-msvc/package.json
+++ b/crates/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-win32-x64-msvc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Prebuilt @chordsketch/node binary for Windows x86_64 (MSVC).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Native Node.js addon for ChordPro parsing and rendering via napi-rs.",
   "license": "MIT",
   "repository": {
@@ -30,11 +30,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@chordsketch/node-linux-x64-gnu": "0.2.0",
-    "@chordsketch/node-linux-arm64-gnu": "0.2.0",
-    "@chordsketch/node-darwin-x64": "0.2.0",
-    "@chordsketch/node-darwin-arm64": "0.2.0",
-    "@chordsketch/node-win32-x64-msvc": "0.2.0"
+    "@chordsketch/node-linux-x64-gnu": "0.2.1",
+    "@chordsketch/node-linux-arm64-gnu": "0.2.1",
+    "@chordsketch/node-darwin-x64": "0.2.1",
+    "@chordsketch/node-darwin-arm64": "0.2.1",
+    "@chordsketch/node-win32-x64-msvc": "0.2.1"
   },
   "napi": {
     "binaryName": "chordsketch-napi",

--- a/crates/render-html/Cargo.toml
+++ b/crates/render-html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-html"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,4 +13,4 @@ description = "HTML renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
+chordsketch-core = { version = "0.2.1", path = "../core" }

--- a/crates/render-pdf/Cargo.toml
+++ b/crates/render-pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-pdf"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ description = "PDF renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
+chordsketch-core = { version = "0.2.1", path = "../core" }
 ttf-parser = { version = "0.25", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/render-text/Cargo.toml
+++ b/crates/render-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-text"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,5 +13,5 @@ description = "Plain text renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
+chordsketch-core = { version = "0.2.1", path = "../core" }
 unicode-width = "0.2.2"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -16,10 +16,10 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-chordsketch-core = { version = "0.2.0", path = "../core" }
-chordsketch-render-text = { version = "0.2.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.0", path = "../render-pdf" }
+chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/wasm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ChordPro parser and renderer compiled to WebAssembly",
   "license": "MIT",
   "type": "module",

--- a/packages/tree-sitter-chordpro/package.json
+++ b/packages/tree-sitter-chordpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-chordpro",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tree-sitter grammar for ChordPro music notation files",
   "license": "MIT",
   "repository": {

--- a/packages/tree-sitter-chordpro/src/parser.c
+++ b/packages/tree-sitter-chordpro/src/parser.c
@@ -1189,7 +1189,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_chordpro(void) {
     .metadata = {
       .major_version = 0,
       .minor_version = 2,
-      .patch_version = 0,
+      .patch_version = 1,
     },
   };
   return &language;

--- a/packages/tree-sitter-chordpro/tree-sitter.json
+++ b/packages/tree-sitter-chordpro/tree-sitter.json
@@ -10,7 +10,7 @@
     }
   ],
   "metadata": {
-    "version": "0.2.0",
+    "version": "0.2.1",
     "license": "MIT",
     "description": "Tree-sitter grammar for ChordPro music notation files",
     "authors": [

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "chordsketch",
   "displayName": "ChordSketch",
   "description": "ChordPro language support with syntax highlighting, diagnostics, completions, and a live HTML preview panel.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "koedame",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Release v0.2.1

Patch release with new distribution channels and CI improvements.

### New distribution channels
- AUR (`yay -S chordsketch`)
- Snap Store (`sudo snap install chordsketch`)
- CocoaPods (`pod 'ChordSketch'`)
- Chocolatey (`choco install chordsketch`) — first auto-publish on this release
- tree-sitter-chordpro on npm
- nixpkgs PR submitted (NixOS/nixpkgs#510263)

### Highlights
- 13 new CLI integration tests for `convert` subcommand
- Fixed hardcoded `/tmp` paths in tests (TOCTOU risk)
- Snap switched from core22 to core24 (glibc 2.39)
- Full setup documentation for all new channels in releasing.md

### Version bump
All 10 Rust crates + 9 non-Rust manifests bumped 0.2.0 → 0.2.1.
`check-version-consistency.py` passes (21 sources in sync).

See CHANGELOG.md for the full list.