### PR TITLE
test(vscode-extension): run integration tests against VS Code matrix (#1918 phase 3)

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -92,10 +92,18 @@ jobs:
       # the only production build — `npm run test:integration` deliberately
       # does NOT have a `pretest` hook that re-invokes `npm run build`, so
       # CI does not pay for two esbuild runs per PR.
+      #
+      # `.vscode-test.mjs` runs each test against two VS Code versions:
+      #   - `stable` (latest release)
+      #   - `engines.vscode` floor (currently 1.85.0, read from package.json)
+      # Both cells execute in a single `npm run test:integration` invocation
+      # — test-cli iterates the matrix internally. The first cold run
+      # downloads both VS Code builds (~200 MB combined); subsequent runs
+      # reuse the local cache.
+      #
       # xvfb-run provides a virtual X display for Electron on the Linux
-      # runner. See issue #1918 for the phased test plan — only the
-      # activation test lands in this first round; LSP, preview, and
-      # serializer tests follow.
+      # runner. See issue #1918 for the phased test plan — LSP and
+      # serializer integration tests are still follow-up phases.
       - name: Compile integration tests
         run: npm run compile:integration
         working-directory: packages/vscode-extension

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -95,7 +95,9 @@ jobs:
       #
       # `.vscode-test.mjs` runs each test against two VS Code versions:
       #   - `stable` (latest release)
-      #   - `engines.vscode` floor (currently 1.85.0, read from package.json)
+      #   - `engines.vscode` floor (read dynamically from package.json at
+      #     config-load time, so a future engines bump is picked up here
+      #     without editing this workflow).
       # Both cells execute in a single `npm run test:integration` invocation
       # — test-cli iterates the matrix internally. The first cold run
       # downloads both VS Code builds (~200 MB combined); subsequent runs

--- a/packages/vscode-extension/.vscode-test.mjs
+++ b/packages/vscode-extension/.vscode-test.mjs
@@ -1,5 +1,5 @@
 // Configuration for `@vscode/test-cli`. Runs the extension-host
-// integration tests against a downloaded VS Code build.
+// integration tests against downloaded VS Code builds.
 //
 // Tests are authored in TypeScript under `test/integration/` and compiled
 // to `out-test/test/integration/` via `tsconfig.integration.json`. The
@@ -8,19 +8,40 @@
 // See the test-electron + test-cli guide:
 //   https://code.visualstudio.com/api/working-with-extensions/testing-extension
 //
-// Tests run against the `stable` channel — the most recent release that
-// real users have installed. A second matrix entry pinned to the
-// `engines.vscode` floor (1.85.0) is a planned follow-up so both ceiling
-// and floor of supported versions are exercised (see issue #1918 for the
-// phased plan; the floor is deliberately deferred to keep the first CI
-// rollout fast).
+// The test suite runs against two VS Code versions:
+//
+//   1. "stable" — the most recent release that real users have installed.
+//      Catches regressions that only manifest on the latest VS Code APIs.
+//
+//   2. The `engines.vscode` floor (kept in sync with `package.json`
+//      `engines.vscode`) — the oldest VS Code version we promise to
+//      support. Catches accidental use of APIs newer than the declared
+//      minimum, which would break install on older VS Code builds.
+//
+// Both matrix cells exercise every test in `test/integration/`. The
+// `.vscode-test/` download cache is shared between them, so only the
+// first cold run incurs the VS Code download cost.
 
 import { defineConfig } from "@vscode/test-cli";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 
-export default defineConfig({
-  label: "integrationTests",
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Read the `engines.vscode` floor from package.json so the matrix cannot
+// silently drift if the engines field is bumped.
+//
+// `engines.vscode` is semver-range style (e.g., "^1.85.0"); strip the
+// leading range operator and use the bare version for the test-cli
+// `version` field, which takes a concrete version string.
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "package.json"), "utf-8"),
+);
+const enginesVscodeFloor = packageJson.engines.vscode.replace(/^[\^~>=<]+/, "");
+
+const sharedTestConfig = {
   files: "out-test/test/integration/**/*.test.js",
-  version: "stable",
   // Workspace is empty by default; tests that open fixture files do so
   // programmatically via `vscode.workspace.openTextDocument`.
   workspaceFolder: "./test/fixtures",
@@ -29,4 +50,17 @@ export default defineConfig({
     timeout: 60_000, // VS Code startup + extension activation can be slow on cold caches
     color: true,
   },
-});
+};
+
+export default defineConfig([
+  {
+    ...sharedTestConfig,
+    label: "stable",
+    version: "stable",
+  },
+  {
+    ...sharedTestConfig,
+    label: "floor",
+    version: enginesVscodeFloor,
+  },
+]);

--- a/packages/vscode-extension/.vscode-test.mjs
+++ b/packages/vscode-extension/.vscode-test.mjs
@@ -32,13 +32,27 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Read the `engines.vscode` floor from package.json so the matrix cannot
 // silently drift if the engines field is bumped.
 //
-// `engines.vscode` is semver-range style (e.g., "^1.85.0"); strip the
-// leading range operator and use the bare version for the test-cli
-// `version` field, which takes a concrete version string.
+// VS Code extensions use a *simple* prefix range for `engines.vscode`
+// (e.g., `"^1.85.0"`, `">=1.85.0"`), never a compound range. Strip the
+// leading range operator to get the bare version that `@vscode/test-cli`
+// accepts as its `version` field.
+//
+// We validate the result against the strict `major.minor.patch` shape
+// and throw a loud error if anything else leaks through — a compound
+// range like `">=1.85.0 <2.0.0"` would otherwise produce
+// `"1.85.0 <2.0.0"` and `@vscode/test-cli` would fail with an opaque
+// error deep inside the VS Code download path.
 const packageJson = JSON.parse(
   readFileSync(resolve(__dirname, "package.json"), "utf-8"),
 );
 const enginesVscodeFloor = packageJson.engines.vscode.replace(/^[\^~>=<]+/, "");
+if (!/^\d+\.\d+\.\d+$/.test(enginesVscodeFloor)) {
+  throw new Error(
+    `engines.vscode must be a simple prefix range (e.g. "^1.85.0"); ` +
+      `after stripping the range operator got ${JSON.stringify(enginesVscodeFloor)}. ` +
+      `If you need a compound range, update this config to pick the floor explicitly.`,
+  );
+}
 
 const sharedTestConfig = {
   files: "out-test/test/integration/**/*.test.js",


### PR DESCRIPTION
## What

Extend the \`@vscode/test-cli\` harness to run every integration test against BOTH the latest \`stable\` VS Code AND the \`engines.vscode\` floor (currently 1.85.0).

## Why

The single-version setup from phase 1 (#1949) catches regressions visible to contemporary users but misses two meaningful classes:

1. **Floor breakage** — accidental use of an API newer than 1.85.0. Would ship to users on older VS Code installs and manifest as \`undefined\` / \`command not found\`. Now fails CI immediately.
2. **Stable-only regression** — an API deprecated in a later VS Code release. Rare but possible; the floor cell catches it while the stable cell fires.

## Design

- \`.vscode-test.mjs\` reads \`engines.vscode\` from \`package.json\` at config-load time and strips the semver range operator (\`^\`) for the floor cell. Bumping \`engines.vscode\` in a future release automatically retargets the floor — no YAML edits needed.
- Both cells share a single \`sharedTestConfig\` spread so \`files\` glob, \`workspaceFolder\`, and mocha timeout never drift between matrix entries.
- \`test-cli\` runs both cells in a single \`npm run test:integration\` invocation (iterates the array returned by \`defineConfig\`), so the CI job structure is unchanged; only the workflow comment was updated.
- First cold CI run downloads both VS Code builds (~200 MB combined); subsequent runs reuse \`.vscode-test/\`.

## Verification

Locally validated that the config resolves the expected matrix:

\`\`\`json
[
  { "label": "stable", "version": "stable" },
  { "label": "floor",  "version": "1.85.0" }
]
\`\`\`

- \`npm run compile:integration\`: clean.
- \`npm run lint\`: clean.

CI will exercise both cells end-to-end.

## Follow-ups still queued under #1918

- **LSP negotiation test** (#1913 gate) — needs either a Node.js stub LSP or a Rust-build step in the extension-CI workflow.
- **Preview serializer restart-cycle test** (#1915 gate) — no tractable in-process restart simulation yet.
- **Required-status-check marking** — branch-protection change, separate maintainer action.

Part of #1918