### PR TITLE
ci(dependabot): ignore semver-major bumps for cargo and github-actions (#1838)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,29 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Block Dependabot from opening semver-major action bumps
+    # automatically. Action major versions regularly change default
+    # values (e.g. actions/checkout@v4 → @v5 changed `fetch-depth`
+    # defaults), and the auto-approval path in
+    # `.github/workflows/claude-dependabot.yml` cannot reliably catch
+    # subtle behaviour deltas that do not show up in a unit-test diff.
+    # Major-version upgrades still happen — they just need a human-
+    # driven PR that reads the action's release notes first. See #1838.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Same rationale as github-actions above (issue #1838). Major
+    # Cargo bumps are especially risky because even under Rust's 1.0
+    # promise, a `0.x → 1.0` or `N → N+1` crate version almost always
+    # introduces breaking changes that require manual audit beyond
+    # "CI is green".
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## What

Adds an \`ignore:\` block to both Dependabot update configs so semver-major bumps are no longer opened automatically:

\`\`\`yaml
ignore:
  - dependency-name: \"*\"
    update-types:
      - \"version-update:semver-major\"
\`\`\`

## Why

\`.github/workflows/claude-dependabot.yml\` auto-approves Dependabot PRs when CI is green and the review comes back clean. For minor/patch bumps that's fine. For **major** bumps, a green CI is not sufficient signal — Rust crates reshape public API across even 1.0 → 1.1 boundaries in practice, and GitHub Actions regularly change their input defaults between major versions (e.g. \`actions/checkout@v4 → @v5\` shifted \`fetch-depth\` defaults). The risk is a silent behaviour change that unit tests don't exercise.

Option A from the issue — simplest and strictest for both ecosystems in this config. Major upgrades still happen; they just become human-driven PRs that read the release notes first.

## Sister-site audit

- \`.github/workflows/claude-dependabot.yml\` review prompt already asks Claude to check for breaking changes on major updates (lines 37-38). This PR closes the gap where that check could still result in approval — now there simply are no major PRs to review.
- No other auto-bump path in the repo today (no npm, pip, etc. in dependabot.yml).

## Test

Dependabot will honour the new \`ignore:\` on its next weekly run. No CI-testable behaviour in this PR itself.

Closes #1838