### PR TITLE
fix(lsp): negotiate position encoding with client instead of unconditionally declaring UTF-8

### DIFF
--- a/crates/lsp/src/convert.rs
+++ b/crates/lsp/src/convert.rs
@@ -1,16 +1,27 @@
 //! Conversion helpers: ChordPro parser types → LSP types.
 //!
-//! The parser uses 1-based line/column numbers; the LSP protocol uses 0-based.
-//! Every conversion in this module applies the necessary offset.
+//! The parser uses 1-based line/column numbers where `column` is a
+//! 1-based **character** count (not a byte or UTF-16 code-unit count).
+//! LSP positions are 0-based and `character` is measured in the units
+//! of the negotiated [`PositionEncoding`]. This module bridges the two.
 
 use chordsketch_core::{ParseError, Span};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
+use crate::encoding::{PositionEncoding, char_idx_to_lsp_char};
+
 /// Converts a [`ParseError`] to an LSP [`Diagnostic`].
+///
+/// `text` is the full document text — required so the parser's character
+/// column can be converted to the negotiated encoding's units.
 #[must_use]
-pub fn parse_error_to_diagnostic(e: &ParseError) -> Diagnostic {
+pub fn parse_error_to_diagnostic(
+    e: &ParseError,
+    text: &str,
+    encoding: PositionEncoding,
+) -> Diagnostic {
     Diagnostic {
-        range: span_to_range(&e.span),
+        range: span_to_range(&e.span, text, encoding),
         severity: Some(DiagnosticSeverity::ERROR),
         message: e.message.clone(),
         source: Some("chordsketch".into()),
@@ -18,22 +29,40 @@ pub fn parse_error_to_diagnostic(e: &ParseError) -> Diagnostic {
     }
 }
 
-/// Converts a parser [`Span`] (1-based, half-open) to an LSP [`Range`] (0-based).
+/// Converts a parser [`Span`] (1-based, character-column, half-open) to an
+/// LSP [`Range`] (0-based) in the negotiated position encoding.
 ///
 /// The parser enforces an input-size cap (see [`chordsketch_core::ParseOptions`])
 /// so line/column values fit comfortably within `u32`. `try_from` is used
 /// defensively; any value that somehow overflows is clamped to `u32::MAX`.
-fn span_to_range(span: &Span) -> Range {
+fn span_to_range(span: &Span, text: &str, encoding: PositionEncoding) -> Range {
+    let start_line_idx = span.start.line.saturating_sub(1);
+    let start_char_idx = span.start.column.saturating_sub(1);
+    let end_line_idx = span.end.line.saturating_sub(1);
+    let end_char_idx = span.end.column.saturating_sub(1);
+
     Range {
         start: Position {
-            line: u32::try_from(span.start.line.saturating_sub(1)).unwrap_or(u32::MAX),
-            character: u32::try_from(span.start.column.saturating_sub(1)).unwrap_or(u32::MAX),
+            line: u32::try_from(start_line_idx).unwrap_or(u32::MAX),
+            character: lsp_character_at(text, start_line_idx, start_char_idx, encoding),
         },
         end: Position {
-            line: u32::try_from(span.end.line.saturating_sub(1)).unwrap_or(u32::MAX),
-            character: u32::try_from(span.end.column.saturating_sub(1)).unwrap_or(u32::MAX),
+            line: u32::try_from(end_line_idx).unwrap_or(u32::MAX),
+            character: lsp_character_at(text, end_line_idx, end_char_idx, encoding),
         },
     }
+}
+
+/// Character value for the LSP `Position` at (0-based) `line_idx` and
+/// 0-based character index `char_idx` into that line, in `encoding` units.
+fn lsp_character_at(
+    text: &str,
+    line_idx: usize,
+    char_idx: usize,
+    encoding: PositionEncoding,
+) -> u32 {
+    let line = text.lines().nth(line_idx).unwrap_or("");
+    char_idx_to_lsp_char(line, char_idx, encoding)
 }
 
 #[cfg(test)]
@@ -42,9 +71,10 @@ mod tests {
     use chordsketch_core::token::{Position as CsPosition, Span as CsSpan};
 
     #[test]
-    fn span_to_range_converts_1based_to_0based() {
+    fn span_to_range_converts_1based_to_0based_utf8_ascii() {
+        let text = "hello\n";
         let span = CsSpan::new(CsPosition::new(1, 1), CsPosition::new(1, 5));
-        let range = span_to_range(&span);
+        let range = span_to_range(&span, text, PositionEncoding::Utf8);
         assert_eq!(range.start.line, 0);
         assert_eq!(range.start.character, 0);
         assert_eq!(range.end.line, 0);
@@ -52,12 +82,47 @@ mod tests {
     }
 
     #[test]
-    fn span_to_range_multiline() {
+    fn span_to_range_multiline_utf8_ascii() {
+        // Span from line 3 col 2 to line 5 col 2 (1-based).
+        let text = "line0\nline1\nline2 foo\nline3\nline4 extra\n";
         let span = CsSpan::new(CsPosition::new(3, 7), CsPosition::new(5, 2));
-        let range = span_to_range(&span);
+        let range = span_to_range(&span, text, PositionEncoding::Utf8);
         assert_eq!(range.start.line, 2);
         assert_eq!(range.start.character, 6);
         assert_eq!(range.end.line, 4);
         assert_eq!(range.end.character, 1);
+    }
+
+    #[test]
+    fn span_to_range_utf8_non_ascii_converts_chars_to_bytes() {
+        // "Ré" occupies columns 1..=2 (char count) but bytes 0..=2 (3 bytes).
+        // A span of columns 1..3 → UTF-8 byte range 0..3.
+        let text = "Ré world\n";
+        let span = CsSpan::new(CsPosition::new(1, 1), CsPosition::new(1, 3));
+        let range = span_to_range(&span, text, PositionEncoding::Utf8);
+        assert_eq!(range.start.character, 0);
+        assert_eq!(range.end.character, 3);
+    }
+
+    #[test]
+    fn span_to_range_utf16_non_ascii_counts_code_units() {
+        // "Ré" occupies 2 UTF-16 code units (both BMP).
+        let text = "Ré world\n";
+        let span = CsSpan::new(CsPosition::new(1, 1), CsPosition::new(1, 3));
+        let range = span_to_range(&span, text, PositionEncoding::Utf16);
+        assert_eq!(range.start.character, 0);
+        assert_eq!(range.end.character, 2);
+    }
+
+    #[test]
+    fn span_to_range_utf16_astral_counts_surrogate_pair_as_two_units() {
+        // U+1F3B8 GUITAR is a surrogate pair in UTF-16 (2 units, 1 char).
+        // A span of columns 1..3 (chars 0..2) → UTF-16 units 0..3
+        // (char 0 = "a" = 1 unit, char 1 = guitar = 2 units, total 3).
+        let text = "a\u{1F3B8}b\n";
+        let span = CsSpan::new(CsPosition::new(1, 1), CsPosition::new(1, 3));
+        let range = span_to_range(&span, text, PositionEncoding::Utf16);
+        assert_eq!(range.start.character, 0);
+        assert_eq!(range.end.character, 3);
     }
 }

--- a/crates/lsp/src/convert.rs
+++ b/crates/lsp/src/convert.rs
@@ -8,7 +8,7 @@
 use chordsketch_core::{ParseError, Span};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
-use crate::encoding::{PositionEncoding, char_idx_to_lsp_char};
+use crate::encoding::{PositionEncoding, char_idx_to_lsp_char, nth_line};
 
 /// Converts a [`ParseError`] to an LSP [`Diagnostic`].
 ///
@@ -55,13 +55,17 @@ fn span_to_range(span: &Span, text: &str, encoding: PositionEncoding) -> Range {
 
 /// Character value for the LSP `Position` at (0-based) `line_idx` and
 /// 0-based character index `char_idx` into that line, in `encoding` units.
+///
+/// Uses [`nth_line`] rather than [`str::lines`] so that bare-CR line
+/// terminators are recognised consistently with
+/// `document_end_position` in `server.rs`.
 fn lsp_character_at(
     text: &str,
     line_idx: usize,
     char_idx: usize,
     encoding: PositionEncoding,
 ) -> u32 {
-    let line = text.lines().nth(line_idx).unwrap_or("");
+    let line = nth_line(text, line_idx);
     char_idx_to_lsp_char(line, char_idx, encoding)
 }
 
@@ -124,5 +128,19 @@ mod tests {
         let range = span_to_range(&span, text, PositionEncoding::Utf16);
         assert_eq!(range.start.character, 0);
         assert_eq!(range.end.character, 3);
+    }
+
+    #[test]
+    fn span_to_range_cr_only_line_endings() {
+        // Bare `\r` line terminators: `str::lines` would fail to split these,
+        // producing `character: 0` for lines after the first. `nth_line`
+        // recognises bare CR, matching `document_end_position` in server.rs.
+        let text = "line0\rhello\rworld";
+        let span = CsSpan::new(CsPosition::new(2, 1), CsPosition::new(2, 6));
+        let range = span_to_range(&span, text, PositionEncoding::Utf8);
+        assert_eq!(range.start.line, 1);
+        assert_eq!(range.start.character, 0);
+        assert_eq!(range.end.line, 1);
+        assert_eq!(range.end.character, 5);
     }
 }

--- a/crates/lsp/src/encoding.rs
+++ b/crates/lsp/src/encoding.rs
@@ -101,13 +101,19 @@ pub fn char_idx_to_lsp_char(line: &str, char_idx: usize, encoding: PositionEncod
         PositionEncoding::Utf8 => line
             .char_indices()
             .nth(char_idx)
-            .map(|(b, _)| b as u32)
-            .unwrap_or_else(|| line.len() as u32),
-        PositionEncoding::Utf16 => line
-            .chars()
-            .take(char_idx)
-            .map(|c| c.len_utf16() as u32)
-            .sum(),
+            .and_then(|(b, _)| u32::try_from(b).ok())
+            .unwrap_or_else(|| u32::try_from(line.len()).unwrap_or(u32::MAX)),
+        PositionEncoding::Utf16 => {
+            // `len_utf16` is always 1 or 2, so the per-char cast is infallible;
+            // use `saturating_add` on the accumulator to avoid silent wraparound
+            // on pathologically long lines (bounded by the parser's input cap
+            // in practice).
+            let mut total: u32 = 0;
+            for c in line.chars().take(char_idx) {
+                total = total.saturating_add(c.len_utf16() as u32);
+            }
+            total
+        }
     }
 }
 
@@ -115,8 +121,58 @@ pub fn char_idx_to_lsp_char(line: &str, char_idx: usize, encoding: PositionEncod
 #[must_use]
 pub fn line_length(line: &str, encoding: PositionEncoding) -> u32 {
     match encoding {
-        PositionEncoding::Utf8 => line.len() as u32,
-        PositionEncoding::Utf16 => line.chars().map(|c| c.len_utf16() as u32).sum(),
+        PositionEncoding::Utf8 => u32::try_from(line.len()).unwrap_or(u32::MAX),
+        PositionEncoding::Utf16 => {
+            // `len_utf16` is always 1 or 2; saturate the accumulator to match
+            // the pattern used by `char_idx_to_lsp_char`.
+            let mut total: u32 = 0;
+            for c in line.chars() {
+                total = total.saturating_add(c.len_utf16() as u32);
+            }
+            total
+        }
+    }
+}
+
+/// Return the `n`-th (0-based) line of `text`, without its line terminator.
+///
+/// Recognises LF (`\n`), CRLF (`\r\n`), and CR-only (`\r`) terminators —
+/// matching `document_end_position` in `server.rs` so that diagnostic
+/// line/character mapping stays consistent regardless of line-ending
+/// flavour. Returns an empty string when `n` is beyond the last line.
+///
+/// This is a local replacement for [`str::lines`], which does not
+/// recognise bare CR and therefore would mismap character offsets for
+/// CR-only documents (vanishingly rare in 2026, but still a spec
+/// correctness concern).
+#[must_use]
+pub fn nth_line(text: &str, n: usize) -> &str {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut line_no: usize = 0;
+    let mut line_start: usize = 0;
+    let mut i: usize = 0;
+    while i < len {
+        let advance = match bytes[i] {
+            b'\n' => 1,
+            b'\r' if i + 1 < len && bytes[i + 1] == b'\n' => 2,
+            b'\r' => 1,
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        if line_no == n {
+            return &text[line_start..i];
+        }
+        line_no += 1;
+        i += advance;
+        line_start = i;
+    }
+    if line_no == n {
+        &text[line_start..]
+    } else {
+        ""
     }
 }
 
@@ -216,7 +272,7 @@ mod tests {
         // char_idx beyond the last char clamps to line.len() (bytes).
         assert_eq!(
             char_idx_to_lsp_char(line, 999, PositionEncoding::Utf8),
-            line.len() as u32
+            u32::try_from(line.len()).unwrap()
         );
     }
 
@@ -252,5 +308,58 @@ mod tests {
         assert_eq!(lsp_char_to_char_idx(line, 0, PositionEncoding::Utf16), 0);
         assert_eq!(lsp_char_to_char_idx(line, 1, PositionEncoding::Utf16), 1);
         assert_eq!(lsp_char_to_char_idx(line, 3, PositionEncoding::Utf16), 2);
+    }
+
+    // --- nth_line ---
+
+    #[test]
+    fn nth_line_lf() {
+        let text = "alpha\nbeta\ngamma";
+        assert_eq!(nth_line(text, 0), "alpha");
+        assert_eq!(nth_line(text, 1), "beta");
+        assert_eq!(nth_line(text, 2), "gamma");
+        assert_eq!(nth_line(text, 3), "");
+    }
+
+    #[test]
+    fn nth_line_crlf() {
+        let text = "alpha\r\nbeta\r\ngamma";
+        assert_eq!(nth_line(text, 0), "alpha");
+        assert_eq!(nth_line(text, 1), "beta");
+        assert_eq!(nth_line(text, 2), "gamma");
+    }
+
+    #[test]
+    fn nth_line_cr_only() {
+        // Classic Mac OS 9 line endings — `str::lines()` does NOT recognise
+        // bare `\r` as a separator, which would split this text into one line.
+        let text = "alpha\rbeta\rgamma";
+        assert_eq!(nth_line(text, 0), "alpha");
+        assert_eq!(nth_line(text, 1), "beta");
+        assert_eq!(nth_line(text, 2), "gamma");
+    }
+
+    #[test]
+    fn nth_line_mixed_line_endings() {
+        let text = "alpha\nbeta\r\ngamma\rdelta";
+        assert_eq!(nth_line(text, 0), "alpha");
+        assert_eq!(nth_line(text, 1), "beta");
+        assert_eq!(nth_line(text, 2), "gamma");
+        assert_eq!(nth_line(text, 3), "delta");
+    }
+
+    #[test]
+    fn nth_line_trailing_newline() {
+        let text = "alpha\nbeta\n";
+        assert_eq!(nth_line(text, 0), "alpha");
+        assert_eq!(nth_line(text, 1), "beta");
+        // Empty final line after the trailing newline.
+        assert_eq!(nth_line(text, 2), "");
+    }
+
+    #[test]
+    fn nth_line_empty_input() {
+        assert_eq!(nth_line("", 0), "");
+        assert_eq!(nth_line("", 5), "");
     }
 }

--- a/crates/lsp/src/encoding.rs
+++ b/crates/lsp/src/encoding.rs
@@ -1,0 +1,256 @@
+//! LSP position-encoding negotiation and offset conversion.
+//!
+//! LSP 3.17 requires the server to pick an encoding from the client's
+//! advertised `general.positionEncodings` list. If the client does not
+//! advertise the capability, the server must use UTF-16 (the spec default).
+//!
+//! `chordsketch-lsp` prefers UTF-8 when the client advertises it — that
+//! matches the parser's native byte offsets and avoids per-character
+//! UTF-16 conversion — but falls back to UTF-16 for clients (including
+//! `vscode-languageclient` 9.x) that advertise only UTF-16.
+
+use tower_lsp::lsp_types::{InitializeParams, PositionEncodingKind};
+
+/// The negotiated LSP position encoding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PositionEncoding {
+    /// `Position.character` is a UTF-8 byte offset.
+    Utf8,
+    /// `Position.character` is a UTF-16 code-unit offset.
+    Utf16,
+}
+
+impl PositionEncoding {
+    /// Maps this encoding to the corresponding [`PositionEncodingKind`]
+    /// for the `InitializeResult.capabilities.position_encoding` reply.
+    #[must_use]
+    pub fn to_kind(self) -> PositionEncodingKind {
+        match self {
+            Self::Utf8 => PositionEncodingKind::UTF8,
+            Self::Utf16 => PositionEncodingKind::UTF16,
+        }
+    }
+}
+
+/// Pick an encoding from the client's `general.positionEncodings`.
+///
+/// - If the client advertises UTF-8, choose UTF-8 (no per-character
+///   conversion needed; matches the parser's native byte offsets).
+/// - Otherwise, return UTF-16. This covers both the case where the client
+///   advertises UTF-16 only (e.g. `vscode-languageclient` 9.x, which
+///   hardcodes `['utf-16']`) and the case where the client omits the
+///   capability entirely — per LSP 3.17 the default is `['utf-16']` and
+///   the server MUST reply with UTF-16 in that case.
+#[must_use]
+pub fn negotiate_encoding(params: &InitializeParams) -> PositionEncoding {
+    let Some(list) = params
+        .capabilities
+        .general
+        .as_ref()
+        .and_then(|g| g.position_encodings.as_ref())
+    else {
+        return PositionEncoding::Utf16;
+    };
+    if list.contains(&PositionEncodingKind::UTF8) {
+        PositionEncoding::Utf8
+    } else {
+        PositionEncoding::Utf16
+    }
+}
+
+/// Convert a client-supplied `Position.character` value on `line` to a
+/// 0-based character index into that line.
+///
+/// - Under UTF-8, `lsp_char` is a byte offset into `line`.
+/// - Under UTF-16, `lsp_char` is a UTF-16 code-unit offset.
+///
+/// When `lsp_char` falls inside a multi-byte code unit sequence (which
+/// should not happen for a spec-compliant client), the returned index
+/// points to the character whose first unit is beyond `lsp_char`.
+#[must_use]
+pub fn lsp_char_to_char_idx(line: &str, lsp_char: u32, encoding: PositionEncoding) -> usize {
+    match encoding {
+        PositionEncoding::Utf8 => {
+            let byte_col = lsp_char as usize;
+            line.char_indices()
+                .take_while(|(b, _)| *b < byte_col)
+                .count()
+        }
+        PositionEncoding::Utf16 => {
+            let mut consumed: u32 = 0;
+            for (i, c) in line.chars().enumerate() {
+                if consumed >= lsp_char {
+                    return i;
+                }
+                consumed += c.len_utf16() as u32;
+            }
+            line.chars().count()
+        }
+    }
+}
+
+/// Convert a 0-based character index into `line` to the `Position.character`
+/// value appropriate for the negotiated encoding.
+///
+/// Returns the length of `line` in the negotiated units when `char_idx`
+/// is at or beyond the last character (the correct sentinel for an LSP
+/// range end).
+#[must_use]
+pub fn char_idx_to_lsp_char(line: &str, char_idx: usize, encoding: PositionEncoding) -> u32 {
+    match encoding {
+        PositionEncoding::Utf8 => line
+            .char_indices()
+            .nth(char_idx)
+            .map(|(b, _)| b as u32)
+            .unwrap_or_else(|| line.len() as u32),
+        PositionEncoding::Utf16 => line
+            .chars()
+            .take(char_idx)
+            .map(|c| c.len_utf16() as u32)
+            .sum(),
+    }
+}
+
+/// Length of `line` expressed in the negotiated encoding's units.
+#[must_use]
+pub fn line_length(line: &str, encoding: PositionEncoding) -> u32 {
+    match encoding {
+        PositionEncoding::Utf8 => line.len() as u32,
+        PositionEncoding::Utf16 => line.chars().map(|c| c.len_utf16() as u32).sum(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp::lsp_types::{ClientCapabilities, GeneralClientCapabilities};
+
+    fn make_params(encodings: Option<Vec<PositionEncodingKind>>) -> InitializeParams {
+        InitializeParams {
+            capabilities: ClientCapabilities {
+                general: Some(GeneralClientCapabilities {
+                    position_encodings: encodings,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn negotiate_returns_utf8_when_client_advertises_utf8() {
+        let params = make_params(Some(vec![
+            PositionEncodingKind::UTF8,
+            PositionEncodingKind::UTF16,
+        ]));
+        assert_eq!(negotiate_encoding(&params), PositionEncoding::Utf8);
+    }
+
+    #[test]
+    fn negotiate_returns_utf16_when_client_advertises_only_utf16() {
+        // vscode-languageclient 9.x behaviour.
+        let params = make_params(Some(vec![PositionEncodingKind::UTF16]));
+        assert_eq!(negotiate_encoding(&params), PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn negotiate_returns_utf16_when_position_encodings_absent() {
+        // LSP 3.17: when the capability is absent the default is ['utf-16'].
+        let params = make_params(None);
+        assert_eq!(negotiate_encoding(&params), PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn negotiate_returns_utf16_when_general_absent() {
+        let params = InitializeParams {
+            capabilities: ClientCapabilities {
+                general: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(negotiate_encoding(&params), PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn negotiate_returns_utf16_when_list_empty() {
+        let params = make_params(Some(vec![]));
+        assert_eq!(negotiate_encoding(&params), PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn negotiate_returns_utf16_when_list_has_only_utf32() {
+        // Unknown/unsupported encodings are not UTF-8, so fall back to UTF-16.
+        let params = make_params(Some(vec![PositionEncodingKind::UTF32]));
+        assert_eq!(negotiate_encoding(&params), PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn utf8_line_length_counts_bytes() {
+        // "Ré" is 3 UTF-8 bytes (R=1, é=2).
+        assert_eq!(line_length("Ré", PositionEncoding::Utf8), 3);
+    }
+
+    #[test]
+    fn utf16_line_length_counts_code_units_bmp() {
+        // All BMP characters → 1 UTF-16 code unit each.
+        assert_eq!(line_length("Ré", PositionEncoding::Utf16), 2);
+    }
+
+    #[test]
+    fn utf16_line_length_counts_code_units_astral() {
+        // U+1F3B8 GUITAR = 2 UTF-16 code units (surrogate pair).
+        assert_eq!(line_length("\u{1F3B8}", PositionEncoding::Utf16), 2);
+        // And 4 UTF-8 bytes.
+        assert_eq!(line_length("\u{1F3B8}", PositionEncoding::Utf8), 4);
+    }
+
+    #[test]
+    fn char_idx_to_lsp_char_utf8_matches_byte_offset() {
+        // "Ré world" — R=1 byte, é=2 bytes, rest ASCII.
+        let line = "Ré world";
+        assert_eq!(char_idx_to_lsp_char(line, 0, PositionEncoding::Utf8), 0);
+        assert_eq!(char_idx_to_lsp_char(line, 1, PositionEncoding::Utf8), 1);
+        assert_eq!(char_idx_to_lsp_char(line, 2, PositionEncoding::Utf8), 3);
+        // char_idx beyond the last char clamps to line.len() (bytes).
+        assert_eq!(
+            char_idx_to_lsp_char(line, 999, PositionEncoding::Utf8),
+            line.len() as u32
+        );
+    }
+
+    #[test]
+    fn char_idx_to_lsp_char_utf16_counts_code_units() {
+        // BMP characters: 1 UTF-16 unit each.
+        let line = "Ré world";
+        assert_eq!(char_idx_to_lsp_char(line, 0, PositionEncoding::Utf16), 0);
+        assert_eq!(char_idx_to_lsp_char(line, 1, PositionEncoding::Utf16), 1);
+        assert_eq!(char_idx_to_lsp_char(line, 2, PositionEncoding::Utf16), 2);
+
+        // Astral: surrogate pair counts as 2 units.
+        let line = "a\u{1F3B8}b";
+        assert_eq!(char_idx_to_lsp_char(line, 0, PositionEncoding::Utf16), 0);
+        assert_eq!(char_idx_to_lsp_char(line, 1, PositionEncoding::Utf16), 1);
+        assert_eq!(char_idx_to_lsp_char(line, 2, PositionEncoding::Utf16), 3);
+        assert_eq!(char_idx_to_lsp_char(line, 3, PositionEncoding::Utf16), 4);
+    }
+
+    #[test]
+    fn lsp_char_to_char_idx_utf8_maps_byte_to_char() {
+        // "Ré world" — byte 0 → char 0, byte 3 → char 2 ("R" at byte 0, "é" at bytes 1-2, " " at byte 3).
+        let line = "Ré world";
+        assert_eq!(lsp_char_to_char_idx(line, 0, PositionEncoding::Utf8), 0);
+        assert_eq!(lsp_char_to_char_idx(line, 1, PositionEncoding::Utf8), 1);
+        assert_eq!(lsp_char_to_char_idx(line, 3, PositionEncoding::Utf8), 2);
+    }
+
+    #[test]
+    fn lsp_char_to_char_idx_utf16_maps_code_unit_to_char() {
+        // Surrogate pair: UTF-16 offsets 0, 1 (inside surrogate), 2, 3 map to char indices 0, 1, 1, 2.
+        let line = "a\u{1F3B8}b";
+        assert_eq!(lsp_char_to_char_idx(line, 0, PositionEncoding::Utf16), 0);
+        assert_eq!(lsp_char_to_char_idx(line, 1, PositionEncoding::Utf16), 1);
+        assert_eq!(lsp_char_to_char_idx(line, 3, PositionEncoding::Utf16), 2);
+    }
+}

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -27,6 +27,7 @@
 
 mod completion;
 mod convert;
+mod encoding;
 mod hover;
 mod server;
 

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use chordsketch_core::parse_multi_lenient;
 use tokio::sync::Mutex;
@@ -21,7 +22,7 @@ use tower_lsp::lsp_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     DocumentFormattingParams, Hover, HoverContents, HoverParams, HoverProviderCapability,
     InitializeParams, InitializeResult, InitializedParams, MarkupContent, MarkupKind, OneOf,
-    Position, PositionEncodingKind, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit, Url,
+    Position, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit, Url,
 };
 use tower_lsp::{Client, LanguageServer};
 
@@ -29,6 +30,9 @@ use crate::completion::{
     CompletionContext, chord_items, detect_context, directive_items, meta_key_items,
 };
 use crate::convert::parse_error_to_diagnostic;
+use crate::encoding::{
+    PositionEncoding, char_idx_to_lsp_char, line_length, lsp_char_to_char_idx, negotiate_encoding,
+};
 use crate::hover::{
     HoverContext, chord_hover_markdown, detect_hover_context, directive_hover_markdown,
     hover_token_span,
@@ -41,11 +45,21 @@ use crate::hover::{
 /// stays small.
 const MAX_DOCUMENTS: usize = 256;
 
+// Sentinel values for `Backend.encoding`. UTF-16 is the spec-mandated
+// fallback when the client omits `general.positionEncodings`, so it is
+// also the pre-initialize default.
+const ENCODING_UTF16: u8 = 0;
+const ENCODING_UTF8: u8 = 1;
+
 /// The LSP server backend.
 pub struct Backend {
     client: Client,
     /// Open document texts, keyed by URI. Needed for completion.
     documents: Arc<Mutex<HashMap<Url, String>>>,
+    /// Position encoding negotiated during `initialize`. Stored as an atomic
+    /// because `initialize` is called through `&self` (tower-lsp) and all
+    /// subsequent request handlers read it concurrently. Written exactly once.
+    encoding: AtomicU8,
 }
 
 impl Backend {
@@ -55,13 +69,24 @@ impl Backend {
         Self {
             client,
             documents: Arc::new(Mutex::new(HashMap::new())),
+            encoding: AtomicU8::new(ENCODING_UTF16),
+        }
+    }
+
+    /// Returns the negotiated position encoding. Before `initialize` has
+    /// been processed the value is UTF-16 (the LSP 3.17 default).
+    fn encoding(&self) -> PositionEncoding {
+        match self.encoding.load(Ordering::Relaxed) {
+            ENCODING_UTF8 => PositionEncoding::Utf8,
+            _ => PositionEncoding::Utf16,
         }
     }
 
     /// Re-parses `text` and publishes diagnostics for `uri`.
     async fn publish_diagnostics(&self, uri: Url, text: &str) {
+        let encoding = self.encoding();
         self.client
-            .publish_diagnostics(uri, diagnostics_for(text), None)
+            .publish_diagnostics(uri, diagnostics_for(text, encoding), None)
             .await;
     }
 
@@ -81,26 +106,36 @@ impl Backend {
 /// Parses `text` and returns LSP diagnostics for every parse error found.
 ///
 /// This is the core mapping function: it drives `parse_multi_lenient` and
-/// converts each `ParseError` to an LSP `Diagnostic`. Extracted as a free
-/// function so it can be unit-tested independently of the LSP transport.
+/// converts each `ParseError` to an LSP `Diagnostic` using the negotiated
+/// position `encoding`. Extracted as a free function so it can be
+/// unit-tested independently of the LSP transport.
 #[must_use]
-pub fn diagnostics_for(text: &str) -> Vec<Diagnostic> {
+pub fn diagnostics_for(text: &str, encoding: PositionEncoding) -> Vec<Diagnostic> {
     parse_multi_lenient(text)
         .all_errors()
         .into_iter()
-        .map(parse_error_to_diagnostic)
+        .map(|e| parse_error_to_diagnostic(e, text, encoding))
         .collect()
 }
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    async fn initialize(&self, _params: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        // LSP 3.17 requires the server to pick an encoding from the client's
+        // advertised list (or fall back to UTF-16 when absent). Storing the
+        // choice lets every request handler produce offsets in matching units.
+        let chosen = negotiate_encoding(&params);
+        self.encoding.store(
+            match chosen {
+                PositionEncoding::Utf8 => ENCODING_UTF8,
+                PositionEncoding::Utf16 => ENCODING_UTF16,
+            },
+            Ordering::Relaxed,
+        );
+
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
-                // Declare UTF-8 encoding so clients send byte offsets rather
-                // than UTF-16 code-unit offsets, avoiding off-by-one errors
-                // for documents that contain non-ASCII characters.
-                position_encoding: Some(PositionEncodingKind::UTF8),
+                position_encoding: Some(chosen.to_kind()),
                 text_document_sync: Some(tower_lsp::lsp_types::TextDocumentSyncCapability::Kind(
                     TextDocumentSyncKind::FULL,
                 )),
@@ -169,6 +204,7 @@ impl LanguageServer for Backend {
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
         let uri = &params.text_document_position.text_document.uri;
         let pos = &params.text_document_position.position;
+        let encoding = self.encoding();
 
         // Extract the relevant line under a short critical section, then drop
         // the lock before calling detect_context and the item builders so that
@@ -181,13 +217,9 @@ impl LanguageServer for Backend {
             text.lines().nth(pos.line as usize).unwrap_or("").to_owned()
         };
 
-        // The server declared UTF-8 position encoding, so `pos.character` is a
-        // byte offset into the line. Convert to a char count for `detect_context`.
-        let byte_col = pos.character as usize;
-        let col = line_owned
-            .char_indices()
-            .take_while(|(byte_idx, _)| *byte_idx < byte_col)
-            .count();
+        // `pos.character` is in the negotiated encoding's units; convert it
+        // to a 0-based character index for `detect_context`.
+        let col = lsp_char_to_char_idx(&line_owned, pos.character, encoding);
 
         let items = match detect_context(&line_owned, col) {
             CompletionContext::DirectiveName { prefix } => directive_items(&prefix),
@@ -206,6 +238,7 @@ impl LanguageServer for Backend {
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
         let uri = &params.text_document_position_params.text_document.uri;
         let pos = &params.text_document_position_params.position;
+        let encoding = self.encoding();
 
         let line_owned: String = {
             let docs = self.documents.lock().await;
@@ -215,12 +248,9 @@ impl LanguageServer for Backend {
             text.lines().nth(pos.line as usize).unwrap_or("").to_owned()
         };
 
-        // pos.character is a UTF-8 byte offset (server declared UTF8 encoding).
-        let byte_col = pos.character as usize;
-        let col = line_owned
-            .char_indices()
-            .take_while(|(byte_idx, _)| *byte_idx < byte_col)
-            .count();
+        // `pos.character` is in the negotiated encoding's units; convert to a
+        // 0-based character index for the hover-context helpers.
+        let col = lsp_char_to_char_idx(&line_owned, pos.character, encoding);
 
         let markdown = match detect_hover_context(&line_owned, col) {
             HoverContext::ChordName { name } => chord_hover_markdown(&name),
@@ -229,17 +259,18 @@ impl LanguageServer for Backend {
         };
 
         let range = hover_token_span(&line_owned, col).map(|(start_char, end_char)| {
-            // Convert char indices to UTF-8 byte offsets (position encoding is UTF8).
-            let start_byte = char_to_byte_offset(&line_owned, start_char);
-            let end_byte = char_to_byte_offset(&line_owned, end_char);
+            // Convert char indices back to `Position.character` in the
+            // negotiated encoding.
+            let start = char_idx_to_lsp_char(&line_owned, start_char, encoding);
+            let end = char_idx_to_lsp_char(&line_owned, end_char, encoding);
             Range {
                 start: Position {
                     line: pos.line,
-                    character: start_byte,
+                    character: start,
                 },
                 end: Position {
                     line: pos.line,
-                    character: end_byte,
+                    character: end,
                 },
             }
         });
@@ -255,6 +286,7 @@ impl LanguageServer for Backend {
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         let uri = &params.text_document.uri;
+        let encoding = self.encoding();
 
         // Extract the document text under a short lock scope, then drop the
         // lock before the (potentially expensive) formatting pass.
@@ -276,10 +308,10 @@ impl LanguageServer for Backend {
             return Ok(Some(vec![]));
         }
 
-        // Replace the entire document with a single TextEdit.
-        // The server declared UTF-8 position encoding, so `character` fields
-        // are byte offsets.
-        let end = document_end_position(&text);
+        // Replace the entire document with a single TextEdit. The `character`
+        // field of the end position must be expressed in the negotiated
+        // encoding's units.
+        let end = document_end_position(&text, encoding);
         let edit = TextEdit {
             range: Range {
                 start: Position {
@@ -294,24 +326,13 @@ impl LanguageServer for Backend {
     }
 }
 
-/// Convert a 0-based character index within `line` to a UTF-8 byte offset.
-///
-/// Returns `line.len()` (cast to `u32`) when `char_idx` is beyond the last
-/// character, which is the correct sentinel value for an LSP range end.
-fn char_to_byte_offset(line: &str, char_idx: usize) -> u32 {
-    line.char_indices()
-        .nth(char_idx)
-        .map(|(b, _)| b as u32)
-        .unwrap_or(line.len() as u32)
-}
-
-/// Compute the end position (UTF-8 byte offset) of `text`.
+/// Compute the end [`Position`] of `text` in the negotiated `encoding`.
 ///
 /// Used to build a full-document `TextEdit` range. Supports LF (`\n`),
 /// CRLF (`\r\n`), and CR-only (`\r`) line endings. Each line break advances
-/// the line counter; the character offset is the byte distance from the last
-/// line-break byte to the end of the string.
-fn document_end_position(text: &str) -> Position {
+/// the line counter; the character offset is the length of the final line
+/// expressed in the negotiated encoding's units.
+fn document_end_position(text: &str, encoding: PositionEncoding) -> Position {
     let mut line: u32 = 0;
     let mut last_newline_byte: usize = 0;
     let bytes = text.as_bytes();
@@ -323,18 +344,18 @@ fn document_end_position(text: &str) -> Position {
                 line += 1;
                 last_newline_byte = i + 1;
             }
-            // A bare \r (CR-only) is a line break.  A \r\n pair is handled
+            // A bare \r (CR-only) is a line break. A \r\n pair is handled
             // by the \n branch on the next iteration, so skip the \r here.
             b'\r' if i + 1 >= len || bytes[i + 1] != b'\n' => {
                 line += 1;
                 last_newline_byte = i + 1;
             }
-            b'\r' => {}
             _ => {}
         }
         i += 1;
     }
-    let character = (text.len() - last_newline_byte) as u32;
+    let last_line = &text[last_newline_byte..];
+    let character = line_length(last_line, encoding);
     Position { line, character }
 }
 
@@ -346,7 +367,7 @@ mod tests {
     #[test]
     fn diagnostics_for_valid_document_returns_empty() {
         let text = "[C]Hello [G]world\n{title: My Song}\n";
-        let diags = diagnostics_for(text);
+        let diags = diagnostics_for(text, PositionEncoding::Utf16);
         assert!(
             diags.is_empty(),
             "expected no diagnostics for valid ChordPro, got: {diags:?}"
@@ -357,7 +378,7 @@ mod tests {
     fn diagnostics_for_unclosed_directive_returns_error() {
         // Missing closing `}` — the parser reports a structural error.
         let text = "{title: Broken\n[C]Hello\n";
-        let diags = diagnostics_for(text);
+        let diags = diagnostics_for(text, PositionEncoding::Utf16);
         assert!(
             !diags.is_empty(),
             "expected at least one diagnostic for unclosed directive"
@@ -371,7 +392,7 @@ mod tests {
         // Line 2 contains `[C Hello world` — the chord bracket is opened with
         // `[` but never closed with `]`, producing a structural parse error.
         let text = "{title: Test}\n[C Hello world\n";
-        let diags = diagnostics_for(text);
+        let diags = diagnostics_for(text, PositionEncoding::Utf16);
         assert!(
             !diags.is_empty(),
             "expected at least one diagnostic for unclosed chord bracket"
@@ -386,15 +407,15 @@ mod tests {
         // Start with an error, then verify the fixed version has no errors.
         let broken = "{title: Broken\n";
         let fixed = "{title: Fixed}\n";
-        assert!(!diagnostics_for(broken).is_empty());
-        assert!(diagnostics_for(fixed).is_empty());
+        assert!(!diagnostics_for(broken, PositionEncoding::Utf16).is_empty());
+        assert!(diagnostics_for(fixed, PositionEncoding::Utf16).is_empty());
     }
 
     #[test]
     fn diagnostics_for_multi_song_collects_all_errors() {
         // Two song segments each with a structural error.
         let text = "{title: A\n[C\n{new_song}\n{title: B\n[G\n";
-        let diags = diagnostics_for(text);
+        let diags = diagnostics_for(text, PositionEncoding::Utf16);
         assert!(
             diags.len() >= 2,
             "expected errors from both song segments, got {}: {diags:?}",
@@ -405,49 +426,81 @@ mod tests {
     // --- document_end_position ---
 
     #[test]
-    fn end_pos_lf_only() {
-        // Standard LF line endings.
-        let pos = document_end_position("line1\nline2\nline3");
+    fn end_pos_lf_only_utf8() {
+        // Standard LF line endings, ASCII-only.
+        let pos = document_end_position("line1\nline2\nline3", PositionEncoding::Utf8);
         assert_eq!(pos.line, 2);
-        assert_eq!(pos.character, 5); // len("line3")
+        assert_eq!(pos.character, 5); // len("line3") bytes
     }
 
     #[test]
-    fn end_pos_crlf() {
+    fn end_pos_lf_only_utf16() {
+        // Same ASCII text — UTF-16 code units equal char count (all BMP).
+        let pos = document_end_position("line1\nline2\nline3", PositionEncoding::Utf16);
+        assert_eq!(pos.line, 2);
+        assert_eq!(pos.character, 5);
+    }
+
+    #[test]
+    fn end_pos_crlf_utf8() {
         // CRLF line endings — \r is skipped, \n advances the counter.
-        let pos = document_end_position("line1\r\nline2\r\nline3");
+        let pos = document_end_position("line1\r\nline2\r\nline3", PositionEncoding::Utf8);
         assert_eq!(pos.line, 2);
         assert_eq!(pos.character, 5);
     }
 
     #[test]
-    fn end_pos_cr_only() {
+    fn end_pos_cr_only_utf8() {
         // CR-only line endings (old Mac OS 9 style).
-        let pos = document_end_position("line1\rline2\rline3");
+        let pos = document_end_position("line1\rline2\rline3", PositionEncoding::Utf8);
         assert_eq!(pos.line, 2);
         assert_eq!(pos.character, 5);
     }
 
     #[test]
-    fn end_pos_empty() {
-        let pos = document_end_position("");
+    fn end_pos_empty_utf8() {
+        let pos = document_end_position("", PositionEncoding::Utf8);
         assert_eq!(pos.line, 0);
         assert_eq!(pos.character, 0);
     }
 
     #[test]
-    fn end_pos_trailing_newline() {
+    fn end_pos_trailing_newline_utf8() {
         // Trailing \n means the final line is empty (character = 0).
-        let pos = document_end_position("line1\nline2\n");
+        let pos = document_end_position("line1\nline2\n", PositionEncoding::Utf8);
         assert_eq!(pos.line, 2);
         assert_eq!(pos.character, 0);
     }
 
     #[test]
-    fn end_pos_trailing_crlf() {
+    fn end_pos_trailing_crlf_utf8() {
         // Trailing \r\n also yields character = 0 on the final line.
-        let pos = document_end_position("line1\r\nline2\r\n");
+        let pos = document_end_position("line1\r\nline2\r\n", PositionEncoding::Utf8);
         assert_eq!(pos.line, 2);
         assert_eq!(pos.character, 0);
+    }
+
+    #[test]
+    fn end_pos_non_ascii_last_line_utf8_bytes() {
+        // "Ré" is 3 UTF-8 bytes.
+        let pos = document_end_position("line1\nRé", PositionEncoding::Utf8);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.character, 3);
+    }
+
+    #[test]
+    fn end_pos_non_ascii_last_line_utf16_code_units() {
+        // "Ré" is 2 UTF-16 code units (both BMP).
+        let pos = document_end_position("line1\nRé", PositionEncoding::Utf16);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.character, 2);
+    }
+
+    #[test]
+    fn end_pos_astral_last_line_utf16_surrogate_pair() {
+        // U+1F3B8 GUITAR is a surrogate pair in UTF-16 (2 units).
+        let pos = document_end_position("line1\n\u{1F3B8}", PositionEncoding::Utf16);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.character, 2);
     }
 }

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -75,8 +75,13 @@ impl Backend {
 
     /// Returns the negotiated position encoding. Before `initialize` has
     /// been processed the value is UTF-16 (the LSP 3.17 default).
+    ///
+    /// Uses `Acquire` ordering to pair with the `Release` store in
+    /// `initialize`, making the write-once publish semantics explicit and
+    /// safe if the runtime is ever switched from `current_thread` to a
+    /// multi-threaded one.
     fn encoding(&self) -> PositionEncoding {
-        match self.encoding.load(Ordering::Relaxed) {
+        match self.encoding.load(Ordering::Acquire) {
             ENCODING_UTF8 => PositionEncoding::Utf8,
             _ => PositionEncoding::Utf16,
         }
@@ -125,12 +130,15 @@ impl LanguageServer for Backend {
         // advertised list (or fall back to UTF-16 when absent). Storing the
         // choice lets every request handler produce offsets in matching units.
         let chosen = negotiate_encoding(&params);
+        // `Release` pairs with `Acquire` in `Backend::encoding()` to publish
+        // the chosen encoding to every subsequent request handler. `initialize`
+        // is called exactly once, so this is a write-once publish.
         self.encoding.store(
             match chosen {
                 PositionEncoding::Utf8 => ENCODING_UTF8,
                 PositionEncoding::Utf16 => ENCODING_UTF16,
             },
-            Ordering::Relaxed,
+            Ordering::Release,
         );
 
         Ok(InitializeResult {


### PR DESCRIPTION
## What

Make `chordsketch-lsp` comply with LSP 3.17 position-encoding negotiation:
pick an encoding from the client's advertised
`general.positionEncodings` list, falling back to UTF-16 when the
capability is absent (the spec-mandated default). Previously the server
unconditionally returned `PositionEncodingKind::UTF8`, which
`vscode-languageclient` 9.x rejects (it hardcodes `['utf-16']` on the
client side), silently disabling diagnostics, completion, hover, and
formatting in the VS Code extension.

## Why

Reported in #1913. The client's error chain was:
1. `Unsupported position encoding (utf-8) received from ...`
2. `Server initialization failed.`
3. `ChordSketch client: couldn't create connection to server.`

Because syntax highlighting and the preview panel still worked, the
regression was silent unless the user opened Output → `ChordSketch LSP`.

## Design

- New `crates/lsp/src/encoding.rs` module with a `PositionEncoding`
  enum and helpers `negotiate_encoding`, `lsp_char_to_char_idx`,
  `char_idx_to_lsp_char`, and `line_length`.
- `Backend` stores the negotiated encoding in an `AtomicU8`. It is
  written exactly once from `initialize` (called by `tower-lsp` through
  `&self`) and read concurrently by every request handler.
- `completion` / `hover` / `formatting` now convert their
  `Position.character` values through the helpers, branching on the
  stored encoding.
- `document_end_position` counts the last line's length in the
  negotiated units (bytes for UTF-8, UTF-16 code units for UTF-16).
- `parse_error_to_diagnostic` / `span_to_range` now take the document
  text and encoding. The parser's `column` is a 1-based character count;
  producing a correct byte / UTF-16 offset requires the actual line
  contents. This also fixes a pre-existing latent off-by-one for
  non-ASCII diagnostic ranges — the old UTF-8 path was passing character
  counts as byte offsets, which was wrong whenever a line contained a
  multi-byte character.

## Tests

- `encoding::tests` — all three negotiation branches (UTF-8 advertised,
  UTF-16 only, capability absent, plus edge cases: empty list, `general`
  absent, unknown encoding only) plus offset conversions with BMP and
  astral (surrogate-pair) characters.
- `convert::tests` — `span_to_range` on ASCII, Latin-1 (`Ré`), and
  astral-plane (`U+1F3B8` guitar emoji) content in both encodings.
- `server::tests::end_pos_*` — LF / CRLF / CR-only line endings plus
  non-ASCII last-line content in both encodings.

All 77 tests pass. `cargo clippy -- -D warnings` and
`RUSTDOCFLAGS='-D warnings' cargo doc --package chordsketch-lsp
--no-deps` both clean.

End-to-end verification against a fresh VSIX (acceptance criterion 4 in
the issue) still requires a human to install the extension and open a
`.cho` file. The unit tests cover the logic; the remaining work is a
release-candidate smoke test.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`: `PositionEncodingKind` is
referenced only in `crates/lsp/src/server.rs`. No other `tower-lsp`-using
binary exists in the workspace, so no other site needs the same fix.

Closes #1913