### PR TITLE
ci(npm-publish): validate inputs.version format

### DIFF
--- a/.github/actions/validate-release-version/action.yml
+++ b/.github/actions/validate-release-version/action.yml
@@ -1,0 +1,35 @@
+name: "Validate release version format"
+description: >
+  Validate that a string matches a bare semver release version
+  `<major>.<minor>.<patch>[-prerelease]` (no `v` prefix). For use by
+  workflows whose `workflow_dispatch` input is a bare npm / cargo
+  version string rather than a tag. Paired with routing
+  `inputs.version` through `env:` so user-controlled values never
+  reach YAML expression interpolation in a `run:` body without first
+  being format-validated. See #1797 / #1815.
+
+  For `v`-prefixed tag strings, use `validate-release-tag` instead.
+inputs:
+  version:
+    description: >
+      The bare version string to validate (e.g. `0.2.1` or
+      `0.2.1-rc.1`). Caller should pass `${{ inputs.version }}`.
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Validate version format
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if [ -z "$VERSION" ]; then
+          echo "Rejecting empty release version (workflow must supply inputs.version)." >&2
+          exit 1
+        fi
+        if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
+          echo "Rejecting malformed release version: $VERSION" >&2
+          echo "Expected format: <major>.<minor>.<patch>[-<prerelease>]" >&2
+          exit 1
+        fi

--- a/.github/workflows/npm-publish-tree-sitter.yml
+++ b/.github/workflows/npm-publish-tree-sitter.yml
@@ -47,6 +47,15 @@ jobs:
           VERSION="${TAG#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
+      - name: Validate workflow_dispatch version
+        # See rationale in npm-publish.yml. Consistent validation
+        # point across every workflow that accepts a version / tag
+        # input. Per #1797 / #1815.
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/validate-release-version
+        with:
+          version: ${{ inputs.version }}
+
       - name: Set version from workflow input
         if: github.event_name == 'workflow_dispatch'
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,6 +88,18 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
         if: github.event_name == 'release'
 
+      - name: Validate workflow_dispatch version
+        # Format-validate the user-supplied `inputs.version` before
+        # passing it to `npm version`. `npm version` also rejects
+        # non-semver, but the earlier, narrower check here matches
+        # the validation point the rest of the release workflows
+        # use (#1797) and fails with a consistent error message
+        # instead of npm's opaque "not a valid version" output.
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/validate-release-version
+        with:
+          version: ${{ inputs.version }}
+
       - name: Set version from workflow input
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## What

Add format validation for `inputs.version` in `npm-publish.yml` and
`npm-publish-tree-sitter.yml`, for consistency with the `inputs.tag`
validation added in #1814 (#1797). Closes #1815.

## Why

Both workflows already env-route `VERSION` and pass it to
`npm version`, which itself rejects non-semver — so the practical
injection surface is nil. Adding a narrower upstream check matches
the consistent validation point every other release workflow uses
after #1797 and surfaces a clearer error than npm's opaque
"invalid version" output.

## Approach

Per #1815's option 2: add a sibling composite action
`.github/actions/validate-release-version` for the bare
`<major>.<minor>.<patch>[-pre]` format (npm / cargo convention) next
to the existing `validate-release-tag` action for `v`-prefixed tags.
Both npm-publish workflows invoke the new action in their
`workflow_dispatch` branch only — the `release:` branch derives the
version from the git tag via `${TAG#v}`, so no `inputs.*`
interpolation is involved there.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both workflows and the new action.
- [x] Regex `^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$` validated against `0.2.1`, `1.0.0-rc.1`, and reject cases `v0.2.1`, `0.2`, `0.2.1; rm -rf /`.

Closes #1815