### PR TITLE
ci(coverage): add cargo-llvm-cov workflow with Codecov upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,12 @@ jobs:
     name: Measure and upload coverage
     runs-on: ubuntu-latest
     # needs: [] — intentional; this workflow must never gate other jobs.
+    permissions:
+      contents: read
+      # Required for codecov-action's `use_oidc: true`: GitHub refuses to
+      # mint the OIDC token without this, and `fail_ci_if_error: false`
+      # would otherwise swallow the failure silently.
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,60 @@
+name: Coverage
+
+# Measures workspace test coverage with cargo-llvm-cov and uploads lcov.info
+# to Codecov. See #1846 for the multi-phase rollout plan.
+#
+# Phase 0+1 scope (issue #1977): upload only, no threshold gating, main-branch
+# pushes only. `needs: []` ensures this job never blocks other workflows.
+# PR trigger is intentionally omitted until baselines stabilise — see
+# tracker §Strategy.2.
+#
+# Token: public repos authenticate codecov-action via GitHub OIDC, so
+# CODECOV_TOKEN is not required. The tracker notes it can be added later if
+# upload reliability becomes an issue.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    name: Measure and upload coverage
+    runs-on: ubuntu-latest
+    # needs: [] — intentional; this workflow must never gate other jobs.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: coverage
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Collect coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          use_oidc: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # ChordSketch
 
+[![codecov](https://codecov.io/gh/koedame/chordsketch/branch/main/graph/badge.svg)](https://codecov.io/gh/koedame/chordsketch)
+
 A Rust implementation of the [ChordPro](https://www.chordpro.org/) file format
 parser and renderer. 100% ChordPro compatible. Supports parsing ChordPro files
 into a structured AST and rendering to plain text, HTML, and PDF.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/coverage.yml` running `cargo-llvm-cov` on pushes
  to `main`, uploading `lcov.info` to Codecov via OIDC (no token).
- Adds the Codecov badge to `README.md`.
- Phase 0+1 scope of the coverage rollout tracked in #1846 — no threshold
  gating, no sister-site fixture work.

## Why this shape

- `on: push` to `main` only, `needs: []` — coverage must not block other
  jobs. PR trigger is intentionally omitted until baselines stabilise
  (tracker §Strategy.2).
- `Swatinem/rust-cache` uses `shared-key: coverage` per
  `.claude/rules/ci-parallelization.md` §2.
- No `Cargo.toml` changes — `cargo-llvm-cov` is a dev-side tool, so the
  `chordsketch-core` zero-deps rule is unaffected.
- No `CODECOV_TOKEN`: public repos authenticate codecov-action v6 via
  GitHub OIDC. Tracker §Rollback notes it can be added later if upload
  reliability becomes an issue.

## Local baseline (for #1846 Phase 0)

`cargo llvm-cov --workspace --summary-only` at this commit:

```
TOTAL  region 92.51%  function 94.81%  line 91.99%
```

Notable per-file gaps (useful input for Phase 2 sub-issues):

- `napi/src/lib.rs`: region 54.07%, line 47.18%
- `wasm/src/lib.rs`: region 61.86%, line 57.39%
- `cli/src/main.rs`: region 67.29%, line 68.10%
- `lsp/src/server.rs`: region 69.70%, line 62.43%
- `lsp/src/main.rs`: 0% (entry point, not exercised by tests)
- `ffi/src/bin/uniffi-bindgen.rs`: 0% (build-time bindgen driver)

These align with the tracker's identified gaps (foreign bindings + LSP)
and confirm the group-floor design in #1846 §Strategy.3.

## Test plan

- [x] `scripts/check-action-pins.sh .github` passes locally
- [x] `python3 scripts/extract-readme-commands.py --check` passes (README
      snapshot unaffected — only the badge line was added)
- [x] `cargo llvm-cov --workspace --summary-only` runs green locally
- [ ] After merge, verify the first `main` push triggers `coverage.yml`
      and Codecov receives the report

Closes #1977.
Part of #1846.