### PR TITLE
docs: raise crate READMEs to L2 and translate Japanese comment (#1823, #1841, #1843)

### DIFF
--- a/ci/version-skew-allowlist.toml
+++ b/ci/version-skew-allowlist.toml
@@ -9,9 +9,10 @@
 # tracking that retirement.
 #
 # EVERY ENTRY MUST HAVE A NON-EMPTY `tracking_issue` FIELD. The check script
-# fails validation if any entry is missing it. This rule exists because the
-# user explicitly asked: "allowlistの更新を忘れないように skip してるやつは 1
-# つずつ issue にしておいてね" (issue #1506). No skip without a paper trail.
+# fails validation if any entry is missing it. The user asked, when this
+# allowlist was introduced (#1506), that every skip be filed as its own
+# issue so the allowlist cannot silently rot — no skip without a paper
+# trail.
 #
 # Removal discipline: the PR that meets an entry's `expires_at` condition MUST
 # remove the entry AND close the tracking issue in the same diff. The check

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -33,6 +33,13 @@ assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
 
 [API documentation on docs.rs](https://docs.rs/chordsketch-core)
 
+## Links
+
+- Project repository: <https://github.com/koedame/chordsketch>
+- Live playground: <https://chordsketch.koeda.me>
+- API docs: <https://docs.rs/chordsketch-core>
+- Issue tracker: <https://github.com/koedame/chordsketch/issues>
+
 ## License
 
 [MIT](../../LICENSE)

--- a/crates/render-html/README.md
+++ b/crates/render-html/README.md
@@ -35,6 +35,13 @@ let html = render_song(&song);
 
 [API documentation on docs.rs](https://docs.rs/chordsketch-render-html)
 
+## Links
+
+- Project repository: <https://github.com/koedame/chordsketch>
+- Live playground: <https://chordsketch.koeda.me>
+- API docs: <https://docs.rs/chordsketch-render-html>
+- Issue tracker: <https://github.com/koedame/chordsketch/issues>
+
 ## License
 
 [MIT](../../LICENSE)

--- a/crates/render-pdf/README.md
+++ b/crates/render-pdf/README.md
@@ -36,6 +36,13 @@ std::fs::write("output.pdf", &pdf_bytes).unwrap();
 
 [API documentation on docs.rs](https://docs.rs/chordsketch-render-pdf)
 
+## Links
+
+- Project repository: <https://github.com/koedame/chordsketch>
+- Live playground: <https://chordsketch.koeda.me>
+- API docs: <https://docs.rs/chordsketch-render-pdf>
+- Issue tracker: <https://github.com/koedame/chordsketch/issues>
+
 ## License
 
 [MIT](../../LICENSE)

--- a/crates/render-text/README.md
+++ b/crates/render-text/README.md
@@ -33,6 +33,13 @@ println!("{text}");
 
 [API documentation on docs.rs](https://docs.rs/chordsketch-render-text)
 
+## Links
+
+- Project repository: <https://github.com/koedame/chordsketch>
+- Live playground: <https://chordsketch.koeda.me>
+- API docs: <https://docs.rs/chordsketch-render-text>
+- Issue tracker: <https://github.com/koedame/chordsketch/issues>
+
 ## License
 
 [MIT](../../LICENSE)

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -1,16 +1,32 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/koedame/chordsketch/main/assets/logo.svg" alt="ChordSketch" width="80" height="80">
+</p>
+
 # chordsketch-wasm
 
-WebAssembly bindings for [ChordSketch](https://github.com/koedame/chordsketch),
-exposing ChordPro parsing and rendering to JavaScript/TypeScript.
+The Rust-side WebAssembly bindings crate for [ChordSketch](https://github.com/koedame/chordsketch).
+It wraps `chordsketch-core` and the three renderers with `wasm-bindgen`
+entry points that are consumed from JavaScript/TypeScript.
 
-## API
+**If you want to use ChordSketch from Node.js or a browser, install
+[`@chordsketch/wasm`](https://www.npmjs.com/package/@chordsketch/wasm)
+from npm instead.** That package is built from this crate and ships the
+dual-package (ESM + CommonJS) layout, type definitions, and pre-compiled
+`.wasm` binary. This crate is the source this README lives next to; it
+is published to crates.io primarily so that `docs.rs` can render the
+Rust-side API and so that other Rust crates can compile the same bindings
+with different `wasm-pack` targets if needed.
 
-### Basic rendering
+Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
+
+## JavaScript/TypeScript usage (npm)
+
+```bash
+npm install @chordsketch/wasm
+```
 
 ```js
-import init, { render_html, render_text, render_pdf, version } from '@chordsketch/wasm';
-
-await init();
+import { render_html, render_text, render_pdf, version } from '@chordsketch/wasm';
 
 const chordpro = `{title: Amazing Grace}
 {key: G}
@@ -23,25 +39,44 @@ const pdfBytes = render_pdf(chordpro); // Uint8Array
 console.log(version());
 ```
 
-### Rendering with options
+See [`packages/npm/README.md`](https://github.com/koedame/chordsketch/blob/main/packages/npm/README.md)
+for browser-vs-Node specifics, options (`transpose`, `config`), and the
+dual-package resolution rules.
 
-```js
-import init, { render_html_with_options } from '@chordsketch/wasm';
-
-await init();
-
-const html = render_html_with_options(input, {
-  transpose: 2,            // semitone offset (-12 to +12)
-  config: 'ukulele',       // preset name or inline RRJSON
-});
-```
-
-## Building
+## Building the crate locally (Rust developers only)
 
 ```bash
 wasm-pack build crates/wasm --target web
 ```
 
+The canonical build script used by the playground and npm publishing is
+`packages/npm/scripts/build.mjs` (runs `wasm-pack` twice — once for the
+browser target and once for the Node target — and merges the output into
+a dual-package layout).
+
+## API
+
+The exported wasm-bindgen functions are:
+
+| Function | Description | Return type |
+|---|---|---|
+| `render_text(input)` | Render ChordPro to plain text | `string` |
+| `render_html(input)` | Render ChordPro to HTML5 | `string` |
+| `render_pdf(input)` | Render ChordPro to a PDF byte array | `Uint8Array` |
+| `render_text_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `string` |
+| `render_html_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `string` |
+| `render_pdf_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `Uint8Array` |
+| `render_songs_with_warnings(input, opts?)` | Multi-song variant that returns warnings | `{ songs: string[], warnings: Warning[] }` |
+| `version()` | Library version string | `string` |
+
+## Links
+
+- Project repository: <https://github.com/koedame/chordsketch>
+- npm package: <https://www.npmjs.com/package/@chordsketch/wasm>
+- Live playground: <https://chordsketch.koeda.me>
+- API docs: <https://docs.rs/chordsketch-wasm>
+- Issue tracker: <https://github.com/koedame/chordsketch/issues>
+
 ## License
 
-MIT
+[MIT](../../LICENSE)


### PR DESCRIPTION
## What

Docs-only batch addressing three low-priority package-documentation gaps surfaced by the v0.2.2 release \`/doc-quality-check\`:

- **#1823** — Full rewrite of \`crates/wasm/README.md\` to L2. New framing: this is the *source* crate; the user-facing consumer artifact is \`@chordsketch/wasm\` on npm. Adds the L2 template elements (logo, tabular API, Links) and points JS/TS consumers directly at the npm package README for browser/Node resolution details.
- **#1841** — Appends the canonical Links section to \`core\`, \`render-text\`, \`render-html\`, \`render-pdf\` crate READMEs so every published crate reaches uniform L2.
- **#1843** — Replaces the inline Japanese quotation in \`ci/version-skew-allowlist.toml\` with an English paraphrase. The referenced issue number (#1506) is preserved.

## Why

The \`package-documentation.md\` rule requires every published package to reach L2 before release. \`doc-quality-check\` flagged these four crate READMEs and the wasm crate as L1, plus \`english-only.md\` flagged the Japanese comment. Bundling them avoids three near-identical docs PRs.

## Sister-site audit

- All four renderer / core READMEs received the same Links block — same ordering, same labels, pointing at each crate's own docs.rs page.
- \`crates/convert-musicxml\`, \`crates/lsp\`, \`crates/napi\`, \`crates/ffi\` already reach L2 per #1841 and were verified to already contain a Links section.
- Japanese quote audit on the rest of the repo came up clean; no other \`english-only.md\` violations to fix here.

## Test

- Docs-only changes; no code paths touched.
- \`ci/version-skew-allowlist.toml\` remains valid TOML (comment-only edit).

Closes #1823
Closes #1841
Closes #1843