### PR TITLE
refactor: consolidate NotationKind into chordsketch-core (#1973)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod heuristic;
 pub mod image_path;
 pub mod inline_markup;
 pub mod lexer;
+pub mod notation;
 pub mod parser;
 pub mod render_result;
 pub mod rrjson;

--- a/crates/core/src/notation.rs
+++ b/crates/core/src/notation.rs
@@ -1,0 +1,171 @@
+//! Notation block kinds recognised by the text and PDF renderers.
+//!
+//! ChordPro documents can embed four kinds of external notation via
+//! `{start_of_<tag>} … {end_of_<tag>}` pairs: ABC, Lilypond, MusicXML,
+//! and SVG. The HTML renderer invokes external tools (`abc2svg`,
+//! `lilypond`, `musescore`) to convert them into embedded SVG; the
+//! text and PDF renderers cannot do the same cheaply and instead emit
+//! a structured warning + placeholder while skipping the block body.
+//!
+//! This module is the single source of truth for the four variants
+//! and their string representations. Both non-HTML renderers import
+//! [`NotationKind`] from here so adding a fifth notation kind is a
+//! one-line change — new variant, new entry in each helper's match.
+//!
+//! The HTML renderer does not depend on this module because it
+//! handles every notation kind via bespoke rendering paths in its
+//! own source (see `crates/render-html/src/lib.rs`).
+
+use crate::ast::DirectiveKind;
+
+/// Notation kinds the text and PDF renderers skip rather than render.
+///
+/// See [`.claude/rules/renderer-parity.md`] for the parity contract:
+/// every renderer must handle every directive, but handling can be
+/// "skip with warning" when full rendering requires infrastructure a
+/// renderer does not have.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotationKind {
+    /// `{start_of_abc} … {end_of_abc}` — ABC notation.
+    Abc,
+    /// `{start_of_ly} … {end_of_ly}` — Lilypond notation.
+    Lilypond,
+    /// `{start_of_musicxml} … {end_of_musicxml}` — MusicXML notation.
+    MusicXml,
+    /// `{start_of_svg} … {end_of_svg}` — inline SVG.
+    Svg,
+}
+
+impl NotationKind {
+    /// Human-readable display name for user-facing output (section
+    /// label, placeholder text, warning message).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Abc => "ABC",
+            Self::Lilypond => "Lilypond",
+            Self::MusicXml => "MusicXML",
+            Self::Svg => "SVG",
+        }
+    }
+
+    /// ChordPro directive token for this notation kind (e.g. `"abc"`
+    /// for `{start_of_abc}` / `{end_of_abc}`). Used when building
+    /// warning messages that embed the tag so users can search the
+    /// spec for the exact directive name they hit.
+    #[must_use]
+    pub fn tag(self) -> &'static str {
+        match self {
+            Self::Abc => "abc",
+            Self::Lilypond => "ly",
+            Self::MusicXml => "musicxml",
+            Self::Svg => "svg",
+        }
+    }
+
+    /// Returns the [`NotationKind`] corresponding to the supplied
+    /// `StartOf…` directive, or [`None`] for any other directive.
+    #[must_use]
+    pub fn from_start_directive(kind: &DirectiveKind) -> Option<Self> {
+        match kind {
+            DirectiveKind::StartOfAbc => Some(Self::Abc),
+            DirectiveKind::StartOfLy => Some(Self::Lilypond),
+            DirectiveKind::StartOfMusicxml => Some(Self::MusicXml),
+            DirectiveKind::StartOfSvg => Some(Self::Svg),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` when `kind` is the matching `EndOf…` directive
+    /// for this notation. Used by the renderer's skip-until-end
+    /// window to know when to exit.
+    #[must_use]
+    pub fn is_end_directive(self, kind: &DirectiveKind) -> bool {
+        matches!(
+            (self, kind),
+            (Self::Abc, DirectiveKind::EndOfAbc)
+                | (Self::Lilypond, DirectiveKind::EndOfLy)
+                | (Self::MusicXml, DirectiveKind::EndOfMusicxml)
+                | (Self::Svg, DirectiveKind::EndOfSvg),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_is_the_display_name() {
+        assert_eq!(NotationKind::Abc.label(), "ABC");
+        assert_eq!(NotationKind::Lilypond.label(), "Lilypond");
+        assert_eq!(NotationKind::MusicXml.label(), "MusicXML");
+        assert_eq!(NotationKind::Svg.label(), "SVG");
+    }
+
+    #[test]
+    fn tag_is_the_directive_token() {
+        assert_eq!(NotationKind::Abc.tag(), "abc");
+        assert_eq!(NotationKind::Lilypond.tag(), "ly");
+        assert_eq!(NotationKind::MusicXml.tag(), "musicxml");
+        assert_eq!(NotationKind::Svg.tag(), "svg");
+    }
+
+    #[test]
+    fn from_start_directive_matches_every_variant() {
+        assert_eq!(
+            NotationKind::from_start_directive(&DirectiveKind::StartOfAbc),
+            Some(NotationKind::Abc)
+        );
+        assert_eq!(
+            NotationKind::from_start_directive(&DirectiveKind::StartOfLy),
+            Some(NotationKind::Lilypond)
+        );
+        assert_eq!(
+            NotationKind::from_start_directive(&DirectiveKind::StartOfMusicxml),
+            Some(NotationKind::MusicXml)
+        );
+        assert_eq!(
+            NotationKind::from_start_directive(&DirectiveKind::StartOfSvg),
+            Some(NotationKind::Svg)
+        );
+    }
+
+    #[test]
+    fn from_start_directive_ignores_unrelated_directives() {
+        assert_eq!(
+            NotationKind::from_start_directive(&DirectiveKind::StartOfChorus),
+            None
+        );
+        assert_eq!(
+            NotationKind::from_start_directive(&DirectiveKind::StartOfTextblock),
+            None,
+            "StartOfTextblock is NOT a notation block — the text and PDF \
+             renderers render its body as plain text",
+        );
+        // The `EndOf…` variants also do not match.
+        assert_eq!(
+            NotationKind::from_start_directive(&DirectiveKind::EndOfAbc),
+            None
+        );
+    }
+
+    #[test]
+    fn is_end_directive_matches_only_the_paired_end() {
+        assert!(NotationKind::Abc.is_end_directive(&DirectiveKind::EndOfAbc));
+        assert!(NotationKind::Lilypond.is_end_directive(&DirectiveKind::EndOfLy));
+        assert!(NotationKind::MusicXml.is_end_directive(&DirectiveKind::EndOfMusicxml));
+        assert!(NotationKind::Svg.is_end_directive(&DirectiveKind::EndOfSvg));
+    }
+
+    #[test]
+    fn is_end_directive_rejects_mismatched_pairs() {
+        // EndOfLy does NOT close an ABC skip window, and so on.
+        assert!(!NotationKind::Abc.is_end_directive(&DirectiveKind::EndOfLy));
+        assert!(!NotationKind::Lilypond.is_end_directive(&DirectiveKind::EndOfAbc));
+        assert!(!NotationKind::MusicXml.is_end_directive(&DirectiveKind::EndOfSvg));
+        assert!(!NotationKind::Svg.is_end_directive(&DirectiveKind::EndOfMusicxml));
+        // And unrelated directives never close the window.
+        assert!(!NotationKind::Abc.is_end_directive(&DirectiveKind::EndOfChorus));
+    }
+}

--- a/crates/core/src/notation.rs
+++ b/crates/core/src/notation.rs
@@ -20,7 +20,7 @@ use crate::ast::DirectiveKind;
 
 /// Notation kinds the text and PDF renderers skip rather than render.
 ///
-/// See [`.claude/rules/renderer-parity.md`] for the parity contract:
+/// See `.claude/rules/renderer-parity.md` for the parity contract:
 /// every renderer must handle every directive, but handling can be
 /// "skip with warning" when full rendering requires infrastructure a
 /// renderer does not have.

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -14,6 +14,7 @@ use chordsketch_core::ast::{CommentStyle, DirectiveKind, ImageAttributes, Line, 
 use chordsketch_core::canonical_chord_name;
 use chordsketch_core::config::Config;
 use chordsketch_core::inline_markup::TextSpan;
+use chordsketch_core::notation::NotationKind;
 use chordsketch_core::render_result::{RenderResult, push_warning, validate_capo};
 use chordsketch_core::resolve_diagrams_instrument;
 use chordsketch_core::transpose::transpose_chord;
@@ -1123,74 +1124,6 @@ fn render_span_list(
         }
     }
     x
-}
-
-/// Notation block kinds the PDF renderer recognises but does not fully
-/// render. Used by the main render loop to track "inside a
-/// `{start_of_<kind>} … {end_of_<kind>}` pair" state so body lines can
-/// be skipped instead of spilled into the PDF as plain text.
-///
-/// Parity with the HTML renderer is documented in
-/// `.claude/rules/renderer-parity.md`; tracked in #1825 — #1825 option
-/// 2 (warning + placeholder) lands here, option 1 (embed a rasterised
-/// or usvg-rendered bitmap) is tracked for the future.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum NotationKind {
-    Abc,
-    Lilypond,
-    MusicXml,
-    Svg,
-}
-
-impl NotationKind {
-    /// Human-readable display name for user-facing output (section
-    /// label, placeholder text, warning message).
-    fn label(self) -> &'static str {
-        match self {
-            Self::Abc => "ABC",
-            Self::Lilypond => "Lilypond",
-            Self::MusicXml => "MusicXML",
-            Self::Svg => "SVG",
-        }
-    }
-
-    /// ChordPro directive token for this notation kind (e.g.
-    /// `{start_of_abc}` / `{end_of_abc}`). Kept as a method on the
-    /// enum rather than an inline `match` at the call site so adding
-    /// a new notation kind in the future only requires editing this
-    /// file in one place.
-    fn tag(self) -> &'static str {
-        match self {
-            Self::Abc => "abc",
-            Self::Lilypond => "ly",
-            Self::MusicXml => "musicxml",
-            Self::Svg => "svg",
-        }
-    }
-
-    /// Match the `StartOf…` directive variants. Returns `None` for any
-    /// other directive.
-    fn from_start_directive(kind: &DirectiveKind) -> Option<Self> {
-        match kind {
-            DirectiveKind::StartOfAbc => Some(Self::Abc),
-            DirectiveKind::StartOfLy => Some(Self::Lilypond),
-            DirectiveKind::StartOfMusicxml => Some(Self::MusicXml),
-            DirectiveKind::StartOfSvg => Some(Self::Svg),
-            _ => None,
-        }
-    }
-
-    /// Returns `true` when `kind` is the matching `EndOf…` directive for
-    /// this notation. Used to close the skip window.
-    fn is_end_directive(self, kind: &DirectiveKind) -> bool {
-        matches!(
-            (self, kind),
-            (Self::Abc, DirectiveKind::EndOfAbc)
-                | (Self::Lilypond, DirectiveKind::EndOfLy)
-                | (Self::MusicXml, DirectiveKind::EndOfMusicxml)
-                | (Self::Svg, DirectiveKind::EndOfSvg),
-        )
-    }
 }
 
 /// Render the section label for a start-of-section directive.

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -5,6 +5,7 @@
 
 use chordsketch_core::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordsketch_core::config::Config;
+use chordsketch_core::notation::NotationKind;
 use chordsketch_core::render_result::{RenderResult, push_warning, validate_capo};
 use chordsketch_core::resolve_diagrams_instrument;
 use chordsketch_core::transpose::transpose_chord;
@@ -13,57 +14,6 @@ use unicode_width::UnicodeWidthStr;
 /// Maximum number of chorus recall directives allowed per song.
 /// Prevents output amplification from malicious inputs with many `{chorus}` lines.
 const MAX_CHORUS_RECALLS: usize = 1000;
-
-/// Notation kinds that the text renderer acknowledges structurally
-/// but does not render. See #1971 (sister-site parity with #1825 in
-/// the PDF renderer).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TextNotationKind {
-    Abc,
-    Lilypond,
-    MusicXml,
-    Svg,
-}
-
-impl TextNotationKind {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Abc => "ABC",
-            Self::Lilypond => "Lilypond",
-            Self::MusicXml => "MusicXML",
-            Self::Svg => "SVG",
-        }
-    }
-
-    fn tag(self) -> &'static str {
-        match self {
-            Self::Abc => "abc",
-            Self::Lilypond => "ly",
-            Self::MusicXml => "musicxml",
-            Self::Svg => "svg",
-        }
-    }
-
-    fn from_start_directive(kind: &DirectiveKind) -> Option<Self> {
-        match kind {
-            DirectiveKind::StartOfAbc => Some(Self::Abc),
-            DirectiveKind::StartOfLy => Some(Self::Lilypond),
-            DirectiveKind::StartOfMusicxml => Some(Self::MusicXml),
-            DirectiveKind::StartOfSvg => Some(Self::Svg),
-            _ => None,
-        }
-    }
-
-    fn is_end_directive(self, kind: &DirectiveKind) -> bool {
-        matches!(
-            (self, kind),
-            (Self::Abc, DirectiveKind::EndOfAbc)
-                | (Self::Lilypond, DirectiveKind::EndOfLy)
-                | (Self::MusicXml, DirectiveKind::EndOfMusicxml)
-                | (Self::Svg, DirectiveKind::EndOfSvg),
-        )
-    }
-}
 
 /// Maximum number of warnings the renderer will accumulate for a single
 /// render pass. Re-exported from the canonical location in
@@ -165,7 +115,7 @@ fn render_song_impl(
     // notation source as plain text (as this renderer did before)
     // was just as unhelpful as in the PDF renderer — readers get a
     // wall of `X:1` / `K:C` / `\relative c' {` with no context.
-    let mut in_notation_block: Option<TextNotationKind> = None;
+    let mut in_notation_block: Option<NotationKind> = None;
 
     // Instrument for the auto-inject ASCII diagram block.
     // Set by {diagrams: guitar/ukulele/on}; cleared by {diagrams: off} / {no_diagrams}.
@@ -209,7 +159,7 @@ fn render_song_impl(
                 // MAX_WARNINGS cap), emit an inline placeholder, and
                 // flip the skip window on. The section header still
                 // renders so readers see where the block was.
-                if let Some(kind) = TextNotationKind::from_start_directive(&directive.kind) {
+                if let Some(kind) = NotationKind::from_start_directive(&directive.kind) {
                     render_section_header(kind.label(), &directive.value, &mut output);
                     let label = kind.label();
                     let tag = kind.tag();


### PR DESCRIPTION
## What

Move the \`NotationKind\` enum (previously duplicated between \`render-text\` as \`TextNotationKind\` and \`render-pdf\` as \`NotationKind\`) to \`chordsketch-core::notation\`. Both renderer crates now \`use\` the canonical definition.

## Why

The two enums were structurally identical: same four variants (ABC / Lilypond / MusicXML / SVG), same four methods (\`label\` / \`tag\` / \`from_start_directive\` / \`is_end_directive\`). Adding a fifth notation kind would require lockstep edits in two files — exactly the kind of duplication \`.claude/rules/renderer-parity.md\` warns against.

## What changed

- **\`crates/core/src/notation.rs\` (new)**: canonical \`pub enum NotationKind\` + six unit tests covering every branch of every helper.
- **\`crates/core/src/lib.rs\`**: register the new module.
- **\`crates/render-text/src/lib.rs\`**: delete local \`TextNotationKind\` (~50 LOC), import from core, rename one call site.
- **\`crates/render-pdf/src/lib.rs\`**: delete local \`NotationKind\` (~65 LOC), import from core.

Zero behavioural change — renderers produce byte-identical output pre- and post-refactor.

## Intentionally NOT changed

- \`crates/render-html/src/lib.rs\`: the HTML renderer handles each notation kind via bespoke external-tool invocations (abc2svg / lilypond / musescore) and does not currently benefit from the shared enum. Can be revisited when/if HTML grows a "skip + warn" fallback for missing tools.

## Tests

- \`cargo test -p chordsketch-core --lib\`: 6 new \`notation::tests\` pass.
- \`cargo test -p chordsketch-render-text -p chordsketch-render-pdf --lib\`: all existing tests pass (88 text + 205 pdf, including the edge-case tests from #1969 / #1974).
- \`cargo clippy -D warnings\` + \`cargo fmt --check\`: clean.

Closes #1973