### PR TITLE
render-pdf: route validate_margin through push_warning (#1873)

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -2235,11 +2235,20 @@ impl PdfDocument {
 
     /// Validate and clamp a margin value. Returns the default if the value is
     /// negative, non-finite, or exceeds `MAX_MARGIN`.
+    ///
+    /// The warning push is routed through the module-level
+    /// [`push_warning`] helper so it participates in the `MAX_WARNINGS`
+    /// cap (issue #1873). Before this fix a pathological config that
+    /// already filled the warnings vector could produce up to
+    /// `MAX_WARNINGS + 1 + 4 * N` entries, where `N` is the number of
+    /// `from_config_with_warnings` calls per render. The extra 4-per-N
+    /// term came from this function bypassing the cap.
     fn validate_margin(value: f32, default: f32, name: &str, warnings: &mut Vec<String>) -> f32 {
         if !value.is_finite() || !(0.0..=Self::MAX_MARGIN).contains(&value) {
-            warnings.push(format!(
-                "invalid pdf.margins.{name} value {value}, using default {default}"
-            ));
+            push_warning(
+                warnings,
+                format!("invalid pdf.margins.{name} value {value}, using default {default}"),
+            );
             default
         } else {
             value


### PR DESCRIPTION
## What

\`PdfDocument::validate_margin\` now pushes its "invalid pdf.margins.{name}" warning via the module-level \`push_warning\` helper instead of calling \`warnings.push\` directly. That restores the \`MAX_WARNINGS = 1000\` cap for every warning produced by the PDF renderer, not just the ones from the main render pass.

## Why

Follow-up from PR #1865's description. Before this fix the effective cap was \`MAX_WARNINGS + 1 + 4 × N\` where \`N\` is the number of \`from_config_with_warnings\` calls per multi-song render. The bound stayed finite so the severity is Low, but the whole point of the helper is a hard cap — every warning should go through it.

## Sister-site audit

- \`validate_margin\` was the only warning-push site in the PDF renderer that bypassed \`push_warning\`.
- Text and HTML renderers had no analogous bypass (verified by \`grep -n "warnings\\.push"\`).

## Test

\`cargo test -p chordsketch-render-pdf --lib\` — 196 passed, including the pre-existing \`test_max_warnings_truncates\`. \`cargo fmt --check\` and \`cargo clippy -p chordsketch-render-pdf -- -D warnings\` clean.

Closes #1873