### PR TITLE
ci: bundle low-priority CI hygiene fixes (#1837, #1839, #1840, #1845)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Fail-closed default: jobs that need write scopes must opt in via
+# job-level `permissions:`. See issue #1839.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -14,6 +14,11 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+# Fail-closed default: jobs that need write scopes must opt in via
+# job-level `permissions:`. See issue #1839.
+permissions:
+  contents: read
+
 env:
   WASM_PACK_VERSION: "0.14.0"
 

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -3,6 +3,11 @@ name: Extended Tests
 on:
   workflow_dispatch:
 
+# Fail-closed default: jobs that need write scopes must opt in via
+# job-level `permissions:`. See issue #1839.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -53,4 +58,4 @@ jobs:
         run: ./scripts/compare-with-perl.sh text
 
       - name: Run Perl comparison (html)
-        run: ./scripts/compare-with-perl.sh html || true
+        run: ./scripts/compare-with-perl.sh html

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -205,6 +205,13 @@ jobs:
     environment:
       name: maven-central
       url: https://repo1.maven.org/maven2/io/github/koedame/chordsketch/
+    # Enforce `bash -eo pipefail` in `run:` blocks. Scoped to this job
+    # rather than workflow-level because kotlin.yml has a Windows matrix
+    # cell (build-jni-others) whose `run:` blocks must keep pwsh defaults.
+    # See issue #1845 (fix-propagation from PR #1821).
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         # No `ref:` override — always check out the default branch (main) so

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -268,6 +268,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # Enforce `bash -eo pipefail` in `run:` blocks. Scoped to this job
+    # rather than workflow-level because python.yml has Windows matrix
+    # cells (build-wheels-windows, test-windows) whose `run:` blocks must
+    # keep pwsh defaults. See issue #1845 (fix-propagation from PR #1821).
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -127,13 +127,20 @@ jobs:
         env:
           TAG: ${{ needs.collect-channels.outputs.tag }}
           FORCE_STALE: ${{ inputs.force_stale_channel }}
+          # Route matrix.channel through env: for script-injection
+          # defense-in-depth, matching the convention established in
+          # PR #1820. matrix.channel is sourced from the build-time
+          # scripts/_release_channels.py output (not user input), so
+          # no active vulnerability today; the env: indirection prevents
+          # a future data-source change from silently introducing one.
+          CHANNEL: ${{ matrix.channel }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/verify-results
-          out=/tmp/verify-results/${{ matrix.channel }}.txt
+          out="/tmp/verify-results/${CHANNEL}.txt"
           if python3 scripts/check-release-channels.py \
               --tag "$TAG" \
-              --channel "${{ matrix.channel }}" \
+              --channel "$CHANNEL" \
               --force-stale "${FORCE_STALE:-}" > "$out" 2>&1; then
             echo "status=ok" >> "$GITHUB_ENV"
           else

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -259,6 +259,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # Enforce `bash -eo pipefail` in `run:` blocks. Scoped to this job
+    # rather than workflow-level because ruby.yml has a Windows matrix
+    # cell (build-native-others) whose `run:` blocks must keep pwsh
+    # defaults. See issue #1845 (fix-propagation from PR #1821).
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,6 +31,13 @@ on:
 permissions:
   contents: read
 
+# Ensure `run:` blocks use `bash -eo pipefail`, not the silent default that
+# swallows mid-pipe failures. swift.yml has no Windows matrix, so a
+# workflow-level default is safe (fix-propagation from PR #1821, issue #1845).
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Build each Apple target on its own runner in parallel.
   # The aarch64-apple-darwin cell also produces the dylib that uniffi-bindgen

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,6 +10,11 @@ concurrency:
   group: wasm-${{ github.ref }}
   cancel-in-progress: true
 
+# Fail-closed default: jobs that need write scopes must opt in via
+# job-level `permissions:`. See issue #1839.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   WASM_PACK_VERSION: "0.14.0"


### PR DESCRIPTION
## What

Bundles four low-priority CI hygiene issues that all touch workflow YAML only:

- **#1839** — Add top-level \`permissions: contents: read\` to \`ci.yml\`, \`wasm.yml\`, \`extended-tests.yml\`, \`deploy-playground.yml\`. Fail-closed default; job-level \`permissions:\` continues to declare write scopes where needed.
- **#1845** — Apply \`defaults.run.shell: bash\` propagation from PR #1821:
  - \`swift.yml\` — workflow-level (no Windows matrix)
  - \`kotlin.yml\`, \`python.yml\`, \`ruby.yml\` — job-level on \`publish:\` only, so Windows build-matrix cells keep their pwsh default
  - \`napi.yml\` is intentionally excluded (still tracked in #1835)
- **#1837** — Route \`matrix.channel\` through an \`env:\` binding in \`release-verify.yml\` for script-injection defense-in-depth (PR #1820 pattern).
- **#1840** — Drop \`|| true\` on \`compare-with-perl.sh html\` in \`extended-tests.yml\` per \`root-cause-fixes.md\`. Dispatch-only workflow, so the blast radius is bounded.

## Why

All four are rule-compliance cleanups flagged during the v0.2.2 release audit. Fixing them together keeps the diff small and avoids four PRs worth of CI cost for changes that share the same review lens (workflow-YAML-only, no runtime behavior change).

## Sister-site audit

Per \`.claude/rules/fix-propagation.md\`:

- **permissions:** — Workflows still missing top-level \`permissions:\` (auto-*, claude-*, conflict-check, upstream-watch, npm-publish*) all have explicit job-level \`permissions:\` blocks. Left out of this PR to keep scope tight; can be swept in a follow-up once the 4 named targets settle.
- **defaults.run.shell:** — napi.yml is excluded per the caveat in #1845 because its unshelled \`run:\` blocks on the Windows matrix are tracked in #1835.
- **env-routing:** — The \`path:\` value in \`upload-artifact\` is a GitHub Actions expression evaluated by the engine (no shell), so it does not need env indirection.
- **|| true removal:** — no other swallowed-failure patterns remain in \`extended-tests.yml\`; \`compare-with-perl.sh text\` already fails loud.

## Test

- YAML-only changes, no runtime logic touched.
- CI will exercise the permissions/defaults/env changes on this PR directly.

Closes #1837
Closes #1839
Closes #1840
Closes #1845