### PR TITLE
Release v0.2.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: koedame/chordsketch
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   ghcr:
     name: Build and push to GHCR

--- a/.github/workflows/npm-publish-tree-sitter.yml
+++ b/.github/workflows/npm-publish-tree-sitter.yml
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   publish:
     name: Publish tree-sitter-chordpro

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,10 @@ on:
 env:
   WASM_PACK_VERSION: "0.14.0"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   publish:
     name: Publish @chordsketch/wasm

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   update-homebrew:
     name: Update Homebrew formula

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -201,7 +201,7 @@ jobs:
           # 0.1.0 → 0.1.1 fix, in the publish PR itself). The README sync
           # check (.github/workflows/readme-sync.yml) does not catch this
           # automatically because the version string lives only here.
-          npm install '@chordsketch/wasm@0.2.1'
+          npm install '@chordsketch/wasm@0.2.2'
 
       - name: Smoke test text + HTML + PDF render
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -43,6 +43,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   collect-channels:
     name: Load channel manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: Build ${{ matrix.target }}

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -27,6 +27,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: Build & Package Extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-18
+
+### Added
+
+- Bundle `chordsketch-lsp` binary in platform-specific VS Code extension VSIXes (#1789)
+
+### Changed
+
+- Refactor render-html `{define}` arm to remove redundant block wrapper (#1804)
+- VS Code extension: L2-compliant README with package.json keyword follow-ups (#1808, #1812)
+- Document VS Code README PNG requirement (SVG rejected by `vsce package`) (#1813)
+- Releasing docs: Open VSX first-time setup, 8-VSIX procedure, release-verify, manual dispatch (#1785, #1801, #1803)
+- Swift `Package.swift` bumped to v0.2.1 (#1783)
+
+### Fixed
+
+- CI: fix YAML parse error in post-release Flathub heredoc (#1782)
+- CI: remove incorrect environment blocks from npm/napi publish workflows (#1791)
+- CI(vscode): add `continue-on-error` to build-platform job (#1805)
+
+### Security
+
+- CI: audit release workflows for `inputs.tag` / `inputs.version` script-injection vectors (#1814, #1819)
+- CI: route release workflow step outputs via env to prevent injection (#1820)
+- CI(readme-smoke): adopt `set -euo pipefail` for fail-closed script behavior (#1807)
+- CI: document fail-closed intent in matrix-publish workflows (#1818)
+
 ## [0.2.1] - 2026-04-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactor render-html `{define}` arm to remove redundant block wrapper (#1804)
-- VS Code extension: L2-compliant README with package.json keyword follow-ups (#1808, #1812)
+- VS Code extension: add L2-compliant README (#1808)
+- VS Code extension: package.json keyword + README command table follow-ups (#1812)
 - Document VS Code README PNG requirement (SVG rejected by `vsce package`) (#1813)
-- Releasing docs: Open VSX first-time setup, 8-VSIX procedure, release-verify, manual dispatch (#1785, #1801, #1803)
+- Document Open VSX first-time setup procedure in releasing.md (#1801)
+- Document 8-VSIX procedure and release-verify workflow in releasing.md (#1803)
+- Document manual workflow dispatch in release checklist (#1785)
 - Swift `Package.swift` bumped to v0.2.1 (#1783)
+- CI: document fail-closed intent in matrix-publish workflows (#1818)
 
 ### Fixed
 
@@ -29,10 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- CI: audit release workflows for `inputs.tag` / `inputs.version` script-injection vectors (#1814, #1819)
+- CI: audit release workflows for `inputs.tag` script-injection vectors (#1814)
+- CI(npm-publish): validate `inputs.version` format before `npm version` (#1819)
 - CI: route release workflow step outputs via env to prevent injection (#1820)
 - CI(readme-smoke): adopt `set -euo pipefail` for fail-closed script behavior (#1807)
-- CI: document fail-closed intent in matrix-publish workflows (#1818)
 
 ## [0.2.1] - 2026-04-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chordsketch"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_cmd",
  "chordsketch-convert-musicxml",
@@ -274,21 +274,21 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-convert-musicxml"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
 ]
 
 [[package]]
 name = "chordsketch-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "chordsketch-ffi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
  "chordsketch-render-html",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-lsp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
  "tokio",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-napi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
  "chordsketch-render-html",
@@ -323,14 +323,14 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-render-html"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
 ]
 
 [[package]]
 name = "chordsketch-render-pdf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
  "flate2",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-render-text"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
  "unicode-width",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-wasm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chordsketch-core",
  "chordsketch-render-html",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -17,11 +17,11 @@ name = "chordsketch"
 path = "src/main.rs"
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
-chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
-chordsketch-convert-musicxml = { version = "0.2.1", path = "../convert-musicxml" }
+chordsketch-core = { version = "0.2.2", path = "../core" }
+chordsketch-render-text = { version = "0.2.2", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.2", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.2", path = "../render-pdf" }
+chordsketch-convert-musicxml = { version = "0.2.2", path = "../convert-musicxml" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tempfile = "3"

--- a/crates/convert-musicxml/Cargo.toml
+++ b/crates/convert-musicxml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-convert-musicxml"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,4 +13,4 @@ readme = "README.md"
 description = "MusicXML ↔ ChordPro bidirectional converter"
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-core = { version = "0.2.2", path = "../core" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-core"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-ffi"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,10 +15,10 @@ description = "UniFFI bindings for ChordPro parsing and rendering"
 crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
-chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
+chordsketch-core = { version = "0.2.2", path = "../core" }
+chordsketch-render-text = { version = "0.2.2", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.2", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.2", path = "../render-pdf" }
 # `uniffi` is pinned to an exact patch version because the .udl + scaffolding
 # generated layout is part of the FFI surface — Python/Swift/Kotlin/Ruby
 # bindings depend on the binary being byte-compatible with the bindgen output.

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-lsp"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ name = "chordsketch-lsp"
 path = "src/main.rs"
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-core = { version = "0.2.2", path = "../core" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["rt", "macros", "io-std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-napi"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,10 +15,10 @@ description = "Native Node.js addon for ChordPro parsing and rendering via napi-
 crate-type = ["cdylib"]
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
-chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
+chordsketch-core = { version = "0.2.2", path = "../core" }
+chordsketch-render-text = { version = "0.2.2", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.2", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.2", path = "../render-pdf" }
 # `napi` and `napi-derive` are pinned to exact patch versions because the
 # `#[napi]` macro emits ABI-sensitive C glue against the Node-API ABI.
 # Caret ranges (`"3"`) would let a 3.5 release land via a casual `cargo

--- a/crates/napi/npm/darwin-arm64/package.json
+++ b/crates/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-darwin-arm64",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Prebuilt @chordsketch/node binary for macOS aarch64 (Apple Silicon).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/darwin-x64/package.json
+++ b/crates/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-darwin-x64",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Prebuilt @chordsketch/node binary for macOS x86_64.",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/crates/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-linux-arm64-gnu",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Prebuilt @chordsketch/node binary for Linux aarch64 (glibc).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/linux-x64-gnu/package.json
+++ b/crates/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-linux-x64-gnu",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Prebuilt @chordsketch/node binary for Linux x86_64 (glibc).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/win32-x64-msvc/package.json
+++ b/crates/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-win32-x64-msvc",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Prebuilt @chordsketch/node binary for Windows x86_64 (MSVC).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Native Node.js addon for ChordPro parsing and rendering via napi-rs.",
   "license": "MIT",
   "repository": {
@@ -30,11 +30,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@chordsketch/node-linux-x64-gnu": "0.2.1",
-    "@chordsketch/node-linux-arm64-gnu": "0.2.1",
-    "@chordsketch/node-darwin-x64": "0.2.1",
-    "@chordsketch/node-darwin-arm64": "0.2.1",
-    "@chordsketch/node-win32-x64-msvc": "0.2.1"
+    "@chordsketch/node-linux-x64-gnu": "0.2.2",
+    "@chordsketch/node-linux-arm64-gnu": "0.2.2",
+    "@chordsketch/node-darwin-x64": "0.2.2",
+    "@chordsketch/node-darwin-arm64": "0.2.2",
+    "@chordsketch/node-win32-x64-msvc": "0.2.2"
   },
   "napi": {
     "binaryName": "chordsketch-napi",

--- a/crates/render-html/Cargo.toml
+++ b/crates/render-html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-html"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,4 +13,4 @@ description = "HTML renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-core = { version = "0.2.2", path = "../core" }

--- a/crates/render-pdf/Cargo.toml
+++ b/crates/render-pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-pdf"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ description = "PDF renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-core = { version = "0.2.2", path = "../core" }
 ttf-parser = { version = "0.25", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/render-text/Cargo.toml
+++ b/crates/render-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-text"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,5 +13,5 @@ description = "Plain text renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
+chordsketch-core = { version = "0.2.2", path = "../core" }
 unicode-width = "0.2.2"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-wasm"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -16,10 +16,10 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-chordsketch-core = { version = "0.2.1", path = "../core" }
-chordsketch-render-text = { version = "0.2.1", path = "../render-text" }
-chordsketch-render-html = { version = "0.2.1", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.2.1", path = "../render-pdf" }
+chordsketch-core = { version = "0.2.2", path = "../core" }
+chordsketch-render-text = { version = "0.2.2", path = "../render-text" }
+chordsketch-render-html = { version = "0.2.2", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.2.2", path = "../render-pdf" }
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -8,15 +8,14 @@
 WebAssembly — parse and render [ChordPro](https://www.chordpro.org/) files
 in the browser **or** in Node.js with the same package.
 
-> Requires `>=0.1.1`. Version `0.1.0` is published but does not work in
-> Node.js (it tries to `fetch()` the wasm file via `file://`, which Node's
-> undici does not support). `0.1.1` introduced a dual-package layout that
-> resolves to a Node-compatible build automatically.
-
 ## Installation
 
+[![npm](https://img.shields.io/npm/v/@chordsketch/wasm)](https://www.npmjs.com/package/@chordsketch/wasm)
+
+Replace `VERSION` with the current version from the badge above.
+
 ```bash
-npm install '@chordsketch/wasm@>=0.1.1'
+npm install '@chordsketch/wasm@VERSION'
 ```
 
 ## Usage

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/wasm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "ChordPro parser and renderer compiled to WebAssembly",
   "license": "MIT",
   "type": "module",

--- a/packages/tree-sitter-chordpro/package.json
+++ b/packages/tree-sitter-chordpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-chordpro",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Tree-sitter grammar for ChordPro music notation files",
   "license": "MIT",
   "repository": {

--- a/packages/tree-sitter-chordpro/src/parser.c
+++ b/packages/tree-sitter-chordpro/src/parser.c
@@ -1189,7 +1189,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_chordpro(void) {
     .metadata = {
       .major_version = 0,
       .minor_version = 2,
-      .patch_version = 1,
+      .patch_version = 2,
     },
   };
   return &language;

--- a/packages/tree-sitter-chordpro/tree-sitter.json
+++ b/packages/tree-sitter-chordpro/tree-sitter.json
@@ -10,7 +10,7 @@
     }
   ],
   "metadata": {
-    "version": "0.2.1",
+    "version": "0.2.2",
     "license": "MIT",
     "description": "Tree-sitter grammar for ChordPro music notation files",
     "authors": [

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "chordsketch",
   "displayName": "ChordSketch",
   "description": "ChordPro language support with syntax highlighting, diagnostics, completions, and a live HTML preview panel.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "koedame",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Release v0.2.2

Patch release bundling CI hardening, VS Code extension polish, and the LSP binary bundled into platform VSIXes.

### Highlights
- `chordsketch-lsp` bundled in platform-specific VSIXes (#1789)
- VS Code extension: L2-compliant README with package.json keyword cleanup (#1808, #1812)
- Release workflows hardened against `inputs.tag` / `inputs.version` script-injection vectors (#1814, #1819, #1820)
- `readme-smoke` scripts adopt `set -euo pipefail` for fail-closed behavior (#1807)
- Matrix-publish fail-closed intent documented (#1818)
- Render-html `{define}` arm refactored to remove a redundant block wrapper (#1804)

### Version bump
All 10 Rust crates + 11 non-Rust manifests bumped 0.2.1 → 0.2.2.
`check-version-consistency.py` passes (21 sources in sync).

### Release-path workflow hardening (added in this PR)
`defaults.run.shell: bash` applied to 7 workflows so every `run:` block gets `-eo pipefail`. This closes a silent-failure path where `post-release.yml` could push empty SHAs into Homebrew / Chocolatey / Scoop formulae.

**Sister-site audit (per `.claude/rules/fix-propagation.md`):** Audited all release-path workflows. Applied to: `post-release.yml`, `docker.yml`, `npm-publish.yml`, `npm-publish-tree-sitter.yml`, `release.yml`, `vscode-extension.yml`, `release-verify.yml`. Intentionally skipped: `napi.yml` (Windows matrix deserves separate audit → tracked as #1835), and `kotlin.yml` / `python.yml` / `ruby.yml` / `swift.yml` (no unprotected pipelines today; rule-compliance cleanup tracked as #1845).

### Out of scope (follow-ups after tag)
- `packages/swift/Package.swift` bump to `v0.2.2` (XCFramework asset must exist before the reference can be updated — matches the v0.2.1 pattern in #1783)

### Pre-existing findings surfaced during full-repo review (not blocking this release)
Filed as #1824–#1845 and #1822–#1823. High/Medium findings apply to v0.2.0/v0.2.1 at the same risk level as v0.2.2 — no new release regression. Scheduled for v0.2.3.

See CHANGELOG.md for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)