### PR TITLE
core(heuristic): sanitize lyric text and chord names on ChordPro emission (#1824)

### DIFF
--- a/crates/core/src/heuristic.rs
+++ b/crates/core/src/heuristic.rs
@@ -771,6 +771,39 @@ fn sanitize_directive_token(s: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+/// Strips characters that would be interpreted as ChordPro structure when a
+/// string is emitted into the **lyric** position of a line.
+///
+/// Four characters are removed: `{`, `}`, `[`, `]`. Braces would start a
+/// directive (`{title: HACKED}`) and square brackets would start an inline
+/// chord annotation (`[Cmaj7]`). ChordPro has no escape syntax for any of
+/// these inside plain lyric text, so stripping is the only safe option —
+/// matching the `sanitize_directive_token` approach used for directive
+/// names/values. See issue #1824 and `sanitizer-security.md` §Security
+/// Asymmetry ("if directive values are sanitized, directive names must be
+/// sanitized too — they appear in the same output context").
+fn sanitize_lyric_text(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.contains('{') || s.contains('}') || s.contains('[') || s.contains(']') {
+        std::borrow::Cow::Owned(s.replace(['{', '}', '[', ']'], ""))
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
+}
+
+/// Strips characters that would be interpreted as ChordPro structure when a
+/// string is emitted inside a **chord annotation** (`[…]`). Only `]` needs
+/// to be stripped (it would close the annotation early); braces are allowed
+/// but unusual so we strip them too for parity with `sanitize_lyric_text`.
+/// `[` inside a chord name has no effect because the parser has already
+/// consumed the opening bracket.
+fn sanitize_chord_name(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.contains('{') || s.contains('}') || s.contains('[') || s.contains(']') {
+        std::borrow::Cow::Owned(s.replace(['{', '}', '[', ']'], ""))
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
+}
+
 /// Serializes a [`Song`] to ChordPro format.
 ///
 /// This serializer is intended for songs produced by [`convert_plain_text`].
@@ -832,10 +865,10 @@ pub fn song_to_chordpro(song: &Song) -> String {
                 for seg in &lyrics.segments {
                     if let Some(ref chord) = seg.chord {
                         out.push('[');
-                        out.push_str(&chord.name);
+                        out.push_str(&sanitize_chord_name(&chord.name));
                         out.push(']');
                     }
-                    out.push_str(&seg.text);
+                    out.push_str(&sanitize_lyric_text(&seg.text));
                 }
                 out.push('\n');
             }
@@ -1272,5 +1305,65 @@ mod tests {
         song.lines.push(Line::Directive(dir));
         let out = song_to_chordpro(&song);
         assert_eq!(out, "{start_of_section: custom}\n");
+    }
+
+    // -- Lyric / chord sanitization (#1824 directive-injection guard) ----
+
+    #[test]
+    fn song_to_chordpro_strips_braces_in_lyric_text() {
+        // Attacker path from #1824: a lyric string containing `{title:
+        // HACKED}` must not round-trip as a forged directive.
+        use crate::ast::{Line, LyricsLine, LyricsSegment};
+        let mut song = Song::default();
+        song.lines.push(Line::Lyrics(LyricsLine {
+            segments: vec![LyricsSegment::text_only("see {title: HACKED} here")],
+        }));
+        let out = song_to_chordpro(&song);
+        assert!(
+            !out.contains('{') && !out.contains('}'),
+            "braces must not appear in serialized lyric output: {out:?}"
+        );
+        assert!(out.contains("see title: HACKED here"));
+    }
+
+    #[test]
+    fn song_to_chordpro_strips_brackets_in_lyric_text() {
+        // The mirror attack uses `[Cmaj7]` to forge a chord annotation.
+        use crate::ast::{Line, LyricsLine, LyricsSegment};
+        let mut song = Song::default();
+        song.lines.push(Line::Lyrics(LyricsLine {
+            segments: vec![LyricsSegment::text_only("pre [Cmaj7] mid")],
+        }));
+        let out = song_to_chordpro(&song);
+        assert!(
+            !out.contains('[') && !out.contains(']'),
+            "square brackets must not appear in serialized lyric output: {out:?}"
+        );
+        assert!(out.contains("pre Cmaj7 mid"));
+    }
+
+    #[test]
+    fn song_to_chordpro_strips_closing_bracket_in_chord_name() {
+        // A crafted chord name containing `]` would close the annotation
+        // early. The sanitizer strips it so the annotation stays intact.
+        use crate::ast::{Chord, Line, LyricsLine, LyricsSegment};
+        let mut song = Song::default();
+        let chord = Chord {
+            name: "C]{title: HACKED}".to_string(),
+            detail: None,
+            display: None,
+        };
+        song.lines.push(Line::Lyrics(LyricsLine {
+            segments: vec![LyricsSegment::new(Some(chord), "hello")],
+        }));
+        let out = song_to_chordpro(&song);
+        assert!(
+            !out.contains('{') && !out.contains('}'),
+            "injected directive braces must be stripped: {out:?}"
+        );
+        // The opening `[` is emitted by the serializer, the closing `]`
+        // comes from the serializer too; the chord name itself contains
+        // no stray `[`/`]` after sanitization.
+        assert_eq!(out, "[Ctitle: HACKED]hello\n");
     }
 }


### PR DESCRIPTION
## What

\`song_to_chordpro\` previously applied \`sanitize_directive_token\` to directive names, directive values, metadata, and comments but pushed lyric-segment text and chord names verbatim. This PR adds symmetric sanitization for the two missing positions.

Two new helpers in \`crates/core/src/heuristic.rs\`:
- \`sanitize_lyric_text\` — strips \`{\`, \`}\`, \`[\`, \`]\` from lyric strings before serialization.
- \`sanitize_chord_name\` — same four characters inside the chord-annotation position, so a chord name containing \`]\` cannot close the annotation early.

Both are applied at the two emission sites in \`song_to_chordpro\`.

## Why

\`.claude/rules/sanitizer-security.md\` §Security Asymmetry: *"if directive values are sanitized, directive names must be sanitized too — they appear in the same output context."* Once a ChordPro file is serialized, lyric text lives in the same output context as directives; the parser on the other end treats the two identically. The attack chain documented in #1824 is:

1. Attacker-controlled MusicXML / plain-text source includes \`see {title: HACKED}\` in lyric content.
2. Victim runs \`chordsketch convert -f cho input.xml\`.
3. The resulting ChordPro file contains a fake \`{title: HACKED}\` directive.
4. Any downstream parser that trusts the ChordPro output picks up the fake directive.

High severity per the project rubric (cross-format directive injection).

## Sister-site audit

Per \`.claude/rules/fix-propagation.md\`:

- \`crates/core/src/heuristic.rs\` is the only ChordPro serializer in the workspace.
- \`crates/convert-musicxml/src/export.rs\` emits MusicXML, not ChordPro, and already XML-escapes at the output boundary.
- MusicXML import passes through \`Song\` → \`song_to_chordpro\`, which is now fully covered.
- \`Directive::value\` / name path was already sanitized by the existing \`sanitize_directive_token\`; this PR closes the asymmetry.
- No other \`Line::Lyrics\` writer in the tree.

## Test

Three new unit tests exercise the attack paths from the issue:

- \`song_to_chordpro_strips_braces_in_lyric_text\`
- \`song_to_chordpro_strips_brackets_in_lyric_text\`
- \`song_to_chordpro_strips_closing_bracket_in_chord_name\`

\`cargo test -p chordsketch-core --lib heuristic::tests::song_to_chordpro\` → 7 passed. \`cargo fmt --check\` / \`cargo clippy -p chordsketch-core -- -D warnings\` clean.

Closes #1824