### PR TITLE
ci: upgrade safe workflow defaults from bash to bash -euo pipefail (#1836)

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -205,13 +205,15 @@ jobs:
     environment:
       name: maven-central
       url: https://repo1.maven.org/maven2/io/github/koedame/chordsketch/
-    # Enforce `bash -eo pipefail` in `run:` blocks. Scoped to this job
+    # Enforce `bash -euo pipefail` in `run:` blocks. Scoped to this job
     # rather than workflow-level because kotlin.yml has a Windows matrix
     # cell (build-jni-others) whose `run:` blocks must keep pwsh defaults.
-    # See issue #1845 (fix-propagation from PR #1821).
+    # See issue #1845 (fix-propagation from PR #1821). `-u` added per
+    # issue #1836 — every var-using block in this job already runs
+    # `set -euo pipefail` explicitly, so the default is defense-in-depth.
     defaults:
       run:
-        shell: bash
+        shell: bash --noprofile --norc -euo pipefail {0}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         # No `ref:` override — always check out the default branch (main) so

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -38,9 +38,12 @@ permissions:
 # add`, `npm install -g`, `napi build` — are all cross-platform CLI
 # tools that behave identically under Git Bash on Windows, so switching
 # away from pwsh has no functional impact.
+# `-u` is added on top (issue #1836) so a typo'd env-var reference
+# fails loud; every var-using block in this workflow already runs
+# `set -euo pipefail` explicitly.
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euo pipefail {0}
 
 env:
   CARGO_INCREMENTAL: "0"

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -45,7 +45,13 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    # Upgrade over the stock `shell: bash` (which runs `bash --noprofile
+    # --norc -eo pipefail {0}`) to add `-u`, so a typo'd environment
+    # variable reference like `$UNDEFIEND_VAR` fails loud instead of
+    # silently producing an empty string. Every `run:` block in this
+    # workflow already begins with `set -euo pipefail` explicitly, so
+    # this is a strict defense-in-depth upgrade (issue #1836).
+    shell: bash --noprofile --norc -euo pipefail {0}
 
 jobs:
   collect-channels:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,9 +34,12 @@ permissions:
 # Ensure `run:` blocks use `bash -eo pipefail`, not the silent default that
 # swallows mid-pipe failures. swift.yml has no Windows matrix, so a
 # workflow-level default is safe (fix-propagation from PR #1821, issue #1845).
+# `-u` is added on top (issue #1836) so a typo'd env-var reference fails
+# loud; every block in this workflow already runs `set -euo pipefail`
+# explicitly, making the default strictly defense-in-depth.
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euo pipefail {0}
 
 jobs:
   # Build each Apple target on its own runner in parallel.

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -29,7 +29,11 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    # See release-verify.yml for the rationale: add `-u` so a typo'd
+    # environment-variable reference fails loud. Every `run:` block in
+    # this workflow already sets `set -euo pipefail` explicitly, so the
+    # default is strictly defense-in-depth (issue #1836).
+    shell: bash --noprofile --norc -euo pipefail {0}
 
 jobs:
   build:


### PR DESCRIPTION
## What

Upgrades \`defaults.run.shell\` from \`bash\` to \`bash --noprofile --norc -euo pipefail {0}\` in five workflows where every var-using \`run:\` block already sets \`set -euo pipefail\` explicitly:

- \`.github/workflows/release-verify.yml\`
- \`.github/workflows/vscode-extension.yml\`
- \`.github/workflows/swift.yml\`
- \`.github/workflows/napi.yml\`
- \`.github/workflows/kotlin.yml\` (publish job only — matches the Windows-matrix-aware scope from PR #1856)

For these, the change is **strict defense-in-depth for existing code** (no block is newly affected) and future-proofs any new \`run: |\` block that forgets its own \`set -euo pipefail\`.

## Why

\`shell: bash\` gives \`-eo pipefail\` but not \`-u\`. A typo like \`\$UNDEFIEND_VAR\` silently expands to an empty string, and downstream interpolation (tags, asset names, secrets) can produce a broken Homebrew formula or a half-configured deployment without the workflow ever going red.

## Audit method

Python AST pass over \`run: |\` blocks: for each workflow, every block that references at least one env/shell variable (\`\$FOO\` or \`\${FOO}\`) was checked for an explicit \`set -u\` or \`set -euo pipefail\` header. Workflows where **every** such block already had the header were selected for this PR.

| Workflow | Var-using blocks | All have \`set -u\`? | Included |
|---|---|---|---|
| release-verify.yml | 5 | ✅ | ✅ |
| vscode-extension.yml | 9 | ✅ | ✅ |
| swift.yml | 8 | ✅ | ✅ |
| napi.yml | 10 | ✅ | ✅ |
| kotlin.yml (publish) | 4 | ✅ | ✅ |
| post-release.yml | 30+ | partial | follow-up |
| docker.yml | 4 | partial | follow-up |
| npm-publish.yml | 3 | partial | follow-up |
| npm-publish-tree-sitter.yml | 2 | partial | follow-up |
| release.yml | 2 | partial | follow-up |
| python.yml (publish) | 1 | partial | follow-up |
| ruby.yml (publish) | 1 | partial | follow-up |

## Sister-site audit

Consistent with PR #1821 (base pattern), PR #1856 (Kotlin/Python/Ruby/Swift), PR #1885 (napi). No other workflows use \`defaults.run.shell: bash\` at this time; the per-block \`shell: bash\` directives are unchanged.

## Test

CI on this PR exercises all five workflows. Any block that secretly references an undefined var will fail loud — exactly the contract the change is introducing.

Closes #1836