### PR TITLE
docs: drop duplicate docs.rs link from crate READMEs (#1861)

### DIFF
--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -29,10 +29,6 @@ assert_eq!(song.metadata.title.as_deref(), Some("Amazing Grace"));
 - Multi-song file parsing (`{new_song}`)
 - Inline markup, delegate environments, conditional selectors
 
-## Documentation
-
-[API documentation on docs.rs](https://docs.rs/chordsketch-core)
-
 ## Links
 
 - Project repository: <https://github.com/koedame/chordsketch>

--- a/crates/render-html/README.md
+++ b/crates/render-html/README.md
@@ -31,10 +31,6 @@ let html = render_song(&song);
   environments such as `{start_of_svg}` emit raw HTML by design;
   use a Content Security Policy when rendering untrusted input)
 
-## Documentation
-
-[API documentation on docs.rs](https://docs.rs/chordsketch-render-html)
-
 ## Links
 
 - Project repository: <https://github.com/koedame/chordsketch>

--- a/crates/render-pdf/README.md
+++ b/crates/render-pdf/README.md
@@ -32,10 +32,6 @@ std::fs::write("output.pdf", &pdf_bytes).unwrap();
 - Image embedding
 - Font size and color configuration
 
-## Documentation
-
-[API documentation on docs.rs](https://docs.rs/chordsketch-render-pdf)
-
 ## Links
 
 - Project repository: <https://github.com/koedame/chordsketch>

--- a/crates/render-text/README.md
+++ b/crates/render-text/README.md
@@ -29,10 +29,6 @@ println!("{text}");
 - Multi-column layout
 - Section labels (verse, chorus, etc.)
 
-## Documentation
-
-[API documentation on docs.rs](https://docs.rs/chordsketch-render-text)
-
 ## Links
 
 - Project repository: <https://github.com/koedame/chordsketch>


### PR DESCRIPTION
Removes the stub `## Documentation` section from `crates/core`, `crates/render-text`, `crates/render-html`, and `crates/render-pdf` READMEs. Each now has exactly one docs.rs pointer, in the canonical `## Links` section.

Surfaced by the PR #1858 review.

Closes #1861