### PR TITLE
test(sanitizer): explicit mhtml: blocklist coverage and <use> fragment-only edge cases

### DIFF
--- a/crates/core/src/image_path.rs
+++ b/crates/core/src/image_path.rs
@@ -207,6 +207,11 @@ mod tests {
         assert!(!is_safe_image_src("file:///etc/passwd"));
         assert!(!is_safe_image_src("blob:https://example.com/uuid"));
         assert!(!is_safe_image_src("vbscript:msgbox"));
+        // `mhtml:` is documented as blocked in the function's doc comment
+        // and is rejected because any scheme other than `http`/`https` is
+        // denied. Explicit assertion per the testing-completeness rule in
+        // `.claude/rules/sanitizer-security.md`.
+        assert!(!is_safe_image_src("mhtml:file:///etc/passwd"));
     }
 
     #[test]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1873,6 +1873,33 @@ mod sanitize_tag_attrs_tests {
         assert!(result.contains("style"));
         assert!(result.contains("fill: red"));
     }
+
+    #[test]
+    fn test_use_strips_relative_url_href() {
+        // #1857 / #1860: `<use>` only allows fragment-only (`#foo`) hrefs.
+        // A relative URL like `sprites.svg#icon` is NOT fragment-only —
+        // it resolves against the document's base URL and could fetch an
+        // external SVG sprite sheet. The fragment-only check strips it.
+        let tag = "<use href=\"sprites.svg#icon\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(
+            !result.contains("href="),
+            "relative URL must be stripped for <use>; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_use_preserves_whitespace_prefixed_fragment_href() {
+        // Some serializers emit `href=" #symbol"` with leading whitespace
+        // around the value. The fragment-only check uses `trim_start` so
+        // whitespace-padded fragments are still accepted.
+        let tag = "<use href=\" #myShape\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(
+            result.contains("href"),
+            "whitespace-prefixed fragment href must be preserved; got {result:?}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1876,10 +1876,12 @@ mod sanitize_tag_attrs_tests {
 
     #[test]
     fn test_use_strips_relative_url_href() {
-        // #1857 / #1860: `<use>` only allows fragment-only (`#foo`) hrefs.
-        // A relative URL like `sprites.svg#icon` is NOT fragment-only —
-        // it resolves against the document's base URL and could fetch an
-        // external SVG sprite sheet. The fragment-only check strips it.
+        // `<use>` only allows fragment-only (`#foo`) hrefs (policy added in
+        // PR #1857, which this test extends; see also #1828 for the broader
+        // SVG attack surface tracker). A relative URL like
+        // `sprites.svg#icon` is NOT fragment-only — it resolves against the
+        // document's base URL and could fetch an external SVG sprite sheet.
+        // The fragment-only check strips it.
         let tag = "<use href=\"sprites.svg#icon\">";
         let result = sanitize_tag_attrs(tag);
         assert!(
@@ -1895,8 +1897,11 @@ mod sanitize_tag_attrs_tests {
         // whitespace-padded fragments are still accepted.
         let tag = "<use href=\" #myShape\">";
         let result = sanitize_tag_attrs(tag);
+        // Match `href=` (with the `=`) specifically: the bare `href`
+        // substring would also match the tag name `<use>` plus the word
+        // `href` appearing in unrelated sanitized output.
         assert!(
-            result.contains("href"),
+            result.contains("href="),
             "whitespace-prefixed fragment href must be preserved; got {result:?}"
         );
     }


### PR DESCRIPTION
## What

Two test-only coverage additions for the sanitizer:

- **#1875** — Add explicit \`assert!(!is_safe_image_src(\"mhtml:...\"))\` to \`safe_src_rejects_dangerous_schemes\` in \`crates/core/src/image_path.rs\`. \`mhtml:\` is already documented as blocked and is rejected in practice (anything other than \`http\`/\`https\` is denied), but it had no explicit test — contrary to the testing-completeness rule in \`.claude/rules/sanitizer-security.md\`.
- **#1860** — Add two unit tests for the \`<use>\` fragment-only policy in \`sanitize_tag_attrs\`:
  - \`test_use_strips_relative_url_href\`: asserts \`href=\"sprites.svg#icon\"\` is stripped (relative URL, not fragment-only).
  - \`test_use_preserves_whitespace_prefixed_fragment_href\`: asserts \`href=\" #symbol\"\` is preserved (the \`trim_start().starts_with('#')\` check must tolerate leading whitespace).

## Why

Pure test additions — no production behaviour changes. Existing integration tests in \`delegate_tests\` only cover external \`https://\` URLs, so the two edge cases above could have silently regressed.

## Test results

- \`cargo test -p chordsketch-core --lib image_path\`: 17 passed.
- \`cargo test -p chordsketch-render-html --lib sanitize_tag_attrs_tests\`: 11 passed (2 new).
- \`cargo clippy -p chordsketch-core -p chordsketch-render-html --all-targets -- -D warnings\`: clean.
- \`cargo fmt --check\`: clean.

Closes #1875
Closes #1860