### PR TITLE
sanitizer: block external <use> refs and extend Lilypond Scheme blocklist (#1828, #1844)

### DIFF
--- a/crates/core/src/external_tool.rs
+++ b/crates/core/src/external_tool.rs
@@ -267,6 +267,18 @@ const DANGEROUS_SCHEME_FUNCTIONS: &[&str] = &[
     "eval-string",
     "load",
     "ly:gulp-file",
+    // ly:gulp-string is the cousin of ly:gulp-file that has also appeared
+    // in `-dsafe`-bypass research; it reads a file and returns its contents
+    // as a string. Block as defense-in-depth (#1844).
+    "ly:gulp-string",
+    "gulp-string",
+    // ly:format can emit attacker-controlled strings into the compiled
+    // output and, in combination with other primitives, enable format-string
+    // tricks against downstream processors. Defense-in-depth only (#1844).
+    "ly:format",
+    // ly:exit terminates the Lilypond process; useful to a sandbox
+    // attacker for masking tampering signals in batch pipelines (#1844).
+    "ly:exit",
     "ly:system",
     "ly:parser-include",
     "ly:set-option",
@@ -984,6 +996,31 @@ mod tests {
         let input = "#(ly:gulp-file \"/etc/passwd\")\n\\relative c' { c4 }\n";
         let result = super::sanitize_lilypond_content(input);
         assert!(!result.contains("ly:gulp-file"));
+    }
+
+    #[test]
+    fn sanitize_lilypond_strips_gulp_string() {
+        // #1844: ly:gulp-string is the string-returning cousin of gulp-file.
+        let input = "#(ly:gulp-string \"/etc/passwd\")\n\\relative c' { c4 }\n";
+        let result = super::sanitize_lilypond_content(input);
+        assert!(!result.contains("ly:gulp-string"));
+        assert!(result.contains("\\relative"));
+    }
+
+    #[test]
+    fn sanitize_lilypond_strips_ly_format() {
+        // #1844: ly:format may emit attacker-controlled strings.
+        let input = "#(ly:format \"~a\" \"x\")\n\\relative c' { c4 }\n";
+        let result = super::sanitize_lilypond_content(input);
+        assert!(!result.contains("ly:format"));
+    }
+
+    #[test]
+    fn sanitize_lilypond_strips_ly_exit() {
+        // #1844: ly:exit terminates the process and masks tampering.
+        let input = "#(ly:exit 0)\n\\relative c' { c4 }\n";
+        let result = super::sanitize_lilypond_content(input);
+        assert!(!result.contains("ly:exit"));
     }
 
     #[test]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -953,9 +953,9 @@ fn sanitize_svg_content(input: &str) -> String {
     // elements that can load external resources: script, feImage, image, iframe,
     // embed, object, and foreign-content containers.
     // Note: <use> elements are NOT stripped here; their href/xlink:href attributes are
-    // sanitized at the attribute level by sanitize_tag_attrs / is_uri_attr, which now
-    // blocks file: and blob: schemes. This preserves legitimate <use href="#symbol"/>
-    // patterns while preventing local-file exfiltration.
+    // restricted by sanitize_tag_attrs to fragment-only references (^#...). External
+    // URIs — including https — are stripped entirely to prevent tracking-pixel,
+    // cross-origin-referer, and timing-based exfiltration attacks (see #1828).
     const DANGEROUS_TAGS: &[&str] = &[
         "script",
         "foreignobject",
@@ -1271,6 +1271,12 @@ fn sanitize_tag_attrs(tag: &str) -> String {
         i += 1;
     }
 
+    // Remember the tag name (without the leading '<') for tag-specific
+    // attribute rules such as the `<use>` fragment-only policy below.
+    let tag_name = &result[1..];
+    let is_use_tag =
+        tag_name.eq_ignore_ascii_case("use") || tag_name.eq_ignore_ascii_case("svg:use");
+
     while i < bytes.len() {
         // Skip whitespace.
         while i < bytes.len() && bytes[i].is_ascii_whitespace() {
@@ -1334,6 +1340,19 @@ fn sanitize_tag_attrs(tag: &str) -> String {
             if let Some(ref val) = attr_value {
                 if has_dangerous_uri_scheme(val) {
                     // Strip the attribute if it uses a dangerous URI scheme.
+                    continue;
+                }
+                // <use href="..."> / <use xlink:href="..."> must be
+                // fragment-only (^#...). External URIs (even over https)
+                // allow cross-origin tracking, referer leakage, and
+                // timing-based exfiltration from rendered ChordPro
+                // content. See issue #1828 and sanitizer-security.md
+                // §SVG tag blocklists.
+                if is_use_tag
+                    && (attr_name.eq_ignore_ascii_case("href")
+                        || attr_name.eq_ignore_ascii_case("xlink:href"))
+                    && !val.trim_start().starts_with('#')
+                {
                     continue;
                 }
             }
@@ -3561,6 +3580,40 @@ mod delegate_tests {
         assert!(
             html.contains("href=\"#myShape\""),
             "fragment-only href must be preserved"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_use_external_https() {
+        // Per #1828, <use href="https://..."> is a tracker/exfiltration
+        // vector even over safe schemes (referer leakage, cross-origin
+        // tracking pixel). Only fragment-only references ^# are allowed.
+        let input = "{start_of_svg}\n<svg><use href=\"https://attacker.example.com/x.svg#sym\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("attacker.example.com"),
+            "external https: URI in <use href> must be stripped; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_strips_use_external_xlink_href() {
+        // Same policy for the legacy xlink:href attribute.
+        let input = "{start_of_svg}\n<svg><use xlink:href=\"https://tracker.example/pixel.svg\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            !html.contains("tracker.example"),
+            "external https: URI in <use xlink:href> must be stripped; got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_svg_section_preserves_fragment_xlink_href() {
+        let input = "{start_of_svg}\n<svg><use xlink:href=\"#mySymbol\"/></svg>\n{end_of_svg}";
+        let html = render(input);
+        assert!(
+            html.contains("xlink:href=\"#mySymbol\""),
+            "fragment-only xlink:href must be preserved"
         );
     }
 


### PR DESCRIPTION
## What

Two sanitizer defense-in-depth fixes bundled because both touch the same review lens (blocklist / attribute policy) and both follow the same fix-propagation audit procedure:

### #1828 — HTML sanitizer: restrict \`<use>\` hrefs to fragment-only

\`crates/render-html/src/lib.rs\`: when the sibling tag is \`<use>\` (or \`<svg:use>\`), \`href\` and \`xlink:href\` may only reference an in-document fragment (\`^#...\`). External URIs are stripped — including over https — because they allow:

- Referer leakage (identifies who is viewing the rendered ChordPro)
- Cross-origin tracking-pixel behavior
- Timing-based data exfiltration

Preserves the common \`<use href=\"#symbol\"/>\` pattern used with SVG \`<symbol>\` definitions.

Stale comment in \`sanitize_svg_content\` updated to reflect the new policy.

### #1844 — Lilypond: extend \`DANGEROUS_SCHEME_FUNCTIONS\`

\`crates/core/src/external_tool.rs\`: add \`ly:gulp-string\`, bare \`gulp-string\`, \`ly:format\`, and \`ly:exit\` to the Lilypond Scheme function blocklist with inline citations. The primary security boundary remains \`-dsafe\`; this is strictly backup per the issue's rationale.

## Sister-site audit

Per \`.claude/rules/fix-propagation.md\`:

- **<use> fix** — text and PDF renderers do not emit or sanitize SVG markup, so the policy is HTML-only. Verified via grep.
- **Lilypond blocklist** — \`abc2svg\` and \`musescore\` have independent stripping logic; reviewed both and confirmed the new function names are not applicable to their input languages.

## Test

- \`cargo test -p chordsketch-render-html --lib\` — 206 passed (3 new: \`_strips_use_external_https\`, \`_strips_use_external_xlink_href\`, \`_preserves_fragment_xlink_href\`).
- \`cargo test -p chordsketch-core --lib external_tool\` — 53 passed (3 new: \`_strips_gulp_string\`, \`_strips_ly_format\`, \`_strips_ly_exit\`).
- \`cargo fmt --check\` / \`cargo clippy --workspace -- -D warnings\` both clean.

Closes #1828
Closes #1844