### PR TITLE
fix(ci): remove environment blocks from npm/napi workflows

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -197,20 +197,9 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.tag != '')
     runs-on: ubuntu-latest
     # `continue-on-error: true` keeps the overall workflow green when the
-    # `napi` environment is absent (forks, fresh instances). The authoritative
-    # success/failure signal for this channel is `release-verify.yml`'s
-    # post-release rollup, which queries registry.npmjs.org for each of the
-    # six packages. See #1506.
-    #
-    # One-time human setup: create the "napi" environment at
-    #   https://github.com/koedame/chordsketch/settings/environments
-    # and add NPM_TOKEN as an environment secret. The npm account must own
-    # the `@chordsketch` scope and have published the six @chordsketch/node*
-    # packages at least once (see docs/releasing.md §napi distribution).
+    # See npm-publish.yml comment — environment block removed to avoid
+    # stale deployment entries (#1790). NPM_TOKEN is a repo-level secret.
     continue-on-error: true
-    environment:
-      name: napi
-      url: https://www.npmjs.com/package/@chordsketch/node
     permissions:
       contents: read
     steps:

--- a/.github/workflows/npm-publish-tree-sitter.yml
+++ b/.github/workflows/npm-publish-tree-sitter.yml
@@ -18,10 +18,9 @@ jobs:
   publish:
     name: Publish tree-sitter-chordpro
     runs-on: ubuntu-latest
+    # See npm-publish.yml comment — environment block removed to avoid
+    # stale deployment entries (#1790).
     continue-on-error: true
-    environment:
-      name: npm
-      url: https://www.npmjs.com/package/tree-sitter-chordpro
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,21 +17,15 @@ jobs:
   publish:
     name: Publish @chordsketch/wasm
     runs-on: ubuntu-latest
-    # Scopes NPM_TOKEN to this environment, consistent with python.yml (pypi),
-    # ruby.yml (rubygems), kotlin.yml (maven-central), and
-    # vscode-extension.yml (vscode-marketplace).
+    # NPM_TOKEN is a repo-level secret, not an environment secret.
+    # The `environment:` block was removed to avoid creating GitHub
+    # deployment entries that stay in "failure" state when the granular
+    # npm token cannot publish (see #1790).
     #
-    # One-time human setup: create the "npm" environment at
-    #   https://github.com/koedame/chordsketch/settings/environments
-    # and move NPM_TOKEN from repository secrets to environment secrets.
-    #
-    # If the "npm" environment does not exist (fork, fresh instance), GitHub
-    # cannot start this job. continue-on-error keeps the overall workflow green
-    # when CI succeeded but publishing infrastructure is absent. See #1443.
+    # npm publish is done MANUALLY as part of the release checklist.
+    # This workflow is kept as a convenience for cases where the token
+    # does work, but failure is expected and non-blocking.
     continue-on-error: true
-    environment:
-      name: npm
-      url: https://www.npmjs.com/package/@chordsketch/wasm
     permissions:
       contents: read
     steps:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -42,9 +42,11 @@ at post-release verification rather than before the tag is cut.
    ```bash
    gh api repos/koedame/chordsketch/environments --jq '.environments[].name'
    ```
-   Every `environment:` name used in a publish job (`npm`, `docker-hub`,
-   `vscode-marketplace`, `pypi`, `rubygems`, `maven-central`, `napi`) must
-   appear in the output.
+   Every `environment:` name used in a publish job (`docker-hub`,
+   `vscode-marketplace`, `pypi`, `rubygems`, `maven-central`) must
+   appear in the output. (`npm` and `napi` environment blocks were
+   removed in #1790 — those channels are published manually; see step 7
+   and the "napi distribution" section.)
 3. **`ci.yml` and `readme-smoke.yml` are green on the target commit.** The
    release workflow builds from that commit, so a red CI is a release
    blocker:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -129,24 +129,38 @@ at post-release verification rather than before the tag is cut.
    cargo publish -p chordsketch
    ```
 
-7. **Manually trigger all publish workflows.** The release created in
-   step 5 uses `GITHUB_TOKEN`, which does NOT trigger `release: published`
-   workflows (GitHub anti-recursion rule). Every workflow that depends on
-   that event must be dispatched manually:
+7. **Publish npm packages manually.** The granular `NPM_TOKEN` cannot
+   reliably publish via CI (see "Known operational quirks" below). Publish
+   from your local machine:
+   ```bash
+   # @chordsketch/wasm
+   cd packages/npm && npm run build && npm publish && cd ../..
+   # tree-sitter-chordpro
+   cd packages/tree-sitter-chordpro && npm publish --access public && cd ../..
+   ```
+   Verify:
+   ```bash
+   npm view @chordsketch/wasm version        # should show X.Y.Z
+   npm view tree-sitter-chordpro version      # should show X.Y.Z
+   ```
+
+8. **Manually trigger all remaining publish workflows.** The release
+   created in step 5 uses `GITHUB_TOKEN`, which does NOT trigger
+   `release: published` workflows (GitHub anti-recursion rule). Every
+   workflow that depends on that event must be dispatched manually:
    ```bash
    V=X.Y.Z  # replace with the actual version
-   gh workflow run npm-publish.yml           -f version=$V -R koedame/chordsketch
-   gh workflow run npm-publish-tree-sitter.yml -f version=$V -R koedame/chordsketch
    gh workflow run post-release.yml          -f tag=v$V    -R koedame/chordsketch
    gh workflow run docker.yml                -f tag=v$V    -R koedame/chordsketch
    gh workflow run vscode-extension.yml      -f tag=v$V    -R koedame/chordsketch
    gh workflow run napi.yml                  -f tag=v$V    -R koedame/chordsketch
    ```
-   ⚠️ **npm packages** (`@chordsketch/wasm`, `tree-sitter-chordpro`,
-   `@chordsketch/node-*`): if the CI publish fails with 404, publish
-   manually — see "Known operational quirks" below.
+   ⚠️ **napi** (`@chordsketch/node-*`): the CI workflow will likely fail
+   with 404 due to the same granular token limitation. napi publish
+   requires manually downloading CI build artifacts — see
+   "napi distribution" section below for the full procedure.
 
-8. **Wait for all workflows to complete** and verify each channel:
+9. **Wait for all workflows to complete** and verify each channel:
    ```bash
    # Watch the triggered runs
    gh run list -R koedame/chordsketch --limit 10
@@ -156,7 +170,7 @@ at post-release verification rather than before the tag is cut.
    GHCR and Docker Hub. VS Code publishes to Marketplace (and Open VSX
    if `OPEN_VSX_TOKEN` is configured).
 
-9. **Submit winget-pkgs PR**: see "Post-Release > winget" below. This is the
+10. **Submit winget-pkgs PR**: see "Post-Release > winget" below. This is the
    only post-release step that involves an external repo (`microsoft/winget-pkgs`).
 
 ## crates.io Publishing Order


### PR DESCRIPTION
## What

Remove `environment:` blocks from npm and napi publish workflows.
Update releasing.md to make npm publish a manual step.

## Why

The granular NPM_TOKEN cannot reliably publish via CI. Failed publish
attempts create deployment entries that stay in "failure" state
permanently on the Deployments page.

## Changes

- `npm-publish.yml`: remove `environment: name: npm`
- `npm-publish-tree-sitter.yml`: remove `environment: name: npm`
- `napi.yml`: remove `environment: name: napi`
- `docs/releasing.md`: add Step 7 (manual npm publish), renumber 8-10

Closes #1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)