### PR TITLE
docs(vscode-extension): package.json keyword + README command table follow-ups

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -90,13 +90,13 @@ cargo install chordsketch-lsp
 Commands are available in the Command Palette when the active editor
 has language `chordpro`.
 
-| Command | Title |
-|---|---|
-| `chordsketch.openPreview` | ChordSketch: Open Preview |
-| `chordsketch.openPreviewToSide` | ChordSketch: Open Preview to the Side |
-| `chordsketch.transposeUp` | ChordSketch: Transpose Up |
-| `chordsketch.transposeDown` | ChordSketch: Transpose Down |
-| `chordsketch.convertTo` | ChordSketch: Export As… (HTML / text / PDF) |
+| Command | Title | Notes |
+|---|---|---|
+| `chordsketch.openPreview` | ChordSketch: Open Preview | |
+| `chordsketch.openPreviewToSide` | ChordSketch: Open Preview to the Side | |
+| `chordsketch.transposeUp` | ChordSketch: Transpose Up | Shifts every chord by +1 semitone |
+| `chordsketch.transposeDown` | ChordSketch: Transpose Down | Shifts every chord by −1 semitone |
+| `chordsketch.convertTo` | ChordSketch: Export As… | Exports the current song to HTML, text, or PDF |
 
 ## Configuration
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -16,6 +16,7 @@
   ],
   "keywords": [
     "chordpro",
+    "chordpro language",
     "chord",
     "music",
     "lyrics",


### PR DESCRIPTION
## What

Two small follow-ups from the review of PR #1808.

- **#1810** — add `chordpro language` to `packages/vscode-extension/package.json`
  `keywords`. `.claude/rules/package-documentation.md` §VS Code
  Marketplace requires it for discoverability.
- **#1811** — split the README Commands table so the Title column
  matches the exact `package.json` string shown in the Command
  Palette, moving the "(HTML / text / PDF)" annotation into a new
  Notes column. Also add short behaviour notes for the transpose
  commands for column consistency.

## Why

Each one would be surfaced by a future `/doc-quality-check` gate and
is trivially fixable in the same PR.

## Test plan

- [x] `package.json` is still valid JSON (`python3 -c "import json; json.load(open(...))"`).
- [x] README Commands table has 3 columns and every Title string
  is a verbatim substring of `contributes.commands[].title` in
  `package.json`.
- [x] No hardcoded versions introduced.

Closes #1810
Closes #1811