### PR TITLE
readme-smoke follow-ups: set -euo pipefail + AUR coverage-exemption ADR

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -579,6 +579,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -euo pipefail
           # GH_REPO is honored by every `gh` invocation below, so we
           # don't need an actions/checkout to read remote.origin.url
           # from a local .git/. Without this, every previous run of

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -447,6 +447,8 @@ jobs:
   # would require bootstrapping pacman on Ubuntu — fragile and slow.
   # AUR package correctness is verified by the PKGBUILD template in
   # packaging/aur/ and the post-release.yml update-aur job.
+  # Rationale, alternatives considered, and watch signals for revisiting
+  # this decision: docs/adr/0002-aur-smoke-coverage-exemption.md.
 
   library-smoke:
     name: Library Usage

--- a/docs/adr/0002-aur-smoke-coverage-exemption.md
+++ b/docs/adr/0002-aur-smoke-coverage-exemption.md
@@ -1,9 +1,3 @@
----
-name: ADR 0002 — AUR install command is exempt from readme-smoke coverage
-description: Captures why `yay -S chordsketch` has no end-to-end smoke job and what instead verifies AUR package correctness.
-type: adr
----
-
 # 0002. AUR install command is exempt from readme-smoke coverage
 
 - **Status**: Accepted

--- a/docs/adr/0002-aur-smoke-coverage-exemption.md
+++ b/docs/adr/0002-aur-smoke-coverage-exemption.md
@@ -1,0 +1,120 @@
+---
+name: ADR 0002 — AUR install command is exempt from readme-smoke coverage
+description: Captures why `yay -S chordsketch` has no end-to-end smoke job and what instead verifies AUR package correctness.
+type: adr
+---
+
+# 0002. AUR install command is exempt from readme-smoke coverage
+
+- **Status**: Accepted
+- **Date**: 2026-04-18
+
+## Context
+
+`README.md` documents `yay -S chordsketch` as the AUR install path, and
+`.github/snapshots/readme-commands.txt` records the command (line 9).
+`.claude/rules/readme-sync.md` states that every install command in
+`README.md` MUST be exercised end-to-end by
+`.github/workflows/readme-smoke.yml` via the `cli-render-smoke` composite
+action; snapshot updates without corresponding CI coverage "defeat the
+purpose of this rule."
+
+PR #1774 added the AUR snapshot entry but did not add a CI job. The
+workflow contains a comment at the point the job would live:
+
+> AUR smoke is intentionally omitted. GitHub-hosted runners do not have
+> yay/paru or an Arch Linux base, and installing an AUR helper in CI
+> would require bootstrapping pacman on Ubuntu — fragile and slow.
+> AUR package correctness is verified by the PKGBUILD template in
+> packaging/aur/ and the post-release.yml update-aur job.
+
+Issue #1775 asked whether this is a rule violation and listed three
+possible resolutions: add the job anyway, write an ADR / rule update
+permitting the omission, or mark the command coverage-exempt in the
+snapshot/extractor.
+
+## Decision
+
+Treat the AUR install command as **exempt from readme-smoke coverage**
+and document the exemption in this ADR. Do not add an AUR smoke job.
+
+## Rationale
+
+1. **No supported runner base.** GitHub-hosted runners use
+   Ubuntu / macOS / Windows. `yay` and `paru` are AUR helpers that
+   require a functioning Arch Linux pacman environment. There is no
+   Arch-based GitHub-hosted runner, so a smoke job would need to run
+   inside an `archlinux` container, install a non-root user, bootstrap
+   an AUR helper from source, and then exercise the install. That
+   bootstrap has historically been fragile (makepkg relies on `sudo`
+   prompts that container defaults disable, and AUR-helper upstream
+   releases shift frequently).
+2. **The install path is already covered by a different guarantee.**
+   `post-release.yml` runs the `update-aur` job that pushes the
+   generated PKGBUILD to the `aur@aur.archlinux.org` repo using the
+   `AUR_SSH_KEY` secret, and `ci/release-channels.toml` marks the
+   `aur` channel as part of the release-verify rollup. If the PKGBUILD
+   is malformed, the publish push fails and the rollup row goes red.
+   The install-side defect surface (the PKGBUILD builds but the
+   installed binary is broken) is caught by the PKGBUILD's own
+   `check()` stage running on an actual Arch environment during
+   submission review, not by CI.
+3. **The cost-benefit ratio is adverse.** The other smoke jobs each
+   take ~1-2 minutes. An Arch bootstrap would take longer and produce
+   false-positive failures whenever AUR-helper upstream changed, at the
+   exact moment a release is being cut. The time would be better spent
+   on other release verifications.
+
+## Consequences
+
+Positive:
+
+- `readme-smoke.yml` remains fast and stable.
+- `readme-sync.md`'s guarantee ("every install command is exercised
+  end-to-end") now has exactly one durably-documented exception.
+
+Negative:
+
+- A future defect in the AUR install path that is NOT caught by the
+  `update-aur` publish push and not caught during PKGBUILD review
+  could reach users. Mitigation: the `packaging/aur/` PKGBUILD template
+  is reviewed whenever `README.md` install instructions change, and
+  the post-release rollup would still show the AUR channel row so a
+  publish-side regression (the most likely failure mode) is visible.
+
+## Alternatives considered
+
+- **Add an `archlinux` container-based smoke job.** Rejected because of
+  the bootstrap fragility described in Rationale §1 and because the
+  install-side surface is already covered by §2. A job that takes four
+  times longer than its siblings and fails semi-regularly for reasons
+  unrelated to ChordSketch is a net negative.
+- **Amend `.github/snapshots/readme-commands.txt` or the extractor
+  script to mark AUR commands coverage-exempt.** Rejected because a
+  file-level exemption hides the rationale inside tooling; a future
+  contributor scanning the snapshot would not see why the AUR entry
+  escapes the rule. An ADR surfaces the rationale at the point a
+  reviewer looks (`docs/adr/README.md`) and is linked from the
+  workflow comment so the omission is durable.
+- **Remove the AUR install command from `README.md`.** Rejected
+  because AUR is a real, documented distribution channel for Arch
+  users; pulling the command to satisfy a CI rule would harm actual
+  users to protect a meta-rule.
+
+## References
+
+- Issue #1775 (this ADR resolves it)
+- PR #1774 (added AUR to README and snapshot)
+- `.claude/rules/readme-sync.md`
+- `.github/workflows/readme-smoke.yml` (comment at the AUR slot cross-
+  references this ADR)
+- `.github/workflows/post-release.yml` `update-aur` job
+- `ci/release-channels.toml` (`aur` channel, release-verify rollup)
+
+Watch signals that should prompt revisiting this decision:
+
+- GitHub adding an Arch-based hosted runner family.
+- An `archlinux` container image with a pre-built AUR helper that is
+  maintained upstream and stable across releases.
+- An AUR install-side regression that publish-push did not catch (which
+  would indicate the current coverage model has a real gap).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,3 +79,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | ADR | Title | Status |
 |---|---|---|
 | [0001](0001-kotlin-maven-central-publishing-credentials.md) | Kotlin Maven Central publishing credentials | Accepted (2026-04-11) |
+| [0002](0002-aur-smoke-coverage-exemption.md) | AUR install command is exempt from readme-smoke coverage | Accepted (2026-04-18) |


### PR DESCRIPTION
## What

Two small follow-ups to recent readme-smoke work, bundled because
they share the same theme (smoke coverage discipline).

- **#1779 — `set -euo pipefail` in `report-failure`.** Every other
  bash `run:` step in `readme-smoke.yml` starts with
  `set -euo pipefail`; the `Open or update tracking issue` step in
  `report-failure` did not. A transient `gh issue list` failure
  would silently yield an empty string and the step would fall
  through to `gh issue create`, masking the real cause.
- **#1775 — ADR for AUR coverage exemption.** `yay -S chordsketch`
  is documented in `README.md` and recorded in the smoke snapshot
  but has no end-to-end smoke job; `.claude/rules/readme-sync.md`
  says every install command MUST be exercised. The intentional
  omission has a workflow comment but no durable rationale. Per
  `.claude/rules/adr-discipline.md`, decisions that decline
  proposed work need an ADR. Add `docs/adr/0002` describing why
  AUR is exempt (runner base, bootstrap fragility, alternative
  coverage via PKGBUILD review + post-release `update-aur` +
  release-verify rollup), what alternatives were rejected, and
  what watch signals should prompt revisiting. Cross-reference
  the ADR from the existing workflow comment.

## Why

Both gaps are small; the value of closing them is that the smoke
workflow stays internally consistent and the one deliberately
uncovered install path has a rationale that outlives the chat
thread that produced it.

## Test plan

- [x] `.github/workflows/readme-smoke.yml` still parses as valid YAML.
- [x] ADR index (`docs/adr/README.md`) is updated.
- [x] ADR structure follows the template in `docs/adr/README.md`.
- [x] Workflow comment at the AUR slot cross-references the ADR path.

Closes #1779
Closes #1775