### PR TITLE
ci(vscode): add continue-on-error to build-platform job

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -102,6 +102,18 @@ jobs:
     # it at server/<platform>-<arch>/chordsketch-lsp[.exe], and packages a
     # platform-specific VSIX. Needed for Tier 3 of the LSP resolver in
     # packages/vscode-extension/src/platform.ts to succeed post-install. See #1786.
+    #
+    # continue-on-error lets the publish jobs run even when a subset of
+    # matrix cells fails (e.g., a transient `gh release download`
+    # failure on one platform). Cell failures are still visible in the
+    # workflow run's Jobs tab. Without this, a single failed cell marks
+    # the whole job failed and GitHub skips both publish jobs entirely,
+    # hiding the partial build behind a silent skip. The `Verify
+    # expected VSIX count` step inside each publish job is the real
+    # guardrail: it fails loudly when fewer than 8 VSIXes are present,
+    # so a partial build still blocks publish — just loudly instead of
+    # silently. See #1795.
+    continue-on-error: true
     if: >-
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.tag != '')


### PR DESCRIPTION
## What

Add `continue-on-error: true` to the `build-platform` job in
`.github/workflows/vscode-extension.yml`.

## Why

Previously, a single failed matrix cell (e.g., a transient
`gh release download` failure on one of 7 platforms) marked the whole
`build-platform` job failed. Both `publish` and `publish-openvsx`
list `needs: [build, build-platform]`, so GitHub Actions would skip
publish entirely — silently hiding the partial build behind a
non-diagnostic skip, including blocking the universal VSIX that was
already successfully built by the `build` job.

The existing `Verify expected VSIX count` step inside each publish job
enforces `EXPECTED=8` and is the real guardrail against shipping an
incomplete set. With `continue-on-error: true`, publish runs, that
guardrail fires when a platform is missing, and the failure is loud
instead of silent.

Individual matrix cell failures remain visible in the workflow run's
Jobs tab (GitHub does not hide cell-level results when
`continue-on-error` is set at the job level).

## Test plan

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] No other YAML/job semantics touched
- [ ] Dry-run verification that publish runs after a simulated matrix
  failure — not feasible without actually failing a matrix cell on
  a release branch; review the logic instead.

Closes #1795