### PR TITLE
Update Swift Package.swift to v0.2.1

### DIFF
--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "chordsketchFFI",
-            url: "https://github.com/koedame/chordsketch/releases/download/v0.2.0/chordsketch-xcframework.zip",
-            checksum: "a5a6fee17846b2caafe61a2b896263f3f71b008967a2001c8474e567e1c24d6d"
+            url: "https://github.com/koedame/chordsketch/releases/download/v0.2.1/chordsketch-xcframework.zip",
+            checksum: "2d613c46cc067f12db022a09f1021eee86e73189b86ef7b94ac9f0aee818c5e1"
         ),
         .target(
             name: "ChordSketch",


### PR DESCRIPTION
## What

Updates `packages/swift/Package.swift`'s `.binaryTarget` to point to
the `v0.2.1` xcframework asset and pin its SHA256.

- **Tag**: `v0.2.1`
- **Asset**: `chordsketch-xcframework.zip`
- **SHA256**: `2d613c46cc067f12db022a09f1021eee86e73189b86ef7b94ac9f0aee818c5e1`

## Why

Auto-generated by `post-release.yml`'s `update-swift-package` job
after the Swift workflow uploaded the xcframework to the release.
Without this update, `swift package add https://github.com/koedame/chordsketch.git`
against the new tag would fail with an invalid checksum error.

See #1062.