### PR TITLE
docs(cli): move crates.io badge to Installation section (#1882)

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -4,8 +4,6 @@
 
 # chordsketch
 
-[![crates.io](https://img.shields.io/crates/v/chordsketch)](https://crates.io/crates/chordsketch)
-
 Command-line tool for rendering [ChordPro](https://www.chordpro.org/)
 files to plain text, HTML, and PDF, plus importers and exporters for
 plain chord+lyrics sheets, ABC notation, and MusicXML.
@@ -13,6 +11,8 @@ plain chord+lyrics sheets, ABC notation, and MusicXML.
 Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
 
 ## Installation
+
+[![crates.io](https://img.shields.io/crates/v/chordsketch)](https://crates.io/crates/chordsketch)
 
 ```bash
 cargo install chordsketch


### PR DESCRIPTION
Moves the `crates.io` badge added in PR #1878 from directly under the `# chordsketch` title into the `## Installation` section, matching `.claude/rules/package-documentation.md`: "When a badge is present, place it at the top of the `## Installation` section, immediately before the note about replacing `VERSION`."

Closes #1882