### PR TITLE
fix(vscode-extension): isolate LSP startup failures from activate()

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -38,14 +38,19 @@ function ensureLspDiagnosticChannel(context: vscode.ExtensionContext): vscode.Ou
 }
 
 async function startLspGuarded(context: vscode.ExtensionContext): Promise<void> {
-  const channel = ensureLspDiagnosticChannel(context);
+  // Do NOT call ensureLspDiagnosticChannel eagerly here — VS Code registers
+  // output channels in the dropdown as soon as they are created, even when
+  // empty. If the LSP starts successfully, vscode-languageclient creates its
+  // own 'ChordSketch LSP' channel; creating a second one unconditionally would
+  // produce a duplicate entry. Defer channel creation into the callbacks so it
+  // only materialises on failure.
   await startLspClientSafely({
     start: () => startLspClient(context),
-    log: (message) => channel.appendLine(message),
+    log: (message) => ensureLspDiagnosticChannel(context).appendLine(message),
     notify: (message) => {
       void vscode.window.showInformationMessage(message, 'Open Output').then((choice) => {
         if (choice === 'Open Output') {
-          channel.show();
+          ensureLspDiagnosticChannel(context).show();
         }
       });
     },

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -5,22 +5,57 @@
  * thanks to the `contributes.languages` declaration in `package.json`.
  *
  * Responsibilities:
- *   - Start the `chordsketch-lsp` language server (if enabled and found)
- *   - Register preview commands
+ *   - Register preview / transpose / convert commands
  *   - Listen for document changes and propagate them to open preview panels
+ *   - Start the `chordsketch-lsp` language server (if enabled and found)
  *   - Restart the LSP when the user changes `chordsketch.lsp.path`
+ *
+ * All non-LSP disposables are registered **before** the LSP is started so
+ * that an LSP initialization failure cannot leave any contributed command
+ * unregistered. See `lsp-activation.ts` for the start guard.
  */
 
 import * as vscode from 'vscode';
 import { startLspClient, stopLspClient } from './lsp.js';
+import { startLspClientSafely } from './lsp-activation.js';
 import { notifyDocumentChanged, disposeAll } from './preview.js';
 import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo, resetCommandSingletons } from './commands.js';
 
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  // Start the LSP client (gracefully degraded if binary not found).
-  await startLspClient(context);
+/**
+ * Output channel used for LSP start-failure diagnostics. Lazily created so we
+ * do not add a `ChordSketch LSP` entry to the Output dropdown when the LSP
+ * starts cleanly (in that case `vscode-languageclient` creates its own
+ * channel with the same name).
+ */
+let lspDiagnosticChannel: vscode.OutputChannel | undefined;
 
-  // Register preview commands.
+function ensureLspDiagnosticChannel(context: vscode.ExtensionContext): vscode.OutputChannel {
+  if (!lspDiagnosticChannel) {
+    lspDiagnosticChannel = vscode.window.createOutputChannel('ChordSketch LSP');
+    context.subscriptions.push(lspDiagnosticChannel);
+  }
+  return lspDiagnosticChannel;
+}
+
+async function startLspGuarded(context: vscode.ExtensionContext): Promise<void> {
+  const channel = ensureLspDiagnosticChannel(context);
+  await startLspClientSafely({
+    start: () => startLspClient(context),
+    log: (message) => channel.appendLine(message),
+    notify: (message) => {
+      void vscode.window.showInformationMessage(message, 'Open Output').then((choice) => {
+        if (choice === 'Open Output') {
+          channel.show();
+        }
+      });
+    },
+  });
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  // Register everything that does not depend on the LSP FIRST. If a later
+  // `startLspClient` call throws, this block has already completed, so
+  // preview / transpose / convert commands remain available.
   context.subscriptions.push(
     registerOpenPreview(context),
     registerOpenPreviewToSide(context),
@@ -35,6 +70,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   // Restart the LSP when the user changes the binary path or enables/disables it.
+  // The restart is wrapped in `startLspGuarded` so a subsequent bad setting
+  // cannot tear down command registrations either.
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(async (event) => {
       if (
@@ -42,14 +79,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         event.affectsConfiguration('chordsketch.lsp.path')
       ) {
         await stopLspClient();
-        await startLspClient(context);
+        await startLspGuarded(context);
       }
     }),
   );
+
+  // Start the LSP client last, under a failure guard.
+  await startLspGuarded(context);
 }
 
 export async function deactivate(): Promise<void> {
   disposeAll();
   await stopLspClient();
   resetCommandSingletons();
+  lspDiagnosticChannel = undefined;
 }

--- a/packages/vscode-extension/src/lsp-activation.test.ts
+++ b/packages/vscode-extension/src/lsp-activation.test.ts
@@ -17,151 +17,148 @@ import {
 
 // --- startLspClientSafely ---
 
-test('startLspClientSafely: returns true when start resolves', async () => {
-    const logs: string[] = [];
-    const notifications: string[] = [];
-    const ok = await startLspClientSafely({
-        start: async () => {},
-        log: (m) => logs.push(m),
-        notify: (m) => notifications.push(m),
-    });
-    assert.equal(ok, true);
-    assert.deepEqual(logs, []);
-    assert.deepEqual(notifications, []);
+test('startLspClientSafely: does not log or notify when start resolves', async () => {
+  const logs: string[] = [];
+  const notifications: string[] = [];
+  await startLspClientSafely({
+    start: async () => {},
+    log: (m) => logs.push(m),
+    notify: (m) => notifications.push(m),
+  });
+  assert.deepEqual(logs, []);
+  assert.deepEqual(notifications, []);
 });
 
-test('startLspClientSafely: returns false and logs Error message when start throws Error', async () => {
-    const logs: string[] = [];
-    const notifications: string[] = [];
-    const ok = await startLspClientSafely({
-        start: async () => {
-            throw new Error('unsupported position encoding (utf-8)');
-        },
-        log: (m) => logs.push(m),
-        notify: (m) => notifications.push(m),
-    });
-    assert.equal(ok, false);
-    // Two diagnostic lines: the failure and the "commands remain" hint.
-    assert.equal(logs.length, 2);
-    assert.ok(logs[0].includes('unsupported position encoding'));
-    assert.ok(logs[1].includes('Preview and transpose/convert commands'));
-    // Single info notification.
-    assert.equal(notifications.length, 1);
-    assert.ok(notifications[0].includes('LSP failed to start'));
+test('startLspClientSafely: logs Error detail and notifies when start throws Error', async () => {
+  const logs: string[] = [];
+  const notifications: string[] = [];
+  await startLspClientSafely({
+    start: async () => {
+      throw new Error('unsupported position encoding (utf-8)');
+    },
+    log: (m) => logs.push(m),
+    notify: (m) => notifications.push(m),
+  });
+  // Two diagnostic lines: the failure and the "commands remain" hint.
+  assert.equal(logs.length, 2);
+  assert.ok(logs[0].includes('unsupported position encoding'));
+  assert.ok(logs[1].includes('Preview and transpose/convert commands'));
+  // Single info notification.
+  assert.equal(notifications.length, 1);
+  assert.ok(notifications[0].includes('LSP failed to start'));
 });
 
 test('startLspClientSafely: handles non-Error rejection values', async () => {
-    const logs: string[] = [];
-    const ok = await startLspClientSafely({
-        start: async () => {
-            // eslint-disable-next-line @typescript-eslint/no-throw-literal
-            throw 'spawn EACCES';
-        },
-        log: (m) => logs.push(m),
-        notify: () => {},
-    });
-    assert.equal(ok, false);
-    assert.ok(logs[0].includes('spawn EACCES'));
+  const logs: string[] = [];
+  await startLspClientSafely({
+    start: async () => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw 'spawn EACCES';
+    },
+    log: (m) => logs.push(m),
+    notify: () => {},
+  });
+  assert.ok(logs[0].includes('spawn EACCES'));
 });
 
 test('startLspClientSafely: never propagates the thrown error', async () => {
-    // The whole point: an unhandled throw inside activate() would skip every
-    // subsequent context.subscriptions.push. Verify the helper absorbs it.
-    await assert.doesNotReject(async () => {
-        await startLspClientSafely({
-            start: async () => {
-                throw new Error('boom');
-            },
-            log: () => {},
-            notify: () => {},
-        });
+  // The whole point: an unhandled throw inside activate() would skip every
+  // subsequent context.subscriptions.push. Verify the helper absorbs it.
+  await assert.doesNotReject(async () => {
+    await startLspClientSafely({
+      start: async () => {
+        throw new Error('boom');
+      },
+      log: () => {},
+      notify: () => {},
     });
+  });
 });
 
 // --- tryStartLanguageClient ---
 
 test('tryStartLanguageClient: assigns the client on successful start', async () => {
-    let published: StartableClient | undefined;
-    const client: StartableClient = {
-        start: async () => {},
-        dispose: () => {},
-    };
-    await tryStartLanguageClient(client, (c) => {
-        published = c;
-    });
-    assert.strictEqual(published, client);
+  let published: StartableClient | undefined;
+  const client: StartableClient = {
+    start: async () => {},
+    dispose: () => {},
+  };
+  await tryStartLanguageClient(client, (c) => {
+    published = c;
+  });
+  assert.strictEqual(published, client);
 });
 
 test('tryStartLanguageClient: resets the published client to undefined when start throws', async () => {
-    // Simulate the previous-successful-start state: setClient holds a stale
-    // reference from an earlier successful attempt.
-    let published: StartableClient | undefined = {
-        start: async () => {},
-        dispose: () => {},
-    };
-    const failingClient: StartableClient = {
-        start: async () => {
-            throw new Error('initialize rejected');
-        },
-        dispose: () => {},
-    };
-    await assert.rejects(
-        tryStartLanguageClient(failingClient, (c) => {
-            published = c;
-        }),
-        /initialize rejected/,
-    );
-    // Must not leak the half-initialized client.
-    assert.strictEqual(published, undefined);
+  // Simulate the previous-successful-start state: setClient holds a stale
+  // reference from an earlier successful attempt.
+  let published: StartableClient | undefined = {
+    start: async () => {},
+    dispose: () => {},
+  };
+  const failingClient: StartableClient = {
+    start: async () => {
+      throw new Error('initialize rejected');
+    },
+    dispose: () => {},
+  };
+  await assert.rejects(
+    tryStartLanguageClient(failingClient, (c) => {
+      published = c;
+    }),
+    /initialize rejected/,
+  );
+  // Must not leak the half-initialized client.
+  assert.strictEqual(published, undefined);
 });
 
 test('tryStartLanguageClient: disposes the failed client', async () => {
-    let disposed = false;
-    const failingClient: StartableClient = {
-        start: async () => {
-            throw new Error('bang');
-        },
-        dispose: () => {
-            disposed = true;
-        },
-    };
-    await assert.rejects(
-        tryStartLanguageClient(failingClient, () => {}),
-        /bang/,
-    );
-    assert.equal(disposed, true);
+  let disposed = false;
+  const failingClient: StartableClient = {
+    start: async () => {
+      throw new Error('bang');
+    },
+    dispose: () => {
+      disposed = true;
+    },
+  };
+  await assert.rejects(
+    tryStartLanguageClient(failingClient, () => {}),
+    /bang/,
+  );
+  assert.equal(disposed, true);
 });
 
 test('tryStartLanguageClient: swallows dispose failures and surfaces the original error', async () => {
-    const failingClient: StartableClient = {
-        start: async () => {
-            throw new Error('primary failure');
-        },
-        dispose: () => {
-            throw new Error('secondary dispose failure');
-        },
-    };
-    // The primary error must reach the caller — dispose-failure noise is suppressed.
-    await assert.rejects(
-        tryStartLanguageClient(failingClient, () => {}),
-        /primary failure/,
-    );
+  const failingClient: StartableClient = {
+    start: async () => {
+      throw new Error('primary failure');
+    },
+    dispose: () => {
+      throw new Error('secondary dispose failure');
+    },
+  };
+  // The primary error must reach the caller — dispose-failure noise is suppressed.
+  await assert.rejects(
+    tryStartLanguageClient(failingClient, () => {}),
+    /primary failure/,
+  );
 });
 
 test('tryStartLanguageClient: re-throws the original error after failure', async () => {
-    const original = new Error('initialize rejected');
-    const failingClient: StartableClient = {
-        start: async () => {
-            throw original;
-        },
-        dispose: () => {},
-    };
-    let caught: unknown;
-    try {
-        await tryStartLanguageClient(failingClient, () => {});
-    } catch (err) {
-        caught = err;
-    }
-    // Identity preserved — the exact Error object reaches activate().
-    assert.strictEqual(caught, original);
+  const original = new Error('initialize rejected');
+  const failingClient: StartableClient = {
+    start: async () => {
+      throw original;
+    },
+    dispose: () => {},
+  };
+  let caught: unknown;
+  try {
+    await tryStartLanguageClient(failingClient, () => {});
+  } catch (err) {
+    caught = err;
+  }
+  // Identity preserved — the exact Error object reaches activate().
+  assert.strictEqual(caught, original);
 });

--- a/packages/vscode-extension/src/lsp-activation.test.ts
+++ b/packages/vscode-extension/src/lsp-activation.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the VS Code-free LSP activation helpers.
+ *
+ * Run with:
+ *   npm test
+ *   node --experimental-transform-types --test src/lsp-activation.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+// Use .ts extension — executed directly by Node with --experimental-transform-types.
+import {
+    startLspClientSafely,
+    tryStartLanguageClient,
+    type StartableClient,
+} from './lsp-activation.ts';
+
+// --- startLspClientSafely ---
+
+test('startLspClientSafely: returns true when start resolves', async () => {
+    const logs: string[] = [];
+    const notifications: string[] = [];
+    const ok = await startLspClientSafely({
+        start: async () => {},
+        log: (m) => logs.push(m),
+        notify: (m) => notifications.push(m),
+    });
+    assert.equal(ok, true);
+    assert.deepEqual(logs, []);
+    assert.deepEqual(notifications, []);
+});
+
+test('startLspClientSafely: returns false and logs Error message when start throws Error', async () => {
+    const logs: string[] = [];
+    const notifications: string[] = [];
+    const ok = await startLspClientSafely({
+        start: async () => {
+            throw new Error('unsupported position encoding (utf-8)');
+        },
+        log: (m) => logs.push(m),
+        notify: (m) => notifications.push(m),
+    });
+    assert.equal(ok, false);
+    // Two diagnostic lines: the failure and the "commands remain" hint.
+    assert.equal(logs.length, 2);
+    assert.ok(logs[0].includes('unsupported position encoding'));
+    assert.ok(logs[1].includes('Preview and transpose/convert commands'));
+    // Single info notification.
+    assert.equal(notifications.length, 1);
+    assert.ok(notifications[0].includes('LSP failed to start'));
+});
+
+test('startLspClientSafely: handles non-Error rejection values', async () => {
+    const logs: string[] = [];
+    const ok = await startLspClientSafely({
+        start: async () => {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw 'spawn EACCES';
+        },
+        log: (m) => logs.push(m),
+        notify: () => {},
+    });
+    assert.equal(ok, false);
+    assert.ok(logs[0].includes('spawn EACCES'));
+});
+
+test('startLspClientSafely: never propagates the thrown error', async () => {
+    // The whole point: an unhandled throw inside activate() would skip every
+    // subsequent context.subscriptions.push. Verify the helper absorbs it.
+    await assert.doesNotReject(async () => {
+        await startLspClientSafely({
+            start: async () => {
+                throw new Error('boom');
+            },
+            log: () => {},
+            notify: () => {},
+        });
+    });
+});
+
+// --- tryStartLanguageClient ---
+
+test('tryStartLanguageClient: assigns the client on successful start', async () => {
+    let published: StartableClient | undefined;
+    const client: StartableClient = {
+        start: async () => {},
+        dispose: () => {},
+    };
+    await tryStartLanguageClient(client, (c) => {
+        published = c;
+    });
+    assert.strictEqual(published, client);
+});
+
+test('tryStartLanguageClient: resets the published client to undefined when start throws', async () => {
+    // Simulate the previous-successful-start state: setClient holds a stale
+    // reference from an earlier successful attempt.
+    let published: StartableClient | undefined = {
+        start: async () => {},
+        dispose: () => {},
+    };
+    const failingClient: StartableClient = {
+        start: async () => {
+            throw new Error('initialize rejected');
+        },
+        dispose: () => {},
+    };
+    await assert.rejects(
+        tryStartLanguageClient(failingClient, (c) => {
+            published = c;
+        }),
+        /initialize rejected/,
+    );
+    // Must not leak the half-initialized client.
+    assert.strictEqual(published, undefined);
+});
+
+test('tryStartLanguageClient: disposes the failed client', async () => {
+    let disposed = false;
+    const failingClient: StartableClient = {
+        start: async () => {
+            throw new Error('bang');
+        },
+        dispose: () => {
+            disposed = true;
+        },
+    };
+    await assert.rejects(
+        tryStartLanguageClient(failingClient, () => {}),
+        /bang/,
+    );
+    assert.equal(disposed, true);
+});
+
+test('tryStartLanguageClient: swallows dispose failures and surfaces the original error', async () => {
+    const failingClient: StartableClient = {
+        start: async () => {
+            throw new Error('primary failure');
+        },
+        dispose: () => {
+            throw new Error('secondary dispose failure');
+        },
+    };
+    // The primary error must reach the caller — dispose-failure noise is suppressed.
+    await assert.rejects(
+        tryStartLanguageClient(failingClient, () => {}),
+        /primary failure/,
+    );
+});
+
+test('tryStartLanguageClient: re-throws the original error after failure', async () => {
+    const original = new Error('initialize rejected');
+    const failingClient: StartableClient = {
+        start: async () => {
+            throw original;
+        },
+        dispose: () => {},
+    };
+    let caught: unknown;
+    try {
+        await tryStartLanguageClient(failingClient, () => {});
+    } catch (err) {
+        caught = err;
+    }
+    // Identity preserved — the exact Error object reaches activate().
+    assert.strictEqual(caught, original);
+});

--- a/packages/vscode-extension/src/lsp-activation.ts
+++ b/packages/vscode-extension/src/lsp-activation.ts
@@ -28,10 +28,6 @@ export interface StartableClient {
  * module-level client reference to `undefined`, and re-throws the original
  * error. This prevents the caller's module from leaking a half-initialized
  * client that a subsequent `stop()` would operate on.
- *
- * The caller is responsible for having already registered `client` with the
- * extension context's subscriptions (so VS Code will still clean it up at
- * deactivation even in the re-throw path).
  */
 export async function tryStartLanguageClient<C extends StartableClient>(
   client: C,
@@ -53,8 +49,8 @@ export async function tryStartLanguageClient<C extends StartableClient>(
 }
 
 /**
- * Run `start` inside a guard that catches any failure, logs it, notifies the
- * user, and returns `false` instead of propagating the error.
+ * Run `start` inside a guard that catches any failure, logs it, and notifies
+ * the user instead of propagating the error.
  *
  * Used by `activate()` to ensure an LSP initialization failure cannot abort
  * activation and leave the preview / transpose / convert commands
@@ -62,32 +58,28 @@ export async function tryStartLanguageClient<C extends StartableClient>(
  * user who invokes them).
  */
 export async function startLspClientSafely(params: {
-    /** The start action — typically `() => startLspClient(context)`. */
-    start: () => Promise<void>;
-    /** Called with any diagnostic line that should land in the LSP output channel. */
-    log: (message: string) => void;
-    /** Called once with a short user-facing message when start fails. */
-    notify: (message: string) => void;
-}): Promise<boolean> {
-    try {
-        await params.start();
-        return true;
-    } catch (err) {
-        const detail = formatError(err);
-        params.log(`Failed to start chordsketch-lsp: ${detail}`);
-        params.log(
-            'Preview and transpose/convert commands remain available.',
-        );
-        params.notify(
-            'ChordSketch: LSP failed to start — preview and transpose/convert commands remain available.',
-        );
-        return false;
-    }
+  /** The start action — typically `() => startLspClient(context)`. */
+  start: () => Promise<void>;
+  /** Called with any diagnostic line that should land in the LSP output channel. */
+  log: (message: string) => void;
+  /** Called once with a short user-facing message when start fails. */
+  notify: (message: string) => void;
+}): Promise<void> {
+  try {
+    await params.start();
+  } catch (err) {
+    const detail = formatError(err);
+    params.log(`Failed to start chordsketch-lsp: ${detail}`);
+    params.log('Preview and transpose/convert commands remain available.');
+    params.notify(
+      'ChordSketch: LSP failed to start — preview and transpose/convert commands remain available.',
+    );
+  }
 }
 
 function formatError(err: unknown): string {
-    if (err instanceof Error) {
-        return err.stack ?? `${err.name}: ${err.message}`;
-    }
-    return String(err);
+  if (err instanceof Error) {
+    return err.stack ?? `${err.name}: ${err.message}`;
+  }
+  return String(err);
 }

--- a/packages/vscode-extension/src/lsp-activation.ts
+++ b/packages/vscode-extension/src/lsp-activation.ts
@@ -1,0 +1,93 @@
+/**
+ * VS Code-free helpers that isolate LSP startup failures from `activate()`.
+ *
+ * Kept in its own module so the logic can be unit-tested with plain Node
+ * (`--experimental-transform-types`) — the `vscode` module is not resolvable
+ * outside the extension host, so any code that imports it (including
+ * `extension.ts` and `lsp.ts`) cannot be loaded directly in Node tests.
+ *
+ * All VS Code types are referenced via `import type` so they are erased at
+ * compile time.
+ */
+
+/**
+ * Minimal shape of a `vscode-languageclient` `LanguageClient` used by
+ * [`tryStartLanguageClient`]. Matches the subset of the real type we depend
+ * on so tests can pass a plain object without importing the real client.
+ */
+export interface StartableClient {
+  start(): Promise<void>;
+  dispose(): Promise<void> | void;
+}
+
+/**
+ * Start `client` and publish it via `setClient` on success.
+ *
+ * If `start()` throws, calls `client.dispose()` (swallowing any dispose
+ * failure — the primary error is what the caller cares about), sets the
+ * module-level client reference to `undefined`, and re-throws the original
+ * error. This prevents the caller's module from leaking a half-initialized
+ * client that a subsequent `stop()` would operate on.
+ *
+ * The caller is responsible for having already registered `client` with the
+ * extension context's subscriptions (so VS Code will still clean it up at
+ * deactivation even in the re-throw path).
+ */
+export async function tryStartLanguageClient<C extends StartableClient>(
+  client: C,
+  setClient: (c: C | undefined) => void,
+): Promise<void> {
+  try {
+    await client.start();
+    setClient(client);
+  } catch (err) {
+    try {
+      await client.dispose();
+    } catch {
+      // Dispose failure on an already-failed client is noise — surface the
+      // primary error instead.
+    }
+    setClient(undefined);
+    throw err;
+  }
+}
+
+/**
+ * Run `start` inside a guard that catches any failure, logs it, notifies the
+ * user, and returns `false` instead of propagating the error.
+ *
+ * Used by `activate()` to ensure an LSP initialization failure cannot abort
+ * activation and leave the preview / transpose / convert commands
+ * unregistered (VS Code would then surface `command '...' not found` to any
+ * user who invokes them).
+ */
+export async function startLspClientSafely(params: {
+    /** The start action — typically `() => startLspClient(context)`. */
+    start: () => Promise<void>;
+    /** Called with any diagnostic line that should land in the LSP output channel. */
+    log: (message: string) => void;
+    /** Called once with a short user-facing message when start fails. */
+    notify: (message: string) => void;
+}): Promise<boolean> {
+    try {
+        await params.start();
+        return true;
+    } catch (err) {
+        const detail = formatError(err);
+        params.log(`Failed to start chordsketch-lsp: ${detail}`);
+        params.log(
+            'Preview and transpose/convert commands remain available.',
+        );
+        params.notify(
+            'ChordSketch: LSP failed to start — preview and transpose/convert commands remain available.',
+        );
+        return false;
+    }
+}
+
+function formatError(err: unknown): string {
+    if (err instanceof Error) {
+        return err.stack ?? `${err.name}: ${err.message}`;
+    }
+    return String(err);
+}

--- a/packages/vscode-extension/src/lsp.ts
+++ b/packages/vscode-extension/src/lsp.ts
@@ -95,20 +95,22 @@ export async function startLspClient(context: vscode.ExtensionContext): Promise<
   // assigned when `start()` resolves — otherwise a `stopLspClient` call from
   // the configuration-change listener would run `stop()` on a half-initialized
   // client, whose state is undefined in `vscode-languageclient` v9.
-  // `context.subscriptions.push` is safe either way: VS Code owns the
-  // disposable and will clean it up on deactivate even if start fails, and
-  // `tryStartLanguageClient` additionally calls `dispose()` immediately so the
-  // stdio child process is freed without waiting for extension-host shutdown.
   const newClient = new LanguageClient(
     'chordsketch',
     'ChordSketch',
     serverOptions,
     clientOptions,
   );
-  context.subscriptions.push(newClient);
+  // `tryStartLanguageClient` disposes `newClient` on failure and re-throws,
+  // so the push below is only reached on a successful start. This avoids
+  // the double-dispose that would occur if we pushed before awaiting —
+  // `LanguageClient.dispose()` is not contractually idempotent across
+  // vscode-languageclient versions, so we register for VS Code cleanup
+  // only after we know we have a live client that won't be disposed eagerly.
   await tryStartLanguageClient(newClient, (c) => {
     client = c;
   });
+  context.subscriptions.push(newClient);
 }
 
 /** Stops the LSP client gracefully and resets the not-found channel reference. */

--- a/packages/vscode-extension/src/lsp.ts
+++ b/packages/vscode-extension/src/lsp.ts
@@ -15,6 +15,7 @@ import {
   TransportKind,
 } from 'vscode-languageclient/node';
 import { resolveLspBinary } from './platform.js';
+import { tryStartLanguageClient } from './lsp-activation.js';
 
 let client: LanguageClient | undefined;
 
@@ -90,9 +91,24 @@ export async function startLspClient(context: vscode.ExtensionContext): Promise<
     outputChannelName: 'ChordSketch LSP',
   };
 
-  client = new LanguageClient('chordsketch', 'ChordSketch', serverOptions, clientOptions);
-  context.subscriptions.push(client);
-  await client.start();
+  // Create the client locally. The module-level `client` reference is only
+  // assigned when `start()` resolves — otherwise a `stopLspClient` call from
+  // the configuration-change listener would run `stop()` on a half-initialized
+  // client, whose state is undefined in `vscode-languageclient` v9.
+  // `context.subscriptions.push` is safe either way: VS Code owns the
+  // disposable and will clean it up on deactivate even if start fails, and
+  // `tryStartLanguageClient` additionally calls `dispose()` immediately so the
+  // stdio child process is freed without waiting for extension-host shutdown.
+  const newClient = new LanguageClient(
+    'chordsketch',
+    'ChordSketch',
+    serverOptions,
+    clientOptions,
+  );
+  context.subscriptions.push(newClient);
+  await tryStartLanguageClient(newClient, (c) => {
+    client = c;
+  });
 }
 
 /** Stops the LSP client gracefully and resets the not-found channel reference. */


### PR DESCRIPTION
## What

Two related fixes for the VS Code extension that prevent an LSP
initialization failure from taking down user-visible commands:

1. `extension.ts`: register preview / transpose / convert commands (and
   the document/configuration event listeners) **before** starting the
   LSP, and wrap the `startLspClient` call in a guard that logs failure
   to the `ChordSketch LSP` output channel and shows a single info
   notification instead of propagating.
2. `lsp.ts`: only assign the module-level `LanguageClient` singleton
   after `client.start()` resolves. On failure, `dispose()` the
   half-initialized instance and leave the singleton `undefined` so the
   configuration-change restart path does not operate on a broken
   client.

## Why

Reported alongside #1913. With the pre-#1919 v0.2.2 LSP server returning
`PositionEncodingKind::UTF8`, `vscode-languageclient` 9.x (which
hardcodes `['utf-16']` and rejects any other reply) threw from
`client.start()`. Because the throw was `await`-ed directly inside
`activate()`, every subsequent `context.subscriptions.push(...)` was
skipped — so invoking the preview button raised `command
'chordsketch.openPreviewToSide' not found`. The preview panel was
documented as a fallback that works without the LSP; in practice it was
unreachable whenever the LSP failed.

This PR fixes the *class* of regression: future LSP bugs cannot take the
preview/transpose/convert commands down with them. It is complementary
to #1919, which fixed the specific server-side trigger.

## Design

- New `src/lsp-activation.ts` — two pure, VS Code-free helpers:
  - `startLspClientSafely({ start, log, notify })`: runs `start`,
    catches any throw, logs the detail (including stack for `Error`
    instances), notifies the user once, and returns a boolean.
  - `tryStartLanguageClient(client, setClient)`: calls `client.start()`
    and publishes the client via `setClient` on success; on throw,
    `dispose()`s the client (swallowing secondary dispose failures),
    calls `setClient(undefined)`, and re-throws the original error.
- `src/extension.ts`: reorders activation so all non-LSP disposables are
  registered first; the LSP is started last under `startLspGuarded`,
  which is also used by the configuration-change restart path.
- `src/lsp.ts`: calls `tryStartLanguageClient` instead of the inline
  `client = new ...; await client.start()` sequence.

## Test results

- `npm test`: **42/42 passing** (9 new tests in `lsp-activation.test.ts`:
  success path, Error / non-Error rejection, absorption guarantee,
  client publishing, reset-on-failure, dispose-on-failure,
  secondary-dispose swallowing, error-identity preservation).
- `npm run lint` (`tsc --noEmit`): clean.
- `npm run build` (esbuild): bundles successfully.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`: there is a single VS Code
extension. No other editor binding in the workspace mounts the LSP via
`vscode-languageclient`. The Zed extension (`packages/zed-extension`)
and JetBrains plugin (`packages/jetbrains-plugin`) each use their own
editor-native LSP client with separate error-isolation guarantees.

## Acceptance Criteria

Per #1914:

- [x] `extension.ts` registers all non-LSP disposables before awaiting
      `startLspClient`.
- [x] `startLspClient` failures are caught, logged to the `ChordSketch
      LSP` output channel, and shown as a single info notification.
      `activate` resolves normally.
- [x] Configuration changes trigger a clean retry path regardless of
      whether the previous attempt threw (same guard used).
- [x] Regression test verifies `activate`-level failure absorption
      (indirectly, via the pure `startLspClientSafely` helper).
- [ ] Manual verification with an older `chordsketch-lsp` binary — left
      to a human reviewer since CI does not run the VS Code host.

Per #1917:

- [x] `startLspClient` assigns the module-level `client` only after
      `client.start()` resolves.
- [x] When `start()` throws, the partial `LanguageClient` is disposed
      and the singleton is `undefined`.
- [x] Unit test covers the "start throws → singleton is undefined"
      sequence via injected mock.
- [x] A subsequent `startLspClient` call after a failed one is able to
      spawn a fresh client (no state bleed — the singleton reset
      guarantees this).

Closes #1914
Closes #1917