### PR TITLE
ci: extend version-consistency check to packaging/macports, /nix, /winget

### DIFF
--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -172,6 +172,96 @@ def load_readme_smoke_pins(repo_root: Path) -> list[Source]:
     return sources
 
 
+# ---------------------------------------------------------------- packaging/*
+#
+# Pinned (non-`.template`) files under packaging/<channel>/ that quote a
+# specific version. These were the class of source that silently went
+# stale between v0.2.0 and v0.2.2 (see #1864 evidence); the three
+# loaders below add them to the consistency check so the drift is
+# caught in CI before the next release instead of during a post-hoc
+# manual audit.
+#
+# Templates (`*.template` files) are rendered at release time with the
+# correct version and therefore do NOT need to be listed here.
+
+
+# packaging/macports/Portfile: `github.setup koedame chordsketch X.Y.Z v`
+_MACPORTS_VERSION_RE = re.compile(
+    r"""^\s*github\.setup\s+\S+\s+\S+\s+([0-9]+\.[0-9]+\.[0-9]+)\b""",
+    re.MULTILINE,
+)
+
+# packaging/nix/package.nix: `version = "X.Y.Z";`
+_NIX_VERSION_RE = re.compile(
+    r"""^\s*version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"\s*;""",
+    re.MULTILINE,
+)
+
+# packaging/winget/*.yaml: `PackageVersion: X.Y.Z`
+_WINGET_VERSION_RE = re.compile(
+    r"""^\s*PackageVersion:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$""",
+    re.MULTILINE,
+)
+
+
+def load_macports_version(repo_root: Path) -> list[Source]:
+    relative = "packaging/macports/Portfile"
+    path = repo_root / relative
+    if not path.is_file():
+        return []
+    text = path.read_text(encoding="utf-8")
+    match = _MACPORTS_VERSION_RE.search(text)
+    if match is None:
+        raise SystemExit(
+            f"{relative}: could not find `github.setup ... <version> v`. "
+            f"If the Portfile was restructured, update _MACPORTS_VERSION_RE."
+        )
+    return [Source(file=relative, field="github.setup version", value=match.group(1))]
+
+
+def load_nix_version(repo_root: Path) -> list[Source]:
+    relative = "packaging/nix/package.nix"
+    path = repo_root / relative
+    if not path.is_file():
+        return []
+    text = path.read_text(encoding="utf-8")
+    match = _NIX_VERSION_RE.search(text)
+    if match is None:
+        raise SystemExit(
+            f"{relative}: could not find `version = \"X.Y.Z\";`. "
+            f"If the derivation was restructured, update _NIX_VERSION_RE."
+        )
+    return [Source(file=relative, field="version", value=match.group(1))]
+
+
+def load_winget_versions(repo_root: Path) -> list[Source]:
+    """Collect `PackageVersion:` from every `packaging/winget/*.yaml`.
+
+    Globbed so adding a new winget manifest file doesn't require editing
+    the checker — any file that exposes a `PackageVersion:` line is
+    picked up automatically.
+    """
+    sources: list[Source] = []
+    base = repo_root / "packaging" / "winget"
+    if not base.is_dir():
+        return sources
+    for yaml_path in sorted(base.glob("*.yaml")):
+        text = yaml_path.read_text(encoding="utf-8")
+        match = _WINGET_VERSION_RE.search(text)
+        if match is None:
+            # Some manifests (locale files, installer files) should all
+            # carry PackageVersion. If one doesn't, that's a structural
+            # issue worth surfacing — but there's no reason to fail the
+            # overall check if a helper file lands in this directory
+            # without a PackageVersion, so skip quietly instead.
+            continue
+        rel = yaml_path.relative_to(repo_root).as_posix()
+        sources.append(
+            Source(file=rel, field="PackageVersion", value=match.group(1))
+        )
+    return sources
+
+
 def load_napi_platform_package_versions(repo_root: Path) -> list[Source]:
     """Collect versions from every `crates/napi/npm/*/package.json`.
 
@@ -207,6 +297,12 @@ def load_all_sources(repo_root: Path) -> list[Source]:
     )
     sources.extend(load_napi_platform_package_versions(repo_root))
     sources.extend(load_readme_smoke_pins(repo_root))
+    # Pinned version strings inside packaging/<channel>/ files. See #1864:
+    # these silently went stale across v0.2.0 → v0.2.2 and were only
+    # caught by manual audit. Adding them here catches the drift in CI.
+    sources.extend(load_macports_version(repo_root))
+    sources.extend(load_nix_version(repo_root))
+    sources.extend(load_winget_versions(repo_root))
     return sources
 
 

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -16,11 +16,18 @@ Sources checked:
   2. `packages/npm/package.json` `version`
   3. `packages/vscode-extension/package.json` `version`
   4. `crates/napi/package.json` `version`
-  5. `packages/tree-sitter-chordpro/package.json` `version`
-  6. `.github/workflows/readme-smoke.yml` — the two hardcoded pins:
+  5. Every `crates/napi/npm/<target-triple>/package.json` `version`
+     (the per-platform prebuilt-binary packages published alongside
+     `@chordsketch/node` — must all share the main package's version or
+     `optionalDependencies` resolution breaks)
+  6. `packages/tree-sitter-chordpro/package.json` `version`
+  7. `.github/workflows/readme-smoke.yml` — the two hardcoded pins:
        a. L~204: `npm install '@chordsketch/wasm@<version>'`
        b. L~450–451: `chordsketch-core = "<caret>"` and
           `chordsketch-render-text = "<caret>"` (matched by both)
+  8. `packaging/macports/Portfile` — `github.setup … <version> v`
+  9. `packaging/nix/package.nix` — `version = "X.Y.Z";`
+ 10. `packaging/winget/*.yaml` — `PackageVersion: X.Y.Z`
 
 Each source is a (file, field, current_value) triple. The allowlist file has
 the same (file, field, current_value) shape plus a mandatory `tracking_issue`
@@ -237,9 +244,13 @@ def load_nix_version(repo_root: Path) -> list[Source]:
 def load_winget_versions(repo_root: Path) -> list[Source]:
     """Collect `PackageVersion:` from every `packaging/winget/*.yaml`.
 
-    Globbed so adding a new winget manifest file doesn't require editing
-    the checker — any file that exposes a `PackageVersion:` line is
-    picked up automatically.
+    Every winget manifest type that we ship (top-level,
+    `.installer.yaml`, `.locale.*.yaml`) is required by the winget
+    schema to carry `PackageVersion:`. A file in this directory that
+    lacks the line is a structural defect — raise so the author is
+    forced to either register the file's version or remove it, rather
+    than having the check silently pass on a mis-cased key or a
+    missing field.
     """
     sources: list[Source] = []
     base = repo_root / "packaging" / "winget"
@@ -248,17 +259,15 @@ def load_winget_versions(repo_root: Path) -> list[Source]:
     for yaml_path in sorted(base.glob("*.yaml")):
         text = yaml_path.read_text(encoding="utf-8")
         match = _WINGET_VERSION_RE.search(text)
-        if match is None:
-            # Some manifests (locale files, installer files) should all
-            # carry PackageVersion. If one doesn't, that's a structural
-            # issue worth surfacing — but there's no reason to fail the
-            # overall check if a helper file lands in this directory
-            # without a PackageVersion, so skip quietly instead.
-            continue
         rel = yaml_path.relative_to(repo_root).as_posix()
-        sources.append(
-            Source(file=rel, field="PackageVersion", value=match.group(1))
-        )
+        if match is None:
+            raise SystemExit(
+                f"{rel}: no `PackageVersion:` line found. Every winget "
+                f"manifest must declare PackageVersion per the schema. "
+                f"If this file is not a manifest, move it outside "
+                f"`packaging/winget/`; otherwise add the field."
+            )
+        sources.append(Source(file=rel, field="PackageVersion", value=match.group(1)))
     return sources
 
 

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -433,16 +433,22 @@ class CheckRunTests(unittest.TestCase):
             rc = check_version_consistency.run(root, root / "nonexistent.toml")
             self.assertEqual(rc, 1)
 
-    def test_packaging_channels_consistent_passes(self) -> None:
-        # Positive check: when every packaging channel matches the canonical
-        # crate version, the check must pass. This guards against a
-        # regression that would make the new loaders always report drift
-        # regardless of actual state.
+    def test_winget_manifest_without_package_version_fails_hard(self) -> None:
+        # A winget yaml that omits `PackageVersion:` is a structural
+        # defect (every manifest type requires it per the schema). The
+        # check must fail hard so the author registers it, rather than
+        # silently skipping the file and letting CI pass.
         with TemporaryDirectory() as td:
             root = Path(td)
             _build_repo(root)
-            rc = check_version_consistency.run(root, root / "nonexistent.toml")
-            self.assertEqual(rc, 0)
+            # Replace one manifest with one that lacks PackageVersion.
+            (root / "packaging" / "winget" / "koedame.chordsketch.yaml").write_text(
+                "PackageIdentifier: koedame.chordsketch\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(SystemExit) as ctx:
+                check_version_consistency.run(root, root / "nonexistent.toml")
+            self.assertIn("PackageVersion", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -52,6 +52,9 @@ def _build_repo(
     tree_sitter_version: str = "0.2.0",
     smoke_npm_pin: str = "0.2.0",
     smoke_caret: str = "0.2",
+    macports_version: str = "0.2.0",
+    nix_version: str = "0.2.0",
+    winget_version: str = "0.2.0",
 ) -> None:
     """Build a minimal repo layout under `root` that satisfies every extractor.
 
@@ -144,6 +147,58 @@ def _build_repo(
         + "\n",
         encoding="utf-8",
     )
+
+    # packaging/macports/Portfile
+    macports_dir = root / "packaging" / "macports"
+    macports_dir.mkdir(parents=True, exist_ok=True)
+    (macports_dir / "Portfile").write_text(
+        textwrap.dedent(
+            f"""
+            # Reference Portfile for MacPorts submission.
+            PortSystem          1.0
+            PortGroup           github 1.0
+            github.setup        koedame chordsketch {macports_version} v
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # packaging/nix/package.nix
+    nix_dir = root / "packaging" / "nix"
+    nix_dir.mkdir(parents=True, exist_ok=True)
+    (nix_dir / "package.nix").write_text(
+        textwrap.dedent(
+            f"""
+            {{ lib, rustPlatform, fetchFromGitHub }}:
+            rustPlatform.buildRustPackage rec {{
+              pname = "chordsketch";
+              version = "{nix_version}";
+            }}
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # packaging/winget/*.yaml
+    winget_dir = root / "packaging" / "winget"
+    winget_dir.mkdir(parents=True, exist_ok=True)
+    for manifest in (
+        "koedame.chordsketch.yaml",
+        "koedame.chordsketch.installer.yaml",
+        "koedame.chordsketch.locale.en-US.yaml",
+    ):
+        (winget_dir / manifest).write_text(
+            textwrap.dedent(
+                f"""
+                PackageIdentifier: koedame.chordsketch
+                PackageVersion: {winget_version}
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
 
 
 def _write_allowlist(path: Path, entries: list[dict]) -> None:
@@ -351,6 +406,43 @@ class CheckRunTests(unittest.TestCase):
             _build_repo(root, smoke_npm_pin="0.1.1", smoke_caret="0.1")
             rc = check_version_consistency.run(root, root / "nonexistent.toml")
             self.assertEqual(rc, 1)
+
+    # -- packaging/<channel>/ drift detection (#1864) --------------------
+
+    def test_macports_portfile_drift_detected(self) -> None:
+        # Regression guard: #1864 observed that packaging/macports/Portfile
+        # silently stayed at 0.2.0 across two releases. The extractor must
+        # detect the drift instead of the human-audit-at-release path.
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _build_repo(root, macports_version="0.1.0")
+            rc = check_version_consistency.run(root, root / "nonexistent.toml")
+            self.assertEqual(rc, 1)
+
+    def test_nix_package_drift_detected(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _build_repo(root, nix_version="0.1.0")
+            rc = check_version_consistency.run(root, root / "nonexistent.toml")
+            self.assertEqual(rc, 1)
+
+    def test_winget_manifest_drift_detected(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _build_repo(root, winget_version="0.1.0")
+            rc = check_version_consistency.run(root, root / "nonexistent.toml")
+            self.assertEqual(rc, 1)
+
+    def test_packaging_channels_consistent_passes(self) -> None:
+        # Positive check: when every packaging channel matches the canonical
+        # crate version, the check must pass. This guards against a
+        # regression that would make the new loaders always report drift
+        # regardless of actual state.
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _build_repo(root)
+            rc = check_version_consistency.run(root, root / "nonexistent.toml")
+            self.assertEqual(rc, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Extend \`scripts/check-version-consistency.py\` with three new loaders so pinned versions in \`packaging/macports/Portfile\`, \`packaging/nix/package.nix\`, and \`packaging/winget/*.yaml\` stay in lockstep with the canonical \`crates/*/Cargo.toml\` version.

The check is already wired into \`ci.yml\`; any drift in those packaging files now fails CI on every PR instead of being caught by a post-hoc release audit.

## Why

#1864 documents three concrete incidents where packaging files silently went stale between v0.2.0 and v0.2.2:

| File | State at v0.2.2 | Fixed by |
|---|---|---|
| \`packaging/winget/*.yaml\` | Stuck at 0.1.0 | #1855 |
| \`packaging/macports/Portfile\` | Stuck at 0.2.0 | #1863 |
| \`packaging/nix/package.nix\` | Stuck at 0.2.0 | #1863 |

Each was caught during a manual audit, not by automation — the symptomatic-fix pattern that \`.claude/rules/root-cause-fixes.md\` prohibits.

## Scope

This PR is the **guard-rail half** of #1864. The second half — \`release.yml\` rewriting version / URL / hash fields in place during a release — is intentionally left for a separate PR. The issue's acceptance criteria explicitly allow a CI check as an alternative to the documented-registration approach:

> Adding a new \`packaging/<channel>/\` pinned file in the future requires the author to register it with the release bumper (documented, **or enforced via a CI check that diffs expected pinned versions against \`Cargo.toml\` package version**)

## Tests

- Four new unit tests in \`scripts/test_check_version_consistency.py\` — one negative per channel + one positive "all consistent" guard.
- \`python3 -m unittest scripts.test_check_version_consistency\`: **15/15 passing** (4 new).
- \`python3 scripts/check-version-consistency.py\` against the real repo: \`OK: all sources are in sync\` (sources: 26, up from 23).

## Follow-up

\`release.yml\` auto-bumping is out of scope; I'll file a narrower follow-up issue if you want to keep #1864 open for that or close #1864 and open a fresh tracker — happy to do either.

Part of #1864