### PR TITLE
Bump packaging/winget templates to 0.2.2

### DIFF
--- a/packaging/winget/koedame.chordsketch.installer.yaml
+++ b/packaging/winget/koedame.chordsketch.installer.yaml
@@ -1,10 +1,10 @@
 PackageIdentifier: koedame.chordsketch
-PackageVersion: 0.1.0
+PackageVersion: 0.2.2
 InstallerType: zip
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/koedame/chordsketch/releases/download/v0.1.0/chordsketch-v0.1.0-x86_64-pc-windows-msvc.zip
-    InstallerSha256: 61D2577FD4EBBFFDF75101058E6689FC69F6BD177D6607AF31198FEB905F44A6
+    InstallerUrl: https://github.com/koedame/chordsketch/releases/download/v0.2.2/chordsketch-v0.2.2-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 1689228ADA287B247405881E2E7F48FC57C8B744E9159814C4010A2ED4814A50
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: chordsketch.exe

--- a/packaging/winget/koedame.chordsketch.locale.en-US.yaml
+++ b/packaging/winget/koedame.chordsketch.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: koedame.chordsketch
-PackageVersion: 0.1.0
+PackageVersion: 0.2.2
 PackageLocale: en-US
 Publisher: koedame
 PackageName: ChordSketch

--- a/packaging/winget/koedame.chordsketch.yaml
+++ b/packaging/winget/koedame.chordsketch.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: koedame.chordsketch
-PackageVersion: 0.1.0
+PackageVersion: 0.2.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Bumps `packaging/winget/*.yaml` from 0.1.0 to 0.2.2. These templates have been stale since #848 (v0.2.0 and v0.2.1 releases did not update them).

Closes #1854 (template bump only; the external `microsoft/winget-pkgs` PR is tracked in that issue as a separate maintainer action).

## Changes

- `PackageVersion`: 0.1.0 → 0.2.2 (all 3 yaml files)
- `InstallerUrl`: v0.1.0 zip → v0.2.2 zip
- `InstallerSha256`: recomputed from the actual v0.2.2 release asset
  (`chordsketch-v0.2.2-x86_64-pc-windows-msvc.zip`,
  `sha256=1689228ADA287B247405881E2E7F48FC57C8B744E9159814C4010A2ED4814A50`)

## Test plan

- [ ] CI passes
- [ ] After merge, the maintainer can copy `packaging/winget/*.yaml` directly into `manifests/k/koedame/chordsketch/0.2.2/` of the `microsoft/winget-pkgs` fork without further edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
