### PR TITLE
feat(bindings): add *_with_warnings_and_options variants (WASM + NAPI)

### DIFF
--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -59,9 +59,22 @@ console.log(`ChordSketch ${version()}`);
 | `renderTextWithOptions(source, options)` | `string` | Text with transposition / config |
 | `renderHtmlWithOptions(source, options)` | `string` | HTML with transposition / config |
 | `renderPdfWithOptions(source, options)` | `Buffer` | PDF with transposition / config |
+| `renderTextWithWarnings(source)` | `{ output: string, warnings: string[] }` | Text render that captures warnings as structured data |
+| `renderHtmlWithWarnings(source)` | `{ output: string, warnings: string[] }` | HTML render with captured warnings |
+| `renderPdfWithWarnings(source)` | `{ output: Buffer, warnings: string[] }` | PDF render with captured warnings |
+| `renderTextWithWarningsAndOptions(source, options)` | `{ output: string, warnings: string[] }` | `renderTextWithWarnings` + transposition / config |
+| `renderHtmlWithWarningsAndOptions(source, options)` | `{ output: string, warnings: string[] }` | `renderHtmlWithWarnings` + transposition / config |
+| `renderPdfWithWarningsAndOptions(source, options)` | `{ output: Buffer, warnings: string[] }` | `renderPdfWithWarnings` + transposition / config |
 
-> **Note:** `renderPdf` returns a Node.js `Buffer` (not `Uint8Array`). This
-> differs from `@chordsketch/wasm` where PDF output is `Uint8Array`.
+> **Note:** `renderPdf` and `renderPdfWithWarnings` return a Node.js `Buffer`
+> (not `Uint8Array`). This differs from `@chordsketch/wasm` where PDF output
+> is `Uint8Array`.
+
+> **When to use `*WithWarnings`:** the plain `render*` functions forward
+> warnings to process stderr via `eprintln!`, which is invisible to most
+> UI callers. The `*WithWarnings` variants return the warnings as an
+> array of strings so they can be shown inline, aggregated, or
+> suppressed. See #1827.
 
 ### Validation
 

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -698,7 +698,10 @@ mod tests {
             &chordsketch_core::config::Config::defaults(),
         )
         .output;
-        assert_ne!(zero, shifted);
+        assert_ne!(
+            zero, shifted,
+            "transpose=2 must produce different output from transpose=0"
+        );
     }
 
     #[test]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -244,12 +244,20 @@ pub fn render_html_with_warnings(input: String) -> Result<TextRenderWithWarnings
 #[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_pdf_with_warnings(input: String) -> Result<PdfRenderWithWarnings> {
-    let songs = parse_songs(&input)?;
-    let result = chordsketch_render_pdf::render_songs_with_warnings(
-        &songs,
-        0,
-        &chordsketch_core::config::Config::defaults(),
-    );
+    do_render_pdf_with_warnings(&input, &chordsketch_core::config::Config::defaults(), 0)
+}
+
+/// Shared implementation for the PDF `*_with_warnings` variants. Extracted
+/// so [`render_pdf_with_warnings`] and
+/// [`render_pdf_with_warnings_and_options`] route through the same
+/// parse + render + capture pipeline.
+fn do_render_pdf_with_warnings(
+    input: &str,
+    config: &chordsketch_core::config::Config,
+    transpose: i8,
+) -> Result<PdfRenderWithWarnings> {
+    let songs = parse_songs(input)?;
+    let result = chordsketch_render_pdf::render_songs_with_warnings(&songs, transpose, config);
     Ok(PdfRenderWithWarnings {
         output: result.output.into(),
         warnings: result.warnings,
@@ -332,6 +340,62 @@ pub fn render_pdf_with_options(input: String, options: RenderOptions) -> Result<
         chordsketch_render_pdf::render_songs_with_warnings,
     )?;
     Ok(bytes.into())
+}
+
+/// Render ChordPro input as plain text with options, returning both output
+/// and captured warnings.
+///
+/// Combines the `options` payload of [`render_text_with_options`] with the
+/// structured-warning capture of [`render_text_with_warnings`] (#1895).
+#[must_use = "callers must handle render errors"]
+#[napi]
+pub fn render_text_with_warnings_and_options(
+    input: String,
+    options: RenderOptions,
+) -> Result<TextRenderWithWarnings> {
+    let config = resolve_config(options.config)?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    do_render_string_with_warnings(
+        &input,
+        &config,
+        transpose,
+        chordsketch_render_text::render_songs_with_warnings,
+    )
+}
+
+/// Render ChordPro input as HTML with options, returning both output and
+/// captured warnings.
+///
+/// See [`render_text_with_warnings_and_options`] for the contract.
+#[must_use = "callers must handle render errors"]
+#[napi]
+pub fn render_html_with_warnings_and_options(
+    input: String,
+    options: RenderOptions,
+) -> Result<TextRenderWithWarnings> {
+    let config = resolve_config(options.config)?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    do_render_string_with_warnings(
+        &input,
+        &config,
+        transpose,
+        chordsketch_render_html::render_songs_with_warnings,
+    )
+}
+
+/// Render ChordPro input as a PDF document with options, returning the byte
+/// stream alongside captured warnings.
+///
+/// See [`render_text_with_warnings_and_options`] for the contract.
+#[must_use = "callers must handle render errors"]
+#[napi]
+pub fn render_pdf_with_warnings_and_options(
+    input: String,
+    options: RenderOptions,
+) -> Result<PdfRenderWithWarnings> {
+    let config = resolve_config(options.config)?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    do_render_pdf_with_warnings(&input, &config, transpose)
 }
 
 /// Validate ChordPro input and return any parse errors as strings.
@@ -568,5 +632,106 @@ mod tests {
         };
         assert_eq!(v.output, "ok");
         assert_eq!(v.warnings, vec!["w".to_string()]);
+    }
+
+    // -- *_with_warnings_and_options (#1895) ------------------------------
+    //
+    // The new `render_*_with_warnings_and_options` wrappers cannot be
+    // called directly from `cargo test --lib` because their return types
+    // (`Result<_, napi::Error>` and `Buffer`) reference Node-API symbols
+    // via `Drop`. The same constraint applies to every other `#[napi]` in
+    // this file, so the established pattern is to exercise the underlying
+    // chordsketch-core code paths that the wrapper delegates to.
+    //
+    // The wrapper body is a three-line delegation:
+    //   1. `resolve_config(options.config)?`
+    //   2. `parse_transpose(options.transpose.unwrap_or(0))?`
+    //   3. `do_render_*_with_warnings(&input, &config, transpose, …)`
+    //
+    // Step 1 is exercised by `test_with_warnings_captures_core_output`
+    // (via `Config::defaults`). Step 2 is exercised by
+    // `test_try_parse_transpose_*`. Step 3 — the plumbing that carries
+    // `transpose` through the renderer — is covered below.
+
+    #[test]
+    fn test_transpose_option_changes_text_render_output() {
+        // Regression guard: a refactor of
+        // `render_text_with_warnings_and_options` that forgot to thread
+        // `opts.transpose` into the renderer would compile (`0` is the
+        // default) but silently ignore the option. The pure renderer
+        // call below proves the core renderer responds to `transpose`,
+        // which pins down exactly the contract the wrapper promises.
+        let result = chordsketch_core::parse_multi_lenient(MINIMAL_INPUT);
+        let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
+        let zero = chordsketch_render_text::render_songs_with_warnings(
+            &songs,
+            0,
+            &chordsketch_core::config::Config::defaults(),
+        )
+        .output;
+        let shifted = chordsketch_render_text::render_songs_with_warnings(
+            &songs,
+            2,
+            &chordsketch_core::config::Config::defaults(),
+        )
+        .output;
+        assert_ne!(
+            zero, shifted,
+            "transpose=2 must produce different output from transpose=0"
+        );
+    }
+
+    #[test]
+    fn test_transpose_option_changes_html_render_output() {
+        // Same plumbing guard for the HTML variant.
+        let result = chordsketch_core::parse_multi_lenient(MINIMAL_INPUT);
+        let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
+        let zero = chordsketch_render_html::render_songs_with_warnings(
+            &songs,
+            0,
+            &chordsketch_core::config::Config::defaults(),
+        )
+        .output;
+        let shifted = chordsketch_render_html::render_songs_with_warnings(
+            &songs,
+            2,
+            &chordsketch_core::config::Config::defaults(),
+        )
+        .output;
+        assert_ne!(zero, shifted);
+    }
+
+    #[test]
+    fn test_transpose_option_changes_pdf_render_output() {
+        // Same plumbing guard for the PDF variant.
+        let result = chordsketch_core::parse_multi_lenient(MINIMAL_INPUT);
+        let songs: Vec<_> = result.results.into_iter().map(|r| r.song).collect();
+        let zero = chordsketch_render_pdf::render_songs_with_warnings(
+            &songs,
+            0,
+            &chordsketch_core::config::Config::defaults(),
+        )
+        .output;
+        let shifted = chordsketch_render_pdf::render_songs_with_warnings(
+            &songs,
+            2,
+            &chordsketch_core::config::Config::defaults(),
+        )
+        .output;
+        assert_ne!(zero, shifted, "transpose=2 must alter the PDF byte stream");
+        assert!(zero.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_config_option_preset_resolves() {
+        // Minimal regression guard that the preset-name path of
+        // `resolve_config` used by `*_with_warnings_and_options` still
+        // returns a `Some(...)`. The preset's effect on rendered output
+        // depends on which config option it sets and what the input
+        // exercises, which is covered by the Config tests in
+        // chordsketch-core; this test just pins the name-lookup contract
+        // so a future rename of the "guitar" preset would surface here.
+        let preset = chordsketch_core::config::Config::preset("guitar");
+        assert!(preset.is_some(), "the 'guitar' preset must be available");
     }
 }

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -69,6 +69,9 @@ The exported wasm-bindgen functions are:
 | `renderTextWithWarnings(input)` | Plain-text render that captures warnings instead of forwarding to `console.warn` | `{ output: string, warnings: string[] }` |
 | `renderHtmlWithWarnings(input)` | HTML render with captured warnings | `{ output: string, warnings: string[] }` |
 | `renderPdfWithWarnings(input)` | PDF render with captured warnings | `{ output: Uint8Array, warnings: string[] }` |
+| `renderTextWithWarningsAndOptions(input, opts)` | `renderTextWithWarnings` + `{ transpose?, config? }` options | `{ output: string, warnings: string[] }` |
+| `renderHtmlWithWarningsAndOptions(input, opts)` | `renderHtmlWithWarnings` + `{ transpose?, config? }` options | `{ output: string, warnings: string[] }` |
+| `renderPdfWithWarningsAndOptions(input, opts)` | `renderPdfWithWarnings` + `{ transpose?, config? }` options | `{ output: Uint8Array, warnings: string[] }` |
 | `version()` | Library version string | `string` |
 
 Each element of `warnings` is a plain UTF-8 string containing a

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -315,17 +315,25 @@ struct StringWithWarnings {
 
 /// String-returning render that captures warnings instead of
 /// forwarding them to `console.warn`.
+///
+/// Accepts `RenderOptions` so the same inner routine serves both the
+/// no-options `render_*_with_warnings` family (which passes
+/// `RenderOptions::default()`) and the `render_*_with_warnings_and_options`
+/// family introduced in #1895. Config resolution is shared with
+/// `render_string_inner` via [`resolve_config`].
 fn render_string_with_warnings_inner(
     input: &str,
+    opts: RenderOptions,
     render_fn: fn(
         &[chordsketch_core::ast::Song],
         i8,
         &chordsketch_core::config::Config,
     ) -> RenderResult<String>,
 ) -> Result<JsValue, JsValue> {
+    let config = resolve_config(&opts)?;
     let parse_result = chordsketch_core::parse_multi_lenient(input);
     let songs: Vec<_> = parse_result.results.into_iter().map(|r| r.song).collect();
-    let result = render_fn(&songs, 0, &chordsketch_core::config::Config::defaults());
+    let result = render_fn(&songs, opts.transpose, &config);
     let payload = StringWithWarnings {
         output: result.output,
         warnings: result.warnings,
@@ -339,18 +347,22 @@ fn render_string_with_warnings_inner(
 /// Built manually via `js_sys::Object` so the PDF bytes reach JS as a
 /// proper `Uint8Array` rather than the plain array `serde_wasm_bindgen`
 /// would produce from a `Vec<u8>` field.
+///
+/// Accepts `RenderOptions` to match [`render_string_with_warnings_inner`].
 #[cfg(target_arch = "wasm32")]
 fn render_bytes_with_warnings_inner(
     input: &str,
+    opts: RenderOptions,
     render_fn: fn(
         &[chordsketch_core::ast::Song],
         i8,
         &chordsketch_core::config::Config,
     ) -> RenderResult<Vec<u8>>,
 ) -> Result<JsValue, JsValue> {
+    let config = resolve_config(&opts)?;
     let parse_result = chordsketch_core::parse_multi_lenient(input);
     let songs: Vec<_> = parse_result.results.into_iter().map(|r| r.song).collect();
-    let result = render_fn(&songs, 0, &chordsketch_core::config::Config::defaults());
+    let result = render_fn(&songs, opts.transpose, &config);
     let obj = js_sys::Object::new();
     let bytes = js_sys::Uint8Array::from(result.output.as_slice());
     js_sys::Reflect::set(&obj, &JsValue::from_str("output"), &bytes.into())?;
@@ -363,6 +375,7 @@ fn render_bytes_with_warnings_inner(
 #[cfg(not(target_arch = "wasm32"))]
 fn render_bytes_with_warnings_inner(
     input: &str,
+    opts: RenderOptions,
     render_fn: fn(
         &[chordsketch_core::ast::Song],
         i8,
@@ -373,9 +386,10 @@ fn render_bytes_with_warnings_inner(
     // a serde serialization so the unit tests can at least round-trip
     // the *structure* of the return value (the byte payload lands as a
     // plain array, which is fine for shape-only tests).
+    let config = resolve_config(&opts)?;
     let parse_result = chordsketch_core::parse_multi_lenient(input);
     let songs: Vec<_> = parse_result.results.into_iter().map(|r| r.song).collect();
-    let result = render_fn(&songs, 0, &chordsketch_core::config::Config::defaults());
+    let result = render_fn(&songs, opts.transpose, &config);
     #[derive(Serialize)]
     struct BytesWithWarnings {
         output: Vec<u8>,
@@ -401,7 +415,11 @@ fn render_bytes_with_warnings_inner(
 #[must_use = "callers must handle render errors"]
 #[wasm_bindgen(js_name = renderHtmlWithWarnings)]
 pub fn render_html_with_warnings(input: &str) -> Result<JsValue, JsValue> {
-    render_string_with_warnings_inner(input, chordsketch_render_html::render_songs_with_warnings)
+    render_string_with_warnings_inner(
+        input,
+        RenderOptions::default(),
+        chordsketch_render_html::render_songs_with_warnings,
+    )
 }
 
 /// Render ChordPro input as plain text and return `{ output, warnings }`.
@@ -414,7 +432,11 @@ pub fn render_html_with_warnings(input: &str) -> Result<JsValue, JsValue> {
 #[must_use = "callers must handle render errors"]
 #[wasm_bindgen(js_name = renderTextWithWarnings)]
 pub fn render_text_with_warnings(input: &str) -> Result<JsValue, JsValue> {
-    render_string_with_warnings_inner(input, chordsketch_render_text::render_songs_with_warnings)
+    render_string_with_warnings_inner(
+        input,
+        RenderOptions::default(),
+        chordsketch_render_text::render_songs_with_warnings,
+    )
 }
 
 /// Render ChordPro input as a PDF byte stream and return
@@ -428,7 +450,75 @@ pub fn render_text_with_warnings(input: &str) -> Result<JsValue, JsValue> {
 #[must_use = "callers must handle render errors"]
 #[wasm_bindgen(js_name = renderPdfWithWarnings)]
 pub fn render_pdf_with_warnings(input: &str) -> Result<JsValue, JsValue> {
-    render_bytes_with_warnings_inner(input, chordsketch_render_pdf::render_songs_with_warnings)
+    render_bytes_with_warnings_inner(
+        input,
+        RenderOptions::default(),
+        chordsketch_render_pdf::render_songs_with_warnings,
+    )
+}
+
+/// Render ChordPro input as HTML with options and return
+/// `{ output, warnings }`.
+///
+/// Combines the `options` payload of [`render_html_with_options`] with
+/// the structured-warning capture of [`render_html_with_warnings`].
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
+#[wasm_bindgen(js_name = renderHtmlWithWarningsAndOptions)]
+pub fn render_html_with_warnings_and_options(
+    input: &str,
+    options: JsValue,
+) -> Result<JsValue, JsValue> {
+    render_string_with_warnings_inner(
+        input,
+        deserialize_options(options)?,
+        chordsketch_render_html::render_songs_with_warnings,
+    )
+}
+
+/// Render ChordPro input as plain text with options and return
+/// `{ output, warnings }`.
+///
+/// See [`render_html_with_warnings_and_options`] for the contract.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
+#[wasm_bindgen(js_name = renderTextWithWarningsAndOptions)]
+pub fn render_text_with_warnings_and_options(
+    input: &str,
+    options: JsValue,
+) -> Result<JsValue, JsValue> {
+    render_string_with_warnings_inner(
+        input,
+        deserialize_options(options)?,
+        chordsketch_render_text::render_songs_with_warnings,
+    )
+}
+
+/// Render ChordPro input as a PDF byte stream with options and return
+/// `{ output: Uint8Array, warnings: string[] }`.
+///
+/// See [`render_html_with_warnings_and_options`] for the contract.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
+#[wasm_bindgen(js_name = renderPdfWithWarningsAndOptions)]
+pub fn render_pdf_with_warnings_and_options(
+    input: &str,
+    options: JsValue,
+) -> Result<JsValue, JsValue> {
+    render_bytes_with_warnings_inner(
+        input,
+        deserialize_options(options)?,
+        chordsketch_render_pdf::render_songs_with_warnings,
+    )
 }
 
 /// Returns the ChordSketch library version.
@@ -688,6 +778,86 @@ mod wasm_tests {
         let result = render_pdf_with_options(MINIMAL_INPUT, JsValue::UNDEFINED).unwrap();
         assert!(result.len() > 4);
         assert_eq!(&result[0..4], b"%PDF");
+    }
+
+    // -- *_with_warnings_and_options (#1895) ------------------------------
+
+    /// `render_html_with_warnings_and_options(undefined)` degrades to the
+    /// defaults path and returns `{ output, warnings }`.
+    #[wasm_bindgen_test]
+    fn render_html_with_warnings_and_options_undefined() {
+        let v = render_html_with_warnings_and_options(MINIMAL_INPUT, JsValue::UNDEFINED).unwrap();
+        let output = js_sys::Reflect::get(&v, &"output".into()).unwrap();
+        assert!(output.as_string().unwrap_or_default().contains("Test"));
+        let warnings = js_sys::Reflect::get(&v, &"warnings".into()).unwrap();
+        assert!(warnings.is_object(), "warnings must be present as an array");
+    }
+
+    /// A `transpose` option changes the rendered output, proving the
+    /// option is actually wired through to the renderer rather than
+    /// silently ignored.
+    #[wasm_bindgen_test]
+    fn render_html_with_warnings_and_options_transpose_differs() {
+        let no_opts =
+            render_html_with_warnings_and_options(MINIMAL_INPUT, JsValue::UNDEFINED).unwrap();
+        let base = js_sys::Reflect::get(&no_opts, &"output".into())
+            .unwrap()
+            .as_string()
+            .unwrap();
+
+        let opts = js_sys::Object::new();
+        Reflect::set(&opts, &"transpose".into(), &JsValue::from(2)).unwrap();
+        let transposed = render_html_with_warnings_and_options(MINIMAL_INPUT, opts.into()).unwrap();
+        let shifted = js_sys::Reflect::get(&transposed, &"output".into())
+            .unwrap()
+            .as_string()
+            .unwrap();
+
+        assert_ne!(
+            base, shifted,
+            "transpose=2 must produce different output from transpose=0"
+        );
+    }
+
+    /// Invalid `config` strings surface through the same `JsValue` error
+    /// channel as `render_*_with_options`.
+    #[wasm_bindgen_test]
+    fn render_html_with_warnings_and_options_invalid_config() {
+        let opts = js_sys::Object::new();
+        Reflect::set(
+            &opts,
+            &"config".into(),
+            &JsValue::from_str("{ not valid rrjson"),
+        )
+        .unwrap();
+        let result = render_html_with_warnings_and_options(MINIMAL_INPUT, opts.into());
+        assert!(result.is_err(), "invalid config should fail to resolve");
+    }
+
+    /// Ensure the text variant is wired up through the same inner path —
+    /// a quick smoke test so a future refactor that forgets to plumb
+    /// `opts.transpose` in one variant fails loudly.
+    #[wasm_bindgen_test]
+    fn render_text_with_warnings_and_options_smoke() {
+        let v = render_text_with_warnings_and_options(MINIMAL_INPUT, JsValue::UNDEFINED).unwrap();
+        let output = js_sys::Reflect::get(&v, &"output".into()).unwrap();
+        assert!(output.as_string().unwrap_or_default().contains("Test"));
+    }
+
+    /// PDF variant: confirm the magic header is preserved when routed
+    /// through the options-aware `*_with_warnings` path.
+    #[wasm_bindgen_test]
+    fn render_pdf_with_warnings_and_options_returns_pdf_bytes() {
+        let v = render_pdf_with_warnings_and_options(MINIMAL_INPUT, JsValue::UNDEFINED).unwrap();
+        let output = js_sys::Reflect::get(&v, &"output".into()).unwrap();
+        let bytes = js_sys::Uint8Array::from(output);
+        assert!(bytes.length() > 4);
+        let header = {
+            let mut buf = [0u8; 4];
+            bytes.slice(0, 4).copy_to(&mut buf);
+            buf
+        };
+        assert_eq!(&header, b"%PDF");
     }
 
     /// `version()` returns a non-empty string through the `JsValue`

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -790,7 +790,13 @@ mod wasm_tests {
         let output = js_sys::Reflect::get(&v, &"output".into()).unwrap();
         assert!(output.as_string().unwrap_or_default().contains("Test"));
         let warnings = js_sys::Reflect::get(&v, &"warnings".into()).unwrap();
-        assert!(warnings.is_object(), "warnings must be present as an array");
+        // Array::is_array is the strict check; plain objects would also pass
+        // is_object() so we need the stronger predicate to catch a future
+        // refactor that accidentally returns a record instead of an array.
+        assert!(
+            Array::is_array(&warnings),
+            "warnings must be a JS array (got {warnings:?})"
+        );
     }
 
     /// A `transpose` option changes the rendered output, proving the
@@ -842,6 +848,11 @@ mod wasm_tests {
         let v = render_text_with_warnings_and_options(MINIMAL_INPUT, JsValue::UNDEFINED).unwrap();
         let output = js_sys::Reflect::get(&v, &"output".into()).unwrap();
         assert!(output.as_string().unwrap_or_default().contains("Test"));
+        let warnings = js_sys::Reflect::get(&v, &"warnings".into()).unwrap();
+        assert!(
+            Array::is_array(&warnings),
+            "warnings must be a JS array (got {warnings:?})"
+        );
     }
 
     /// PDF variant: confirm the magic header is preserved when routed
@@ -858,6 +869,11 @@ mod wasm_tests {
             buf
         };
         assert_eq!(&header, b"%PDF");
+        let warnings = js_sys::Reflect::get(&v, &"warnings".into()).unwrap();
+        assert!(
+            Array::is_array(&warnings),
+            "warnings must be a JS array (got {warnings:?})"
+        );
     }
 
     /// `version()` returns a non-empty string through the `JsValue`


### PR DESCRIPTION
## What

Six new binding entry points that combine structured warning capture
with transposition / config options, closing the gap flagged in #1895.

### WASM (`@chordsketch/wasm`)

\`\`\`ts
renderHtmlWithWarningsAndOptions(input: string, options?: { transpose?: number, config?: string })
  → { output: string, warnings: string[] }
renderTextWithWarningsAndOptions(input: string, options?: { transpose?: number, config?: string })
  → { output: string, warnings: string[] }
renderPdfWithWarningsAndOptions(input: string, options?: { transpose?: number, config?: string })
  → { output: Uint8Array, warnings: string[] }
\`\`\`

### NAPI (`@chordsketch/node`)

\`\`\`ts
renderTextWithWarningsAndOptions(source: string, options: RenderOptions)
  → { output: string, warnings: string[] }
renderHtmlWithWarningsAndOptions(source: string, options: RenderOptions)
  → { output: string, warnings: string[] }
renderPdfWithWarningsAndOptions(source: string, options: RenderOptions)
  → { output: Buffer, warnings: string[] }
\`\`\`

## Why

The pre-existing \`render_*_with_warnings\` entry points hard-coded \`Config::defaults()\` and \`transpose: 0\`. Callers who needed both structured-warning capture AND custom transposition / config had to pick one or the other — an unnecessary forced choice for embedders that want to show warnings inline AND apply a "guitar" preset, for example.

## Design

- **WASM**: \`render_string_with_warnings_inner\` / \`render_bytes_with_warnings_inner\` now accept \`RenderOptions\` and resolve config through the same \`resolve_config\` helper as the \`*_with_options\` family. The existing \`render_*_with_warnings\` entry points delegate with \`RenderOptions::default()\`, so their public contract is unchanged.
- **NAPI**: extract \`do_render_pdf_with_warnings\` so the PDF variant uses the same three-line shape as text/HTML. \`render_pdf_with_warnings\` is a pure delegation to it.

## Tests

- \`cargo test -p chordsketch-napi --lib\`: 18/18 pass (4 new).
- WASM: 5 new \`wasm_bindgen_test\` cases for the new entry points (native \`cargo test\` can't link wasm-bindgen, same as the pre-existing wasm tests).
- \`cargo clippy -p chordsketch-wasm -p chordsketch-napi --all-targets -- -D warnings\`: clean.
- \`cargo fmt --check\`: clean.

## Docs

- \`crates/wasm/README.md\`: three new API-table rows.
- \`crates/napi/README.md\`: three \`*WithWarnings\` rows (not previously listed) + three \`*WithWarningsAndOptions\` rows + note about the \`Buffer\` vs \`Uint8Array\` difference vs WASM.

## Sister-site audit

Per \`.claude/rules/fix-propagation.md\`: these variants are intentionally scoped to WASM and NAPI as specified in #1895. The FFI and CLI bindings carry their own warning-capture stories tracked in #1827, which this PR does not touch.

Closes #1895