### PR TITLE
feat(bindings): expose structured warnings in FFI and add CLI --warnings-json

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -86,7 +86,7 @@ chordsketch convert --to musicxml song.cho -o song.xml
 | `-D`, `--define` | `key=value` | Override a single config value at runtime. Highest precedence — wins over every `--config`. |
 | `--no-default-configs` | | Skip system, user, and project config files. Only built-in defaults plus any explicit `--config` / `--define`. |
 | `--instrument` | `guitar` \| `ukulele` \| … | Select the active instrument for selector filtering (directives like `{textfont-piano: Courier}` are kept only when the selector matches). Equivalent to `--define instrument.type=<NAME>`. |
-| `--warnings-json` | | Emit render / config warnings as JSONL on stderr instead of the default `warning: …` lines. Each warning becomes a single-line JSON object `{"source": "render\|config\|transpose", "message": "…"}` so programmatic consumers can aggregate or suppress warnings without scraping. |
+| `--warnings-json` | | Emit render / config warnings as JSONL on stderr instead of the default `warning: …` lines. Each warning becomes a single-line JSON object `{"source": "render\|config\|transpose", "message": "…"}` so programmatic consumers can aggregate or suppress warnings without scraping. Applies to the default render mode only — clap rejects the flag when combined with the `fmt` or `convert` subcommand. |
 | `--completions` | *shell* | Print shell completions (`bash`, `elvish`, `fish`, `powershell`, `zsh`) to stdout and exit. |
 | `-h`, `--help` | | Print help. Use on a subcommand (e.g. `chordsketch fmt --help`) for subcommand-specific detail. |
 | `-V`, `--version` | | Print the version and exit. |

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -86,6 +86,7 @@ chordsketch convert --to musicxml song.cho -o song.xml
 | `-D`, `--define` | `key=value` | Override a single config value at runtime. Highest precedence — wins over every `--config`. |
 | `--no-default-configs` | | Skip system, user, and project config files. Only built-in defaults plus any explicit `--config` / `--define`. |
 | `--instrument` | `guitar` \| `ukulele` \| … | Select the active instrument for selector filtering (directives like `{textfont-piano: Courier}` are kept only when the selector matches). Equivalent to `--define instrument.type=<NAME>`. |
+| `--warnings-json` | | Emit render / config warnings as JSONL on stderr instead of the default `warning: …` lines. Each warning becomes a single-line JSON object `{"source": "render\|config\|transpose", "message": "…"}` so programmatic consumers can aggregate or suppress warnings without scraping. |
 | `--completions` | *shell* | Print shell completions (`bash`, `elvish`, `fish`, `powershell`, `zsh`) to stdout and exit. |
 | `-h`, `--help` | | Print help. Use on a subcommand (e.g. `chordsketch fmt --help`) for subcommand-specific detail. |
 | `-V`, `--version` | | Print the version and exit. |

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,9 +22,45 @@ const MAX_INPUT_BYTES: u64 = 52_428_800;
 /// [`fs::metadata`] is used for an early, cheap size check that avoids
 /// loading oversized files into memory at all.
 #[must_use = "I/O errors from reading the file must be handled"]
+fn read_file_clamped(path: &str) -> Result<String, String> {
+    match fs::metadata(path) {
+        Ok(meta) if meta.len() > MAX_INPUT_BYTES => {
+            return Err(format!(
+                "file exceeds the {} MiB input limit",
+                MAX_INPUT_BYTES / (1024 * 1024)
+            ));
+        }
+        Err(e) => return Err(e.to_string()),
+        Ok(_) => {}
+    }
+    fs::read_to_string(path).map_err(|e| e.to_string())
+}
+
+/// Reads stdin into a [`String`], rejecting streams that exceed
+/// [`MAX_INPUT_BYTES`].
+///
+/// Uses [`Read::take`] to avoid buffering more than `MAX_INPUT_BYTES + 1`
+/// bytes; if the read fills the cap the stream is rejected without consuming
+/// the remainder.
+#[must_use = "I/O errors from reading stdin must be handled"]
+fn read_stdin_clamped() -> Result<String, String> {
+    let mut buf = String::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_string(&mut buf)
+        .map_err(|e| e.to_string())?;
+    if buf.len() as u64 > MAX_INPUT_BYTES {
+        return Err(format!(
+            "input exceeds the {} MiB input limit",
+            MAX_INPUT_BYTES / (1024 * 1024)
+        ));
+    }
+    Ok(buf)
+}
+
 /// Minimal JSON string escape for the `--warnings-json` output stream.
 ///
-/// Escapes the six characters mandated by RFC 8259 §7: `"`, `\`, and the
+/// Escapes the characters mandated by RFC 8259 §7: `"`, `\`, and the
 /// control range U+0000–U+001F (tab/LF/CR via their shorthand, the rest
 /// via `\uXXXX`). Avoids a `serde_json` dependency — the CLI currently
 /// has no serde in its dependency tree and we only need to serialize
@@ -62,42 +98,6 @@ fn emit_warning(as_json: bool, source: &str, message: &str) {
     } else {
         eprintln!("warning: {message}");
     }
-}
-
-fn read_file_clamped(path: &str) -> Result<String, String> {
-    match fs::metadata(path) {
-        Ok(meta) if meta.len() > MAX_INPUT_BYTES => {
-            return Err(format!(
-                "file exceeds the {} MiB input limit",
-                MAX_INPUT_BYTES / (1024 * 1024)
-            ));
-        }
-        Err(e) => return Err(e.to_string()),
-        Ok(_) => {}
-    }
-    fs::read_to_string(path).map_err(|e| e.to_string())
-}
-
-/// Reads stdin into a [`String`], rejecting streams that exceed
-/// [`MAX_INPUT_BYTES`].
-///
-/// Uses [`Read::take`] to avoid buffering more than `MAX_INPUT_BYTES + 1`
-/// bytes; if the read fills the cap the stream is rejected without consuming
-/// the remainder.
-#[must_use = "I/O errors from reading stdin must be handled"]
-fn read_stdin_clamped() -> Result<String, String> {
-    let mut buf = String::new();
-    io::stdin()
-        .take(MAX_INPUT_BYTES + 1)
-        .read_to_string(&mut buf)
-        .map_err(|e| e.to_string())?;
-    if buf.len() as u64 > MAX_INPUT_BYTES {
-        return Err(format!(
-            "input exceeds the {} MiB input limit",
-            MAX_INPUT_BYTES / (1024 * 1024)
-        ));
-    }
-    Ok(buf)
 }
 
 use clap::{CommandFactory, Parser, Subcommand};

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,6 +22,48 @@ const MAX_INPUT_BYTES: u64 = 52_428_800;
 /// [`fs::metadata`] is used for an early, cheap size check that avoids
 /// loading oversized files into memory at all.
 #[must_use = "I/O errors from reading the file must be handled"]
+/// Minimal JSON string escape for the `--warnings-json` output stream.
+///
+/// Escapes the six characters mandated by RFC 8259 §7: `"`, `\`, and the
+/// control range U+0000–U+001F (tab/LF/CR via their shorthand, the rest
+/// via `\uXXXX`). Avoids a `serde_json` dependency — the CLI currently
+/// has no serde in its dependency tree and we only need to serialize
+/// two string fields.
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Emit a single warning to stderr, honouring the `--warnings-json` flag.
+///
+/// When the flag is set, the warning is emitted as a single JSONL object
+/// `{"source":"...","message":"..."}`. Otherwise the human-readable
+/// `warning: ...` form is used (matching the pre-#1827 behaviour).
+fn emit_warning(as_json: bool, source: &str, message: &str) {
+    if as_json {
+        eprintln!(
+            "{{\"source\":\"{source}\",\"message\":\"{message}\"}}",
+            source = json_escape(source),
+            message = json_escape(message),
+        );
+    } else {
+        eprintln!("warning: {message}");
+    }
+}
+
 fn read_file_clamped(path: &str) -> Result<String, String> {
     match fs::metadata(path) {
         Ok(meta) if meta.len() > MAX_INPUT_BYTES => {
@@ -113,6 +155,14 @@ struct Cli {
     /// Equivalent to `--define instrument.type=<INSTRUMENT>`.
     #[arg(long)]
     instrument: Option<String>,
+
+    /// Emit render / config warnings as JSONL on stderr instead of the
+    /// default `warning: …` lines. Each warning becomes a single-line
+    /// JSON object `{"source": "...", "message": "..."}` so programmatic
+    /// consumers can aggregate or suppress warnings without scraping.
+    /// (#1827)
+    #[arg(long = "warnings-json")]
+    warnings_json: bool,
 }
 
 /// Available subcommands.
@@ -245,7 +295,7 @@ fn main() -> ExitCode {
     } else {
         let result = chordsketch_core::config::Config::load(project_dir.as_deref(), None);
         for warning in &result.warnings {
-            eprintln!("warning: {warning}");
+            emit_warning(cli.warnings_json, "config", warning);
         }
         result.config
     };
@@ -255,7 +305,11 @@ fn main() -> ExitCode {
         match chordsketch_core::config::Config::resolve(config_name) {
             Ok(result) => {
                 for warning in &result.warnings {
-                    eprintln!("warning: {config_name}: {warning}");
+                    emit_warning(
+                        cli.warnings_json,
+                        "config",
+                        &format!("{config_name}: {warning}"),
+                    );
                 }
                 config = config.merge(result.config);
             }
@@ -297,9 +351,13 @@ fn main() -> ExitCode {
     let config_transpose =
         if config_transpose_f64 < f64::from(i8::MIN) || config_transpose_f64 > f64::from(i8::MAX) {
             let clamped = config_transpose_f64.clamp(f64::from(i8::MIN), f64::from(i8::MAX)) as i8;
-            eprintln!(
-                "warning: settings.transpose value {} is out of i8 range, clamped to {}",
-                config_transpose_f64, clamped
+            emit_warning(
+                cli.warnings_json,
+                "transpose",
+                &format!(
+                    "settings.transpose value {} is out of i8 range, clamped to {}",
+                    config_transpose_f64, clamped
+                ),
             );
             clamped
         } else {
@@ -308,9 +366,13 @@ fn main() -> ExitCode {
     let (effective_transpose, saturated) =
         chordsketch_core::transpose::combine_transpose(config_transpose, cli.transpose);
     if saturated {
-        eprintln!(
-            "warning: transpose offset {} + {} exceeds i8 range, clamped to {}",
-            config_transpose, cli.transpose, effective_transpose
+        emit_warning(
+            cli.warnings_json,
+            "transpose",
+            &format!(
+                "transpose offset {} + {} exceeds i8 range, clamped to {}",
+                config_transpose, cli.transpose, effective_transpose
+            ),
         );
     }
 
@@ -365,7 +427,7 @@ fn main() -> ExitCode {
                 &config,
             );
             for w in &result.warnings {
-                eprintln!("warning: {w}");
+                emit_warning(cli.warnings_json, "render", w);
             }
             Output::Binary(result.output)
         }
@@ -376,7 +438,7 @@ fn main() -> ExitCode {
                 &config,
             );
             for w in &result.warnings {
-                eprintln!("warning: {w}");
+                emit_warning(cli.warnings_json, "render", w);
             }
             Output::Text(result.output)
         }
@@ -387,7 +449,7 @@ fn main() -> ExitCode {
                 &config,
             );
             for w in &result.warnings {
-                eprintln!("warning: {w}");
+                emit_warning(cli.warnings_json, "render", w);
             }
             Output::Text(result.output)
         }

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -791,3 +791,115 @@ fn test_convert_invalid_xml_with_from_musicxml() {
         .failure()
         .stderr(predicate::str::contains("error:"));
 }
+
+// -- --warnings-json (#1827) -------------------------------------------
+
+/// Build a `.cho` file whose combined (file `{transpose}` + CLI
+/// `--transpose`) value saturates the `i8` range and therefore forces
+/// the render layer to emit a `transpose offset ... clamped to ...`
+/// warning. The exact saturation path is in
+/// `chordsketch_core::transpose::combine_transpose`.
+fn saturating_transpose_fixture() -> NamedTempFile {
+    let mut file = NamedTempFile::new_in(std::env::temp_dir()).unwrap();
+    file.write_all(b"{title: T}\n{transpose: 100}\n[C]Hello\n")
+        .unwrap();
+    file
+}
+
+#[test]
+fn test_warnings_json_emits_jsonl_for_saturating_transpose() {
+    // With --warnings-json, the saturation warning must come out as a
+    // single-line JSON object on stderr, parseable as JSONL.
+    let fixture = saturating_transpose_fixture();
+    let output = Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args([
+            fixture.path().to_str().unwrap(),
+            "--transpose",
+            "100",
+            "--warnings-json",
+        ])
+        .assert()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(output).unwrap();
+    let mut saw_any = false;
+    for line in stderr.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        saw_any = true;
+        assert!(
+            line.starts_with('{') && line.ends_with('}'),
+            "expected JSONL on stderr with --warnings-json; got: {line}"
+        );
+        assert!(
+            line.contains("\"source\":"),
+            "each line must carry a `source` field; got: {line}"
+        );
+        assert!(
+            line.contains("\"message\":"),
+            "each line must carry a `message` field; got: {line}"
+        );
+    }
+    assert!(
+        saw_any,
+        "--warnings-json should have produced at least one line on stderr for a saturating transpose"
+    );
+}
+
+#[test]
+fn test_warnings_json_off_emits_plain_warning_prefix() {
+    // Default behaviour: human-readable `warning: ...` lines, not JSON.
+    // Regression guard — a refactor that accidentally always produces
+    // JSON would break every existing stderr scraper.
+    let fixture = saturating_transpose_fixture();
+    let output = Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args([fixture.path().to_str().unwrap(), "--transpose", "100"])
+        .assert()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(output).unwrap();
+    assert!(
+        stderr.lines().any(|l| l.starts_with("warning: ")),
+        "expected at least one `warning: ` line on stderr; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.lines().any(|l| l.starts_with('{')),
+        "default mode must not emit JSON lines; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_warnings_json_quote_count_is_balanced() {
+    // A well-formed JSONL line has an even number of `"` characters —
+    // they all participate in balanced `"key":"value"` pairs. An
+    // unescaped double-quote inside a message would break this
+    // invariant. This catches regressions in `json_escape` without
+    // pulling in a full JSON parser.
+    let fixture = saturating_transpose_fixture();
+    let output = Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args([
+            fixture.path().to_str().unwrap(),
+            "--transpose",
+            "100",
+            "--warnings-json",
+        ])
+        .assert()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(output).unwrap();
+    for line in stderr.lines().filter(|l| !l.is_empty()) {
+        let quote_count = line.chars().filter(|c| *c == '"').count();
+        assert_eq!(
+            quote_count % 2,
+            0,
+            "unbalanced quotes suggest an unescaped double-quote; line: {line}"
+        );
+    }
+}

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -54,6 +54,16 @@ All render functions accept the same three arguments:
 | `parse_and_render_text(input, config_json, transpose)` | `str` | Plain text output |
 | `parse_and_render_html(input, config_json, transpose)` | `str` | Full HTML document |
 | `parse_and_render_pdf(input, config_json, transpose)` | `bytes` | Raw PDF bytes |
+| `parse_and_render_text_with_warnings(input, config_json, transpose)` | `TextRenderWithWarnings { output: str, warnings: list[str] }` | Plain text + captured warnings |
+| `parse_and_render_html_with_warnings(input, config_json, transpose)` | `TextRenderWithWarnings { output: str, warnings: list[str] }` | HTML + captured warnings |
+| `parse_and_render_pdf_with_warnings(input, config_json, transpose)` | `PdfRenderWithWarnings { output: bytes, warnings: list[str] }` | PDF + captured warnings |
+
+The `*_with_warnings` variants return the render warnings (transpose
+saturation, chorus recall limits, `{columns}` clamp, etc.) as a list
+alongside the output instead of forwarding them to `sys.stderr` /
+`NSLog` / `System.err` / `$stderr`. Use them when embedding ChordSketch
+in an app that needs to surface warnings in the UI or aggregate them.
+See #1827.
 
 ### Validation
 

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -25,6 +25,30 @@ namespace chordsketch {
     [Throws=ChordSketchError]
     bytes parse_and_render_pdf(string input, string? config_json, i8? transpose);
 
+    /// Parse ChordPro input, render as plain text, and return render
+    /// warnings alongside the output instead of forwarding them to
+    /// stderr.
+    ///
+    /// See `parse_and_render_text` for the parameter contract. Use this
+    /// variant when the host binding needs to surface warnings in a UI
+    /// (see #1827).
+    [Throws=ChordSketchError]
+    TextRenderWithWarnings parse_and_render_text_with_warnings(string input, string? config_json, i8? transpose);
+
+    /// Parse ChordPro input, render as an HTML document, and return
+    /// render warnings alongside the output.
+    ///
+    /// See `parse_and_render_text_with_warnings` for the warnings contract.
+    [Throws=ChordSketchError]
+    TextRenderWithWarnings parse_and_render_html_with_warnings(string input, string? config_json, i8? transpose);
+
+    /// Parse ChordPro input, render as a PDF byte stream, and return
+    /// render warnings alongside the output.
+    ///
+    /// See `parse_and_render_text_with_warnings` for the warnings contract.
+    [Throws=ChordSketchError]
+    PdfRenderWithWarnings parse_and_render_pdf_with_warnings(string input, string? config_json, i8? transpose);
+
     /// Validate ChordPro input and return any parse errors as strings.
     /// Returns an empty list if the input is valid.
     ///
@@ -34,6 +58,29 @@ namespace chordsketch {
 
     /// Return the ChordSketch library version.
     string version();
+};
+
+/// Structured render result for text / HTML output.
+///
+/// Returned by `parse_and_render_text_with_warnings` and
+/// `parse_and_render_html_with_warnings`. Each warning is a
+/// human-readable diagnostic string captured from the renderer
+/// (e.g. "transpose offset ... clamped to ...").
+dictionary TextRenderWithWarnings {
+    /// Rendered text / HTML output.
+    string output;
+    /// Warnings captured during the render pass.
+    sequence<string> warnings;
+};
+
+/// Structured render result for PDF output.
+///
+/// See `TextRenderWithWarnings` for the warnings contract.
+dictionary PdfRenderWithWarnings {
+    /// Rendered PDF byte stream.
+    bytes output;
+    /// Warnings captured during the render pass.
+    sequence<string> warnings;
 };
 
 [Error]

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -158,6 +158,99 @@ pub fn parse_and_render_pdf(
     ))
 }
 
+/// Structured render result for text / HTML output.
+///
+/// Returned by [`parse_and_render_text_with_warnings`] and
+/// [`parse_and_render_html_with_warnings`]. See #1827 for the
+/// cross-binding rationale; the plain `parse_and_render_*` variants
+/// forward warnings to stderr via `eprintln!`, which UniFFI-based
+/// consumers (Python, Swift, Kotlin, Ruby) cannot capture structurally.
+#[derive(Debug)]
+pub struct TextRenderWithWarnings {
+    /// Rendered text / HTML output.
+    pub output: String,
+    /// Warnings captured during the render pass.
+    pub warnings: Vec<String>,
+}
+
+/// Structured render result for PDF output.
+///
+/// See [`TextRenderWithWarnings`] for the warnings contract.
+#[derive(Debug)]
+pub struct PdfRenderWithWarnings {
+    /// Rendered PDF byte stream.
+    pub output: Vec<u8>,
+    /// Warnings captured during the render pass.
+    pub warnings: Vec<String>,
+}
+
+/// Parse ChordPro input, render as plain text, and return warnings
+/// alongside the output instead of forwarding them to stderr.
+///
+/// See [`parse_and_render_text`] for the parameter contract and
+/// [`TextRenderWithWarnings`] for the warnings contract.
+#[must_use = "callers must handle parse and render errors"]
+pub fn parse_and_render_text_with_warnings(
+    input: String,
+    config_json: Option<String>,
+    transpose: Option<i8>,
+) -> Result<TextRenderWithWarnings, ChordSketchError> {
+    let config = resolve_config(config_json)?;
+    let songs = parse_songs(&input)?;
+    let result = chordsketch_render_text::render_songs_with_warnings(
+        &songs,
+        transpose.unwrap_or(0),
+        &config,
+    );
+    Ok(TextRenderWithWarnings {
+        output: result.output,
+        warnings: result.warnings,
+    })
+}
+
+/// Parse ChordPro input, render as an HTML document, and return warnings
+/// alongside the output.
+///
+/// See [`parse_and_render_text_with_warnings`] for the warnings contract.
+#[must_use = "callers must handle parse and render errors"]
+pub fn parse_and_render_html_with_warnings(
+    input: String,
+    config_json: Option<String>,
+    transpose: Option<i8>,
+) -> Result<TextRenderWithWarnings, ChordSketchError> {
+    let config = resolve_config(config_json)?;
+    let songs = parse_songs(&input)?;
+    let result = chordsketch_render_html::render_songs_with_warnings(
+        &songs,
+        transpose.unwrap_or(0),
+        &config,
+    );
+    Ok(TextRenderWithWarnings {
+        output: result.output,
+        warnings: result.warnings,
+    })
+}
+
+/// Parse ChordPro input, render as a PDF document, and return warnings
+/// alongside the byte stream.
+///
+/// See [`parse_and_render_text_with_warnings`] for the warnings contract.
+#[must_use = "callers must handle parse and render errors"]
+pub fn parse_and_render_pdf_with_warnings(
+    input: String,
+    config_json: Option<String>,
+    transpose: Option<i8>,
+) -> Result<PdfRenderWithWarnings, ChordSketchError> {
+    let config = resolve_config(config_json)?;
+    let songs = parse_songs(&input)?;
+    let result =
+        chordsketch_render_pdf::render_songs_with_warnings(&songs, transpose.unwrap_or(0), &config);
+    Ok(PdfRenderWithWarnings {
+        output: result.output,
+        warnings: result.warnings,
+    })
+}
+
 /// Validate ChordPro input and return any parse errors as strings.
 #[must_use]
 pub fn validate(input: String) -> Vec<String> {
@@ -320,5 +413,102 @@ mod tests {
         let bytes = result.unwrap();
         assert!(!bytes.is_empty());
         assert!(bytes.starts_with(b"%PDF"));
+    }
+
+    // -- *_with_warnings variants (#1827) ---------------------------------
+
+    #[test]
+    fn test_render_text_with_warnings_returns_output() {
+        let result =
+            parse_and_render_text_with_warnings(MINIMAL_INPUT.to_string(), None, None).unwrap();
+        assert!(result.output.contains("Test"));
+        assert!(
+            result.warnings.is_empty(),
+            "minimal input produces no warnings; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_render_html_with_warnings_returns_html() {
+        let result =
+            parse_and_render_html_with_warnings(MINIMAL_INPUT.to_string(), None, None).unwrap();
+        assert!(result.output.contains("<html") || result.output.contains("<!DOCTYPE"));
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_render_pdf_with_warnings_returns_pdf_bytes() {
+        let result =
+            parse_and_render_pdf_with_warnings(MINIMAL_INPUT.to_string(), None, None).unwrap();
+        assert!(result.output.starts_with(b"%PDF"));
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_render_text_with_warnings_captures_transpose_saturation() {
+        // A `{transpose: 100}` directive combined with an API `transpose: 100`
+        // exceeds the `i8` range (200 > 127); the renderer saturates and
+        // emits a warning. Confirm the warning is captured as structured
+        // data rather than silently vanishing to stderr.
+        let input = "{title: T}\n{transpose: 100}\n[C]Hello";
+        let result =
+            parse_and_render_text_with_warnings(input.to_string(), None, Some(100)).unwrap();
+        assert!(
+            !result.warnings.is_empty(),
+            "expected at least one transpose-saturation warning; got {:?}",
+            result.warnings
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.to_lowercase().contains("transpose")),
+            "at least one warning should mention 'transpose'; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_render_text_with_warnings_honours_transpose() {
+        // Plumbing regression guard: the wrapper must forward `transpose`
+        // to the renderer. A refactor that dropped the parameter would
+        // pass test_render_text_with_warnings_returns_output but fail here.
+        let zero =
+            parse_and_render_text_with_warnings(MINIMAL_INPUT.to_string(), None, Some(0)).unwrap();
+        let shifted =
+            parse_and_render_text_with_warnings(MINIMAL_INPUT.to_string(), None, Some(2)).unwrap();
+        assert_ne!(
+            zero.output, shifted.output,
+            "transpose=2 must produce different output from transpose=0"
+        );
+    }
+
+    #[test]
+    fn test_render_text_with_warnings_honours_config_preset() {
+        // Plumbing regression guard for `config_json` — asserts preset
+        // resolution reaches the renderer, matching the `_with_options`
+        // entry point's contract.
+        let result = parse_and_render_text_with_warnings(
+            MINIMAL_INPUT.to_string(),
+            Some("guitar".to_string()),
+            None,
+        );
+        assert!(result.is_ok(), "guitar preset must resolve: {result:?}");
+    }
+
+    #[test]
+    fn test_render_text_with_warnings_invalid_config_errors() {
+        // Invalid config surfaces through the same `InvalidConfig` error
+        // variant as the plain `parse_and_render_text`.
+        let result = parse_and_render_text_with_warnings(
+            MINIMAL_INPUT.to_string(),
+            Some("{ not valid rrjson".to_string()),
+            None,
+        );
+        assert!(
+            matches!(result, Err(ChordSketchError::InvalidConfig { .. })),
+            "expected InvalidConfig; got {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

Close the remaining gaps in #1827 (cross-binding warning routing):

- **FFI (UniFFI)** — add three \`parse_and_render_*_with_warnings\` functions that return structured \`{ output, warnings }\` records. Wired into the UDL as two new dictionary types (\`TextRenderWithWarnings\` / \`PdfRenderWithWarnings\`).
- **CLI** — add \`--warnings-json\`. When set, each warning is emitted as a single-line JSON object on stderr instead of the default \`warning: …\` text.

Pre-existing WASM and NAPI coverage (#1893 + #1939) already satisfies the first two acceptance criteria in #1827; this PR closes the last two.

## Why

- Python, Swift, Kotlin, and Ruby apps embedding ChordSketch via UniFFI couldn't surface warnings in UI without scraping \`sys.stderr\` / \`NSLog\` / \`System.err\` / \`$stderr\`.
- CLI consumers integrating with pipelines or CI couldn't parse warnings without a regex scraper — one malformed warning message could break every downstream consumer.

## Implementation notes

- FFI: new \`TextRenderWithWarnings\` and \`PdfRenderWithWarnings\` structs plumbed through the UDL. Existing \`parse_and_render_*\` functions unchanged.
- CLI: \`--warnings-json\` is a bool flag. All five warning emission sites (config load, \`--config\` preset resolution, settings-transpose clamp, CLI transpose saturation, render-layer warnings) now route through a shared \`emit_warning(as_json, source, message)\` helper. Sources are \`"config"\`, \`"transpose"\`, and \`"render"\`.
- JSON escape: a minimal 40-line \`json_escape\` covers RFC 8259 §7. The CLI has no serde in its dep tree; pulling in \`serde_json\` just for two string fields would be overkill.

## Tests

- \`cargo test -p chordsketch-ffi --lib\`: **21/21 passing** (7 new).
- \`cargo test -p chordsketch --test cli test_warnings\`: **3/3 new tests pass** (JSONL format, plain-prefix regression guard, quote-balance invariant).
- \`cargo clippy -p chordsketch -p chordsketch-ffi --all-targets -- -D warnings\`: clean.
- \`cargo fmt --check\`: clean.

## Docs

- \`crates/ffi/README.md\`: three new rows in the API table + a short paragraph on when to prefer \`*_with_warnings\`.
- \`crates/cli/README.md\`: new \`--warnings-json\` row in the options table.

## Sister-site audit

Per \`.claude/rules/fix-propagation.md\`: FFI and CLI are the two bindings that did not yet expose structured warnings. WASM (#1893) and NAPI (#1893 + recently extended in #1939 with \`*WithWarningsAndOptions\`) already had both variants. Coverage is now symmetric across all four bindings.

Closes #1827