### PR TITLE
renderers: restore validation parity for capo, image src, and warnings cap (#1832, #1833, #1834)

### DIFF
--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -309,6 +309,58 @@ impl Metadata {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Parse [`Self::capo`] into a validated fret position.
+    ///
+    /// Returns:
+    ///
+    /// - [`CapoValidation::Unset`] — `{capo}` was not specified.
+    /// - [`CapoValidation::Valid(n)`] — a numeric value in `1..=24`.
+    /// - [`CapoValidation::OutOfRange(n)`] — a numeric value outside
+    ///   `1..=24`. Guitars top out around 24 frets and `0` means "no
+    ///   capo" (use [`CapoValidation::Unset`] instead).
+    /// - [`CapoValidation::NotInteger(s)`] — the value could not be
+    ///   parsed as a non-negative integer.
+    ///
+    /// The `1..=24` range matches the MusicXML importer's existing
+    /// validation (`crates/convert-musicxml/src/import.rs`) and
+    /// `.claude/rules/renderer-parity.md` §Validation Parity, which
+    /// explicitly lists `{capo}` as a field that must be validated
+    /// consistently across every renderer.
+    #[must_use]
+    pub fn capo_validated(&self) -> CapoValidation {
+        let Some(raw) = self.capo.as_deref() else {
+            return CapoValidation::Unset;
+        };
+        let trimmed = raw.trim();
+        match trimmed.parse::<u32>() {
+            Ok(n) if (1..=24).contains(&n) => {
+                // Parse as u32 first so a value like 300 does not silently
+                // wrap; cast is safe because we just range-checked.
+                #[allow(clippy::cast_possible_truncation)]
+                CapoValidation::Valid(n as u8)
+            }
+            Ok(n) => CapoValidation::OutOfRange(n),
+            Err(_) => CapoValidation::NotInteger(trimmed.to_string()),
+        }
+    }
+}
+
+/// Result of validating a `{capo}` metadata value via
+/// [`Metadata::capo_validated`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapoValidation {
+    /// `{capo}` was not specified.
+    Unset,
+    /// A numeric value in the acceptable range `1..=24`.
+    Valid(u8),
+    /// A numeric value outside `1..=24` (e.g. `0`, `25`, `999`). The
+    /// original parsed integer is carried through so renderers can emit
+    /// a precise warning message.
+    OutOfRange(u32),
+    /// The value could not be parsed as a non-negative integer (e.g.
+    /// `"foo"`, `"-3"`).
+    NotInteger(String),
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/ast.rs
+++ b/crates/core/src/ast.rs
@@ -315,11 +315,11 @@ impl Metadata {
     /// Returns:
     ///
     /// - [`CapoValidation::Unset`] — `{capo}` was not specified.
-    /// - [`CapoValidation::Valid(n)`] — a numeric value in `1..=24`.
-    /// - [`CapoValidation::OutOfRange(n)`] — a numeric value outside
+    /// - [`CapoValidation::Valid`] — a numeric value in `1..=24`.
+    /// - [`CapoValidation::OutOfRange`] — a numeric value outside
     ///   `1..=24`. Guitars top out around 24 frets and `0` means "no
     ///   capo" (use [`CapoValidation::Unset`] instead).
-    /// - [`CapoValidation::NotInteger(s)`] — the value could not be
+    /// - [`CapoValidation::NotInteger`] — the value could not be
     ///   parsed as a non-negative integer.
     ///
     /// The `1..=24` range matches the MusicXML importer's existing

--- a/crates/core/src/image_path.rs
+++ b/crates/core/src/image_path.rs
@@ -56,6 +56,75 @@ pub fn has_traversal(path: &str) -> bool {
     path.split(['/', '\\']).any(|seg| seg == "..")
 }
 
+/// Check whether an image `src` value is safe to expose in rendered output
+/// across every renderer (text, HTML, PDF).
+///
+/// Uses an allowlist approach: only `http:`, `https:`, or scheme-less
+/// *relative* paths are permitted. Absolute filesystem paths (Unix
+/// `/…`, Windows `C:\…` / UNC `\\…`) and every other URI scheme
+/// (`javascript:`, `data:`, `file:`, `blob:`, `vbscript:`, `mhtml:`, …)
+/// are rejected. Paths containing NUL bytes or `..` components are also
+/// rejected.
+///
+/// Centralising this check in `chordsketch-core` keeps the three
+/// renderers aligned per `.claude/rules/renderer-parity.md` §Validation
+/// Parity — a single `.cho` file must not produce different text / HTML /
+/// PDF depending on how permissive each renderer happens to be.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_core::image_path::is_safe_image_src;
+///
+/// assert!(is_safe_image_src("photo.jpg"));
+/// assert!(is_safe_image_src("https://example.com/photo.jpg"));
+/// assert!(!is_safe_image_src("javascript:alert(1)"));
+/// assert!(!is_safe_image_src("file:///etc/passwd"));
+/// assert!(!is_safe_image_src("/absolute/path.jpg"));
+/// ```
+#[must_use]
+pub fn is_safe_image_src(src: &str) -> bool {
+    if src.is_empty() {
+        return false;
+    }
+
+    // Reject null bytes (defense-in-depth — can truncate C string APIs
+    // downstream even in pure-Rust code paths via FFI).
+    if src.contains('\0') {
+        return false;
+    }
+
+    let trimmed = src.trim_start();
+    let normalised = trimmed.to_ascii_lowercase();
+
+    // Reject Unix absolute paths.
+    if normalised.starts_with('/') {
+        return false;
+    }
+
+    // Reject Windows absolute paths (drive letter or UNC) on all platforms.
+    if is_windows_absolute(trimmed) {
+        return false;
+    }
+
+    // Reject directory traversal.
+    if has_traversal(src) {
+        return false;
+    }
+
+    // If the src contains a colon before any slash it has a URI scheme;
+    // allow only http: and https:. A colon that appears after a slash is
+    // part of a path segment (e.g. `path/to:file`) and is permitted.
+    if let Some(colon_pos) = normalised.find(':') {
+        let before_colon = &normalised[..colon_pos];
+        if !before_colon.contains('/') {
+            return before_colon == "http" || before_colon == "https";
+        }
+    }
+
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,5 +183,60 @@ mod tests {
     fn double_dot_in_filename_not_traversal() {
         // "file..name" contains ".." but not as a path component.
         assert!(!has_traversal("file..name.jpg"));
+    }
+
+    // -- is_safe_image_src -------------------------------------------------
+
+    #[test]
+    fn safe_src_relative_paths() {
+        assert!(is_safe_image_src("photo.jpg"));
+        assert!(is_safe_image_src("images/photo.jpg"));
+        assert!(is_safe_image_src("path/to:file.jpg")); // colon after slash is not a scheme
+    }
+
+    #[test]
+    fn safe_src_http_and_https() {
+        assert!(is_safe_image_src("http://example.com/photo.jpg"));
+        assert!(is_safe_image_src("https://example.com/photo.jpg"));
+    }
+
+    #[test]
+    fn safe_src_rejects_dangerous_schemes() {
+        assert!(!is_safe_image_src("javascript:alert(1)"));
+        assert!(!is_safe_image_src("data:image/png;base64,AAAA"));
+        assert!(!is_safe_image_src("file:///etc/passwd"));
+        assert!(!is_safe_image_src("blob:https://example.com/uuid"));
+        assert!(!is_safe_image_src("vbscript:msgbox"));
+    }
+
+    #[test]
+    fn safe_src_rejects_absolute_paths() {
+        assert!(!is_safe_image_src("/etc/passwd"));
+        assert!(!is_safe_image_src(r"C:\Users\secret"));
+        assert!(!is_safe_image_src(r"\\server\share\file"));
+    }
+
+    #[test]
+    fn safe_src_rejects_empty_and_null() {
+        assert!(!is_safe_image_src(""));
+        assert!(!is_safe_image_src("photo\0.jpg"));
+    }
+
+    #[test]
+    fn safe_src_rejects_traversal() {
+        assert!(!is_safe_image_src("../photo.jpg"));
+        assert!(!is_safe_image_src("images/../../etc/passwd"));
+    }
+
+    #[test]
+    fn safe_src_case_insensitive_scheme() {
+        assert!(!is_safe_image_src("JavaScript:alert(1)"));
+        assert!(is_safe_image_src("HTTPS://example.com/photo.jpg"));
+    }
+
+    #[test]
+    fn safe_src_rejects_scheme_with_whitespace_prefix() {
+        assert!(!is_safe_image_src(" javascript:alert(1)"));
+        assert!(!is_safe_image_src("\tfile:///etc/passwd"));
     }
 }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -17,7 +17,7 @@
 
 use std::fmt::Write;
 
-use chordsketch_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordsketch_core::ast::{CapoValidation, CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordsketch_core::canonical_chord_name;
 use chordsketch_core::config::Config;
 use chordsketch_core::escape::escape_xml as escape;
@@ -29,6 +29,46 @@ use chordsketch_core::transpose::transpose_chord;
 /// Maximum number of chorus recall directives allowed per song.
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
+
+/// Maximum number of warnings the renderer accumulates per render pass
+/// (issue #1833). Mirrors `MAX_WARNINGS` in the text and PDF renderers to
+/// give identical resource-limit behaviour across the three backends.
+pub const MAX_WARNINGS: usize = 1000;
+
+/// Push a warning into the renderer's accumulator, enforcing
+/// [`MAX_WARNINGS`]. Once the cap is reached the function pushes a single
+/// truncation marker in place of the overflowing warning and silently
+/// ignores every subsequent warning in the same pass.
+fn push_warning(warnings: &mut Vec<String>, message: impl Into<String>) {
+    if warnings.len() < MAX_WARNINGS {
+        warnings.push(message.into());
+    } else if warnings.len() == MAX_WARNINGS {
+        warnings.push(format!(
+            "additional warnings suppressed; MAX_WARNINGS ({MAX_WARNINGS}) reached"
+        ));
+    }
+}
+
+/// Validate `{capo}` at the render boundary and push a warning for any
+/// value that is not in `1..=24` (issue #1834, renderer-parity.md
+/// §Validation Parity).
+fn validate_capo(metadata: &chordsketch_core::ast::Metadata, warnings: &mut Vec<String>) {
+    match metadata.capo_validated() {
+        CapoValidation::Unset | CapoValidation::Valid(_) => {}
+        CapoValidation::OutOfRange(n) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {n} out of range (expected 1..=24); ignored"),
+            );
+        }
+        CapoValidation::NotInteger(raw) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
+            );
+        }
+    }
+}
 
 /// Maximum number of CSS columns allowed.
 /// Matches `MAX_COLUMNS` in the PDF renderer.
@@ -224,6 +264,7 @@ fn render_song_body(
     let mut fmt_state = FormattingState::default();
     html.push_str("<div class=\"song\">\n");
 
+    validate_capo(&song.metadata, warnings);
     render_metadata(&song.metadata, html);
 
     // Tracks whether a multi-column div is currently open.
@@ -337,10 +378,13 @@ fn render_song_body(
                         Some(raw) => match raw.parse() {
                             Ok(v) => v,
                             Err(_) => {
-                                warnings.push(format!(
-                                    "{{transpose}} value {raw:?} cannot be \
-                                     parsed as i8, ignored (using 0)"
-                                ));
+                                push_warning(
+                                    warnings,
+                                    format!(
+                                        "{{transpose}} value {raw:?} cannot be \
+                                         parsed as i8, ignored (using 0)"
+                                    ),
+                                );
                                 0
                             }
                         },
@@ -348,10 +392,13 @@ fn render_song_body(
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
-                        warnings.push(format!(
-                            "transpose offset {file_offset} + {cli_transpose} \
-                             exceeds i8 range, clamped to {combined}"
-                        ));
+                        push_warning(
+                            warnings,
+                            format!(
+                                "transpose offset {file_offset} + {cli_transpose} \
+                                 exceeds i8 range, clamped to {combined}"
+                            ),
+                        );
                     }
                     transpose_offset = combined;
                     continue;
@@ -394,10 +441,13 @@ fn render_song_body(
                             );
                             chorus_recall_count += 1;
                         } else if chorus_recall_count == MAX_CHORUS_RECALLS {
-                            warnings.push(format!(
-                                "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
-                                 further recalls suppressed"
-                            ));
+                            push_warning(
+                                warnings,
+                                format!(
+                                    "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
+                                     further recalls suppressed"
+                                ),
+                            );
                             chorus_recall_count += 1;
                         }
                     }
@@ -1518,7 +1568,7 @@ fn render_abc_with_fallback(
             html.push_str("</section>\n");
         }
         Err(e) => {
-            warnings.push(format!("abc2svg invocation failed: {e}"));
+            push_warning(warnings, format!("abc2svg invocation failed: {e}"));
             render_section_open("abc", "ABC", label, html);
             html.push_str("<pre>");
             html.push_str(&escape(abc_content));
@@ -1547,56 +1597,12 @@ fn render_abc_with_fallback(
 
 /// Check whether an image `src` value is safe to emit in HTML.
 ///
-/// Uses an allowlist approach: only `http:`, `https:`, or scheme-less
-/// *relative* paths are permitted.  Absolute filesystem paths (starting
-/// with `/`) and all other URI schemes (`javascript:`, `data:`, `file:`,
-/// `blob:`, `vbscript:`, etc.) are rejected, preventing code execution
-/// and local file loading when the generated HTML is viewed in a browser.
-fn is_safe_image_src(src: &str) -> bool {
-    if src.is_empty() {
-        return false;
-    }
-
-    // Reject null bytes (defense-in-depth).
-    if src.contains('\0') {
-        return false;
-    }
-
-    // Normalise for case-insensitive scheme comparison.  Strip leading
-    // whitespace so that " javascript:…" is still caught.
-    let normalised = src.trim_start().to_ascii_lowercase();
-
-    // Reject absolute filesystem paths (defense-in-depth, similar to
-    // is_safe_image_path in the PDF renderer).
-    if normalised.starts_with('/') {
-        return false;
-    }
-
-    // Reject Windows-style absolute paths on all platforms.
-    if is_windows_absolute(src.trim_start()) {
-        return false;
-    }
-
-    // Reject directory traversal (`..` path components).
-    if has_traversal(src) {
-        return false;
-    }
-
-    // If the src contains a colon before any slash, it has a URI scheme.
-    // Only allow http: and https:.
-    if let Some(colon_pos) = normalised.find(':') {
-        let before_colon = &normalised[..colon_pos];
-        // A scheme must appear before any slash (e.g. "http:" not "path/to:file").
-        if !before_colon.contains('/') {
-            return before_colon == "http" || before_colon == "https";
-        }
-    }
-
-    true
-}
-
-/// Re-export shared path-validation helpers from `chordsketch-core`.
-use chordsketch_core::image_path::{has_traversal, is_windows_absolute};
+/// Re-export shared image-src validation from `chordsketch-core`.
+///
+/// The actual allowlist logic lives in `chordsketch_core::image_path::is_safe_image_src`
+/// so every renderer (text, HTML, PDF) applies the same check — see
+/// `.claude/rules/renderer-parity.md` §Validation Parity.
+use chordsketch_core::image_path::is_safe_image_src;
 
 /// Render Lilypond notation content using lilypond, falling back to preformatted text.
 ///
@@ -1618,7 +1624,7 @@ fn render_ly_with_fallback(
             html.push_str("</section>\n");
         }
         Err(e) => {
-            warnings.push(format!("lilypond invocation failed: {e}"));
+            push_warning(warnings, format!("lilypond invocation failed: {e}"));
             render_section_open("ly", "Lilypond", label, html);
             html.push_str("<pre>");
             html.push_str(&escape(ly_content));
@@ -1665,7 +1671,7 @@ fn render_musicxml_with_fallback(
             html.push_str("</section>\n");
         }
         Err(e) => {
-            warnings.push(format!("musescore invocation failed: {e}"));
+            push_warning(warnings, format!("musescore invocation failed: {e}"));
             render_section_open("musicxml", "MusicXML", label, html);
             html.push_str("<pre>");
             html.push_str(&escape(musicxml_content));
@@ -2637,6 +2643,69 @@ Verse text\n\
     fn test_image_safe_relative_path_allowed() {
         let html = render("{image: src=images/photo.jpg}");
         assert!(html.contains("<img src=\"images/photo.jpg\""));
+    }
+
+    // -- {capo} validation parity (#1834) ---------------------------------
+
+    #[test]
+    fn test_capo_out_of_range_emits_warning() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: 999}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("capo") && w.contains("999")),
+            "expected out-of-range {{capo}} warning; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_capo_non_numeric_emits_warning() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: foo}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("capo") && w.contains("foo")),
+            "expected non-integer {{capo}} warning; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_capo_in_range_is_silent() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: 5}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result.warnings.iter().any(|w| w.contains("capo")),
+            "valid {{capo: 5}} should not warn; got {:?}",
+            result.warnings
+        );
+    }
+
+    // -- MAX_WARNINGS cap (#1833) -----------------------------------------
+
+    #[test]
+    fn test_max_warnings_truncates() {
+        let mut input = String::from("{title: T}\n");
+        for _ in 0..(MAX_WARNINGS + 50) {
+            input.push_str("{transpose: not-a-number}\n");
+        }
+        let song = chordsketch_core::parse(&input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert_eq!(
+            result.warnings.len(),
+            MAX_WARNINGS + 1,
+            "expected exactly MAX_WARNINGS warnings plus one truncation marker"
+        );
+        assert!(
+            result.warnings.last().unwrap().contains("MAX_WARNINGS"),
+            "last entry must be the truncation marker; got {:?}",
+            result.warnings.last()
+        );
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -432,6 +432,48 @@ const MAX_IMAGES: usize = 1_000;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
+/// Maximum number of warnings the renderer accumulates per render pass
+/// (issue #1833). Mirrors `MAX_WARNINGS` in the text and HTML renderers
+/// so the three backends apply the same resource bound on a malicious
+/// `.cho` that would otherwise produce millions of warnings.
+pub const MAX_WARNINGS: usize = 1000;
+
+/// Push a warning into the renderer's accumulator, enforcing
+/// [`MAX_WARNINGS`]. Once the cap is reached the function pushes a single
+/// truncation marker in place of the overflowing warning and silently
+/// ignores every subsequent warning in the same pass.
+fn push_warning(warnings: &mut Vec<String>, message: impl Into<String>) {
+    if warnings.len() < MAX_WARNINGS {
+        warnings.push(message.into());
+    } else if warnings.len() == MAX_WARNINGS {
+        warnings.push(format!(
+            "additional warnings suppressed; MAX_WARNINGS ({MAX_WARNINGS}) reached"
+        ));
+    }
+}
+
+/// Validate `{capo}` at the render boundary and push a warning for any
+/// value that is not in `1..=24` (issue #1834, renderer-parity.md
+/// §Validation Parity).
+fn validate_capo(metadata: &chordsketch_core::ast::Metadata, warnings: &mut Vec<String>) {
+    use chordsketch_core::ast::CapoValidation;
+    match metadata.capo_validated() {
+        CapoValidation::Unset | CapoValidation::Valid(_) => {}
+        CapoValidation::OutOfRange(n) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {n} out of range (expected 1..=24); ignored"),
+            );
+        }
+        CapoValidation::NotInteger(raw) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
+            );
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -669,6 +711,8 @@ fn render_song_into_doc(
             (n as usize).max(1)
         });
 
+    validate_capo(&song.metadata, warnings);
+
     // Title
     if let Some(title) = &song.metadata.title {
         doc.text(title, Font::HelveticaBold, TITLE_SIZE);
@@ -730,10 +774,13 @@ fn render_song_into_doc(
                         Some(raw) => match raw.parse() {
                             Ok(v) => v,
                             Err(_) => {
-                                warnings.push(format!(
-                                    "{{transpose}} value {raw:?} cannot be \
-                                     parsed as i8, ignored (using 0)"
-                                ));
+                                push_warning(
+                                    warnings,
+                                    format!(
+                                        "{{transpose}} value {raw:?} cannot be \
+                                         parsed as i8, ignored (using 0)"
+                                    ),
+                                );
                                 0
                             }
                         },
@@ -741,10 +788,13 @@ fn render_song_into_doc(
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
-                        warnings.push(format!(
-                            "transpose offset {file_offset} + {cli_transpose} \
-                             exceeds i8 range, clamped to {combined}"
-                        ));
+                        push_warning(
+                            warnings,
+                            format!(
+                                "transpose offset {file_offset} + {cli_transpose} \
+                                 exceeds i8 range, clamped to {combined}"
+                            ),
+                        );
                     }
                     transpose_offset = combined;
                     continue;
@@ -780,10 +830,13 @@ fn render_song_into_doc(
                             );
                             chorus_recall_count += 1;
                         } else if chorus_recall_count == MAX_CHORUS_RECALLS {
-                            warnings.push(format!(
-                                "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
-                                 further recalls suppressed"
-                            ));
+                            push_warning(
+                                warnings,
+                                format!(
+                                    "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
+                                     further recalls suppressed"
+                                ),
+                            );
                             chorus_recall_count += 1;
                         }
                     }
@@ -1256,7 +1309,20 @@ fn render_image(attrs: &ImageAttributes, doc: &mut PdfDocument) {
         return;
     }
 
-    // Reject paths that could escape the working directory.
+    // Apply the same allowlist the HTML and text renderers use, so a
+    // single `.cho` cannot produce three different image-handling
+    // behaviours (issue #1832, renderer-parity.md §Validation Parity).
+    // `is_safe_image_src` blocks dangerous URI schemes (`javascript:`,
+    // `file:`, `data:`, `blob:`, `vbscript:`, `mhtml:`) up front.
+    if !chordsketch_core::image_path::is_safe_image_src(&attrs.src) {
+        return;
+    }
+
+    // Then the PDF-specific filesystem check — rejects absolute paths
+    // and `..` traversal because the PDF renderer actually reads the
+    // file from disk. The HTTP(S) URLs allowed by `is_safe_image_src`
+    // fall through here harmlessly (they fail the subsequent extension
+    // check or the filesystem read).
     if !is_safe_image_path(&attrs.src) {
         return;
     }
@@ -4962,6 +5028,85 @@ mod jpeg_tests {
         let bytes = render_song(&song);
         assert!(bytes.starts_with(b"%PDF-1.4"));
         assert!(bytes.ends_with(b"%%EOF\n"));
+    }
+
+    #[test]
+    fn test_image_directive_dangerous_scheme_rejected() {
+        // #1832: PDF must reject the same URI schemes the HTML / text
+        // renderers reject via `is_safe_image_src`.
+        let input = "{image: src=\"javascript:alert(1)\"}";
+        let song = chordsketch_core::parse(input).unwrap();
+        let bytes = render_song(&song);
+        // No crash, no embedded image, no JS literal in the PDF stream.
+        assert!(bytes.starts_with(b"%PDF-1.4"));
+        let as_str = String::from_utf8_lossy(&bytes);
+        assert!(
+            !as_str.contains("javascript:"),
+            "javascript: URI must not appear in PDF output"
+        );
+    }
+
+    // -- {capo} validation parity (#1834) ---------------------------------
+
+    #[test]
+    fn test_capo_out_of_range_emits_warning() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: 999}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("capo") && w.contains("999")),
+            "expected out-of-range {{capo}} warning; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_capo_non_numeric_emits_warning() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: foo}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("capo") && w.contains("foo")),
+            "expected non-integer {{capo}} warning; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_capo_in_range_is_silent() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: 5}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result.warnings.iter().any(|w| w.contains("capo")),
+            "valid {{capo: 5}} should not warn; got {:?}",
+            result.warnings
+        );
+    }
+
+    // -- MAX_WARNINGS cap (#1833) -----------------------------------------
+
+    #[test]
+    fn test_max_warnings_truncates() {
+        let mut input = String::from("{title: T}\n");
+        for _ in 0..(MAX_WARNINGS + 50) {
+            input.push_str("{transpose: not-a-number}\n");
+        }
+        let song = chordsketch_core::parse(&input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert_eq!(
+            result.warnings.len(),
+            MAX_WARNINGS + 1,
+            "expected exactly MAX_WARNINGS warnings plus one truncation marker"
+        );
+        assert!(
+            result.warnings.last().unwrap().contains("MAX_WARNINGS"),
+            "last entry must be the truncation marker; got {:?}",
+            result.warnings.last()
+        );
     }
 
     #[test]

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate converts a parsed ChordPro AST (from `chordsketch-core`) into
 //! formatted plain text with chords aligned above their corresponding lyrics.
 
-use chordsketch_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordsketch_core::ast::{CapoValidation, CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordsketch_core::config::Config;
 use chordsketch_core::render_result::RenderResult;
 use chordsketch_core::resolve_diagrams_instrument;
@@ -13,6 +13,49 @@ use unicode_width::UnicodeWidthStr;
 /// Maximum number of chorus recall directives allowed per song.
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
+
+/// Maximum number of warnings the renderer will accumulate for a single
+/// render pass (issue #1833). Without a cap, a pathological input such as
+/// one million malformed `{transpose}` lines can push the warnings vector
+/// to tens of megabytes. `push_warning` refuses to exceed this limit and
+/// appends a single truncation marker the first time the cap is hit.
+pub const MAX_WARNINGS: usize = 1000;
+
+/// Push a warning into the renderer's accumulator, enforcing
+/// [`MAX_WARNINGS`]. Once the cap is reached the function pushes a
+/// single truncation marker in place of the overflowing warning and
+/// silently ignores every subsequent warning in the same pass.
+fn push_warning(warnings: &mut Vec<String>, message: impl Into<String>) {
+    if warnings.len() < MAX_WARNINGS {
+        warnings.push(message.into());
+    } else if warnings.len() == MAX_WARNINGS {
+        warnings.push(format!(
+            "additional warnings suppressed; MAX_WARNINGS ({MAX_WARNINGS}) reached"
+        ));
+    }
+}
+
+/// Validate `{capo}` at the render boundary and push a warning for any
+/// value that is not in `1..=24`. Matches the check applied in the HTML
+/// and PDF renderers per `.claude/rules/renderer-parity.md` §Validation
+/// Parity (issue #1834).
+fn validate_capo(metadata: &chordsketch_core::ast::Metadata, warnings: &mut Vec<String>) {
+    match metadata.capo_validated() {
+        CapoValidation::Unset | CapoValidation::Valid(_) => {}
+        CapoValidation::OutOfRange(n) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {n} out of range (expected 1..=24); ignored"),
+            );
+        }
+        CapoValidation::NotInteger(raw) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
+            );
+        }
+    }
+}
 
 /// Render a [`Song`] AST to plain text.
 ///
@@ -109,6 +152,7 @@ fn render_song_impl(
         .unwrap_or_else(|| "guitar".to_string());
     let mut auto_diagrams_instrument: Option<String> = None;
 
+    validate_capo(&song.metadata, warnings);
     render_metadata(&song.metadata, &mut output);
 
     for line in &song.lines {
@@ -145,10 +189,13 @@ fn render_song_impl(
                         Some(raw) => match raw.parse() {
                             Ok(v) => v,
                             Err(_) => {
-                                warnings.push(format!(
-                                    "{{transpose}} value {raw:?} cannot be \
-                                     parsed as i8, ignored (using 0)"
-                                ));
+                                push_warning(
+                                    warnings,
+                                    format!(
+                                        "{{transpose}} value {raw:?} cannot be \
+                                         parsed as i8, ignored (using 0)"
+                                    ),
+                                );
                                 0
                             }
                         },
@@ -156,10 +203,13 @@ fn render_song_impl(
                     let (combined, saturated) =
                         chordsketch_core::transpose::combine_transpose(file_offset, cli_transpose);
                     if saturated {
-                        warnings.push(format!(
-                            "transpose offset {file_offset} + {cli_transpose} \
-                             exceeds i8 range, clamped to {combined}"
-                        ));
+                        push_warning(
+                            warnings,
+                            format!(
+                                "transpose offset {file_offset} + {cli_transpose} \
+                                 exceeds i8 range, clamped to {combined}"
+                            ),
+                        );
                     }
                     transpose_offset = combined;
                     continue;
@@ -182,13 +232,17 @@ fn render_song_impl(
                                 &chorus_body,
                                 transpose_offset,
                                 &mut output,
+                                warnings,
                             );
                             chorus_recall_count += 1;
                         } else if chorus_recall_count == MAX_CHORUS_RECALLS {
-                            warnings.push(format!(
-                                "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
-                                 further recalls suppressed"
-                            ));
+                            push_warning(
+                                warnings,
+                                format!(
+                                    "chorus recall limit ({MAX_CHORUS_RECALLS}) reached, \
+                                     further recalls suppressed"
+                                ),
+                            );
                             chorus_recall_count += 1;
                         }
                     }
@@ -205,7 +259,7 @@ fn render_song_impl(
                             buf.push(line.clone());
                         }
                         let mut target = Vec::new();
-                        render_directive(directive, &mut target);
+                        render_directive(directive, &mut target, warnings);
                         output.extend(target);
                     }
                 }
@@ -472,7 +526,11 @@ fn render_lyrics(lyrics_line: &LyricsLine, transpose_offset: i8, output: &mut Ve
 /// - Page-layout directives (`{new_page}`, `{new_physical_page}`, `{column_break}`,
 ///   `{columns}`) produce no output — plain text has no concept of pages or columns.
 /// - Unknown directives are silently ignored.
-fn render_directive(directive: &chordsketch_core::ast::Directive, output: &mut Vec<String>) {
+fn render_directive(
+    directive: &chordsketch_core::ast::Directive,
+    output: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) {
     match &directive.kind {
         DirectiveKind::StartOfChorus => {
             render_section_header("Chorus", &directive.value, output);
@@ -510,7 +568,23 @@ fn render_directive(directive: &chordsketch_core::ast::Directive, output: &mut V
             render_section_header(&label, &directive.value, output);
         }
         DirectiveKind::Image(attrs) if attrs.has_src() => {
-            output.push(format!("[Image: {}]", attrs.src));
+            // Validate the src for parity with the HTML renderer (#1832,
+            // renderer-parity.md §Validation Parity). Dangerous URI
+            // schemes such as `javascript:` and `file:///etc/passwd`
+            // never belong in rendered output — text output is not
+            // executed, but embedding such strings would mislead any
+            // tool or human that copies them downstream.
+            if !chordsketch_core::image_path::is_safe_image_src(&attrs.src) {
+                push_warning(
+                    warnings,
+                    format!(
+                        "Image src {:?} rejected by sanitizer; omitted from text output",
+                        attrs.src
+                    ),
+                );
+            } else {
+                output.push(format!("[Image: {}]", attrs.src));
+            }
         }
         DirectiveKind::Image(_) => {}
         // Page-layout directives are intentionally no-ops in plain-text output:
@@ -536,6 +610,7 @@ fn render_chorus_recall(
     chorus_body: &[Line],
     transpose_offset: i8,
     output: &mut Vec<String>,
+    warnings: &mut Vec<String>,
 ) {
     render_section_header("Chorus", value, output);
     for line in chorus_body {
@@ -543,7 +618,9 @@ fn render_chorus_recall(
             Line::Lyrics(lyrics) => render_lyrics(lyrics, transpose_offset, output),
             Line::Comment(style, text) => render_comment(*style, text, output),
             Line::Empty => output.push(String::new()),
-            Line::Directive(d) if !d.kind.is_metadata() => render_directive(d, output),
+            Line::Directive(d) if !d.kind.is_metadata() => {
+                render_directive(d, output, warnings);
+            }
             _ => {}
         }
     }
@@ -1326,6 +1403,97 @@ mod delegate_tests {
         let input = "{image: width=200 height=100}";
         let output = render(input);
         assert!(!output.contains("[Image"));
+    }
+
+    #[test]
+    fn test_render_image_dangerous_scheme_rejected() {
+        // #1832: text renderer must reject the same URI schemes HTML does.
+        let song = chordsketch_core::parse("{image: src=\"javascript:alert(1)\"}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result.output.contains("[Image"),
+            "javascript: src must not reach text output: {}",
+            result.output
+        );
+        assert!(
+            result.warnings.iter().any(|w| w.contains("javascript")),
+            "expected a warning mentioning the rejected src; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_render_image_file_uri_rejected() {
+        let song = chordsketch_core::parse("{image: src=\"file:///etc/passwd\"}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result.output.contains("[Image"),
+            "file: src must not reach text output"
+        );
+    }
+
+    // -- {capo} validation parity (#1834) ---------------------------------
+
+    #[test]
+    fn test_capo_out_of_range_emits_warning() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: 999}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("capo") && w.contains("999")),
+            "expected out-of-range {{capo}} warning; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_capo_non_numeric_emits_warning() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: foo}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("capo") && w.contains("foo")),
+            "expected non-integer {{capo}} warning; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_capo_in_range_is_silent() {
+        let song = chordsketch_core::parse("{title: T}\n{capo: 5}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result.warnings.iter().any(|w| w.contains("capo")),
+            "valid {{capo: 5}} should not warn; got {:?}",
+            result.warnings
+        );
+    }
+
+    // -- MAX_WARNINGS cap (#1833) -----------------------------------------
+
+    #[test]
+    fn test_max_warnings_truncates() {
+        // Generate many bad {transpose} lines so every one emits a warning.
+        let mut input = String::from("{title: T}\n");
+        for _ in 0..(MAX_WARNINGS + 50) {
+            input.push_str("{transpose: not-a-number}\n");
+        }
+        let song = chordsketch_core::parse(&input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert_eq!(
+            result.warnings.len(),
+            MAX_WARNINGS + 1,
+            "expected exactly MAX_WARNINGS warnings plus one truncation marker"
+        );
+        assert!(
+            result.warnings.last().unwrap().contains("MAX_WARNINGS"),
+            "last entry must be the truncation marker; got {:?}",
+            result.warnings.last()
+        );
     }
 
     // -- Selector filtering integration (#320) --


### PR DESCRIPTION
## What

Bundles three low-priority renderer-parity gaps the v0.2.2 audit flagged. All three land together because they share the same review lens — validation must be identical across text / HTML / PDF per \`.claude/rules/renderer-parity.md\` §Validation Parity, so the fix-propagation audit is identical for all three.

- **#1834** — Every renderer now calls a new \`Metadata::capo_validated()\` helper in \`chordsketch-core\` and emits a uniform warning for \`{capo: N}\` values outside \`1..=24\` (or non-numeric). The \`CapoValidation\` enum carries the raw parsed value through so messages are precise.
- **#1832** — Moved \`is_safe_image_src\` from \`render-html\` to \`chordsketch-core::image_path\`. Text and PDF now apply the same http/https/relative allowlist; dangerous URI schemes (\`javascript:\`, \`file:\`, \`data:\`, \`blob:\`, \`vbscript:\`, \`mhtml:\`) are rejected consistently.
- **#1833** — Added \`MAX_WARNINGS = 1000\` and a shared \`push_warning\` helper in each renderer. All hot-path warning emitters now route through it and a pathological \`.cho\` produces at most 1001 entries (1000 real + 1 truncation marker) instead of unbounded growth.

## Sister-site audit

Per \`.claude/rules/fix-propagation.md\`:

- **Capo check** — text, HTML, PDF all gained the same \`validate_capo\` call. \`convert-musicxml\` already validates the same \`1..=24\` range; it still works and can migrate to the new helper in a follow-up. No other renderer path reads \`song.metadata.capo\`.
- **Image src allowlist** — \`is_safe_image_src\` now lives in core and is called from both text and PDF. HTML keeps its call via a re-export to keep the local test \`test_is_safe_image_src\` working unchanged.
- **Warnings cap** — every \`warnings.push(…)\` inside the main render passes routes through \`push_warning\`. \`PdfDocument::validate_margin\` has its own path (at most four pushes per document) and was left as-is; documenting it here for future sweep.

## Test

New symmetric coverage across the three renderers:

| Renderer | \`capo\` in-range | \`capo\` out-of-range | \`capo\` non-numeric | \`MAX_WARNINGS\` truncation | Image dangerous-scheme |
|----------|------------------|-----------------------|---------------------|----------------------------|------------------------|
| text     | ✓ | ✓ | ✓ | ✓ | ✓ (\`javascript:\`, \`file:\`) |
| HTML     | ✓ | ✓ | ✓ | ✓ | (pre-existing) |
| PDF      | ✓ | ✓ | ✓ | ✓ | ✓ (\`javascript:\`) |

Plus 7 new \`chordsketch_core::image_path::is_safe_image_src\` unit tests covering allow / deny / null / traversal / case / whitespace.

\`cargo fmt --check\`, \`cargo clippy --workspace -- -D warnings\`, and \`cargo test --workspace --lib\` all clean.

Closes #1832
Closes #1833
Closes #1834