### PR TITLE
test(render-pdf): regression guard for validate_margin respecting MAX_WARNINGS cap

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -5083,6 +5083,40 @@ mod jpeg_tests {
     }
 
     #[test]
+    fn test_validate_margin_respects_max_warnings_cap() {
+        // #1899: `validate_margin` previously called `warnings.push` directly
+        // and bypassed the `MAX_WARNINGS` cap. Regression guard: fill the
+        // vector to exactly MAX_WARNINGS via the canonical `push_warning`
+        // path (which appends the truncation marker on the first overflow),
+        // then hit the margin validator with an invalid value. If the
+        // function ever reverts to bypassing the cap, the vector will grow
+        // past MAX_WARNINGS + 1 and this assertion will fire.
+        let mut warnings: Vec<String> = Vec::new();
+        for i in 0..MAX_WARNINGS {
+            push_warning(&mut warnings, format!("filler warning {i}"));
+        }
+        // The cap helper appends a single truncation marker on the first
+        // overflow and then short-circuits; future pushes must not grow
+        // the vector further.
+        push_warning(&mut warnings, "overflow warning".to_string());
+        assert_eq!(
+            warnings.len(),
+            MAX_WARNINGS + 1,
+            "precondition: vector is at MAX_WARNINGS + 1 after first overflow",
+        );
+
+        // Now ask the margin validator for a value that would emit a
+        // warning. Because the vector is already at the truncation point,
+        // nothing must be appended.
+        let _ = PdfDocument::validate_margin(-100.0, MARGIN_TOP, "top", &mut warnings);
+        assert_eq!(
+            warnings.len(),
+            MAX_WARNINGS + 1,
+            "validate_margin must route through push_warning and respect the cap",
+        );
+    }
+
+    #[test]
     fn test_embed_jpeg_produces_xobject() {
         let jpeg = minimal_jpeg(320, 240);
         let mut doc = PdfDocument::new();


### PR DESCRIPTION
## What

Add \`test_validate_margin_respects_max_warnings_cap\` in \`crates/render-pdf/src/lib.rs\` — a targeted regression guard for the PR #1899 fix.

## Why

#1899 routed \`PdfDocument::validate_margin\`'s warning through the \`push_warning\` helper so it participates in the \`MAX_WARNINGS\` cap. The existing \`test_max_warnings_truncates\` exercises the cap via transpose warnings, but nothing asserted the margin-validator path specifically. A future refactor reverting to a raw \`warnings.push\` would cause the vector to grow to \`MAX_WARNINGS + 2\`, which is exactly what this new test catches.

The test:
1. Fills \`warnings\` to \`MAX_WARNINGS\` via \`push_warning\`.
2. Pushes one more to append the truncation marker.
3. Asserts precondition \`len == MAX_WARNINGS + 1\`.
4. Calls \`PdfDocument::validate_margin(-100.0, ...)\`.
5. Asserts length still equals \`MAX_WARNINGS + 1\`.

## Test results

\`\`\`
cargo test -p chordsketch-render-pdf --lib test_validate_margin_respects
  → 1 passed
cargo clippy -p chordsketch-render-pdf --all-targets -- -D warnings
  → clean
cargo fmt --check
  → clean
\`\`\`

Closes #1906