### PR TITLE
fix(renderers): tag() method + notation-block skip window in text renderer + edge-case coverage

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -806,19 +806,13 @@ fn render_song_into_doc(
                 if let Some(kind) = NotationKind::from_start_directive(&d.kind) {
                     render_section_label(d, doc);
                     let label = kind.label();
+                    let tag = kind.tag();
                     push_warning(
                         warnings,
                         format!(
                             "PDF renderer does not support {label} blocks; body of the \
                              `{{start_of_{tag}}} … {{end_of_{tag}}}` section has been \
                              omitted. Use the HTML renderer for full {label} support.",
-                            label = label,
-                            tag = match kind {
-                                NotationKind::Abc => "abc",
-                                NotationKind::Lilypond => "ly",
-                                NotationKind::MusicXml => "musicxml",
-                                NotationKind::Svg => "svg",
-                            },
                         ),
                     );
                     let placeholder = format!(
@@ -1149,12 +1143,28 @@ enum NotationKind {
 }
 
 impl NotationKind {
+    /// Human-readable display name for user-facing output (section
+    /// label, placeholder text, warning message).
     fn label(self) -> &'static str {
         match self {
             Self::Abc => "ABC",
             Self::Lilypond => "Lilypond",
             Self::MusicXml => "MusicXML",
             Self::Svg => "SVG",
+        }
+    }
+
+    /// ChordPro directive token for this notation kind (e.g.
+    /// `{start_of_abc}` / `{end_of_abc}`). Kept as a method on the
+    /// enum rather than an inline `match` at the call site so adding
+    /// a new notation kind in the future only requires editing this
+    /// file in one place.
+    fn tag(self) -> &'static str {
+        match self {
+            Self::Abc => "abc",
+            Self::Lilypond => "ly",
+            Self::MusicXml => "musicxml",
+            Self::Svg => "svg",
         }
     }
 
@@ -4096,6 +4106,90 @@ mod delegate_tests {
         let content = String::from_utf8_lossy(&result.output);
         assert!(content.contains("Hello world"));
         assert!(!content.contains("body"));
+    }
+
+    // #1969 — edge-case coverage for the notation-block skip window.
+
+    #[test]
+    fn test_notation_block_inside_chorus_is_excluded_from_recall() {
+        // A notation block INSIDE a chorus body must:
+        //   (a) still produce its structured warning at the initial
+        //       render, and
+        //   (b) NOT be replayed by a subsequent `{chorus}` recall —
+        //       lines are only appended to the chorus buffer from the
+        //       default match arm, which the notation-block
+        //       short-circuit bypasses. A recall after this source
+        //       therefore only replays the surrounding lyrics, not
+        //       the placeholder.
+        let input = "{start_of_chorus}\n\
+                     [G]Sing along\n\
+                     {start_of_abc}\n\
+                     X:1\n\
+                     {end_of_abc}\n\
+                     [C]another line\n\
+                     {end_of_chorus}\n\
+                     {chorus}\n";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        // One ABC block seen once → at most one ABC warning. The
+        // recall must NOT produce a second.
+        let abc_warnings = result.warnings.iter().filter(|w| w.contains("ABC")).count();
+        assert_eq!(
+            abc_warnings, 1,
+            "exactly one ABC warning expected (recall must not re-emit); got {:?}",
+            result.warnings,
+        );
+        let content = String::from_utf8_lossy(&result.output);
+        // The surrounding chorus lyrics are recalled normally.
+        assert!(content.contains("Sing along"));
+        assert!(content.contains("another line"));
+    }
+
+    #[test]
+    fn test_unterminated_notation_block_renders_without_panic() {
+        // A file that enters a notation block and ends before the
+        // matching `end_of_<tag>` must not panic. The section label,
+        // warning, and placeholder all land; any content after the
+        // unterminated StartOf is simply swallowed by the skip
+        // window.
+        let input = "{title: T}\n[C]Before\n{start_of_abc}\nX:1\nK:C\n";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result.warnings.iter().any(|w| w.contains("ABC")),
+            "unterminated ABC block should still emit the warning; got {:?}",
+            result.warnings,
+        );
+        let content = String::from_utf8_lossy(&result.output);
+        assert!(content.contains("Before"));
+        assert!(content.contains("[ABC block omitted"));
+        // Body must not leak even though no EndOf was seen.
+        assert!(!content.contains("X:1"));
+        assert!(!content.contains("K:C"));
+    }
+
+    #[test]
+    fn test_stray_end_of_notation_is_silently_ignored() {
+        // A stray `{end_of_abc}` outside any notation block must not
+        // panic and must not produce a spurious warning. The skip
+        // state is `None` at that point, so the End directive flows
+        // through the default match arm (which treats it like any
+        // other unknown directive — rendered via `render_directive`
+        // but with no special behaviour for EndOf variants).
+        let input = "{title: T}\n[C]Hello\n{end_of_abc}\n[D]World\n";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("ABC") && w.contains("omitted")),
+            "stray `end_of_abc` must not trigger the notation-block warning; got {:?}",
+            result.warnings,
+        );
+        let content = String::from_utf8_lossy(&result.output);
+        assert!(content.contains("Hello"));
+        assert!(content.contains("World"));
     }
 }
 

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -1406,6 +1406,77 @@ mod delegate_tests {
         let output = render(input);
         assert!(output.contains("[MusicXML: Score]"));
         assert!(output.contains("[MusicXML block omitted"));
+        // Negative assertion — body must not leak even when the
+        // section header carries a label. Mirrors the unlabelled
+        // variant so a future regression touching either code path
+        // fails here.
+        assert!(
+            !output.contains("<score-partwise"),
+            "MusicXML body must not leak into text output; got:\n{output}"
+        );
+    }
+
+    // #1974 — edge-case coverage for the notation-block skip window.
+    // Mirrors the tests added to the PDF renderer in #1969 so both
+    // skip-and-warn implementations are guarded by the same set of
+    // scenarios.
+
+    #[test]
+    fn test_text_notation_block_inside_chorus_is_excluded_from_recall() {
+        let input = "{start_of_chorus}\n\
+                     [G]Sing along\n\
+                     {start_of_abc}\n\
+                     X:1\n\
+                     {end_of_abc}\n\
+                     [C]another line\n\
+                     {end_of_chorus}\n\
+                     {chorus}\n";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        // One ABC block seen once → exactly one ABC warning. A recall
+        // that re-emitted the placeholder would double this.
+        let abc_warnings = result.warnings.iter().filter(|w| w.contains("ABC")).count();
+        assert_eq!(
+            abc_warnings, 1,
+            "exactly one ABC warning expected (recall must not re-emit); got {:?}",
+            result.warnings,
+        );
+        assert!(result.output.contains("Sing along"));
+        assert!(result.output.contains("another line"));
+    }
+
+    #[test]
+    fn test_text_unterminated_notation_block_renders_without_panic() {
+        let input = "[C]Before\n{start_of_abc}\nX:1\nK:C\n";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result.warnings.iter().any(|w| w.contains("ABC")),
+            "unterminated ABC block should still emit the warning; got {:?}",
+            result.warnings,
+        );
+        assert!(result.output.contains("Before"));
+        assert!(result.output.contains("[ABC block omitted"));
+        // Body must not leak even though no EndOf was seen.
+        assert!(!result.output.contains("X:1"));
+        assert!(!result.output.contains("K:C"));
+    }
+
+    #[test]
+    fn test_text_stray_end_of_notation_is_silently_ignored() {
+        let input = "[C]Hello\n{end_of_abc}\n[D]World\n";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("ABC") && w.contains("omitted")),
+            "stray `end_of_abc` must not trigger the notation-block warning; got {:?}",
+            result.warnings,
+        );
+        assert!(result.output.contains("Hello"));
+        assert!(result.output.contains("World"));
     }
 
     #[test]

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -14,6 +14,57 @@ use unicode_width::UnicodeWidthStr;
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
 
+/// Notation kinds that the text renderer acknowledges structurally
+/// but does not render. See #1971 (sister-site parity with #1825 in
+/// the PDF renderer).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TextNotationKind {
+    Abc,
+    Lilypond,
+    MusicXml,
+    Svg,
+}
+
+impl TextNotationKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Abc => "ABC",
+            Self::Lilypond => "Lilypond",
+            Self::MusicXml => "MusicXML",
+            Self::Svg => "SVG",
+        }
+    }
+
+    fn tag(self) -> &'static str {
+        match self {
+            Self::Abc => "abc",
+            Self::Lilypond => "ly",
+            Self::MusicXml => "musicxml",
+            Self::Svg => "svg",
+        }
+    }
+
+    fn from_start_directive(kind: &DirectiveKind) -> Option<Self> {
+        match kind {
+            DirectiveKind::StartOfAbc => Some(Self::Abc),
+            DirectiveKind::StartOfLy => Some(Self::Lilypond),
+            DirectiveKind::StartOfMusicxml => Some(Self::MusicXml),
+            DirectiveKind::StartOfSvg => Some(Self::Svg),
+            _ => None,
+        }
+    }
+
+    fn is_end_directive(self, kind: &DirectiveKind) -> bool {
+        matches!(
+            (self, kind),
+            (Self::Abc, DirectiveKind::EndOfAbc)
+                | (Self::Lilypond, DirectiveKind::EndOfLy)
+                | (Self::MusicXml, DirectiveKind::EndOfMusicxml)
+                | (Self::Svg, DirectiveKind::EndOfSvg),
+        )
+    }
+}
+
 /// Maximum number of warnings the renderer will accumulate for a single
 /// render pass. Re-exported from the canonical location in
 /// `chordsketch-core::render_result` so existing downstream callers can
@@ -107,6 +158,15 @@ fn render_song_impl(
     let mut chorus_buf: Option<Vec<Line>> = None;
     let mut chorus_recall_count: usize = 0;
 
+    // #1971: parity with the PDF renderer (#1825). When inside a
+    // `{start_of_<tag>} … {end_of_<tag>}` pair for a notation block
+    // (ABC, Lilypond, MusicXML, SVG), discard every body line and
+    // emit a single structured warning at StartOf. Rendering the raw
+    // notation source as plain text (as this renderer did before)
+    // was just as unhelpful as in the PDF renderer — readers get a
+    // wall of `X:1` / `K:C` / `\relative c' {` with no context.
+    let mut in_notation_block: Option<TextNotationKind> = None;
+
     // Instrument for the auto-inject ASCII diagram block.
     // Set by {diagrams: guitar/ukulele/on}; cleared by {diagrams: off} / {no_diagrams}.
     let default_instrument = _config
@@ -120,6 +180,17 @@ fn render_song_impl(
     render_metadata(&song.metadata, &mut output);
 
     for line in &song.lines {
+        // #1971: inside a notation block, discard every line until
+        // the matching EndOf directive. Mirrors the PDF renderer's
+        // skip-until-end window introduced in #1825/#1968.
+        if let Some(kind) = in_notation_block {
+            if let Line::Directive(d) = line {
+                if kind.is_end_directive(&d.kind) {
+                    in_notation_block = None;
+                }
+            }
+            continue;
+        }
         match line {
             Line::Lyrics(lyrics_line) => {
                 if let Some(buf) = chorus_buf.as_mut() {
@@ -131,6 +202,29 @@ fn render_song_impl(
                 // Metadata directives are already rendered via song.metadata;
                 // skip them in the body to avoid duplicate output.
                 if directive.kind.is_metadata() {
+                    continue;
+                }
+                // #1971: handle notation block openers. Route the
+                // warning through `push_warning` (participates in the
+                // MAX_WARNINGS cap), emit an inline placeholder, and
+                // flip the skip window on. The section header still
+                // renders so readers see where the block was.
+                if let Some(kind) = TextNotationKind::from_start_directive(&directive.kind) {
+                    render_section_header(kind.label(), &directive.value, &mut output);
+                    let label = kind.label();
+                    let tag = kind.tag();
+                    push_warning(
+                        warnings,
+                        format!(
+                            "Text renderer does not support {label} blocks; body of the \
+                             `{{start_of_{tag}}} … {{end_of_{tag}}}` section has been \
+                             omitted. Use the HTML renderer for full {label} support.",
+                        ),
+                    );
+                    output.push(format!(
+                        "[{label} block omitted — use the HTML renderer to view it]",
+                    ));
+                    in_notation_block = Some(kind);
                     continue;
                 }
                 if directive.kind == DirectiveKind::Diagrams {
@@ -511,20 +605,13 @@ fn render_directive(
         DirectiveKind::StartOfGrid => {
             render_section_header("Grid", &directive.value, output);
         }
-        DirectiveKind::StartOfAbc => {
-            render_section_header("ABC", &directive.value, output);
-        }
-        DirectiveKind::StartOfLy => {
-            render_section_header("Lilypond", &directive.value, output);
-        }
-        DirectiveKind::StartOfSvg => {
-            render_section_header("SVG", &directive.value, output);
-        }
+        // Notation block openers (ABC / Lilypond / MusicXML / SVG) are
+        // handled in the main render loop's notation-block skip window
+        // so they never reach this function. The `{start_of_textblock}`
+        // directive is NOT a notation block — it's documented text so
+        // it renders its section header here like any other section.
         DirectiveKind::StartOfTextblock => {
             render_section_header("Textblock", &directive.value, output);
-        }
-        DirectiveKind::StartOfMusicxml => {
-            render_section_header("MusicXML", &directive.value, output);
         }
         DirectiveKind::StartOfSection(section_name) => {
             // Capitalize the first letter of the section name for display.
@@ -1236,37 +1323,67 @@ Second chorus
 mod delegate_tests {
     use super::*;
 
+    // -- Notation blocks (#1971): body is skipped, warning is captured,
+    //    placeholder line renders. Parity with the PDF renderer's
+    //    behaviour from #1825/#1968.
+
     #[test]
     fn test_render_abc_section() {
         let input = "{start_of_abc}\nX:1\nK:G\n{end_of_abc}";
         let output = render(input);
         assert!(output.contains("[ABC]"));
-        assert!(output.contains("X:1"));
+        assert!(
+            !output.contains("X:1"),
+            "ABC body must not leak into text output; got:\n{output}"
+        );
+        assert!(output.contains("[ABC block omitted"));
     }
 
     #[test]
     fn test_render_abc_section_with_label() {
         let input = "{start_of_abc: Melody}\nX:1\n{end_of_abc}";
         let output = render(input);
-        assert_eq!(output, "[ABC: Melody]\nX:1\n");
+        // Section header + placeholder; body is gone.
+        assert!(output.contains("[ABC: Melody]"));
+        assert!(!output.contains("X:1"));
+        assert!(output.contains("[ABC block omitted"));
+    }
+
+    #[test]
+    fn test_render_abc_section_emits_warning() {
+        let input = "{start_of_abc}\nX:1\n{end_of_abc}";
+        let song = chordsketch_core::parse(input).unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result.warnings.iter().any(|w| w.contains("ABC")),
+            "expected an ABC warning; got {:?}",
+            result.warnings,
+        );
     }
 
     #[test]
     fn test_render_ly_section() {
-        let input = "{start_of_ly}\nnotes\n{end_of_ly}";
+        let input = "{start_of_ly}\n\\relative c' { c4 d }\n{end_of_ly}";
         let output = render(input);
         assert!(output.contains("[Lilypond]"));
+        assert!(!output.contains("\\relative"));
+        assert!(output.contains("[Lilypond block omitted"));
     }
 
     #[test]
     fn test_render_svg_section() {
-        let input = "{start_of_svg}\n<svg/>\n{end_of_svg}";
+        let input = "{start_of_svg}\n<svg><circle/></svg>\n{end_of_svg}";
         let output = render(input);
         assert!(output.contains("[SVG]"));
+        assert!(!output.contains("<circle"));
+        assert!(output.contains("[SVG block omitted"));
     }
 
     #[test]
     fn test_render_textblock_section() {
+        // `{start_of_textblock}` is NOT a notation block — body must
+        // continue to render as plain text. Guard against accidental
+        // inclusion in the notation skip window.
         let input = "{start_of_textblock}\nPreformatted text\n{end_of_textblock}";
         let output = render(input);
         assert!(output.contains("[Textblock]"));
@@ -1275,9 +1392,12 @@ mod delegate_tests {
 
     #[test]
     fn test_render_musicxml_section() {
-        let input = "{start_of_musicxml}\n<score-partwise/>\n{end_of_musicxml}";
+        let input =
+            "{start_of_musicxml}\n<score-partwise>notes</score-partwise>\n{end_of_musicxml}";
         let output = render(input);
         assert!(output.contains("[MusicXML]"));
+        assert!(!output.contains("<score-partwise"));
+        assert!(output.contains("[MusicXML block omitted"));
     }
 
     #[test]
@@ -1285,6 +1405,7 @@ mod delegate_tests {
         let input = "{start_of_musicxml: Score}\n<score-partwise/>\n{end_of_musicxml}";
         let output = render(input);
         assert!(output.contains("[MusicXML: Score]"));
+        assert!(output.contains("[MusicXML block omitted"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Batch follow-up to #1968 covering three review-surfaced issues:

| # | Sev | What |
|---|---|---|
| #1970 | Nit | Add \`NotationKind::tag()\` to \`render-pdf\`; replace inline \`match\` at the warning \`format!\` site. |
| #1971 | Low | Sister-site parity: apply the same notation-block skip window + warning + placeholder to the **text renderer**. Before this PR it spilled raw ABC / Lilypond / MusicXML / SVG source into text output. |
| #1969 | Low | Three edge-case tests in \`render-pdf\`: notation block inside chorus, unterminated StartOf, stray EndOf. |

## Renderer parity audit (updated)

- HTML renderer — unchanged. Full notation support via external tools.
- Text renderer — NOW emits section label + placeholder + structured warning, skips body. Matches PDF.
- PDF renderer — already at this contract since #1968.

Both text and PDF warnings route through \`push_warning\` (participate in the \`MAX_WARNINGS\` cap).

## Text-renderer test changes

Sister-site parity required asserting the **new** (skipped) behaviour:

| Test | Before | After |
|---|---|---|
| \`test_render_abc_section\` | asserted body \`X:1\` rendered | asserts body is gone + placeholder present |
| \`test_render_abc_section_with_label\` | \`assert_eq!\` on raw body | placeholder-only assertions |
| \`test_render_abc_section_emits_warning\` | — | new; pins the warning path |
| \`test_render_ly_section\` / \`_svg_section\` / \`_musicxml_section\` | body rendered | body skipped + placeholder |
| \`test_render_textblock_section\` | unchanged | **preserved** — textblock is NOT a notation block |

## Results

- \`cargo test -p chordsketch-render-text --lib\`: 85 passed.
- \`cargo test -p chordsketch-render-pdf --lib\`: 205 passed.
- \`cargo clippy -p chordsketch-render-text -p chordsketch-render-pdf --all-targets -- -D warnings\`: clean.
- \`cargo fmt --check\`: clean.

Closes #1969
Closes #1970
Closes #1971