### PR TITLE
refactor(test): move subprocess import to module level

### DIFF
--- a/scripts/test_check_release_channels.py
+++ b/scripts/test_check_release_channels.py
@@ -21,6 +21,7 @@ tag. This file covers the behaviors most likely to break under refactoring:
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -490,8 +491,6 @@ class CliOutputOrderingTests(unittest.TestCase):
     SCRIPT = SCRIPTS_DIR / "check-release-channels.py"
 
     def _run_with_combined_redirect(self, argv: list[str]) -> tuple[int, str]:
-        import subprocess
-
         # The workflow does `> out 2>&1`; emulate that by merging streams
         # so we observe whichever Python actually writes first.
         completed = subprocess.run(


### PR DESCRIPTION
## What

Move \`import subprocess\` from inside \`CliOutputOrderingTests._run_with_combined_redirect\` to the module-level imports in \`scripts/test_check_release_channels.py\`.

## Why

Style consistency — the rest of the file's imports sit at the top. Per #1877.

## Test results

\`python3 -m unittest scripts.test_check_release_channels\` — 26/26 passing.

Closes #1877