### PR TITLE
ci: env-route step outputs in release workflow run bodies

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -342,13 +342,13 @@ jobs:
         # and be silently invisible to anonymous pulls.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           for triple in linux-x64-gnu linux-arm64-gnu darwin-x64 darwin-arm64 win32-x64-msvc; do
             pkg="@chordsketch/node-${triple}"
-            version="${{ steps.version.outputs.version }}"
-            if npm view "$pkg@$version" version >/dev/null 2>&1; then
-              echo "$pkg@$version already published — skipping"
+            if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
+              echo "$pkg@$VERSION already published — skipping"
               continue
             fi
             (cd "crates/napi/npm/${triple}" && npm publish --access public)
@@ -360,11 +360,11 @@ jobs:
         # platform loop above.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ steps.version.outputs.version }}"
-          if npm view "@chordsketch/node@$version" version >/dev/null 2>&1; then
-            echo "@chordsketch/node@$version already published — skipping"
+          if npm view "@chordsketch/node@$VERSION" version >/dev/null 2>&1; then
+            echo "@chordsketch/node@$VERSION already published — skipping"
             exit 0
           fi
           cd crates/napi

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -45,13 +45,14 @@ jobs:
       - name: Download checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh release download "${{ steps.version.outputs.tag }}" -p checksums.txt
+          gh release download "$TAG" -p checksums.txt
 
       - name: Generate formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Extract and validate SHA256 values from checksums.txt
           SHA_AARCH64_APPLE=$(grep "aarch64-apple-darwin" checksums.txt | awk '{print $1}')
           SHA_X86_64_APPLE=$(grep "x86_64-apple-darwin" checksums.txt | awk '{print $1}')
@@ -80,9 +81,8 @@ jobs:
       - name: Push to homebrew-tap
         env:
           TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Note on credential persistence: both this URL-form approach
           # AND the previous `git config http.<url>.extraheader "..."`
           # approach persist the token to `tap/.git/config` — the URL
@@ -136,12 +136,14 @@ jobs:
       - name: Download checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh release download "${{ steps.version.outputs.tag }}" -p checksums.txt
+          gh release download "$TAG" -p checksums.txt
 
       - name: Generate manifest
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           SHA_WINDOWS=$(grep "x86_64-pc-windows-msvc" checksums.txt | awk '{print $1}')
 
           if [[ ! "$SHA_WINDOWS" =~ ^[0-9a-fA-F]{64}$ ]]; then
@@ -159,9 +161,8 @@ jobs:
       - name: Push to scoop-bucket
         env:
           TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # See the credential-persistence note on `update-homebrew` above.
           # The token IS written to `bucket/.git/config`; do not artifact
           # this directory. #1086.
@@ -208,13 +209,15 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh release download "${{ steps.version.outputs.tag }}" -p checksums.txt
+          gh release download "$TAG" -p checksums.txt
 
       - name: Generate package
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           SHA_WINDOWS=$(grep "x86_64-pc-windows-msvc" checksums.txt | awk '{print $1}')
 
           if [[ ! "$SHA_WINDOWS" =~ ^[0-9a-fA-F]{64}$ ]]; then
@@ -242,6 +245,7 @@ jobs:
         shell: pwsh
         env:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           if (-not $env:CHOCOLATEY_API_KEY) {
             Write-Host "CHOCOLATEY_API_KEY secret is not set; skipping Chocolatey push."
@@ -252,7 +256,7 @@ jobs:
 
           cd choco-pkg
           choco pack chordsketch.nuspec
-          choco push chordsketch.${{ steps.version.outputs.version }}.nupkg `
+          choco push "chordsketch.$env:VERSION.nupkg" `
             --source https://push.chocolatey.org/ `
             --api-key $env:CHOCOLATEY_API_KEY
 
@@ -287,18 +291,19 @@ jobs:
       - name: Download binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh release download "${{ steps.version.outputs.tag }}" \
-            -p "chordsketch-${{ steps.version.outputs.tag }}-x86_64-unknown-linux-gnu.tar.gz"
+          ARCHIVE="chordsketch-${TAG}-x86_64-unknown-linux-gnu.tar.gz"
+          gh release download "$TAG" -p "$ARCHIVE"
           mkdir -p stage
-          tar xzf "chordsketch-${{ steps.version.outputs.tag }}-x86_64-unknown-linux-gnu.tar.gz" \
-            --strip-components=1 -C stage
+          tar xzf "$ARCHIVE" --strip-components=1 -C stage
           chmod +x stage/chordsketch
           ls -la stage/
 
       - name: Generate snapcraft.yaml
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           mkdir -p snap
           sed -e "s/{{VERSION}}/${VERSION}/g" \
             packaging/snap/snapcraft.yaml.template > snap/snapcraft.yaml
@@ -356,8 +361,9 @@ jobs:
           tag: ${{ steps.version.outputs.tag }}
 
       - name: Generate podspec
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           sed -e "s/{{VERSION}}/${VERSION}/g" \
             packaging/cocoapods/ChordSketch.podspec.template > ChordSketch.podspec
           cat ChordSketch.podspec
@@ -406,12 +412,14 @@ jobs:
       - name: Download checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh release download "${{ steps.version.outputs.tag }}" -p checksums.txt
+          gh release download "$TAG" -p checksums.txt
 
       - name: Generate PKGBUILD and .SRCINFO
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           SHA_LINUX=$(grep "x86_64-unknown-linux-gnu" checksums.txt | awk '{print $1}')
 
           if [[ ! "$SHA_LINUX" =~ ^[0-9a-fA-F]{64}$ ]]; then
@@ -451,6 +459,7 @@ jobs:
       - name: Push to AUR
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           if [ -z "$AUR_SSH_KEY" ]; then
             echo "AUR_SSH_KEY secret is not set; skipping AUR push."
@@ -458,8 +467,6 @@ jobs:
             echo "as a repository secret named AUR_SSH_KEY."
             exit 0
           fi
-
-          VERSION="${{ steps.version.outputs.version }}"
 
           # Set up SSH for AUR access
           mkdir -p ~/.ssh
@@ -736,13 +743,14 @@ jobs:
       - name: Download checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh release download "${{ steps.version.outputs.tag }}" -p checksums.txt
+          gh release download "$TAG" -p checksums.txt
 
       - name: Generate manifest
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Validate VERSION format to prevent sed injection from crafted
           # workflow_dispatch tags.
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
@@ -772,6 +780,7 @@ jobs:
       - name: Push to Flathub
         env:
           FLATHUB_TOKEN: ${{ secrets.FLATHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           if [ -z "$FLATHUB_TOKEN" ]; then
             echo "FLATHUB_TOKEN secret is not set; skipping Flathub push."
@@ -781,8 +790,6 @@ jobs:
             echo "     flathub/me.koeda.chordsketch as FLATHUB_TOKEN secret."
             exit 0
           fi
-
-          VERSION="${{ steps.version.outputs.version }}"
 
           # See the credential-persistence note on `update-homebrew` above.
           # The token IS written to `flathub/.git/config`; do not artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,15 @@ jobs:
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET: ${{ matrix.target }}
         run: |
-          ARCHIVE_NAME="chordsketch-${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz"
-          STAGING="chordsketch-${{ steps.version.outputs.version }}-${{ matrix.target }}"
+          ARCHIVE_NAME="chordsketch-${VERSION}-${TARGET}.tar.gz"
+          STAGING="chordsketch-${VERSION}-${TARGET}"
           mkdir "$STAGING"
-          cp "target/${{ matrix.target }}/release/chordsketch" "$STAGING/"
-          cp "target/${{ matrix.target }}/release/chordsketch-lsp" "$STAGING/"
+          cp "target/${TARGET}/release/chordsketch" "$STAGING/"
+          cp "target/${TARGET}/release/chordsketch-lsp" "$STAGING/"
           cp LICENSE README.md "$STAGING/"
           tar czf "$ARCHIVE_NAME" "$STAGING"
           echo "ARCHIVE=$ARCHIVE_NAME" >> "$GITHUB_ENV"
@@ -116,14 +119,15 @@ jobs:
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET: ${{ matrix.target }}
         run: |
-          $Version = "${{ steps.version.outputs.version }}"
-          $Target = "${{ matrix.target }}"
-          $ArchiveName = "chordsketch-$Version-$Target.zip"
-          $Staging = "chordsketch-$Version-$Target"
+          $ArchiveName = "chordsketch-$env:VERSION-$env:TARGET.zip"
+          $Staging = "chordsketch-$env:VERSION-$env:TARGET"
           New-Item -ItemType Directory -Path $Staging
-          Copy-Item "target/$Target/release/chordsketch.exe" "$Staging/"
-          Copy-Item "target/$Target/release/chordsketch-lsp.exe" "$Staging/"
+          Copy-Item "target/$env:TARGET/release/chordsketch.exe" "$Staging/"
+          Copy-Item "target/$env:TARGET/release/chordsketch-lsp.exe" "$Staging/"
           Copy-Item LICENSE, README.md "$Staging/"
           Compress-Archive -Path "$Staging/*" -DestinationPath $ArchiveName
           echo "ARCHIVE=$ArchiveName" >> $env:GITHUB_ENV
@@ -171,6 +175,7 @@ jobs:
             VERSION="$REF_NAME"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        shell: bash
 
       - name: Generate checksums
         run: |
@@ -181,8 +186,8 @@ jobs:
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           gh release create "$VERSION" \
             --title "$VERSION" \
             --notes "See [CHANGELOG.md](https://github.com/koedame/chordsketch/blob/main/CHANGELOG.md) for details." \


### PR DESCRIPTION
## What

Complete the env-routing discipline that PR #1814 began for release
workflows. Closes #1816 and #1817.

- **#1816**: `release.yml` release job's `Determine version` step
  was missing `shell: bash` (the `build` job has it). Added for
  consistency.
- **#1817**: Migrate all `${{ steps.version.outputs.* }}` inline
  interpolations in `run:` bodies across `release.yml`,
  `post-release.yml`, and `napi.yml` to `env:` routing. Also fixed
  one stale lowercase `$version` diagnostic reference in napi.yml
  that no longer existed after the rename.

## Why

After PR #1814 the invariant "no `${{ inputs.* }}` or
`${{ github.event.release.* }}` in any `run:` body" was restored,
but second-order `${{ steps.*.outputs.* }}` values (the resolved
tag / version) were still inline-interpolated. Those values are
format-validated by `validate-release-tag` /
`validate-release-version` so there is no current injection
vulnerability, but aligning them with the same env-routing
discipline removes the exception and makes the invariant total
for release workflows.

## Final audit

```python
# Zero `${{ steps.*.outputs.* }}` inside any `run:` body across
# release.yml, post-release.yml, and napi.yml.
```

returns **0**.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on all 3 touched workflows.
- [x] Final audit script returns 0 remaining interpolations in release workflows.
- [x] PowerShell step in `release.yml` Package (Windows) migrated to `$env:VERSION` / `$env:TARGET` (matching pwsh env-var syntax).

Closes #1816
Closes #1817