### PR TITLE
Remove expression-like syntax from composite action descriptions (release-blocker v2)

### DIFF
--- a/.github/actions/validate-release-tag/action.yml
+++ b/.github/actions/validate-release-tag/action.yml
@@ -10,9 +10,10 @@ description: >
 inputs:
   tag:
     description: >
-      The tag string to validate. Caller should usually pass
-      `$${{ inputs.tag || github.event.release.tag_name || github.ref_name }}`
-      so all three entry points are covered.
+      The tag string to validate. Caller should usually pass the first
+      non-empty of inputs.tag, github.event.release.tag_name, or
+      github.ref_name so all three entry points are covered. See the
+      workflow callers of this action for the exact expression.
     required: true
 runs:
   using: "composite"

--- a/.github/actions/validate-release-version/action.yml
+++ b/.github/actions/validate-release-version/action.yml
@@ -12,8 +12,9 @@ description: >
 inputs:
   version:
     description: >
-      The bare version string to validate (e.g. `0.2.1` or
-      `0.2.1-rc.1`). Caller should pass `$${{ inputs.version }}`.
+      The bare version string to validate (e.g. 0.2.1 or 0.2.1-rc.1).
+      Caller should pass inputs.version via a workflow expression; see
+      workflow callers for the exact form.
     required: true
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary

Second attempt at fixing #1847. PR #1848 tried `$${{` escape in composite action descriptions; that did **not** work. The v0.2.2 re-tagged release run ([24599563640](https://github.com/koedame/chordsketch/actions/runs/24599563640)) failed with the same load-time error:

```
Unrecognized named-value: 'inputs'.
Located at position 1 within expression:
  inputs.tag || github.event.release.tag_name || github.ref_name
```

The `$${{` escape documented for workflow files is not honored inside composite-action input `description:` fields. The only reliable fix is to remove expression-like syntax from the description entirely.

Reopens #1847 effectively (PR #1848 claimed to fix it but didn't).

## Fix

Rewrite both composite-action input descriptions as prose with no backticked expression syntax. The documentation intent survives; the string no longer trips the Actions expression parser.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`:
- `validate-release-tag/action.yml` — fixed
- `validate-release-version/action.yml` — fixed
- `cli-render-smoke/action.yml` — uses `${{ inputs.fixtures-dir }}` only in `run:` bodies where evaluation is intended. No change.

## Post-merge release recovery (for v0.2.2)

1. Delete broken v0.2.2 tag on origin
2. Re-tag v0.2.2 at new main HEAD (will include this fix)
3. `release.yml` re-runs; proceed with the rest of `docs/releasing.md`

## Severity

**High / release-blocker** — still blocking v0.2.2.

## Test plan

- [ ] CI passes on this branch
- [ ] Post-merge: v0.2.2 re-tag passes the "Validate release tag" step on all 7 build matrix cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)
