### PR TITLE
docs: refresh nix verification note, add cli platform table, fix wasm README Warning shape

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -23,6 +23,24 @@ Snap, Chocolatey, the GitHub Container Registry, and Docker Hub — see
 the [top-level README](https://github.com/koedame/chordsketch#installation)
 for the registry-specific commands.
 
+### Platform compatibility
+
+Official release binaries (produced by `.github/workflows/release.yml`)
+are available for the following targets:
+
+| Target triple | OS | Arch | Notes |
+|---|---|---|---|
+| `x86_64-unknown-linux-gnu` | Linux | x86_64 | glibc |
+| `aarch64-unknown-linux-gnu` | Linux | ARM64 | glibc |
+| `x86_64-unknown-linux-musl` | Linux | x86_64 | static (musl) |
+| `aarch64-unknown-linux-musl` | Linux | ARM64 | static (musl) |
+| `x86_64-apple-darwin` | macOS | Intel (x86_64) | — |
+| `aarch64-apple-darwin` | macOS | Apple Silicon (ARM64) | — |
+| `x86_64-pc-windows-msvc` | Windows | x86_64 | MSVC runtime |
+
+For any other target, use `cargo install chordsketch`; the crate has no
+external build-time dependencies beyond a stable Rust toolchain.
+
 ## Quick Start
 
 ```bash

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -66,8 +66,17 @@ The exported wasm-bindgen functions are:
 | `render_text_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `string` |
 | `render_html_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `string` |
 | `render_pdf_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `Uint8Array` |
-| `render_songs_with_warnings(input, opts?)` | Multi-song variant that returns warnings | `{ songs: string[], warnings: Warning[] }` |
+| `renderTextWithWarnings(input)` | Plain-text render that captures warnings instead of forwarding to `console.warn` | `{ output: string, warnings: string[] }` |
+| `renderHtmlWithWarnings(input)` | HTML render with captured warnings | `{ output: string, warnings: string[] }` |
+| `renderPdfWithWarnings(input)` | PDF render with captured warnings | `{ output: Uint8Array, warnings: string[] }` |
 | `version()` | Library version string | `string` |
+
+Each element of `warnings` is a plain UTF-8 string containing a
+human-readable diagnostic (e.g., `"{capo: 999} out of range 0..=11 — ignored"`).
+Use the `*WithWarnings` variants when embedding the WASM package in a
+UI that needs to show warnings inline or aggregate them across renders;
+the plain `render_*` functions forward warnings to `console.warn`
+instead.
 
 ## Links
 

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -4,11 +4,15 @@
 # Place it at pkgs/by-name/ch/chordsketch/package.nix in a nixpkgs
 # checkout and submit a PR.
 #
-# Verified: builds and passes tests on x86_64-linux with nixpkgs unstable.
+# Last verified build: v0.2.0 on x86_64-linux with nixpkgs unstable.
+# v0.2.2 hashes are intentionally blank (see `hash` / `cargoHash`
+# below) — the release PR #1897 bumped `version` but leaves the
+# derivation in its "awaiting-build" state per the workflow below.
 #
 # When bumping to a new release, update `version` and recompute `hash`
 # and `cargoHash` by setting both to "" and building once — nix will
-# report the correct SRI hashes in the error messages.
+# report the correct SRI hashes in the error messages. After a
+# successful build, update the "Last verified build" line above.
 
 {
   lib,


### PR DESCRIPTION
## What

Three unrelated but trivial docs fixes, batched into one PR to keep CI / review load down:

- **#1901** — \`packaging/nix/package.nix\`: the top-of-file "Verified" comment was accurate for v0.2.0 but after #1897 bumped the version to v0.2.2 and left \`hash\`/\`cargoHash\` intentionally blank, it misleadingly implied the v0.2.2 derivation had been validated. Reword to "Last verified build: v0.2.0" and spell out that the blank hashes are intentional.
- **#1881** — \`crates/cli/README.md\`: add the L3-required platform compatibility table. Lists the seven target triples that \`release.yml\` actually builds (Linux glibc/musl × x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64-msvc). Satisfies the platform-table requirement in \`.claude/rules/package-documentation.md\`.
- **#1862** — \`crates/wasm/README.md\`: the API table listed \`render_songs_with_warnings(input, opts?)\` with return type \`{ songs: string[], warnings: Warning[] }\`. Neither the function nor the \`Warning\` type exists — the real exports are \`renderTextWithWarnings\` / \`renderHtmlWithWarnings\` / \`renderPdfWithWarnings\`, each returning \`{ output, warnings: string[] }\`. Replace the stale row with the three real entries and add a short paragraph on the \`*WithWarnings\` contract.

## Why

Documentation-only — no code paths, no tests. Each fix was flagged in a prior PR review; batching avoids three separate PRs for three one-file changes.

## Test results

N/A (docs-only). Contents verified against current source:
- nix: \`version = "0.2.2"\`, \`hash\`/\`cargoHash = ""\` per #1897.
- cli: matrix in \`.github/workflows/release.yml:43-59\`.
- wasm: actual exports / serialization in \`crates/wasm/src/lib.rs:310-314, 401-431\`.

Closes #1901
Closes #1881
Closes #1862