### PR TITLE
test(napi,wasm): add JS-boundary public-API tests (Phase 2 of #1846)

### DIFF
--- a/crates/napi/__tests__/public-api.test.js
+++ b/crates/napi/__tests__/public-api.test.js
@@ -1,0 +1,118 @@
+"use strict";
+
+// Public-API integration tests for the @chordsketch/node NAPI binding.
+//
+// Each test loads the compiled `.node` artifact (produced by `npm run build`
+// or the napi CI job) and exercises one documented function. The suite
+// together covers every #[napi] item declared in `crates/napi/src/lib.rs`
+// and mirrored in `crates/napi/index.d.ts`.
+//
+// Complements `warning-routing.test.js`, which covers the
+// Rust-eprintln-to-stderr path via spawned child processes.
+
+const fs = require("fs");
+const path = require("path");
+
+function findNodeFile() {
+  const dir = path.join(__dirname, "..");
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith(".node"));
+  if (files.length !== 1) {
+    throw new Error(
+      `Expected exactly 1 .node file in ${dir}, found ${files.length}: ${files.join(", ")}`
+    );
+  }
+  return path.join(dir, files[0]);
+}
+
+const MINIMAL = "{title: Test}\n[C]Hello";
+
+describe("NAPI public API surface", () => {
+  let m;
+
+  beforeAll(() => {
+    m = require(findNodeFile());
+  });
+
+  test("version() returns a non-empty string", () => {
+    const v = m.version();
+    expect(typeof v).toBe("string");
+    expect(v.length).toBeGreaterThan(0);
+  });
+
+  test("renderText() renders the title into plain text", () => {
+    const out = m.renderText(MINIMAL);
+    expect(typeof out).toBe("string");
+    expect(out).toContain("Test");
+    expect(out).toContain("Hello");
+  });
+
+  test("renderTextWithOptions({ transpose: 2 }) returns non-empty text", () => {
+    const out = m.renderTextWithOptions(MINIMAL, { transpose: 2 });
+    expect(typeof out).toBe("string");
+    expect(out).toContain("Test");
+  });
+
+  test("renderTextWithOptions({ config: 'guitar' }) accepts preset names", () => {
+    const out = m.renderTextWithOptions(MINIMAL, { config: "guitar" });
+    expect(typeof out).toBe("string");
+    expect(out).toContain("Test");
+  });
+
+  test("renderHtml() renders the title into HTML", () => {
+    const out = m.renderHtml(MINIMAL);
+    expect(typeof out).toBe("string");
+    expect(out).toContain("Test");
+    // Sanity: output should at least contain an HTML structural marker, not
+    // be an arbitrary string.
+    expect(out).toMatch(/<!DOCTYPE|<html|<body/i);
+  });
+
+  test("renderHtmlWithOptions({ transpose: 1 }) returns HTML", () => {
+    const out = m.renderHtmlWithOptions(MINIMAL, { transpose: 1 });
+    expect(out).toContain("Test");
+  });
+
+  test("renderPdf() returns a Buffer starting with the PDF magic header", () => {
+    const pdf = m.renderPdf(MINIMAL);
+    expect(Buffer.isBuffer(pdf)).toBe(true);
+    expect(pdf.length).toBeGreaterThan(4);
+    expect(pdf.slice(0, 4).toString("utf8")).toBe("%PDF");
+  });
+
+  test("renderPdfWithOptions({ transpose: 2 }) returns a PDF Buffer", () => {
+    const pdf = m.renderPdfWithOptions(MINIMAL, { transpose: 2 });
+    expect(Buffer.isBuffer(pdf)).toBe(true);
+    expect(pdf.slice(0, 4).toString("utf8")).toBe("%PDF");
+  });
+
+  test("validate() returns an empty array for a well-formed document", () => {
+    const errs = m.validate(MINIMAL);
+    expect(Array.isArray(errs)).toBe(true);
+    expect(errs).toHaveLength(0);
+  });
+
+  test("validate() returns at least one ValidationError for a broken document", () => {
+    // Unterminated chord bracket — parser rejects this.
+    const errs = m.validate("{title: T}\n[G");
+    expect(Array.isArray(errs)).toBe(true);
+    expect(errs.length).toBeGreaterThan(0);
+    // Every element must match the ValidationError shape documented in
+    // `crates/napi/index.d.ts`.
+    for (const e of errs) {
+      expect(typeof e.line).toBe("number");
+      expect(typeof e.column).toBe("number");
+      expect(typeof e.message).toBe("string");
+      expect(e.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("transpose: 0 and omitted transpose produce equal output", () => {
+    // Regression guard for #1541's warning-routing ancestry: the `transpose`
+    // option must be honoured even when its value is the identity. If a
+    // future refactor accidentally drops the `0` branch, this test catches
+    // it immediately.
+    const a = m.renderText(MINIMAL);
+    const b = m.renderTextWithOptions(MINIMAL, { transpose: 0 });
+    expect(a).toBe(b);
+  });
+});

--- a/crates/napi/__tests__/public-api.test.js
+++ b/crates/napi/__tests__/public-api.test.js
@@ -91,18 +91,18 @@ describe("NAPI public API surface", () => {
     expect(errs).toHaveLength(0);
   });
 
-  test("validate() returns at least one ValidationError for a broken document", () => {
+  test("validate() returns at least one error message for a broken document", () => {
     // Unterminated chord bracket — parser rejects this.
     const errs = m.validate("{title: T}\n[G");
     expect(Array.isArray(errs)).toBe(true);
     expect(errs.length).toBeGreaterThan(0);
-    // Every element must match the ValidationError shape documented in
-    // `crates/napi/index.d.ts`.
+    // The Rust implementation returns `Vec<String>` — flat error messages,
+    // not structured `{line, column, message}` records. The
+    // `ValidationError[]` type in `crates/napi/index.d.ts` is inaccurate;
+    // tracked in #1990.
     for (const e of errs) {
-      expect(typeof e.line).toBe("number");
-      expect(typeof e.column).toBe("number");
-      expect(typeof e.message).toBe("string");
-      expect(e.message.length).toBeGreaterThan(0);
+      expect(typeof e).toBe("string");
+      expect(e.length).toBeGreaterThan(0);
     }
   });
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1003,6 +1003,41 @@ mod wasm_tests {
         assert!(!v.is_empty());
     }
 
+    // -- bare public entry points (#1982) --------------------------------
+    //
+    // The `_with_options` variants have explicit JS-boundary tests above,
+    // but the bare `render_text` / `render_html` / `render_pdf` and
+    // `render_text_with_options` entry points only had native `#[test]`
+    // coverage. Add wasm-side tests so a future regression in the bare
+    // delegation path is caught by `wasm-pack test --node` in CI.
+
+    #[wasm_bindgen_test]
+    fn render_html_bare_js_boundary() {
+        let result = render_html(MINIMAL_INPUT).unwrap();
+        assert!(result.contains("Test"));
+    }
+
+    #[wasm_bindgen_test]
+    fn render_text_bare_js_boundary() {
+        let result = render_text(MINIMAL_INPUT).unwrap();
+        assert!(result.contains("Test"));
+    }
+
+    #[wasm_bindgen_test]
+    fn render_pdf_bare_js_boundary() {
+        let bytes = render_pdf(MINIMAL_INPUT).unwrap();
+        assert!(bytes.len() > 4);
+        assert_eq!(&bytes[0..4], b"%PDF");
+    }
+
+    #[wasm_bindgen_test]
+    fn render_text_with_options_js_boundary() {
+        let opts = js_sys::Object::new();
+        Reflect::set(&opts, &"transpose".into(), &JsValue::from(2)).unwrap();
+        let result = render_text_with_options(MINIMAL_INPUT, opts.into()).unwrap();
+        assert!(result.contains("Test"));
+    }
+
     /// Smoke test that the `start` panic hook function exists and is
     /// callable through the wasm-bindgen boundary. We don't trigger an
     /// actual panic (it would abort the test runner), but calling


### PR DESCRIPTION
## Summary

- **NAPI**: new `crates/napi/__tests__/public-api.test.js` — jest file
  covering every public function declared in `index.d.ts`. Picked up
  automatically by the existing `npx jest --no-coverage` step in
  `napi.yml`.
- **WASM**: four new `wasm_bindgen_test` cases in `wasm_tests` for the
  bare entry points (`render_html`, `render_text`, `render_pdf`,
  `render_text_with_options`) that previously only had native unit
  tests — the `JsValue` boundary is now exercised end-to-end under
  `wasm-pack test --node`.
- **FFI**: no changes — `scripts/smoke-test-python.py` already
  exercises every Python-side public function and runs in three per-OS
  CI jobs.

## Why this shape

The sub-issue asks for "a test harness that loads the built artifact
and exercises every public function at least once" for each binding.
Auditing the existing state:

| Binding | Existing state | This PR |
|---|---|---|
| NAPI | Inline `node -e` smoke in workflow + jest file for warning routing only | Proper jest file covering the full public API |
| WASM | `wasm_bindgen_test` for `_with_options` / `_with_warnings` variants; bare variants only had native `#[test]` | 4 new wasm-side tests for the bare entry points |
| FFI | `smoke-test-python.py` exercises `version`, `parse_and_render_text`, `parse_and_render_html`, `parse_and_render_pdf`, `validate` + options | Nothing to add |

Regression guard included in the NAPI jest file:
`renderText(src)` and `renderTextWithOptions(src, { transpose: 0 })`
must produce byte-identical output. The `transpose: 0` branch is the
kind of identity-case that a future refactor is likely to drop.

## Test plan

- [x] `wasm-pack test --node crates/wasm` → 22 passed (18 existing + 4
  new)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p chordsketch-wasm --tests --target wasm32-unknown-unknown -- -D warnings` clean
- [x] `node --check crates/napi/__tests__/public-api.test.js` clean
- [ ] NAPI jest test will be validated by CI (local run requires
  `napi build` against a Node toolchain; CI already has this wired)

## Non-goal — preserving the inline `node -e` smoke in `napi.yml`

The NAPI workflow still runs an inline `node -e` smoke with the same
coverage. I deliberately did not remove it — that's a separate
cleanup that would widen this PR's diff and the deletion of
pre-existing test code is outside the scope of #1982.

Closes #1982.
Part of #1846.