### PR TITLE
Fix ${{ }} escaping in composite action descriptions (release-blocker)

### DIFF
--- a/.github/actions/validate-release-tag/action.yml
+++ b/.github/actions/validate-release-tag/action.yml
@@ -11,7 +11,7 @@ inputs:
   tag:
     description: >
       The tag string to validate. Caller should usually pass
-      `${{ inputs.tag || github.event.release.tag_name || github.ref_name }}`
+      `$${{ inputs.tag || github.event.release.tag_name || github.ref_name }}`
       so all three entry points are covered.
     required: true
 runs:

--- a/.github/actions/validate-release-version/action.yml
+++ b/.github/actions/validate-release-version/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: >
       The bare version string to validate (e.g. `0.2.1` or
-      `0.2.1-rc.1`). Caller should pass `${{ inputs.version }}`.
+      `0.2.1-rc.1`). Caller should pass `$${{ inputs.version }}`.
     required: true
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary

Hotfix for #1847 — the v0.2.2 tag push failed all 7 `release.yml` build matrix cells because `validate-release-tag/action.yml` contained an unescaped `${{ ... }}` inside an input description, which GitHub Actions evaluated as an expression and rejected.

Closes #1847

## Root cause

`validate-release-tag/action.yml` was introduced by PR #1814 (2026-04-17) and documented its expected input as:

```yaml
inputs:
  tag:
    description: >
      The tag string to validate. Caller should usually pass
      `${{ inputs.tag || github.event.release.tag_name || github.ref_name }}`
      so all three entry points are covered.
```

GitHub Actions evaluates `${{ }}` in composite action input descriptions the same as in a `run:` body, causing load-time failure:

```
Unrecognized named-value: 'inputs'.
```

v0.2.1 was released before PR #1814 merged, so this never exercised until v0.2.2.

## Fix

Escape the leading `$` by doubling it (`$${{ }}`), which Actions renders as the literal `${{ }}`. No functional change, only the rendered description.

## Sister-site audit

Per `.claude/rules/fix-propagation.md` — checked all composite actions under `.github/actions/`:

- `validate-release-tag/action.yml:14` — **fixed**
- `validate-release-version/action.yml:16` — same bug, **fixed**
- `cli-render-smoke/action.yml` — contains `${{ inputs.fixtures-dir }}` but only inside `run:` bodies where evaluation is intended. No change.

## Post-merge release recovery

Once this merges to main:

1. Delete the current v0.2.2 tag locally and remotely
2. Re-create v0.2.2 at the new main HEAD (includes this fix)
3. `release.yml` re-runs; proceed with the rest of `docs/releasing.md`

## Severity

**High / release-blocker** — blocks the v0.2.2 release that was approved and merged via PR #1821.

## Test plan

- [ ] CI passes on this branch
- [ ] Post-merge: v0.2.2 re-tag succeeds and release.yml passes
- [ ] Composite action description still renders correctly in the Actions UI (visual check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
