### PR TITLE
test(vscode-extension): add LSP configuration-change restart tests (#1918 phase 4)

### DIFF
--- a/packages/vscode-extension/test/integration/activation.test.ts
+++ b/packages/vscode-extension/test/integration/activation.test.ts
@@ -1,12 +1,15 @@
 /**
  * Integration test: extension activation + command registration.
  *
- * This is the foundational regression gate for issue #1914. It opens a
- * `.cho` fixture (which triggers the extension's `onLanguage:chordpro`
- * activation event) and asserts that every contributed command is
- * present in `vscode.commands.getCommands(true)`. A future refactor of
- * `activate()` that propagates an error before `context.subscriptions.push`
- * runs would silently drop commands and be caught here.
+ * Foundational regression gate for issue #1914. `activateExtension()`
+ * opens a `.cho` fixture (which triggers the extension's
+ * `onLanguage:chordpro` activation event) and
+ * `assertAllContributedCommandsRegistered()` checks every
+ * `package.json`-contributed command reaches
+ * `vscode.commands.getCommands(true)`. A future refactor of
+ * `activate()` that propagates an error before
+ * `context.subscriptions.push` runs would silently drop commands and
+ * be caught here.
  *
  * Run from `packages/vscode-extension/`:
  *
@@ -16,50 +19,17 @@
  * runs reuse it.
  */
 
-import * as assert from "node:assert/strict";
-import * as path from "node:path";
-import * as vscode from "vscode";
-
-/** Commands the extension contributes via `package.json#contributes.commands`. */
-const CONTRIBUTED_COMMANDS = [
-  "chordsketch.openPreview",
-  "chordsketch.openPreviewToSide",
-  "chordsketch.transposeUp",
-  "chordsketch.transposeDown",
-  "chordsketch.convertTo",
-];
+import {
+  activateExtension,
+  assertAllContributedCommandsRegistered,
+} from "./helpers.js";
 
 suite("extension activation", () => {
   suiteSetup(async () => {
-    // Open a fixture to trigger the extension's `onLanguage:chordpro`
-    // activation event. The actual rendered content does not matter —
-    // we only need the ChordPro language association to fire.
-    const fixtureDir = path.resolve(__dirname, "..", "..", "..", "test", "fixtures");
-    const uri = vscode.Uri.file(path.join(fixtureDir, "hello.cho"));
-    const doc = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(doc);
-
-    // Wait for activation to complete. `getExtension` returns `undefined`
-    // briefly during host startup, and `activate()` is async, so poll
-    // with a generous timeout before the per-test assertions run.
-    const extension = vscode.extensions.getExtension("koedame.chordsketch");
-    assert.ok(
-      extension,
-      "koedame.chordsketch extension must be installed in the extension-dev host",
-    );
-    if (!extension.isActive) {
-      await extension.activate();
-    }
-    assert.ok(extension.isActive, "extension must be active after activation");
+    await activateExtension();
   });
 
   test("every contributed command is registered after activation", async () => {
-    const registered = new Set(await vscode.commands.getCommands(/* filterInternal */ true));
-    const missing = CONTRIBUTED_COMMANDS.filter((cmd) => !registered.has(cmd));
-    assert.deepEqual(
-      missing,
-      [],
-      `expected all contributed commands to be registered; missing: ${JSON.stringify(missing)}`,
-    );
+    await assertAllContributedCommandsRegistered();
   });
 });

--- a/packages/vscode-extension/test/integration/helpers.ts
+++ b/packages/vscode-extension/test/integration/helpers.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared helpers for the `test/integration/` suites.
+ *
+ * Extracted so the contributed-command list, fixture-path resolution,
+ * and extension-activation bootstrap live in a single place — adding a
+ * new command or renaming the fixture directory touches one file, not
+ * four.
+ */
+
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as vscode from "vscode";
+
+/**
+ * Commands the extension contributes via `package.json#contributes.commands`.
+ *
+ * Single source of truth for the integration tests' command-registration
+ * assertions. A new command added to `package.json` should also be added
+ * here; the activation test will then assert its presence automatically.
+ */
+export const CONTRIBUTED_COMMANDS: readonly string[] = [
+  "chordsketch.openPreview",
+  "chordsketch.openPreviewToSide",
+  "chordsketch.transposeUp",
+  "chordsketch.transposeDown",
+  "chordsketch.convertTo",
+];
+
+/**
+ * Resolve a file in `test/fixtures/` by walking up from the compiled
+ * test location.
+ *
+ * Tests compile to `out-test/test/integration/*.js`; fixtures live at
+ * `test/fixtures/` (source tree root relative to the package). The
+ * three-`..` traversal matches `out-test/test/integration/ →
+ * out-test/ → packages/vscode-extension/` where the `test/` directory
+ * sits.
+ */
+export function fixture(name: string): vscode.Uri {
+  const fixtureDir = path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "test",
+    "fixtures",
+  );
+  return vscode.Uri.file(path.join(fixtureDir, name));
+}
+
+/**
+ * Open `hello.cho` in the active column (triggers the
+ * `onLanguage:chordpro` activation event) and ensure the extension is
+ * active. Shared bootstrap for every `suiteSetup` in this folder.
+ */
+export async function activateExtension(): Promise<void> {
+  const doc = await vscode.workspace.openTextDocument(fixture("hello.cho"));
+  await vscode.window.showTextDocument(doc);
+  const extension = vscode.extensions.getExtension("koedame.chordsketch");
+  assert.ok(
+    extension,
+    "koedame.chordsketch extension must be installed in the extension-dev host",
+  );
+  if (!extension.isActive) {
+    await extension.activate();
+  }
+  assert.ok(extension.isActive, "extension must be active after activation");
+}
+
+/**
+ * Assert that every command in [`CONTRIBUTED_COMMANDS`] is currently
+ * registered with VS Code. `filterInternal: true` skips VS Code's
+ * built-in command ids so the diff is specific to extension contributions.
+ */
+export async function assertAllContributedCommandsRegistered(): Promise<void> {
+  const registered = new Set(
+    await vscode.commands.getCommands(/* filterInternal */ true),
+  );
+  const missing = CONTRIBUTED_COMMANDS.filter((cmd) => !registered.has(cmd));
+  assert.deepEqual(
+    missing,
+    [],
+    `contributed commands must be registered; missing: ${JSON.stringify(missing)}`,
+  );
+}

--- a/packages/vscode-extension/test/integration/lsp-config.test.ts
+++ b/packages/vscode-extension/test/integration/lsp-config.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration test: configuration-driven LSP restart path must not
+ * crash activation or de-register commands.
+ *
+ * Regression gate for the class of bug covered by #1914 and #1917:
+ * the `onDidChangeConfiguration` listener in `extension.ts` calls
+ * `stopLspClient()` → `startLspGuarded()`. If either step propagates an
+ * unhandled error, the extension host would log a crash and subsequent
+ * commands would silently stop working. This test toggles the relevant
+ * settings and confirms:
+ *
+ *   1. No exception escapes the configuration-change handler.
+ *   2. All five contributed commands remain registered afterwards.
+ *
+ * It does NOT actually launch `chordsketch-lsp` — the binary is almost
+ * certainly absent on CI runners — so the test exercises the
+ * "binary-not-found" graceful-degradation branch, which is the specific
+ * path that was broken in #1917.
+ */
+
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as vscode from "vscode";
+
+const CONTRIBUTED_COMMANDS = [
+  "chordsketch.openPreview",
+  "chordsketch.openPreviewToSide",
+  "chordsketch.transposeUp",
+  "chordsketch.transposeDown",
+  "chordsketch.convertTo",
+];
+
+async function assertCommandsStillRegistered(): Promise<void> {
+  const registered = new Set(await vscode.commands.getCommands(true));
+  const missing = CONTRIBUTED_COMMANDS.filter((c) => !registered.has(c));
+  assert.deepEqual(
+    missing,
+    [],
+    `contributed commands must survive LSP restart; missing: ${JSON.stringify(missing)}`,
+  );
+}
+
+suite("LSP configuration restart", () => {
+  suiteSetup(async () => {
+    // Activate the extension via a fixture open.
+    const fixtureDir = path.resolve(__dirname, "..", "..", "..", "test", "fixtures");
+    const uri = vscode.Uri.file(path.join(fixtureDir, "hello.cho"));
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc);
+    const ext = vscode.extensions.getExtension("koedame.chordsketch");
+    assert.ok(ext, "koedame.chordsketch extension must be installed");
+    if (!ext.isActive) {
+      await ext.activate();
+    }
+  });
+
+  test("toggling chordsketch.lsp.enabled does not crash the extension or drop commands", async () => {
+    const config = vscode.workspace.getConfiguration("chordsketch.lsp");
+
+    // Flip to false, then back to true. Both transitions go through
+    // the same restart path in `onDidChangeConfiguration`.
+    try {
+      await config.update(
+        "enabled",
+        false,
+        vscode.ConfigurationTarget.Workspace,
+      );
+      // Give the async handler a chance to run; the event is fired
+      // synchronously but the handler's `await` chain yields.
+      await new Promise((r) => setTimeout(r, 500));
+      await assertCommandsStillRegistered();
+
+      await config.update(
+        "enabled",
+        true,
+        vscode.ConfigurationTarget.Workspace,
+      );
+      await new Promise((r) => setTimeout(r, 500));
+      await assertCommandsStillRegistered();
+    } finally {
+      // Restore default so test state does not leak across tests.
+      await config.update(
+        "enabled",
+        undefined,
+        vscode.ConfigurationTarget.Workspace,
+      );
+    }
+  });
+
+  test("pointing chordsketch.lsp.path at a non-existent binary does not crash the extension", async () => {
+    // This exercises the exact code path that failed in #1917:
+    //   1. `onDidChangeConfiguration` fires.
+    //   2. `stopLspClient()` runs against whatever state the client is in.
+    //   3. `startLspGuarded()` → `startLspClient()` → `resolveLspBinary`
+    //      returns `undefined` for a path that does not exist.
+    //   4. The fallback should log to the notFoundChannel and return
+    //      without throwing.
+    const config = vscode.workspace.getConfiguration("chordsketch.lsp");
+    try {
+      await config.update(
+        "path",
+        "/nonexistent/definitely-no-chordsketch-lsp-here",
+        vscode.ConfigurationTarget.Workspace,
+      );
+      await new Promise((r) => setTimeout(r, 500));
+      // Core regression gate: commands must still exist after the
+      // non-existent-binary restart path runs.
+      await assertCommandsStillRegistered();
+    } finally {
+      await config.update(
+        "path",
+        undefined,
+        vscode.ConfigurationTarget.Workspace,
+      );
+    }
+  });
+});

--- a/packages/vscode-extension/test/integration/lsp-config.test.ts
+++ b/packages/vscode-extension/test/integration/lsp-config.test.ts
@@ -18,40 +18,15 @@
  * path that was broken in #1917.
  */
 
-import * as assert from "node:assert/strict";
-import * as path from "node:path";
 import * as vscode from "vscode";
-
-const CONTRIBUTED_COMMANDS = [
-  "chordsketch.openPreview",
-  "chordsketch.openPreviewToSide",
-  "chordsketch.transposeUp",
-  "chordsketch.transposeDown",
-  "chordsketch.convertTo",
-];
-
-async function assertCommandsStillRegistered(): Promise<void> {
-  const registered = new Set(await vscode.commands.getCommands(true));
-  const missing = CONTRIBUTED_COMMANDS.filter((c) => !registered.has(c));
-  assert.deepEqual(
-    missing,
-    [],
-    `contributed commands must survive LSP restart; missing: ${JSON.stringify(missing)}`,
-  );
-}
+import {
+  activateExtension,
+  assertAllContributedCommandsRegistered,
+} from "./helpers.js";
 
 suite("LSP configuration restart", () => {
   suiteSetup(async () => {
-    // Activate the extension via a fixture open.
-    const fixtureDir = path.resolve(__dirname, "..", "..", "..", "test", "fixtures");
-    const uri = vscode.Uri.file(path.join(fixtureDir, "hello.cho"));
-    const doc = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(doc);
-    const ext = vscode.extensions.getExtension("koedame.chordsketch");
-    assert.ok(ext, "koedame.chordsketch extension must be installed");
-    if (!ext.isActive) {
-      await ext.activate();
-    }
+    await activateExtension();
   });
 
   test("toggling chordsketch.lsp.enabled does not crash the extension or drop commands", async () => {
@@ -68,7 +43,7 @@ suite("LSP configuration restart", () => {
       // Give the async handler a chance to run; the event is fired
       // synchronously but the handler's `await` chain yields.
       await new Promise((r) => setTimeout(r, 500));
-      await assertCommandsStillRegistered();
+      await assertAllContributedCommandsRegistered();
 
       await config.update(
         "enabled",
@@ -76,7 +51,7 @@ suite("LSP configuration restart", () => {
         vscode.ConfigurationTarget.Workspace,
       );
       await new Promise((r) => setTimeout(r, 500));
-      await assertCommandsStillRegistered();
+      await assertAllContributedCommandsRegistered();
     } finally {
       // Restore default so test state does not leak across tests.
       await config.update(
@@ -105,7 +80,7 @@ suite("LSP configuration restart", () => {
       await new Promise((r) => setTimeout(r, 500));
       // Core regression gate: commands must still exist after the
       // non-existent-binary restart path runs.
-      await assertCommandsStillRegistered();
+      await assertAllContributedCommandsRegistered();
     } finally {
       await config.update(
         "path",

--- a/packages/vscode-extension/test/integration/preview.test.ts
+++ b/packages/vscode-extension/test/integration/preview.test.ts
@@ -15,18 +15,12 @@
  */
 
 import * as assert from "node:assert/strict";
-import * as path from "node:path";
 import * as vscode from "vscode";
+import { activateExtension, fixture } from "./helpers.js";
 
 const OPEN_PREVIEW = "chordsketch.openPreview";
 const OPEN_PREVIEW_TO_SIDE = "chordsketch.openPreviewToSide";
 const PREVIEW_VIEW_TYPE = "chordsketchPreview";
-
-/** Resolve the fixture by walking up from the compiled test location. */
-function fixture(name: string): vscode.Uri {
-  const fixtureDir = path.resolve(__dirname, "..", "..", "..", "test", "fixtures");
-  return vscode.Uri.file(path.join(fixtureDir, name));
-}
 
 /**
  * Poll until the tab group surface reports a webview tab of the expected
@@ -76,12 +70,7 @@ async function closeAllPreviewTabs(): Promise<void> {
 
 suite("preview panel", () => {
   suiteSetup(async () => {
-    // Make sure the extension is active so its commands are registered.
-    const ext = vscode.extensions.getExtension("koedame.chordsketch");
-    assert.ok(ext, "koedame.chordsketch extension must be installed");
-    if (!ext.isActive) {
-      await ext.activate();
-    }
+    await activateExtension();
   });
 
   setup(async () => {


### PR DESCRIPTION
## What

Third slice of the #1918 harness rollout. Adds two integration tests that exercise the \`onDidChangeConfiguration\` → \`stopLspClient\` → \`startLspGuarded\` restart path — the exact code path that broke in #1917 (leaked half-initialized \`LanguageClient\` singleton) and #1914 (crashing activation silently dropped commands).

## Regression gates

- **Class of bug**: a misconfigured \`chordsketch.lsp.*\` setting triggers a restart, the restart throws, and the \`onDidChangeConfiguration\` handler propagates — the extension host logs a crash and every subsequent contributed command silently stops working.
- **Before these tests**: this path was only verified by running the PR branch in a real VS Code instance and fiddling with settings.
- **After these tests**: CI fires the restart path on every push and asserts all five contributed commands remain registered.

## Tests added

- \`toggling chordsketch.lsp.enabled does not crash the extension or drop commands\` — flips \`chordsketch.lsp.enabled\` off then back on.
- \`pointing chordsketch.lsp.path at a non-existent binary does not crash the extension\` — drives the "binary-not-found" graceful-degradation branch that regressed in #1917.

Both tests wrap the mutation in \`try/finally\` that restores the config via \`update(..., undefined, ...)\` so state does not leak between tests.

## Tested locally

- \`npm run compile:integration\`: clean.
- \`npm run lint\`: clean.

The two-version CI matrix from phase 3 runs the new tests against both \`stable\` and the \`engines.vscode\` floor.

## What is NOT covered here

Tracked against the remaining #1918 acceptance-list items:

- **Real LSP negotiation test** (#1913 gate) — needs either a stub Node.js LSP server or a Rust build step in the extension-CI workflow. This phase covers the "LSP binary path misconfigured" subset of #1913's root cause (activation not aborting on LSP failures), but does not assert the position-encoding negotiation itself.
- **Preview serializer restart-cycle test** (#1915 gate) — simulating a real extension-host restart from inside the harness is still not tractable. The VS Code-free \`parseSerializedState\` helper is covered by the unit-test suite.

Part of #1918