### PR TITLE
test(render-text): assert warning emitted for rejected file: image src

### DIFF
--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -1394,6 +1394,14 @@ mod delegate_tests {
             !result.output.contains("[Image"),
             "file: src must not reach text output"
         );
+        // Sister-site parity with `test_render_image_dangerous_scheme_rejected`:
+        // silent rejection is not enough — the renderer must surface a
+        // warning so users know the `{image}` directive was dropped.
+        assert!(
+            result.warnings.iter().any(|w| w.contains("file")),
+            "expected a warning mentioning the rejected src; got {:?}",
+            result.warnings
+        );
     }
 
     // -- {capo} validation parity (#1834) ---------------------------------


### PR DESCRIPTION
## What

Strengthen \`test_render_image_file_uri_rejected\` in \`crates/render-text/src/lib.rs\` to additionally assert that a warning is emitted when a \`file:\` image src is rejected.

## Why

Sister-site parity: the \`javascript:\` test (\`test_render_image_dangerous_scheme_rejected\`) already asserts both absence-from-output **and** warning emission; the \`file:\` test only checked the first. A future refactor that silently drops the warning (e.g., replacing \`push_warning\` with \`eprintln!\`) would regress user-visible behaviour without failing any test.

## Test results

\`\`\`
cargo test -p chordsketch-render-text --lib test_render_image_file_uri
  → 1 passed
cargo clippy -p chordsketch-render-text --all-targets -- -D warnings
  → clean
cargo fmt --check
  → clean
\`\`\`

Closes #1876