### PR TITLE
fix(vscode-extension): persist preview panels across VS Code restarts

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -18,7 +18,7 @@
 import * as vscode from 'vscode';
 import { startLspClient, stopLspClient } from './lsp.js';
 import { startLspClientSafely } from './lsp-activation.js';
-import { notifyDocumentChanged, disposeAll } from './preview.js';
+import { notifyDocumentChanged, disposeAll, registerPreviewSerializer } from './preview.js';
 import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo, resetCommandSingletons } from './commands.js';
 
 /**
@@ -67,6 +67,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     registerTransposeUp(),
     registerTransposeDown(),
     registerConvertTo(context),
+    // Register the preview-panel serializer so that preview tabs survive
+    // VS Code restarts. Registration is synchronous and purely structural; it
+    // does not touch the LSP.
+    registerPreviewSerializer(context),
   );
 
   // Propagate document changes to open preview panels (debounced inside PreviewPanel).

--- a/packages/vscode-extension/src/preview-helpers.ts
+++ b/packages/vscode-extension/src/preview-helpers.ts
@@ -1,0 +1,42 @@
+/**
+ * VS Code-free helpers for the preview panel.
+ *
+ * Kept in a dedicated module so they can be unit-tested with plain Node
+ * (`--experimental-transform-types`) — anything that imports the `vscode`
+ * module (including `preview.ts`) cannot be loaded directly in Node tests
+ * because the module is only resolvable inside the extension host.
+ */
+
+/**
+ * Extracts the persisted source-document URI from a deserialized WebView state.
+ *
+ * Returns `undefined` when the state is missing, malformed, or the URI is not
+ * a non-empty string. Used by the preview-panel serializer in `preview.ts`
+ * to decide whether the state handed back by VS Code is actionable.
+ */
+export function parseSerializedState(state: unknown): { documentUri: string } | undefined {
+  if (typeof state !== 'object' || state === null) {
+    return undefined;
+  }
+  const raw = state as Record<string, unknown>;
+  const uri = raw['documentUri'];
+  if (typeof uri !== 'string' || uri.length === 0) {
+    return undefined;
+  }
+  return { documentUri: uri };
+}
+
+/**
+ * Minimal HTML-attribute escape for embedding values (URIs, config strings)
+ * into the `content=` attribute of an injected `<meta>` element.
+ *
+ * Escapes `&` first so subsequent `&amp;` sequences are not re-escaped.
+ */
+export function escapeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/packages/vscode-extension/src/preview.test.ts
+++ b/packages/vscode-extension/src/preview.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the VS Code-free helpers in preview-helpers.ts:
+ * `parseSerializedState` and `escapeHtmlAttr`.
+ *
+ * The preview-panel lifecycle itself depends on the `vscode` host and is
+ * covered by manual verification and the integration tests tracked in #1918.
+ *
+ * Run with:
+ *   npm test
+ *   node --experimental-transform-types --test src/preview.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+// Use .ts extension — executed directly by Node with --experimental-transform-types.
+import { escapeHtmlAttr, parseSerializedState } from './preview-helpers.ts';
+
+// --- parseSerializedState ---
+
+test('parseSerializedState: valid state returns { documentUri }', () => {
+  const state = { documentUri: 'file:///tmp/song.cho', mode: 'html', transpose: 2 };
+  assert.deepEqual(parseSerializedState(state), {
+    documentUri: 'file:///tmp/song.cho',
+  });
+});
+
+test('parseSerializedState: documentUri alone is enough', () => {
+  assert.deepEqual(parseSerializedState({ documentUri: 'untitled:Untitled-1' }), {
+    documentUri: 'untitled:Untitled-1',
+  });
+});
+
+test('parseSerializedState: null returns undefined', () => {
+  assert.equal(parseSerializedState(null), undefined);
+});
+
+test('parseSerializedState: undefined returns undefined', () => {
+  assert.equal(parseSerializedState(undefined), undefined);
+});
+
+test('parseSerializedState: primitive returns undefined', () => {
+  assert.equal(parseSerializedState('file:///song.cho'), undefined);
+  assert.equal(parseSerializedState(42), undefined);
+  assert.equal(parseSerializedState(true), undefined);
+});
+
+test('parseSerializedState: missing documentUri returns undefined', () => {
+  assert.equal(parseSerializedState({ mode: 'html', transpose: 0 }), undefined);
+});
+
+test('parseSerializedState: empty-string documentUri returns undefined', () => {
+  assert.equal(parseSerializedState({ documentUri: '' }), undefined);
+});
+
+test('parseSerializedState: non-string documentUri returns undefined', () => {
+  assert.equal(parseSerializedState({ documentUri: 42 }), undefined);
+  assert.equal(parseSerializedState({ documentUri: null }), undefined);
+  assert.equal(parseSerializedState({ documentUri: { nested: 'x' } }), undefined);
+});
+
+// --- escapeHtmlAttr ---
+
+test('escapeHtmlAttr: ordinary URI is unchanged', () => {
+  assert.equal(
+    escapeHtmlAttr('file:///Users/me/song.cho'),
+    'file:///Users/me/song.cho',
+  );
+});
+
+test('escapeHtmlAttr: ampersand is escaped', () => {
+  assert.equal(escapeHtmlAttr('a&b'), 'a&amp;b');
+});
+
+test('escapeHtmlAttr: double quote is escaped so attribute is not broken out', () => {
+  assert.equal(escapeHtmlAttr('x"><script>y'), 'x&quot;&gt;&lt;script&gt;y');
+});
+
+test('escapeHtmlAttr: single quote is escaped', () => {
+  assert.equal(escapeHtmlAttr("O'Brien"), 'O&#39;Brien');
+});
+
+test('escapeHtmlAttr: escapes combined & and < in order', () => {
+  // & must be first so later &amp; sequences are not double-escaped.
+  assert.equal(escapeHtmlAttr('&<'), '&amp;&lt;');
+});
+
+test('escapeHtmlAttr: empty string round-trips', () => {
+  assert.equal(escapeHtmlAttr(''), '');
+});

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -4,12 +4,21 @@
  * Manages a `vscode.WebviewPanel` that renders the active ChordPro document as
  * HTML using `@chordsketch/wasm` loaded in the WebView context. Updates are
  * debounced at 300 ms to avoid flooding the WASM renderer on every keystroke.
+ *
+ * Panel state (view mode, transpose offset, source document URI) is persisted
+ * via the WebView's `vscode.setState` API so that preview tabs are restored
+ * across VS Code restarts by [`ChordSketchPreviewSerializer`].
  */
 
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import * as path from 'path';
 import { resolveDefaultMode } from './config.js';
+import { escapeHtmlAttr, parseSerializedState } from './preview-helpers.js';
+
+// Re-export the VS Code-free helpers from their dedicated module so older
+// imports keep working if anything references them through this file.
+export { escapeHtmlAttr, parseSerializedState };
 
 /** Message types sent from the extension host to the WebView. */
 type ExtToWebview = { type: 'update'; text: string } | { type: 'transpose'; delta: 1 | -1 };
@@ -40,6 +49,10 @@ function isWebviewToExt(raw: unknown): raw is WebviewToExt {
 /** Debounce delay in milliseconds. */
 const DEBOUNCE_MS = 300;
 
+/** WebView-panel `viewType` identifier — also the key under which VS Code
+ *  looks up the registered serializer. */
+export const PREVIEW_VIEW_TYPE = 'chordsketchPreview';
+
 /** Tracks all open preview panels keyed by document URI string. */
 const panels = new Map<string, PreviewPanel>();
 
@@ -60,8 +73,7 @@ export function createOrShow(
     existing.reveal(column);
     return;
   }
-  const panel = new PreviewPanel(context, document);
-  panel.show(column);
+  const panel = PreviewPanel.createNew(context, document, column);
   panels.set(key, panel);
 }
 
@@ -99,6 +111,90 @@ export function disposeAll(): void {
   panels.clear();
 }
 
+/**
+ * Registers a WebView panel serializer so that preview tabs survive VS Code
+ * restarts. Must be called once from `activate()`.
+ *
+ * On deserialization the source `vscode.TextDocument` is looked up via the
+ * persisted `documentUri`. If the document is no longer available (file moved
+ * or deleted) the panel renders a friendly message and is left open so the
+ * user can close it without error.
+ */
+export function registerPreviewSerializer(context: vscode.ExtensionContext): vscode.Disposable {
+  return vscode.window.registerWebviewPanelSerializer(PREVIEW_VIEW_TYPE, {
+    async deserializeWebviewPanel(panel: vscode.WebviewPanel, state: unknown): Promise<void> {
+      const parsed = parseSerializedState(state);
+      if (!parsed) {
+        renderUnavailableMessage(
+          panel,
+          'The previewed document could not be determined from the restored state.',
+        );
+        return;
+      }
+
+      let documentUri: vscode.Uri;
+      try {
+        documentUri = vscode.Uri.parse(parsed.documentUri, /* strict */ true);
+      } catch {
+        renderUnavailableMessage(
+          panel,
+          `Could not parse the restored preview source URI: ${parsed.documentUri}`,
+        );
+        return;
+      }
+
+      let document: vscode.TextDocument;
+      try {
+        document = await vscode.workspace.openTextDocument(documentUri);
+      } catch {
+        renderUnavailableMessage(
+          panel,
+          `The file previously previewed could no longer be opened:\n${documentUri.fsPath}`,
+        );
+        return;
+      }
+
+      // Make sure localResourceRoots still matches the extension install path —
+      // VS Code restores the panel options but we re-apply to stay safe.
+      panel.webview.options = {
+        enableScripts: true,
+        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'dist', 'webview')],
+      };
+
+      PreviewPanel.restore(context, document, panel);
+    },
+  });
+}
+
+function renderUnavailableMessage(panel: vscode.WebviewPanel, message: string): void {
+  panel.webview.options = { enableScripts: false };
+  const escaped = message
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\n/g, '<br>');
+  panel.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+  <title>ChordSketch Preview</title>
+  <style>
+    body {
+      font-family: var(--vscode-font-family, sans-serif);
+      padding: 1.5rem;
+      color: var(--vscode-descriptionForeground, #888);
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body>
+  <p>${escaped}</p>
+  <p>You can close this tab safely.</p>
+</body>
+</html>`;
+}
+
 /** Manages a single WebView preview panel for one ChordPro document. */
 class PreviewPanel {
   private readonly panel: vscode.WebviewPanel;
@@ -111,15 +207,35 @@ class PreviewPanel {
   /** Set to true once the panel is disposed so stale timer callbacks are no-ops. */
   private disposed = false;
 
-  constructor(context: vscode.ExtensionContext, document: vscode.TextDocument) {
+  private constructor(
+    context: vscode.ExtensionContext,
+    document: vscode.TextDocument,
+    panel: vscode.WebviewPanel,
+  ) {
     this.context = context;
     this.document = document;
+    this.panel = panel;
 
+    // `buildHtml` is called on every (re)attach so the injected
+    // `<meta name="chordsketch-document-uri">` matches this instance's
+    // document; the WebView persists the URI via `vscode.setState` on
+    // startup so the serializer can find it after a restart.
+    this.panel.webview.html = this.buildHtml();
+    this.wireMessageHandling();
+    this.wireDisposal();
+  }
+
+  /** Creates a fresh panel for `document` and displays it in `column`. */
+  static createNew(
+    context: vscode.ExtensionContext,
+    document: vscode.TextDocument,
+    column: vscode.ViewColumn,
+  ): PreviewPanel {
     const fileName = path.basename(document.uri.fsPath);
-    this.panel = vscode.window.createWebviewPanel(
-      'chordsketchPreview',
+    const panel = vscode.window.createWebviewPanel(
+      PREVIEW_VIEW_TYPE,
       `Preview: ${fileName}`,
-      vscode.ViewColumn.Active,
+      column,
       {
         enableScripts: true,
         // Restrict the WebView to loading resources only from dist/webview/.
@@ -128,10 +244,25 @@ class PreviewPanel {
         retainContextWhenHidden: true,
       },
     );
+    return new PreviewPanel(context, document, panel);
+  }
 
-    this.panel.webview.html = this.buildHtml();
+  /**
+   * Reattaches to a `vscode.WebviewPanel` handed back by VS Code's
+   * `WebviewPanelSerializer`. The panel already exists — we rebuild its HTML
+   * and re-register message and dispose handlers.
+   */
+  static restore(
+    context: vscode.ExtensionContext,
+    document: vscode.TextDocument,
+    panel: vscode.WebviewPanel,
+  ): PreviewPanel {
+    const restored = new PreviewPanel(context, document, panel);
+    panels.set(document.uri.toString(), restored);
+    return restored;
+  }
 
-    // Handle messages from the WebView.
+  private wireMessageHandling(): void {
     this.panel.webview.onDidReceiveMessage((raw: unknown) => {
       if (this.disposed) {
         return;
@@ -154,7 +285,9 @@ class PreviewPanel {
         this.outputChannel.appendLine(`Preview render error: ${raw.message}`);
       }
     });
+  }
 
+  private wireDisposal(): void {
     // Remove this panel from the map when the user closes it, and clean up
     // associated resources immediately so they do not outlive the panel tab.
     // Setting disposed=true before clearTimeout guards against a stale timer
@@ -169,11 +302,6 @@ class PreviewPanel {
       this.outputChannel?.dispose();
       this.outputChannel = undefined;
     });
-  }
-
-  /** Shows the panel in the given column. */
-  show(column: vscode.ViewColumn): void {
-    this.panel.reveal(column);
   }
 
   /** Reveals the panel in the given column (no-op if already visible). */
@@ -242,6 +370,10 @@ class PreviewPanel {
    *     setting value, used as the initial view mode when no persisted state
    *     exists (only `"html"` and `"text"` are accepted; anything else falls
    *     back to `"html"` in the WebView script).
+   *   - `chordsketch-document-uri`: the source-document URI. The WebView
+   *     persists this via `vscode.setState` on startup so that
+   *     [`registerPreviewSerializer`] can reopen the correct document after
+   *     a VS Code restart.
    *
    * A `data-` attribute on `<script type="module">` cannot be used because
    * `document.currentScript` is always `null` for ES module scripts (HTML spec).
@@ -271,6 +403,13 @@ class PreviewPanel {
       .get<string>('preview.defaultMode', 'html');
     const defaultMode = resolveDefaultMode(rawMode);
 
+    // Escape the document URI for safe interpolation into a `content`
+    // attribute. The URI is derived from VS Code's own `TextDocument.uri`
+    // so it is already well-formed, but escaping `&`/`<`/`>`/`"` defends
+    // against pathological file names that could otherwise break out of
+    // the attribute.
+    const documentUriAttr = escapeHtmlAttr(this.document.uri.toString());
+
     // cspSource includes the extension's own dist/webview/ origin.
     const csp = webview.cspSource;
 
@@ -289,6 +428,7 @@ class PreviewPanel {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="chordsketch-wasm-uri" content="${wasmUri}">
   <meta name="chordsketch-default-mode" content="${defaultMode}">
+  <meta name="chordsketch-document-uri" content="${documentUriAttr}">
   <title>ChordSketch Preview</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -414,3 +554,4 @@ class PreviewPanel {
 </html>`;
   }
 }
+

--- a/packages/vscode-extension/src/preview.ts
+++ b/packages/vscode-extension/src/preview.ts
@@ -16,10 +16,6 @@ import * as path from 'path';
 import { resolveDefaultMode } from './config.js';
 import { escapeHtmlAttr, parseSerializedState } from './preview-helpers.js';
 
-// Re-export the VS Code-free helpers from their dedicated module so older
-// imports keep working if anything references them through this file.
-export { escapeHtmlAttr, parseSerializedState };
-
 /** Message types sent from the extension host to the WebView. */
 type ExtToWebview = { type: 'update'; text: string } | { type: 'transpose'; delta: 1 | -1 };
 
@@ -168,11 +164,13 @@ export function registerPreviewSerializer(context: vscode.ExtensionContext): vsc
 
 function renderUnavailableMessage(panel: vscode.WebviewPanel, message: string): void {
   panel.webview.options = { enableScripts: false };
-  const escaped = message
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\n/g, '<br>');
+  // Reuse the same escape routine as `<meta>` attribute injection. Running
+  // the attribute-level escape on body content is safe (and strictly
+  // stronger than strictly necessary): it escapes `&`, `<`, `>`, `"`, `'`,
+  // none of which can re-introduce markup when written into a `<p>` text
+  // node. Line breaks in the input become `<br>` so multi-line messages
+  // stay readable.
+  const escaped = escapeHtmlAttr(message).replace(/\n/g, '<br>');
   panel.webview.html = `<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -31,6 +31,14 @@ interface PanelState {
   mode?: ViewMode;
   /** Semitone transposition offset; clamped to [-11, +11] by adjustTranspose. */
   transpose?: number;
+  /**
+   * URI string of the source document this panel is previewing.
+   *
+   * Written on first run so that VS Code's `WebviewPanelSerializer` can look
+   * up the document when restoring the panel after a restart. See
+   * `registerPreviewSerializer` in `../src/preview.ts`.
+   */
+  documentUri?: string;
 }
 
 /** Message types received from the extension host. */
@@ -188,6 +196,9 @@ function safeGetState(): PanelState {
   if (typeof raw?.['transpose'] === 'number' && Number.isFinite(raw['transpose'])) {
     result.transpose = Math.max(-11, Math.min(11, raw['transpose'] as number));
   }
+  if (typeof raw?.['documentUri'] === 'string' && raw['documentUri'].length > 0) {
+    result.documentUri = raw['documentUri'];
+  }
   return result;
 }
 
@@ -316,6 +327,17 @@ async function main(): Promise<void> {
     transposeLabel.textContent = formatTranspose(transpose);
     btnTransposeDown.disabled = transpose === -11;
     btnTransposeUp.disabled = transpose === 11;
+  }
+
+  // Persist the source-document URI so VS Code's WebviewPanelSerializer can
+  // look it up on the next extension-host activation (after a restart) and
+  // restore this panel bound to the same TextDocument. The URI is injected
+  // by the extension host at HTML build time via a <meta> element.
+  const metaDocumentUri = document.querySelector<HTMLMetaElement>(
+    'meta[name="chordsketch-document-uri"]',
+  )?.content;
+  if (metaDocumentUri && metaDocumentUri !== saved.documentUri) {
+    vscode.setState({ ...safeGetState(), documentUri: metaDocumentUri } satisfies PanelState);
   }
 
   // Register the message listener early — before WASM init — so that


### PR DESCRIPTION
## What

Register a `vscode.WebviewPanelSerializer` so that ChordSketch preview
tabs survive a VS Code restart. Previously the tab was silently lost on
restart because `retainContextWhenHidden: true` only preserves DOM
across hide/show cycles *within* a single process — it is not a
persistence mechanism.

## Why

Reported in #1915. After the LSP-encoding fix (#1919) and activation
guard (#1923), the preview panel is the most visible piece of state
that silently goes missing across restarts.

## Design

- **Split `PreviewPanel` construction** into two factories:
  - `createNew(context, document, column)` — creates a fresh panel.
  - `restore(context, document, panel)` — reattaches to an existing
    `WebviewPanel` handed back by `deserializeWebviewPanel`.
- **Persist the source `documentUri`** on the WebView side via
  `vscode.setState`. The extension host injects the URI as
  `<meta name="chordsketch-document-uri">` at HTML build time (escaped
  through `escapeHtmlAttr`); the WebView reads it on startup and writes
  it to state.
- **New `registerPreviewSerializer(context)`** implements
  `vscode.WebviewPanelSerializer`. It validates state via
  `parseSerializedState`, parses the URI with
  `vscode.Uri.parse(..., strict=true)`, opens the `TextDocument`, and
  calls `PreviewPanel.restore`. Every failure branch (state missing,
  URI unparseable, file unavailable) renders a friendly no-script
  message so the user can close the tab without error.
- **VS Code-free helpers** (`parseSerializedState`, `escapeHtmlAttr`)
  live in a new `preview-helpers.ts` module so they can be unit-tested
  with plain Node.

## Tests

- `npm run lint`: clean.
- `npm test`: **56/56 passing** (14 new).
- `npm run build`: bundles successfully.

Automated end-to-end verification is gated on the `@vscode/test-electron`
harness tracked in #1918.

## Sister-site audit

The VS Code extension is the only workspace consumer of
`vscode.WebviewPanelSerializer`. No sibling editor binding needs the
same fix.

Closes #1915