### PR TITLE
test(convert-musicxml): strengthen multi-verse lyric coverage and add U+FFFF export guard

### DIFF
--- a/crates/convert-musicxml/src/export.rs
+++ b/crates/convert-musicxml/src/export.rs
@@ -661,6 +661,24 @@ mod tests {
     }
 
     #[test]
+    fn export_survives_ffff_in_title() {
+        // Sibling of `export_survives_ffe_in_title` for U+FFFF.  Both
+        // noncharacters were added together in PR #1902 and carry the same
+        // risk; an explicit end-to-end test closes the coverage asymmetry.
+        let mut song = Song::new();
+        song.metadata.title = Some("Hello\u{FFFF}World".to_string());
+        let xml = to_musicxml(&song);
+        assert!(
+            !xml.contains('\u{FFFF}'),
+            "U+FFFF must be stripped from XML output"
+        );
+        assert!(
+            xml.contains("HelloWorld"),
+            "surrounding title text must be preserved"
+        );
+    }
+
+    #[test]
     fn export_survives_control_char_in_title() {
         // Round-trip guard: a title containing U+0007 must produce XML
         // that does not carry the forbidden byte through. Any conformant

--- a/crates/convert-musicxml/src/import.rs
+++ b/crates/convert-musicxml/src/import.rs
@@ -659,15 +659,11 @@ mod tests {
         assert_eq!(lyrics.len(), 1);
         if let Line::Lyrics(ll) = lyrics[0] {
             assert_eq!(ll.segments.len(), 1);
-            let text = &ll.segments[0].text;
-            assert!(
-                text.contains("Amazing") && text.contains("'Twas"),
-                "expected both verses in joined lyric text; got {text:?}"
-            );
-            assert!(
-                text.contains(" / "),
-                "expected ' / ' delimiter between verses; got {text:?}"
-            );
+            // Exact equality — a `.contains()` check would have accepted
+            // the pre-#1870/#1879 double-space output `"Amazing  / 'Twas "`
+            // and silently missed the regression. See the unit-level
+            // sibling test `collect_lyric_text_multi_verse_single_single_no_double_space`.
+            assert_eq!(ll.segments[0].text, "Amazing / 'Twas ");
         }
     }
 
@@ -740,5 +736,37 @@ mod tests {
 </note>"#;
         let element = crate::xml::parse(xml).unwrap();
         assert_eq!(collect_lyric_text(&element), "a / word-");
+    }
+
+    #[test]
+    fn collect_lyric_text_multi_verse_middle_single() {
+        // `begin` and `middle` both emit `<text>-` (a hyphen, not a
+        // space) so they share the non-last trailing-space stripping
+        // branch — the existing `begin`+`single` test implicitly covers
+        // `middle` too. This explicit test makes the coverage visible so
+        // a future refactor that treats `middle` differently from `begin`
+        // cannot silently change the output.
+        let xml = r#"<note>
+  <lyric number="1"><syllabic>middle</syllabic><text>a</text></lyric>
+  <lyric number="2"><syllabic>single</syllabic><text>word</text></lyric>
+</note>"#;
+        let element = crate::xml::parse(xml).unwrap();
+        assert_eq!(collect_lyric_text(&element), "a- / word ");
+    }
+
+    #[test]
+    fn collect_lyric_text_three_verses_single_single_single() {
+        // 3+ verse coverage: document the expected output for more than
+        // two verses so a future refactor of the joining loop (e.g., a
+        // switch from iterative folding to `join`) cannot silently change
+        // interior-separator semantics. Each non-last `single` verse's
+        // trailing space is stripped; only the last one keeps its space.
+        let xml = r#"<note>
+  <lyric number="1"><syllabic>single</syllabic><text>one</text></lyric>
+  <lyric number="2"><syllabic>single</syllabic><text>two</text></lyric>
+  <lyric number="3"><syllabic>single</syllabic><text>three</text></lyric>
+</note>"#;
+        let element = crate::xml::parse(xml).unwrap();
+        assert_eq!(collect_lyric_text(&element), "one / two / three ");
     }
 }


### PR DESCRIPTION
## What

Close two coverage gaps in \`crates/convert-musicxml\` identified during recent reviews:

- **#1908** — Add \`export_survives_ffff_in_title\` mirroring the existing \`export_survives_ffe_in_title\`. Both U+FFFE and U+FFFF were introduced as stripped noncharacters in the same PR (#1902); previously only U+FFFE had an end-to-end round-trip guard.
- **#1909** — Strengthen \`collect_lyric_text\` tests:
  - Replace \`.contains()\` assertions in \`import_multi_verse_lyrics\` with exact equality — the old check would have accepted the pre-#1870/#1879 double-space output.
  - Add \`collect_lyric_text_multi_verse_middle_single\` to make \`syllabic=middle\` non-last coverage explicit (it was implicitly covered via the \`begin\`+\`single\` test).
  - Add \`collect_lyric_text_three_verses_single_single_single\` for the 3+ verse case.

## Why

Pure test-coverage additions — no production behaviour changes. The existing tests were not tight enough to catch regressions that actually shipped (the double-space output in #1870).

## Test results

- \`cargo test --package chordsketch-convert-musicxml\`: 12 unit tests pass (3 new); doc tests pass.
- \`cargo clippy --package chordsketch-convert-musicxml --all-targets -- -D warnings\`: clean.
- \`cargo fmt --check\`: clean.

Closes #1908
Closes #1909