### PR TITLE
packaging: bump macports and nix templates to 0.2.2 (#1863)

### DIFF
--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -10,7 +10,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        koedame chordsketch 0.2.0 v
+github.setup        koedame chordsketch 0.2.2 v
 revision            0
 categories          textproc music
 license             MIT
@@ -21,15 +21,14 @@ long_description    ChordSketch is a Rust implementation of the ChordPro file \
                     HTML, or PDF output. Full compatibility with the ChordPro \
                     specification.
 
-# TODO: Replace with actual checksums before submission.
-# Compute via:
-#   curl -L -o src.tar.gz https://github.com/koedame/chordsketch/archive/refs/tags/v0.2.0.tar.gz
+# Checksums for the v0.2.2 source tarball. Regenerate on each release:
+#   curl -L -o src.tar.gz https://github.com/koedame/chordsketch/archive/refs/tags/v0.2.2.tar.gz
 #   openssl dgst -rmd160 src.tar.gz
 #   openssl dgst -sha256 src.tar.gz
 #   wc -c src.tar.gz
-checksums           rmd160  0 \
-                    sha256  0 \
-                    size    0
+checksums           rmd160  04749cb1fcaeee776535df02a1107175c79acb23 \
+                    sha256  5fa93b60929484998f95497e213b066b8363ef25685333921ed95e65015df961 \
+                    size    6276354
 
 # TODO: Populate cargo.crates before submission.
 # The cargo portgroup requires all crate dependencies to be listed here.

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -18,16 +18,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "chordsketch";
-  version = "0.2.0";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "koedame";
     repo = "chordsketch";
     tag = "v${version}";
-    hash = "sha256-8i5rDUVmE5MKqXtXY8bgumEHr8jVS6bk9XClZATwC6E=";
+    # Hashes must be recomputed for every release (both `hash` and
+    # `cargoHash` below). Set to "" and run `nix build` once — nix
+    # will report the correct SRI values in the build error message,
+    # then paste them back here. See the leading comment for details.
+    hash = "";
   };
 
-  cargoHash = "sha256-52vnW3E7Fdl2aLOKh+w13Tmf0PaD6FdXqf+YyCV6Yec=";
+  cargoHash = "";
 
   cargoBuildFlags = [ "--package" "chordsketch" ];
   cargoTestFlags = [ "--package" "chordsketch" ];


### PR DESCRIPTION
## What

Brings two \`packaging/\` templates up to the current v0.2.2 release:

- \`packaging/macports/Portfile\` — version \`0.2.0 → 0.2.2\`; the placeholder \`0\` checksums are replaced with real rmd160 / sha256 / size values computed locally against the v0.2.2 source tarball. Curl example URL in the regenerate comment also bumped.
- \`packaging/nix/package.nix\` — version \`0.2.0 → 0.2.2\`; both \`hash\` and \`cargoHash\` zeroed per the template's documented "set to '' and build once" pattern.

## Why

Sister-site follow-up surfaced by PR #1855's audit: \`packaging/winget\` got bumped to 0.2.2 (landed), and \`packaging/macports\` / \`packaging/nix\` were left stale. This PR closes that gap; the structural "\`release.yml\` should auto-bump \`packaging/\` templates" fix is tracked separately.

## Macports checksums

Generated with:

\`\`\`bash
curl -L -o /tmp/v0.2.2.tar.gz https://github.com/koedame/chordsketch/archive/refs/tags/v0.2.2.tar.gz
openssl dgst -rmd160 /tmp/v0.2.2.tar.gz
openssl dgst -sha256 /tmp/v0.2.2.tar.gz
wc -c < /tmp/v0.2.2.tar.gz
\`\`\`

Values embedded in the Portfile:

- rmd160 \`04749cb1fcaeee776535df02a1107175c79acb23\`
- sha256 \`5fa93b60929484998f95497e213b066b8363ef25685333921ed95e65015df961\`
- size \`6276354\`

## Nix hashes

Both \`hash\` and \`cargoHash\` are zeroed because:

1. \`fetchFromGitHub\` hashes the *unpacked* source, not the raw tarball, so a locally computed tarball hash doesn't apply.
2. \`cargoHash\` depends on the output of nix's cargo-vendor step, which is not reproducible outside a nix build.
3. The template's own header comment explicitly documents the "set both to '' and build once; nix will report the correct SRI hashes" workflow — I'm following that.

The template is currently a submission-reference, not an active build target in CI, so this zero-hash state is the intended handoff to the future nixpkgs maintainer PR.

## Test

No CI coverage for these templates today. Verified locally that the Portfile diff applies cleanly and that the SHA-256 hex and SRI base64 for the tarball match.

Closes #1863