### PR TITLE
renderers: share push_warning/validate_capo via core (#1874)

### DIFF
--- a/crates/core/src/render_result.rs
+++ b/crates/core/src/render_result.rs
@@ -1,4 +1,63 @@
-//! Structured render result type for capturing warnings during rendering.
+//! Structured render result type for capturing warnings during rendering,
+//! plus the canonical warning-accumulation helpers used by every renderer.
+//!
+//! Shared by `chordsketch-render-text`, `chordsketch-render-html`, and
+//! `chordsketch-render-pdf`. Consolidating the helpers here eliminates
+//! three maintenance points for the same logic (issue #1874).
+
+use crate::ast::{CapoValidation, Metadata};
+
+/// Maximum number of warnings any renderer accumulates for a single
+/// render pass (issue #1833). Without a cap, a pathological input such
+/// as one million malformed `{transpose}` lines would push the warnings
+/// vector to tens of megabytes. `push_warning` refuses to exceed this
+/// limit and appends a single truncation marker the first time the cap
+/// is hit.
+pub const MAX_WARNINGS: usize = 1000;
+
+/// Push a warning into the renderer's accumulator, enforcing
+/// [`MAX_WARNINGS`].
+///
+/// Once the cap is reached the function pushes a single truncation
+/// marker in place of the overflowing warning and silently ignores
+/// every subsequent warning in the same pass. Every renderer
+/// (`render-text`, `render-html`, `render-pdf`) calls this helper so
+/// the cap behaviour is identical across output formats.
+pub fn push_warning(warnings: &mut Vec<String>, message: impl Into<String>) {
+    if warnings.len() < MAX_WARNINGS {
+        warnings.push(message.into());
+    } else if warnings.len() == MAX_WARNINGS {
+        warnings.push(format!(
+            "additional warnings suppressed; MAX_WARNINGS ({MAX_WARNINGS}) reached"
+        ));
+    }
+}
+
+/// Validate the `{capo}` metadata value at the render boundary and push
+/// a warning for any value outside `1..=24` (issue #1834,
+/// `.claude/rules/renderer-parity.md` §Validation Parity).
+///
+/// Renderers call this helper once at the top of their main entry point
+/// so the validation message is byte-identical across output formats —
+/// a user who pipes the same `.cho` file to text, HTML, and PDF now
+/// sees the same warning regardless of which renderer they chose.
+pub fn validate_capo(metadata: &Metadata, warnings: &mut Vec<String>) {
+    match metadata.capo_validated() {
+        CapoValidation::Unset | CapoValidation::Valid(_) => {}
+        CapoValidation::OutOfRange(n) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {n} out of range (expected 1..=24); ignored"),
+            );
+        }
+        CapoValidation::NotInteger(raw) => {
+            push_warning(
+                warnings,
+                format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
+            );
+        }
+    }
+}
 
 /// Result of a render operation, containing both the rendered output
 /// and any warnings produced during rendering.
@@ -61,5 +120,70 @@ mod tests {
         let result = RenderResult::with_warnings(42, Vec::new());
         assert_eq!(result.output, 42);
         assert!(!result.has_warnings());
+    }
+
+    // -- push_warning cap -------------------------------------------------
+
+    #[test]
+    fn test_push_warning_under_cap_appends() {
+        let mut v: Vec<String> = Vec::new();
+        push_warning(&mut v, "a");
+        push_warning(&mut v, "b");
+        assert_eq!(v, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn test_push_warning_caps_and_truncates_once() {
+        let mut v: Vec<String> = Vec::with_capacity(MAX_WARNINGS + 5);
+        for i in 0..(MAX_WARNINGS + 50) {
+            push_warning(&mut v, format!("w{i}"));
+        }
+        assert_eq!(v.len(), MAX_WARNINGS + 1);
+        assert!(
+            v.last().unwrap().contains("MAX_WARNINGS"),
+            "last entry must be the truncation marker; got {:?}",
+            v.last()
+        );
+    }
+
+    // -- validate_capo uniform messages -----------------------------------
+
+    #[test]
+    fn test_validate_capo_unset_and_valid_emit_nothing() {
+        let mut v = Vec::<String>::new();
+        let md = Metadata::default();
+        validate_capo(&md, &mut v);
+        assert!(v.is_empty());
+
+        let md = Metadata {
+            capo: Some("5".to_string()),
+            ..Metadata::default()
+        };
+        validate_capo(&md, &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_validate_capo_out_of_range_warns_with_value() {
+        let mut v = Vec::<String>::new();
+        let md = Metadata {
+            capo: Some("999".to_string()),
+            ..Metadata::default()
+        };
+        validate_capo(&md, &mut v);
+        assert_eq!(v.len(), 1);
+        assert!(v[0].contains("999") && v[0].contains("out of range"));
+    }
+
+    #[test]
+    fn test_validate_capo_non_integer_warns_with_value() {
+        let mut v = Vec::<String>::new();
+        let md = Metadata {
+            capo: Some("foo".to_string()),
+            ..Metadata::default()
+        };
+        validate_capo(&md, &mut v);
+        assert_eq!(v.len(), 1);
+        assert!(v[0].contains("foo") && v[0].contains("not a valid integer"));
     }
 }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -17,12 +17,12 @@
 
 use std::fmt::Write;
 
-use chordsketch_core::ast::{CapoValidation, CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordsketch_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordsketch_core::canonical_chord_name;
 use chordsketch_core::config::Config;
 use chordsketch_core::escape::escape_xml as escape;
 use chordsketch_core::inline_markup::{SpanAttributes, TextSpan};
-use chordsketch_core::render_result::RenderResult;
+use chordsketch_core::render_result::{RenderResult, push_warning, validate_capo};
 use chordsketch_core::resolve_diagrams_instrument;
 use chordsketch_core::transpose::transpose_chord;
 
@@ -30,45 +30,11 @@ use chordsketch_core::transpose::transpose_chord;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
-/// Maximum number of warnings the renderer accumulates per render pass
-/// (issue #1833). Mirrors `MAX_WARNINGS` in the text and PDF renderers to
-/// give identical resource-limit behaviour across the three backends.
-pub const MAX_WARNINGS: usize = 1000;
-
-/// Push a warning into the renderer's accumulator, enforcing
-/// [`MAX_WARNINGS`]. Once the cap is reached the function pushes a single
-/// truncation marker in place of the overflowing warning and silently
-/// ignores every subsequent warning in the same pass.
-fn push_warning(warnings: &mut Vec<String>, message: impl Into<String>) {
-    if warnings.len() < MAX_WARNINGS {
-        warnings.push(message.into());
-    } else if warnings.len() == MAX_WARNINGS {
-        warnings.push(format!(
-            "additional warnings suppressed; MAX_WARNINGS ({MAX_WARNINGS}) reached"
-        ));
-    }
-}
-
-/// Validate `{capo}` at the render boundary and push a warning for any
-/// value that is not in `1..=24` (issue #1834, renderer-parity.md
-/// §Validation Parity).
-fn validate_capo(metadata: &chordsketch_core::ast::Metadata, warnings: &mut Vec<String>) {
-    match metadata.capo_validated() {
-        CapoValidation::Unset | CapoValidation::Valid(_) => {}
-        CapoValidation::OutOfRange(n) => {
-            push_warning(
-                warnings,
-                format!("{{capo}} value {n} out of range (expected 1..=24); ignored"),
-            );
-        }
-        CapoValidation::NotInteger(raw) => {
-            push_warning(
-                warnings,
-                format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
-            );
-        }
-    }
-}
+/// Maximum number of warnings the renderer accumulates per render pass.
+/// Re-exported from `chordsketch-core::render_result` so callers can
+/// keep importing `chordsketch_render_html::MAX_WARNINGS` unchanged
+/// (issue #1874).
+pub use chordsketch_core::render_result::MAX_WARNINGS;
 
 /// Maximum number of CSS columns allowed.
 /// Matches `MAX_COLUMNS` in the PDF renderer.

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -14,7 +14,7 @@ use chordsketch_core::ast::{CommentStyle, DirectiveKind, ImageAttributes, Line, 
 use chordsketch_core::canonical_chord_name;
 use chordsketch_core::config::Config;
 use chordsketch_core::inline_markup::TextSpan;
-use chordsketch_core::render_result::RenderResult;
+use chordsketch_core::render_result::{RenderResult, push_warning, validate_capo};
 use chordsketch_core::resolve_diagrams_instrument;
 use chordsketch_core::transpose::transpose_chord;
 
@@ -432,47 +432,11 @@ const MAX_IMAGES: usize = 1_000;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
-/// Maximum number of warnings the renderer accumulates per render pass
-/// (issue #1833). Mirrors `MAX_WARNINGS` in the text and HTML renderers
-/// so the three backends apply the same resource bound on a malicious
-/// `.cho` that would otherwise produce millions of warnings.
-pub const MAX_WARNINGS: usize = 1000;
-
-/// Push a warning into the renderer's accumulator, enforcing
-/// [`MAX_WARNINGS`]. Once the cap is reached the function pushes a single
-/// truncation marker in place of the overflowing warning and silently
-/// ignores every subsequent warning in the same pass.
-fn push_warning(warnings: &mut Vec<String>, message: impl Into<String>) {
-    if warnings.len() < MAX_WARNINGS {
-        warnings.push(message.into());
-    } else if warnings.len() == MAX_WARNINGS {
-        warnings.push(format!(
-            "additional warnings suppressed; MAX_WARNINGS ({MAX_WARNINGS}) reached"
-        ));
-    }
-}
-
-/// Validate `{capo}` at the render boundary and push a warning for any
-/// value that is not in `1..=24` (issue #1834, renderer-parity.md
-/// §Validation Parity).
-fn validate_capo(metadata: &chordsketch_core::ast::Metadata, warnings: &mut Vec<String>) {
-    use chordsketch_core::ast::CapoValidation;
-    match metadata.capo_validated() {
-        CapoValidation::Unset | CapoValidation::Valid(_) => {}
-        CapoValidation::OutOfRange(n) => {
-            push_warning(
-                warnings,
-                format!("{{capo}} value {n} out of range (expected 1..=24); ignored"),
-            );
-        }
-        CapoValidation::NotInteger(raw) => {
-            push_warning(
-                warnings,
-                format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
-            );
-        }
-    }
-}
+/// Maximum number of warnings the renderer accumulates per render pass.
+/// Re-exported from `chordsketch-core::render_result` so callers can
+/// keep importing `chordsketch_render_pdf::MAX_WARNINGS` unchanged
+/// (issue #1874).
+pub use chordsketch_core::render_result::MAX_WARNINGS;
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -3,9 +3,9 @@
 //! This crate converts a parsed ChordPro AST (from `chordsketch-core`) into
 //! formatted plain text with chords aligned above their corresponding lyrics.
 
-use chordsketch_core::ast::{CapoValidation, CommentStyle, DirectiveKind, Line, LyricsLine, Song};
+use chordsketch_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordsketch_core::config::Config;
-use chordsketch_core::render_result::RenderResult;
+use chordsketch_core::render_result::{RenderResult, push_warning, validate_capo};
 use chordsketch_core::resolve_diagrams_instrument;
 use chordsketch_core::transpose::transpose_chord;
 use unicode_width::UnicodeWidthStr;
@@ -15,47 +15,11 @@ use unicode_width::UnicodeWidthStr;
 const MAX_CHORUS_RECALLS: usize = 1000;
 
 /// Maximum number of warnings the renderer will accumulate for a single
-/// render pass (issue #1833). Without a cap, a pathological input such as
-/// one million malformed `{transpose}` lines can push the warnings vector
-/// to tens of megabytes. `push_warning` refuses to exceed this limit and
-/// appends a single truncation marker the first time the cap is hit.
-pub const MAX_WARNINGS: usize = 1000;
-
-/// Push a warning into the renderer's accumulator, enforcing
-/// [`MAX_WARNINGS`]. Once the cap is reached the function pushes a
-/// single truncation marker in place of the overflowing warning and
-/// silently ignores every subsequent warning in the same pass.
-fn push_warning(warnings: &mut Vec<String>, message: impl Into<String>) {
-    if warnings.len() < MAX_WARNINGS {
-        warnings.push(message.into());
-    } else if warnings.len() == MAX_WARNINGS {
-        warnings.push(format!(
-            "additional warnings suppressed; MAX_WARNINGS ({MAX_WARNINGS}) reached"
-        ));
-    }
-}
-
-/// Validate `{capo}` at the render boundary and push a warning for any
-/// value that is not in `1..=24`. Matches the check applied in the HTML
-/// and PDF renderers per `.claude/rules/renderer-parity.md` §Validation
-/// Parity (issue #1834).
-fn validate_capo(metadata: &chordsketch_core::ast::Metadata, warnings: &mut Vec<String>) {
-    match metadata.capo_validated() {
-        CapoValidation::Unset | CapoValidation::Valid(_) => {}
-        CapoValidation::OutOfRange(n) => {
-            push_warning(
-                warnings,
-                format!("{{capo}} value {n} out of range (expected 1..=24); ignored"),
-            );
-        }
-        CapoValidation::NotInteger(raw) => {
-            push_warning(
-                warnings,
-                format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
-            );
-        }
-    }
-}
+/// render pass. Re-exported from the canonical location in
+/// `chordsketch-core::render_result` so existing downstream callers can
+/// keep importing `chordsketch_render_text::MAX_WARNINGS` unchanged
+/// (issue #1874).
+pub use chordsketch_core::render_result::MAX_WARNINGS;
 
 /// Render a [`Song`] AST to plain text.
 ///


### PR DESCRIPTION
## What

PR #1865 added byte-identical copies of \`push_warning\`, \`validate_capo\`, and \`MAX_WARNINGS = 1000\` in each of the three renderer crates. This PR consolidates them into \`chordsketch_core::render_result\` so there is a single canonical implementation.

- **Core** — \`MAX_WARNINGS\`, \`push_warning\`, and \`validate_capo\` promoted to public functions of \`chordsketch_core::render_result\`. Logic unchanged.
- **Renderers** — each crate drops its local copy, imports the shared helpers, and \`pub use\`s \`MAX_WARNINGS\` so downstream callers that write \`chordsketch_render_html::MAX_WARNINGS\` continue to compile.

## Why

Three maintenance points for identical logic was an intentional-but-awkward trade in #1865. Any future change (cap value, new capo variant, message rewording) would need three matching edits. Consolidating eliminates that class of drift before it happens. Core's zero-external-dependency policy is respected — the helpers are pure stdlib.

## Sister-site audit

- Every emission site in \`render-text\`, \`render-html\`, \`render-pdf\` already called \`push_warning\` via the local function — now it calls the same logic via the shared one.
- The only other warning-pushing path I found in the tree is \`PdfDocument::validate_margin\` (tracked as #1873); it intentionally uses a direct \`warnings.push\` and is outside the scope of this refactor.

## Test

- \`cargo test --workspace --lib\` — all pass (5 new tests in \`render_result::tests\`, existing renderer tests unchanged).
- \`cargo fmt --check\` and \`cargo clippy --workspace -- -D warnings\` clean.

Closes #1874