### PR TITLE
fix(wasm): move js-sys to [dependencies] to unbreak wasm32 build

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -21,6 +21,13 @@ chordsketch-render-text = { version = "0.2.2", path = "../render-text" }
 chordsketch-render-html = { version = "0.2.2", path = "../render-html" }
 chordsketch-render-pdf = { version = "0.2.2", path = "../render-pdf" }
 wasm-bindgen = "0.2"
+# `render_pdf_with_warnings` (#1893) builds its JS return value via
+# `js_sys::Object` + `js_sys::Reflect` and converts the byte payload
+# through `js_sys::Uint8Array`, so `js-sys` is a runtime dependency for
+# the wasm32 target — not just a test-time one. The production use is
+# gated `#[cfg(target_arch = "wasm32")]`, and native test builds fall
+# through to a serde fallback that does not touch `js_sys`.
+js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1"
@@ -30,4 +37,3 @@ console_error_panic_hook = "0.1"
 # actual `#[wasm_bindgen]` -> `JsValue` boundary that native `cargo test`
 # cannot reach. Run via `wasm-pack test --node` (see `.github/workflows/wasm.yml`).
 wasm-bindgen-test = "0.3"
-js-sys = "0.3"


### PR DESCRIPTION
## What

Moves \`js-sys = \"0.3\"\` from \`[dev-dependencies]\` to \`[dependencies]\` in \`crates/wasm/Cargo.toml\`.

## Why — main is currently red

PR #1893 (WASM+NAPI \`*_with_warnings\`) added a \`render_pdf_with_warnings\` variant that builds its JS return value via \`js_sys::Object\` + \`js_sys::Reflect\` and wraps the PDF bytes through \`js_sys::Uint8Array\`. The code is gated \`#[cfg(target_arch = \"wasm32\")]\`, and the native fallback uses serde instead, so \`cargo test --lib\` on the dev host passed.

The wasm32 build reaches the \`js_sys::*\` references for real, and \`js-sys\` was only listed under \`[dev-dependencies]\`. Result: \`cargo build --target wasm32-unknown-unknown\` fails with four copies of \`cannot find module or crate \`js_sys\` in this scope\`. Every \`.github/workflows/wasm.yml\` run since #1893 merged has been red, including the runs on every PR opened after it.

## Test

Local reproduction:

\`\`\`
cargo build -p chordsketch-wasm --target wasm32-unknown-unknown
\`\`\`

Pre-PR: 4 errors. Post-PR: clean build.