### PR TITLE
fix(ci): fix YAML parse error in post-release.yml Flathub heredoc

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -751,18 +751,17 @@ jobs:
 
           # Open a PR on the Flathub repo for review
           cd ..
+          PR_BODY="## Update chordsketch to ${VERSION}
+
+          - **Version**: ${VERSION}
+          - **Architectures**: x86_64, aarch64
+          - **Source**: Pre-built binaries from [GitHub Release](https://github.com/koedame/chordsketch/releases/tag/v${VERSION})
+
+          Automated update from the [chordsketch post-release workflow](https://github.com/koedame/chordsketch/blob/main/.github/workflows/post-release.yml)."
+
           GH_TOKEN="$FLATHUB_TOKEN" gh pr create \
             --repo flathub/me.koeda.chordsketch \
             --base master \
             --head "$BRANCH" \
             --title "Update chordsketch to ${VERSION}" \
-            --body "$(cat <<PR_BODY
-## Update chordsketch to ${VERSION}
-
-- **Version**: ${VERSION}
-- **Architectures**: x86_64, aarch64
-- **Source**: Pre-built binaries from [GitHub Release](https://github.com/koedame/chordsketch/releases/tag/v${VERSION})
-
-Automated update from the [chordsketch post-release workflow](https://github.com/koedame/chordsketch/blob/main/.github/workflows/post-release.yml).
-PR_BODY
-          )"
+            --body "$PR_BODY"


### PR DESCRIPTION
## What

Fix a YAML parse error that broke the entire post-release.yml workflow.

## Why

The v0.2.1 release triggered post-release.yml but it failed with
"workflow file issue" — no jobs ran. The Flathub job's PR body heredoc
contained markdown list items at column 0 inside a `run: |` block,
which the YAML parser interpreted as new list items.

## Fix

Replace the heredoc with a shell variable assignment, keeping all
content inside the block scalar's indentation level.

## Verification

```python
import yaml; yaml.safe_load(open('post-release.yml'))  # OK
```

After merging, post-release.yml can be re-triggered via workflow_dispatch
for the v0.2.1 release.

Closes #1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)