### PR TITLE
ci: document fail-closed intent in matrix-publish workflows

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -62,6 +62,15 @@ jobs:
   build-jni-others:
     name: Build JNI library (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    # Intentionally fail-closed: if any JNI matrix cell fails, the
+    # downstream `publish` job (needs: build-jni-linux-x64,
+    # build-jni-others, generate-and-test) is skipped. The published
+    # Maven Central artifact bundles every platform's JNI .so/.dylib/.dll
+    # inside the JAR; a missing triple means the JNI library loader
+    # fails at runtime on that platform with no fallback. Blocking
+    # the release until all cells succeed is the safer failure mode.
+    # Contrast with `vscode-extension.yml build-platform`, which has
+    # a universal VSIX fallback (#1795). See #1806.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -37,6 +37,15 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    # Intentionally fail-closed: if any build matrix cell fails, the
+    # downstream `publish` job is skipped. The published
+    # `@chordsketch/node` package resolves a platform-specific
+    # prebuilt binary at install time via optionalDependencies; a
+    # missing platform triple results in a hard install failure on
+    # that platform with no universal fallback. Blocking the whole
+    # release until every cell succeeds is the safer failure mode.
+    # Contrast with `vscode-extension.yml build-platform`, which has
+    # a universal VSIX fallback (#1795). See #1806.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,6 +43,16 @@ jobs:
 
   # Build Linux wheels (x86_64 and aarch64) in parallel.
   # test-ubuntu waits only on this job, not on macOS or Windows builds (#1463).
+  #
+  # build-wheels-* matrices are intentionally fail-closed: if any cell
+  # fails, the downstream `publish` job (needs: every build-wheels-*
+  # cell and every test-* cell) is skipped. The PyPI release ships
+  # wheels per (python-version, os, arch) triple; a missing triple
+  # means `pip install chordsketch` falls back to sdist compilation on
+  # that platform, which requires a Rust toolchain and fails for most
+  # end users. Blocking the release until all cells succeed is the
+  # safer failure mode. Contrast with `vscode-extension.yml
+  # build-platform`, which has a universal VSIX fallback (#1795). See #1806.
   build-wheels-ubuntu:
     name: Build ${{ matrix.target }} wheels on ubuntu-latest
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,17 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    # Intentionally fail-closed: if any build matrix cell fails, the
+    # downstream `release` job (needs: build) is skipped and no GitHub
+    # Release is created. This is correct because release.yml creates
+    # the authoritative artifact set that every downstream channel
+    # (Docker, VS Code, napi, post-release rollup) keys off. A partial
+    # release with one missing archive would silently degrade every
+    # install path for that platform; holding the release until all
+    # cells pass is the safer failure mode. Contrast with
+    # `vscode-extension.yml build-platform`, which ships a universal
+    # VSIX so users on a failing platform still get a working extension
+    # (see #1795). See #1806.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -62,6 +62,15 @@ jobs:
   build-native-others:
     name: Build native library (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    # Intentionally fail-closed: if any native-library matrix cell
+    # fails, the downstream `publish` job (needs: build-native-linux-x64,
+    # build-native-others, generate-and-test) is skipped. The RubyGems
+    # gem bundles every platform's native library; a missing triple
+    # means `require 'chordsketch'` fails at runtime on that platform
+    # with no fallback. Blocking the release until all cells succeed
+    # is the safer failure mode. Contrast with
+    # `vscode-extension.yml build-platform`, which has a universal
+    # VSIX fallback (#1795). See #1806.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -42,6 +42,15 @@ jobs:
   build-target:
     name: Build ${{ matrix.target }}
     runs-on: macos-latest
+    # Intentionally fail-closed: if any Apple target fails, the
+    # downstream `assemble-xcframework` + `publish` jobs are skipped.
+    # XCFramework is a sealed container of per-platform static
+    # libraries; missing a triple produces an incomplete framework
+    # that breaks Swift consumers on that platform at link time.
+    # Blocking the release until every cell succeeds is the safer
+    # failure mode. Contrast with `vscode-extension.yml
+    # build-platform`, which has a universal VSIX fallback (#1795).
+    # See #1806.
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## What

Audit the matrix-publish fan-in pattern (build matrix with
`fail-fast: false` → downstream publish job with `needs: [...]`)
that was changed for `vscode-extension.yml` in #1795 / PR #1805,
across the other release-time workflows.

## Audit result

The `vscode-extension.yml` case is **structurally unique**: its
`build` job produces a universal VSIX that works on every platform
(without the bundled LSP), and the platform-specific VSIXes from
`build-platform` are an enhancement layer. So when a platform-
specific cell fails, the universal VSIX can still ship and users
on that platform fall back to the universal build. That's the
reason PR #1805 switched to `continue-on-error: true` plus a
`Verify expected VSIX count` guardrail.

No other matrix-publish workflow has that universal-fallback
structure:

- `release.yml` — ships the per-target CLI archive. Missing archive = broken release for that target.
- `napi.yml` — ships the per-platform prebuilt `.node` via optionalDependencies. Missing platform = hard install failure.
- `kotlin.yml` — JAR bundles every JNI shared library. Missing triple = JNI loader fails at runtime.
- `ruby.yml` — gem bundles every native library. Missing triple = `require 'chordsketch'` fails at runtime.
- `python.yml` — per-(python, os, arch) wheels. Missing triple = pip falls back to sdist and needs a Rust toolchain on the install machine.

In all five cases the current fail-closed behaviour is the
**correct** design — blocking the whole release until every matrix
cell succeeds avoids shipping a release that silently breaks for
some users.

## Changes

Add a workflow-level comment to each of the five files documenting:
- The intentional fail-closed behaviour
- Why the graceful-fallback pattern from `vscode-extension.yml`
  does not apply here
- A back-reference to #1795 so the structural difference is
  discoverable for the next contributor

No behavioural change. Closes #1806.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on all 5 touched workflows.
- [x] No structural diff beyond the added comments.

Closes #1806