### PR TITLE
test(render-pdf): add 10 golden fixtures (Phase 2 of #1846)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# PDF fixtures and other binary artifacts must never be CRLF-converted by
+# git, or byte-exact golden comparisons break on Windows checkouts under
+# `core.autocrlf=true`. See #1979 for the original regression.
+*.pdf binary
+*.otf binary
+*.ttf binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+*.wasm binary
+
+# Golden test input fixtures parse differently under CRLF on some
+# platforms; pin to LF so the committed byte content is what every
+# runner sees.
+crates/*/tests/fixtures/**/input.cho text eol=lf
+crates/*/tests/fixtures/**/expected.txt text eol=lf

--- a/crates/render-pdf/tests/fixtures/chord-alignment/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/chord-alignment/expected.pdf
@@ -1,0 +1,93 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 387 >>
+stream
+BT
+/F2 9 Tf
+56 786 Td
+(Cmaj7) Tj
+ET
+BT
+/F2 9 Tf
+84 786 Td
+(G) Tj
+ET
+BT
+/F1 11 Tf
+56 775 Td
+(I see) Tj
+ET
+BT
+/F2 9 Tf
+56 760 Td
+(Am) Tj
+ET
+BT
+/F2 9 Tf
+180.11 760 Td
+(D) Tj
+ET
+BT
+/F1 11 Tf
+56 749 Td
+(A very long text segment end) Tj
+ET
+BT
+/F2 9 Tf
+56 734 Td
+(F#m) Tj
+ET
+BT
+/F2 9 Tf
+85.35 734 Td
+(Bb) Tj
+ET
+BT
+/F2 9 Tf
+98.35 734 Td
+(G7sus4) Tj
+ET
+BT
+/F1 11 Tf
+56 723 Td
+(Short x done) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+1144
+%%EOF

--- a/crates/render-pdf/tests/fixtures/chord-alignment/input.cho
+++ b/crates/render-pdf/tests/fixtures/chord-alignment/input.cho
@@ -1,0 +1,3 @@
+[Cmaj7]I [G]see
+[Am]A very long text segment [D]end
+[F#m]Short [Bb]x [G7sus4]done

--- a/crates/render-pdf/tests/fixtures/chords-over-lyrics/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/chords-over-lyrics/expected.pdf
@@ -1,0 +1,78 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 266 >>
+stream
+BT
+/F2 9 Tf
+56 786 Td
+(Am) Tj
+ET
+BT
+/F2 9 Tf
+84.12 786 Td
+(G) Tj
+ET
+BT
+/F1 11 Tf
+56 775 Td
+(Hello world) Tj
+ET
+BT
+/F2 9 Tf
+56 760 Td
+(C) Tj
+ET
+BT
+/F2 9 Tf
+100.02 760 Td
+(D7) Tj
+ET
+BT
+/F2 9 Tf
+125.09 760 Td
+(Em) Tj
+ET
+BT
+/F1 11 Tf
+56 749 Td
+(Just text here now) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+1023
+%%EOF

--- a/crates/render-pdf/tests/fixtures/chords-over-lyrics/input.cho
+++ b/crates/render-pdf/tests/fixtures/chords-over-lyrics/input.cho
@@ -1,0 +1,2 @@
+[Am]Hello [G]world
+[C]Just text [D7]here [Em]now

--- a/crates/render-pdf/tests/fixtures/comments/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/comments/expected.pdf
@@ -1,0 +1,62 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 174 >>
+stream
+BT
+/F1 9 Tf
+56 786 Td
+(This is a normal comment) Tj
+ET
+BT
+/F3 9 Tf
+56 773 Td
+(This is italic) Tj
+ET
+q
+0.5 w
+56 748 59.02 15 re S
+Q
+BT
+/F3 9 Tf
+59 760 Td
+(This is boxed) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+931
+%%EOF

--- a/crates/render-pdf/tests/fixtures/comments/input.cho
+++ b/crates/render-pdf/tests/fixtures/comments/input.cho
@@ -1,0 +1,3 @@
+{comment: This is a normal comment}
+{comment_italic: This is italic}
+{comment_box: This is boxed}

--- a/crates/render-pdf/tests/fixtures/define-display/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/define-display/expected.pdf
@@ -1,0 +1,137 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 1385 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Display Test) Tj
+ET
+BT
+/F2 9 Tf
+56 764 Td
+(A minor) Tj
+ET
+q
+2 w
+56 749 m 106 749 l S
+Q
+q
+0.5 w
+56 749 m 56 689 l S
+Q
+q
+0.5 w
+66 749 m 66 689 l S
+Q
+q
+0.5 w
+76 749 m 76 689 l S
+Q
+q
+0.5 w
+86 749 m 86 689 l S
+Q
+q
+0.5 w
+96 749 m 96 689 l S
+Q
+q
+0.5 w
+106 749 m 106 689 l S
+Q
+q
+0.5 w
+56 749 m 106 749 l S
+Q
+q
+0.5 w
+56 737 m 106 737 l S
+Q
+q
+0.5 w
+56 725 m 106 725 l S
+Q
+q
+0.5 w
+56 713 m 106 713 l S
+Q
+q
+0.5 w
+56 701 m 106 701 l S
+Q
+q
+0.5 w
+56 689 m 106 689 l S
+Q
+BT
+/F1 7 Tf
+53.5 753 Td
+(X) Tj
+ET
+0.5 w
+68.5 755 m 68.5 756.38 67.38 757.5 66 757.5 c 64.62 757.5 63.5 756.38 63.5 755 c 63.5 753.62 64.62 752.5 66 752.5 c 67.38 752.5 68.5 753.62 68.5 755 c S
+79 731 m 79 732.66 77.66 734 76 734 c 74.34 734 73 732.66 73 731 c 73 729.34 74.34 728 76 728 c 77.66 728 79 729.34 79 731 c f
+89 731 m 89 732.66 87.66 734 86 734 c 84.34 734 83 732.66 83 731 c 83 729.34 84.34 728 86 728 c 87.66 728 89 729.34 89 731 c f
+99 743 m 99 744.66 97.66 746 96 746 c 94.34 746 93 744.66 93 743 c 93 741.34 94.34 740 96 740 c 97.66 740 99 741.34 99 743 c f
+0.5 w
+108.5 755 m 108.5 756.38 107.38 757.5 106 757.5 c 104.62 757.5 103.5 756.38 103.5 755 c 103.5 753.62 104.62 752.5 106 752.5 c 107.38 752.5 108.5 753.62 108.5 755 c S
+BT
+/F2 9 Tf
+56 675 Td
+(A minor) Tj
+ET
+BT
+/F2 9 Tf
+89 675 Td
+(G) Tj
+ET
+BT
+/F2 9 Tf
+118.34 675 Td
+(A minor) Tj
+ET
+BT
+/F1 11 Tf
+56 664 Td
+(Hello world again) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+2143
+%%EOF

--- a/crates/render-pdf/tests/fixtures/define-display/input.cho
+++ b/crates/render-pdf/tests/fixtures/define-display/input.cho
@@ -1,0 +1,3 @@
+{title: Display Test}
+{define: Am base-fret 1 frets x 0 2 2 1 0 display="A minor"}
+[Am]Hello [G]world [Am]again

--- a/crates/render-pdf/tests/fixtures/directives-and-sections/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/directives-and-sections/expected.pdf
@@ -1,0 +1,113 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 553 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Test Song) Tj
+ET
+BT
+/F1 13 Tf
+56 764 Td
+(A Subtitle) Tj
+ET
+BT
+/F4 10 Tf
+56 739 Td
+(Verse: Verse 1) Tj
+ET
+BT
+/F2 9 Tf
+56 725 Td
+(G) Tj
+ET
+BT
+/F2 9 Tf
+112.85 725 Td
+(C) Tj
+ET
+BT
+/F1 11 Tf
+56 714 Td
+(First line of verse) Tj
+ET
+BT
+/F4 10 Tf
+56 691 Td
+(Chorus) Tj
+ET
+BT
+/F2 9 Tf
+56 677 Td
+(D) Tj
+ET
+BT
+/F2 9 Tf
+94.51 677 Td
+(G) Tj
+ET
+BT
+/F1 11 Tf
+56 666 Td
+(Chorus line) Tj
+ET
+BT
+/F4 10 Tf
+56 643 Td
+(Bridge) Tj
+ET
+BT
+/F1 11 Tf
+56 629 Td
+(Bridge text) Tj
+ET
+BT
+/F4 10 Tf
+56 606 Td
+(Tab) Tj
+ET
+BT
+/F1 11 Tf
+56 592 Td
+(e|---0---|) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+1310
+%%EOF

--- a/crates/render-pdf/tests/fixtures/directives-and-sections/input.cho
+++ b/crates/render-pdf/tests/fixtures/directives-and-sections/input.cho
@@ -1,0 +1,18 @@
+{title: Test Song}
+{subtitle: A Subtitle}
+
+{start_of_verse: Verse 1}
+[G]First line of [C]verse
+{end_of_verse}
+
+{start_of_chorus}
+[D]Chorus [G]line
+{end_of_chorus}
+
+{start_of_bridge}
+Bridge text
+{end_of_bridge}
+
+{start_of_tab}
+e|---0---|
+{end_of_tab}

--- a/crates/render-pdf/tests/fixtures/empty-lines/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/empty-lines/expected.pdf
@@ -1,0 +1,58 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 126 >>
+stream
+BT
+/F1 11 Tf
+56 786 Td
+(First line) Tj
+ET
+BT
+/F1 11 Tf
+56 763 Td
+(Second line) Tj
+ET
+BT
+/F1 11 Tf
+56 740 Td
+(Third line) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+883
+%%EOF

--- a/crates/render-pdf/tests/fixtures/empty-lines/input.cho
+++ b/crates/render-pdf/tests/fixtures/empty-lines/input.cho
@@ -1,0 +1,5 @@
+First line
+
+Second line
+
+Third line

--- a/crates/render-pdf/tests/fixtures/full-song/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/full-song/expected.pdf
@@ -1,0 +1,183 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 1151 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Amazing Grace) Tj
+ET
+BT
+/F1 13 Tf
+56 764 Td
+(Traditional) Tj
+ET
+BT
+/F4 10 Tf
+56 739 Td
+(Verse: Verse 1) Tj
+ET
+BT
+/F2 9 Tf
+56 725 Td
+(G) Tj
+ET
+BT
+/F2 9 Tf
+101.85 725 Td
+(G7) Tj
+ET
+BT
+/F2 9 Tf
+158.71 725 Td
+(C) Tj
+ET
+BT
+/F2 9 Tf
+208.85 725 Td
+(G) Tj
+ET
+BT
+/F1 11 Tf
+56 714 Td
+(Amazing grace, how sweet the sound) Tj
+ET
+BT
+/F2 9 Tf
+56 699 Td
+(G) Tj
+ET
+BT
+/F2 9 Tf
+122.65 699 Td
+(Em) Tj
+ET
+BT
+/F2 9 Tf
+177.66 699 Td
+(D) Tj
+ET
+BT
+/F1 11 Tf
+56 688 Td
+(That saved a wretch like me) Tj
+ET
+BT
+/F4 10 Tf
+56 665 Td
+(Verse: Verse 2) Tj
+ET
+BT
+/F2 9 Tf
+56 651 Td
+(G) Tj
+ET
+BT
+/F2 9 Tf
+111.64 651 Td
+(G7) Tj
+ET
+BT
+/F2 9 Tf
+153.22 651 Td
+(C) Tj
+ET
+BT
+/F2 9 Tf
+194.79 651 Td
+(G) Tj
+ET
+BT
+/F1 11 Tf
+56 640 Td
+(I once was lost, but now am found) Tj
+ET
+BT
+/F2 9 Tf
+56 625 Td
+(G) Tj
+ET
+BT
+/F2 9 Tf
+128.75 625 Td
+(Em) Tj
+ET
+BT
+/F2 9 Tf
+158.1 625 Td
+(D) Tj
+ET
+BT
+/F1 11 Tf
+56 614 Td
+(Was blind, but now I see) Tj
+ET
+BT
+/F4 10 Tf
+56 591 Td
+(Chorus) Tj
+ET
+BT
+/F2 9 Tf
+56 577 Td
+(G) Tj
+ET
+BT
+/F2 9 Tf
+81.06 577 Td
+(C) Tj
+ET
+BT
+/F2 9 Tf
+131.2 577 Td
+(G) Tj
+ET
+BT
+/F1 11 Tf
+56 566 Td
+(How sweet the sound) Tj
+ET
+BT
+/F1 9 Tf
+56 543 Td
+(Repeat chorus) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+1909
+%%EOF

--- a/crates/render-pdf/tests/fixtures/full-song/input.cho
+++ b/crates/render-pdf/tests/fixtures/full-song/input.cho
@@ -1,0 +1,20 @@
+{title: Amazing Grace}
+{subtitle: Traditional}
+{artist: John Newton}
+{key: G}
+
+{start_of_verse: Verse 1}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound
+[G]That saved a [Em]wretch like [D]me
+{end_of_verse}
+
+{start_of_verse: Verse 2}
+[G]I once was [G7]lost, but [C]now am [G]found
+[G]Was blind, but [Em]now I [D]see
+{end_of_verse}
+
+{start_of_chorus}
+[G]How [C]sweet the [G]sound
+{end_of_chorus}
+
+{comment: Repeat chorus}

--- a/crates/render-pdf/tests/fixtures/metadata-header/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/metadata-header/expected.pdf
@@ -1,0 +1,63 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 169 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Amazing Grace) Tj
+ET
+BT
+/F1 13 Tf
+56 764 Td
+(Traditional Hymn) Tj
+ET
+BT
+/F2 9 Tf
+56 739 Td
+(G) Tj
+ET
+BT
+/F1 11 Tf
+56 728 Td
+(Amazing grace) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+926
+%%EOF

--- a/crates/render-pdf/tests/fixtures/metadata-header/input.cho
+++ b/crates/render-pdf/tests/fixtures/metadata-header/input.cho
@@ -1,0 +1,7 @@
+{title: Amazing Grace}
+{subtitle: Traditional Hymn}
+{artist: John Newton}
+{key: G}
+{capo: 2}
+
+[G]Amazing grace

--- a/crates/render-pdf/tests/fixtures/minimal-song/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/minimal-song/expected.pdf
@@ -1,0 +1,53 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 85 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Hello World) Tj
+ET
+BT
+/F1 11 Tf
+56 756 Td
+(Hello world) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000230 00000 n 
+0000000327 00000 n 
+0000000429 00000 n 
+0000000534 00000 n 
+0000000643 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+841
+%%EOF

--- a/crates/render-pdf/tests/fixtures/minimal-song/input.cho
+++ b/crates/render-pdf/tests/fixtures/minimal-song/input.cho
@@ -1,0 +1,3 @@
+{title: Hello World}
+
+Hello world

--- a/crates/render-pdf/tests/fixtures/page-control-directives/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/page-control-directives/expected.pdf
@@ -1,0 +1,132 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R >> /ProcSet [/PDF /Text] >> /Kids [7 0 R 9 0 R 11 0 R] /Count 3 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 166 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Page Control Test) Tj
+ET
+q
+56 0 0 842 re W n
+BT
+/F2 9 Tf
+56 764 Td
+(G) Tj
+ET
+Q
+q
+56 0 0 842 re W n
+BT
+/F1 11 Tf
+56 753 Td
+(First line) Tj
+ET
+Q
+endstream
+endobj
+9 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 10 0 R >>
+endobj
+10 0 obj
+<< /Length 118 >>
+stream
+q
+56 0 0 842 re W n
+BT
+/F2 9 Tf
+56 786 Td
+(C) Tj
+ET
+Q
+q
+56 0 0 842 re W n
+BT
+/F1 11 Tf
+56 775 Td
+(Second line) Tj
+ET
+Q
+endstream
+endobj
+11 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 12 0 R >>
+endobj
+12 0 obj
+<< /Length 237 >>
+stream
+q
+56 0 0 842 re W n
+BT
+/F2 9 Tf
+56 786 Td
+(D) Tj
+ET
+Q
+q
+56 0 0 842 re W n
+BT
+/F1 11 Tf
+56 775 Td
+(Third line) Tj
+ET
+Q
+q
+76 0 0 842 re W n
+BT
+/F2 9 Tf
+76 786 Td
+(Am) Tj
+ET
+Q
+q
+76 0 0 842 re W n
+BT
+/F1 11 Tf
+76 775 Td
+(Fourth line) Tj
+ET
+Q
+endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000243 00000 n 
+0000000340 00000 n 
+0000000442 00000 n 
+0000000547 00000 n 
+0000000656 00000 n 
+0000000719 00000 n 
+0000000936 00000 n 
+0000001000 00000 n 
+0000001170 00000 n 
+0000001235 00000 n 
+trailer
+<< /Size 13 /Root 1 0 R >>
+startxref
+1524
+%%EOF

--- a/crates/render-pdf/tests/fixtures/page-control-directives/input.cho
+++ b/crates/render-pdf/tests/fixtures/page-control-directives/input.cho
@@ -1,0 +1,9 @@
+{title: Page Control Test}
+{columns: 999}
+[G]First line
+{new_page}
+[C]Second line
+{new_physical_page}
+[D]Third line
+{column_break}
+[Am]Fourth line

--- a/crates/render-pdf/tests/golden.rs
+++ b/crates/render-pdf/tests/golden.rs
@@ -1,0 +1,187 @@
+//! Golden tests for the PDF renderer.
+//!
+//! Discovers every subdirectory under `tests/fixtures/` that contains an
+//! `input.cho`, parses it through [`chordsketch_core::parse`], renders via
+//! [`chordsketch_render_pdf::render_song`], and compares the resulting bytes
+//! against an `expected.pdf` snapshot.
+//!
+//! The PDF renderer is deterministic (no clock, no RNG, stable map
+//! orderings), so byte-exact comparison is the right primitive. When the
+//! renderer's output changes intentionally, regenerate the snapshots with:
+//!
+//! ```sh
+//! UPDATE_GOLDEN=1 cargo test -p chordsketch-render-pdf --test golden
+//! ```
+//!
+//! Each fixture deliberately mirrors an existing `render-text` fixture so
+//! sister-site parity (see `.claude/rules/renderer-parity.md`) can be
+//! verified by cross-referencing fixture names.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+fn discover_fixtures() -> Vec<PathBuf> {
+    let dir = fixtures_dir();
+    let mut fixtures: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("cannot read fixtures directory {}: {}", dir.display(), e))
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.is_dir() && path.join("input.cho").exists() {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    fixtures.sort();
+    fixtures
+}
+
+/// Formats a short hex dump around the first differing byte, giving humans
+/// enough context to tell whether a diff is stream content, an offset
+/// pointer, or a length field.
+fn diff_context(expected: &[u8], actual: &[u8]) -> String {
+    let mismatch = expected
+        .iter()
+        .zip(actual.iter())
+        .position(|(e, a)| e != a)
+        .unwrap_or_else(|| expected.len().min(actual.len()));
+
+    let window = 32usize;
+    let start = mismatch.saturating_sub(window);
+    let end_e = (mismatch + window).min(expected.len());
+    let end_a = (mismatch + window).min(actual.len());
+
+    let hex = |bytes: &[u8]| -> String {
+        bytes
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+
+    format!(
+        "first differing byte: offset {mismatch}\n\
+         expected len: {}\n\
+         actual   len: {}\n\
+         expected [{start}..{end_e}]: {}\n\
+         actual   [{start}..{end_a}]: {}\n",
+        expected.len(),
+        actual.len(),
+        hex(&expected[start..end_e]),
+        hex(&actual[start..end_a]),
+    )
+}
+
+fn run_golden_test(fixture_dir: &Path) {
+    let name = fixture_dir
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    let input_path = fixture_dir.join("input.cho");
+    let expected_path = fixture_dir.join("expected.pdf");
+
+    let input = fs::read_to_string(&input_path)
+        .unwrap_or_else(|e| panic!("[{name}] cannot read {}: {e}", input_path.display()));
+
+    let song =
+        chordsketch_core::parse(&input).unwrap_or_else(|e| panic!("[{name}] parse error: {e}"));
+    let actual = chordsketch_render_pdf::render_song(&song);
+
+    assert!(
+        !actual.is_empty(),
+        "[{name}] PDF renderer returned zero bytes"
+    );
+    assert!(
+        actual.starts_with(b"%PDF-"),
+        "[{name}] output does not start with the PDF magic header"
+    );
+
+    if std::env::var("UPDATE_GOLDEN").is_ok() {
+        fs::write(&expected_path, &actual)
+            .unwrap_or_else(|e| panic!("[{name}] cannot write {}: {e}", expected_path.display()));
+        eprintln!("[{name}] updated {}", expected_path.display());
+        return;
+    }
+
+    let expected = fs::read(&expected_path).unwrap_or_else(|e| {
+        panic!(
+            "[{name}] cannot read {} (run `UPDATE_GOLDEN=1 cargo test -p chordsketch-render-pdf --test golden` to create it): {e}",
+            expected_path.display()
+        )
+    });
+
+    if expected != actual {
+        panic!(
+            "\n\ngolden test '{name}' failed!\n\
+             \n\
+             Fixture: {}\n\
+             Expected file: {}\n\
+             \n\
+             {}\n\
+             If this change is intentional, run:\n\
+             UPDATE_GOLDEN=1 cargo test -p chordsketch-render-pdf --test golden\n",
+            fixture_dir.display(),
+            expected_path.display(),
+            diff_context(&expected, &actual),
+        );
+    }
+}
+
+#[test]
+fn golden_tests() {
+    let fixtures = discover_fixtures();
+    assert!(
+        !fixtures.is_empty(),
+        "no golden test fixtures found in {}",
+        fixtures_dir().display()
+    );
+
+    let mut failures = Vec::new();
+    for fixture in &fixtures {
+        let name = fixture.file_name().unwrap().to_string_lossy().to_string();
+        let result = std::panic::catch_unwind(|| run_golden_test(fixture));
+        if let Err(e) = result {
+            let msg = if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = e.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else {
+                "unknown panic".to_string()
+            };
+            failures.push((name, msg));
+        }
+    }
+
+    if !failures.is_empty() {
+        let mut report = format!("\n{} golden test(s) failed:\n", failures.len());
+        for (name, msg) in &failures {
+            report.push_str(&format!("\n--- {name} ---\n{msg}\n"));
+        }
+        panic!("{report}");
+    }
+
+    eprintln!("all {} golden test(s) passed", fixtures.len());
+}
+
+/// Guards the determinism assumption that underlies byte-exact PDF
+/// snapshots. If a future change introduces a clock read, RNG, or unstable
+/// map order into the PDF pipeline, this test fails loudly instead of
+/// snapshot updates silently drifting every run.
+#[test]
+fn pdf_output_is_deterministic() {
+    let input = "{title: Determinism Check}\n\n[C]Hello [G]world\n";
+    let song = chordsketch_core::parse(input).expect("parse");
+    let a = chordsketch_render_pdf::render_song(&song);
+    let b = chordsketch_render_pdf::render_song(&song);
+    assert_eq!(a, b, "PDF renderer is not deterministic");
+}


### PR DESCRIPTION
## Summary

- Adds `crates/render-pdf/tests/golden.rs` harness plus **10 byte-exact
  PDF fixtures** mirroring existing `render-text` fixtures.
- Closes the largest coverage gap identified in #1846 (render-pdf had
  zero fixtures vs. render-text 30 / render-html 4).
- Includes a `{columns: 999}` fixture that exercises the out-of-range
  clamp motivating #1540 — satisfies the validation-parity clause in
  `.claude/rules/renderer-parity.md`.

## Why byte-exact

The PDF renderer is deterministic — no clock, no RNG, stable BTreeMap
ordering (`grep -rnE "time\(\)|SystemTime|Utc::now|rand|chrono"
crates/render-pdf/` returns nothing). A dedicated
`pdf_output_is_deterministic` test renders the same input twice and
asserts equality, so any future change that breaks determinism fails
loudly instead of silently drifting through snapshot updates.

Total fixture size: ~15 KB across all 10 PDFs.

## Fixtures

| Name | Parity with | Notes |
|---|---|---|
| `minimal-song` | render-text | sanity |
| `metadata-header` | render-text | `{title}`/`{subtitle}`/`{artist}`/`{key}`/`{capo}` |
| `chord-alignment` | render-text | long chord/lyric segments |
| `chords-over-lyrics` | render-text | inline chord/lyric interleaving |
| `comments` | render-text | normal/italic/box comment styles |
| `directives-and-sections` | render-text | verse/chorus/bridge/tab |
| `empty-lines` | render-text | blank line preservation |
| `define-display` | render-text | custom chord definition with display name |
| `full-song` | render-text | realistic multi-directive combo |
| `page-control-directives` | render-text | `{columns: 999}` (clamp) + `{new_page}` + `{new_physical_page}` + `{column_break}` |

## Regeneration

```sh
UPDATE_GOLDEN=1 cargo test -p chordsketch-render-pdf --test golden
```

## Intentional omission — unicode

`unicode-lyrics` was attempted but produced a 6.6 MB PDF because any
non-Latin1 character triggers embedding of the bundled NotoSansCJK
subset font. Byte-exact snapshots are impractical at that size, so
unicode PDF coverage is deferred to a text-extraction approach —
tracked separately in #1983.

## Test plan

- [x] `cargo test -p chordsketch-render-pdf --test golden` passes
  against the committed snapshots (11 assertions: 10 fixtures + the
  determinism guard).
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p chordsketch-render-pdf --tests -- -D warnings`
  clean
- [x] `cargo test --workspace` passes
- [x] Regeneration flow (`UPDATE_GOLDEN=1 ...`) exercised to produce
  the committed snapshots

Closes #1979.
Part of #1846.