### PR TITLE
ci(napi): apply workflow-level bash -eo pipefail default (#1835)

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -30,6 +30,18 @@ on:
 permissions:
   contents: read
 
+# Force `bash -eo pipefail` for every `run:` block, including on the
+# Windows matrix cell, so a broken command in a pipe or an empty
+# `rustup target add` fails loud instead of being swallowed by pwsh's
+# permissive defaults. Closes the fix-propagation gap from PR #1821
+# (issue #1835). The unshelled blocks in this workflow — `rustup target
+# add`, `npm install -g`, `napi build` — are all cross-platform CLI
+# tools that behave identically under Git Bash on Windows, so switching
+# away from pwsh has no functional impact.
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_INCREMENTAL: "0"
 


### PR DESCRIPTION
## What

Adds \`defaults.run.shell: bash\` at the workflow level of \`.github/workflows/napi.yml\`, closing the fix-propagation gap deferred in PR #1821 (issue #1835).

## Why

Every other release-path workflow (\`release.yml\`, \`docker.yml\`, \`npm-publish*.yml\`, \`post-release.yml\`, \`release-verify.yml\`, \`vscode-extension.yml\`, \`swift.yml\`, and as of PR #1856 \`kotlin.yml\` / \`python.yml\` / \`ruby.yml\`) now enforces \`bash -eo pipefail\` on every \`run:\` block. \`napi.yml\` was the last holdout because its build matrix includes \`windows-latest\`, where the default shell is pwsh and a switch to Git Bash needed to be verified against each unshelled block.

## Audit

Every unshelled \`run: |\` block in \`napi.yml\` was checked:

| Block | Command(s) | Safe on Git Bash? |
|---|---|---|
| Install Rust toolchain | \`rustup target add <triple>\` | ✅ Cross-platform CLI |
| Install @napi-rs/cli | \`npm install -g @napi-rs/cli\` | ✅ Cross-platform CLI |
| Install cross-compilation tools (aarch64-linux) | \`apt-get\` | ✅ Linux-only via \`if:\` |
| Build native addon | \`napi build --release --target …\` | ✅ Cross-platform CLI |
| publish → Check required secrets present | \`python3 scripts/check-env-secrets.py\` | ✅ Already ubuntu-only |
| publish → Stage each platform package | \`declare -A\` Bash associative array | ✅ Already requires bash |
| publish → Publish each platform package | \`set -euo pipefail\` loop | ✅ Already bash |
| publish → Publish resolver package | \`set -euo pipefail\` guard | ✅ Already bash |

Every block either already specifies \`shell: bash\` explicitly, runs on ubuntu-only publish infrastructure, or uses a CLI that behaves identically under Git Bash. No functional impact on artifact contents — the change adds \`-eo pipefail\` to the build-matrix blocks and nothing else.

## Sister-site audit

- \`kotlin.yml\` / \`python.yml\` / \`ruby.yml\` already added the same default at the publish job level in PR #1856 because their Windows matrix cells had pwsh-specific syntax. \`napi.yml\`'s Windows cell has no pwsh-specific syntax, so workflow-level is safe here.
- \`swift.yml\` already uses workflow-level bash default (no Windows matrix).

## Test

CI will exercise the change on this PR's own run — in particular, the \`Build x86_64-pc-windows-msvc\` cell will exercise Git Bash. If any block is secretly pwsh-dependent, that cell will go red and this PR will be bounced.

Closes #1835