### PR TITLE
docs(macports): clarify Portfile header now carries real v0.2.2 checksums

### DIFF
--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -2,7 +2,8 @@
 
 # Reference Portfile for MacPorts submission. Before submitting to
 # macports/macports-ports, you must:
-#   1. Replace the placeholder checksums with actual values
+#   1. Update the checksums to match the new release tarball
+#      (currently set for v0.2.2 — refresh on each release)
 #   2. Populate the cargo.crates block via cargo2port.py
 # See docs/releasing.md for the full procedure.
 


### PR DESCRIPTION
## What

Update the release-prep checklist in `packaging/macports/Portfile`:
item 1 previously said "Replace the placeholder checksums with actual
values", but #1897 already populated real rmd160/sha256/size values for
v0.2.2. Reword to "Update the checksums to match the new release tarball
(currently set for v0.2.2 — refresh on each release)" so the header no
longer reads as if nothing has been done.

## Why

Documentation-only nit. Avoids misleading a future release preparer into
thinking the Portfile still has placeholder hashes. Item 2 (populate
`cargo.crates` via cargo2port.py) is intentionally left unchanged.

## Test results

No runtime behaviour changed. Portfile is a template — it is not consumed
by the Rust build, and no CI job renders or parses this file.

Closes #1900