### PR TITLE
docs(convert-musicxml): clarify xml_text/xml_escape strip BMP noncharacters

### DIFF
--- a/crates/convert-musicxml/src/export.rs
+++ b/crates/convert-musicxml/src/export.rs
@@ -489,8 +489,9 @@ fn is_xml_forbidden_control(c: char) -> bool {
 
 /// Escape a string for use as XML text content, appending to `out`.
 ///
-/// Strips XML 1.0 forbidden C0 control characters per
-/// [`is_xml_forbidden_control`]. Tab / LF / CR are preserved.
+/// Strips characters forbidden by the XML 1.0 Char production (C0 controls
+/// and BMP noncharacters U+FFFE/U+FFFF) per [`is_xml_forbidden_control`].
+/// Tab / LF / CR are preserved.
 fn xml_text(s: &str, out: &mut String) {
     for c in s.chars() {
         if is_xml_forbidden_control(c) {
@@ -509,8 +510,9 @@ fn xml_text(s: &str, out: &mut String) {
 
 /// Escape a string for use in an XML attribute value (double-quoted).
 ///
-/// Strips XML 1.0 forbidden C0 control characters per
-/// [`is_xml_forbidden_control`]. Tab / LF / CR are preserved.
+/// Strips characters forbidden by the XML 1.0 Char production (C0 controls
+/// and BMP noncharacters U+FFFE/U+FFFF) per [`is_xml_forbidden_control`].
+/// Tab / LF / CR are preserved.
 fn xml_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {


### PR DESCRIPTION
## What

Update the one-line doc summaries on `xml_text` and `xml_escape` in
`crates/convert-musicxml/src/export.rs`. They previously read "Strips
XML 1.0 forbidden C0 control characters per `is_xml_forbidden_control`",
which became inaccurate after #1902 extended `is_xml_forbidden_control`
to also strip the BMP noncharacters U+FFFE and U+FFFF (which are not C0
controls).

New wording: "Strips characters forbidden by the XML 1.0 Char production
(C0 controls and BMP noncharacters U+FFFE/U+FFFF) per
`is_xml_forbidden_control`."

## Why

Documentation-only nit. The intra-doc link to `is_xml_forbidden_control`
is authoritative, but the summary line itself was misleading at a glance.

## Test results

- `cargo doc --package chordsketch-convert-musicxml --no-deps` with
  `RUSTDOCFLAGS="-D warnings"` — passes, no broken intra-doc links.
- `cargo fmt --check` — passes.

No behaviour change, so no new runtime tests needed.

Closes #1907