### PR TITLE
ci: keep status line first in release-verify results (#1853)

### DIFF
--- a/scripts/check-release-channels.py
+++ b/scripts/check-release-channels.py
@@ -419,9 +419,26 @@ def main() -> int:
     result = verify_channel(channel, args.tag, force_stale)
 
     status = "OK" if result.ok else "FAIL"
-    print(f"{status} {result.channel_id} expected={result.expected} observed={result.observed}")
-    if not result.ok:
-        print(f"detail: {result.detail}", file=sys.stderr)
+    # Ordering matters: the release-verify rollup (.github/workflows/release-verify.yml)
+    # reads `head -n1 result.txt` and parses `<status> <channel_id>
+    # expected=… observed=…`. Previously `detail:` was written to stderr;
+    # the workflow redirects stderr into the same file via `> out 2>&1`,
+    # and Python's unbuffered stderr landed above the block-buffered
+    # stdout, so the first line was `detail: …` and the rollup misparsed
+    # the status column (#1853).
+    #
+    # Fix both parts of the contract:
+    #   1. Always print the machine-readable status line to stdout first,
+    #      with explicit flush so the file offset reflects the write
+    #      order even when stdout is block-buffered.
+    #   2. Put the human detail on stdout on the second line (instead of
+    #      stderr) so it can't outrun the status line through a different
+    #      stream's buffering policy.
+    print(
+        f"{status} {result.channel_id} expected={result.expected} observed={result.observed}",
+        flush=True,
+    )
+    print(f"detail: {result.detail}", flush=True)
     return 0 if result.ok else 1
 
 

--- a/scripts/test_check_release_channels.py
+++ b/scripts/test_check_release_channels.py
@@ -471,5 +471,74 @@ end
         self.assertIn("not found on Maven Central", result.detail)
 
 
+class CliOutputOrderingTests(unittest.TestCase):
+    """Regression guard for #1853.
+
+    The release-verify rollup reads `head -n1 result.txt` and expects the
+    first word to be `OK` or `FAIL`. Before the fix the CLI wrote
+    `detail: …` to stderr and the machine-readable status line to stdout;
+    when the workflow redirected both streams into the same file with
+    `> out 2>&1`, Python's stderr buffering landed the detail line first
+    and the rollup parser saw `detail:` as the status column. Docker /
+    GHCR / Maven Central silently showed `❌ detail:` on v0.2.2.
+
+    This test invokes the script as a subprocess with the same shell
+    redirection the workflow uses and asserts that the first line of the
+    combined output is always the status line.
+    """
+
+    SCRIPT = SCRIPTS_DIR / "check-release-channels.py"
+
+    def _run_with_combined_redirect(self, argv: list[str]) -> tuple[int, str]:
+        import subprocess
+
+        # The workflow does `> out 2>&1`; emulate that by merging streams
+        # so we observe whichever Python actually writes first.
+        completed = subprocess.run(
+            [sys.executable, str(self.SCRIPT), *argv],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+            text=True,
+        )
+        return completed.returncode, completed.stdout
+
+    def test_first_line_is_status_on_skip_channel(self) -> None:
+        # `aur` is a `kind = "manual"` channel in the checked-in manifest,
+        # so no HTTP request is made; this exercises the happy path
+        # deterministically.
+        rc, out = self._run_with_combined_redirect(
+            ["--tag", "v0.0.0", "--channel", "aur"]
+        )
+        self.assertEqual(rc, 0)
+        first = out.splitlines()[0]
+        self.assertTrue(
+            first.startswith("OK aur "),
+            f"first line must start with the status word; got {first!r}",
+        )
+        self.assertIn("expected=", first)
+        self.assertIn("observed=", first)
+
+    def test_first_line_is_status_on_force_stale(self) -> None:
+        # `--force-stale` produces a synthetic red result and exits with
+        # status 1; the detail line must not outrun the status line.
+        rc, out = self._run_with_combined_redirect(
+            [
+                "--tag",
+                "v0.0.0",
+                "--channel",
+                "npm-wasm",
+                "--force-stale",
+                "npm-wasm",
+            ]
+        )
+        self.assertEqual(rc, 1)
+        first = out.splitlines()[0]
+        self.assertTrue(
+            first.startswith("FAIL npm-wasm "),
+            f"first line must start with the status word; got {first!r}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Changes \`scripts/check-release-channels.py\` so the machine-readable status line is always the first line of the combined stdout+stderr output, regardless of Python's per-stream buffering policy.

The release-verify rollup reads \`head -n1 result.txt\` and parses \`<OK|FAIL> <channel_id> expected=… observed=…\`. The workflow merges stderr into the result file with \`> out 2>&1\`. Previously the CLI printed the status line to stdout (block-buffered when redirected) and \`detail: …\` to stderr (unbuffered), so stderr landed first and \`detail:\` became the parsed status column. On v0.2.2 this caused Docker Hub, GHCR, and Maven Central to display as \`❌ detail:\` in the release body despite the underlying artifacts actually verifying — see run [24599991734](https://github.com/koedame/chordsketch/actions/runs/24599991734).

## Fix

- Print the status line with \`flush=True\` so the file offset reflects the write order.
- Route the detail line through stdout (on line 2) on *both* OK and FAIL paths, instead of stderr on FAIL only. This keeps the artifact self-describing and makes the per-channel log strictly a superset of the old output.

## Sister-site audit

- No other rollup aggregators read this script's output format.
- The workflow's \`head -n1\` + \`awk\`/\`grep\` parse is unchanged by this PR — it now always sees the intended contract regardless of stream buffering.
- The existing 24 \`verify_channel\` tests are unchanged because they call the function directly rather than running main().

## Test

Two new \`CliOutputOrderingTests\` that invoke the script via \`subprocess\` with \`stderr → stdout\` merged (matching the workflow's redirect) and assert the first line starts with \`OK <id>\` / \`FAIL <id>\`. All 26 tests in \`scripts/test_check_release_channels.py\` pass.

Closes #1853