### PR TITLE
ci(coverage): enable Codecov gating thresholds and PR trigger (Phase 3 of #1846)

### DIFF
--- a/.claude/rules/fix-propagation.md
+++ b/.claude/rules/fix-propagation.md
@@ -68,6 +68,33 @@ A PR that fixes a bug in one sister site but leaves an equivalent defect in anot
 - **Medium** if it causes incorrect output or violates a spec
 - **Low** if it is a defense-in-depth or quality gap
 
+## Coverage Floors
+
+Each sister-site group carries a numeric coverage floor enforced by
+`codecov.yml`. These floors are derived from the tracker in #1846
+§Strategy.3:
+
+| Group | Group floor | Max intra-group skew |
+|---|---|---|
+| Renderers (`render-text`, `render-html`, `render-pdf`) | 80% | 5 pp |
+| Bindings (`chordsketch-ffi`, `chordsketch-napi`, `chordsketch-wasm`) | 70% | 10 pp |
+| `chordsketch-core` (standalone) | 85% | — |
+| Patch (new lines in any PR) | 70% | — |
+
+Intra-group skew is not enforced natively by Codecov; it is verified by
+the auto-review step by reading the per-crate percentages from the
+Codecov PR comment. A PR that pushes a group's min-to-max spread over
+the skew threshold is a fix-propagation defect by the same definition
+as a missing match arm: one binding or renderer is diverging from its
+siblings. Severity defaults to Medium, raised to High if the drop is
+in a security-relevant function.
+
+Binding floors are intentionally lower because the lines `llvm-cov` sees
+are mostly marshalling glue; the public API surface is exercised via
+language-runtime integration tests (jest, wasm_bindgen_test, Python
+smoke) that llvm-cov does not observe. Raising the floors requires
+closing that observability gap first.
+
 ## Why
 
 6 of the 14 findings in the 2026-04-12 main-branch review were caused by fix locality bias:

--- a/.claude/rules/golden-tests.md
+++ b/.claude/rules/golden-tests.md
@@ -8,6 +8,24 @@
 - New ChordPro directives or syntax support must include at least one golden test before
   merging.
 
+## Minimum Fixture Counts
+
+The renderers each maintain their own fixture corpus. These minimums are the
+floor for sister-site parity (see [`renderer-parity.md`](renderer-parity.md));
+Codecov thresholds alone do not guarantee structural coverage of directive
+classes, so a PR that drops below any of these numbers blocks on human review:
+
+| Renderer | Minimum fixtures | Location |
+|---|---|---|
+| `render-text` | 30 | `crates/render-text/tests/fixtures/` |
+| `render-html` | 15 | `crates/render-html/tests/fixtures/` |
+| `render-pdf`  | 10 | `crates/render-pdf/tests/fixtures/`  |
+
+The asymmetry reflects snapshot cost — render-text fixtures are tiny plain
+text, render-pdf fixtures are binary PDFs whose byte-exact snapshots cost
+~1–2 KB each, and byte-exact snapshots for unicode input are impractical in
+render-pdf (tracked in #1983). Raise the floor when those costs change.
+
 ## Stop-Word Collision Tests
 
 When adding or modifying the chord parser or heuristic importer, add at least one

--- a/.claude/rules/renderer-parity.md
+++ b/.claude/rules/renderer-parity.md
@@ -46,6 +46,20 @@ Before closing a PR that touches any renderer:
    and clamping logic is identical in all three renderers.
 4. If an arm or validation is missing, either add it or file a sub-issue.
 
+## Coverage Parity
+
+Sister-site parity extends to numeric test coverage. The renderer group
+(`render-text`, `render-html`, `render-pdf`) has a **group floor of 80%**
+line coverage, and the **intra-group skew must not exceed 5 percentage
+points**. A drop below either bound is a structural signal that one
+renderer is diverging from its siblings — the same class of defect as a
+missing match arm, just detected by metric instead of by grep.
+
+Thresholds are enforced via `codecov.yml` at the repo root. The skew
+clause is not natively supported by Codecov and is verified by auto-review
+using the per-crate percentages in the Codecov dashboard comment on each
+PR. See tracker #1846 §Strategy.3 for the full gating model.
+
 ## Why
 
 45 renderer parity issues were filed — the most common was a new directive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,18 +3,25 @@ name: Coverage
 # Measures workspace test coverage with cargo-llvm-cov and uploads lcov.info
 # to Codecov. See #1846 for the multi-phase rollout plan.
 #
-# Phase 0+1 scope (issue #1977): upload only, no threshold gating, main-branch
-# pushes only. `needs: []` ensures this job never blocks other workflows.
-# PR trigger is intentionally omitted until baselines stabilise — see
-# tracker §Strategy.2.
+# Triggers:
+# - push to main: captures the authoritative baseline that every PR diff
+#   is compared against.
+# - pull_request: posts the Codecov diff comment and status check on each
+#   PR. The status check is NOT yet wired into branch protection — per
+#   tracker §Strategy, "add to branch protection required checks only
+#   after two consecutive green main builds at the gate value".
+#
+# `needs: []` ensures the coverage job never blocks other CI jobs; only
+# the Codecov status becomes a required check once branch protection is
+# updated.
 #
 # Token: public repos authenticate codecov-action via GitHub OIDC, so
-# CODECOV_TOKEN is not required. The tracker notes it can be added later if
-# upload reliability becomes an issue.
+# CODECOV_TOKEN is not required.
 
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,115 @@
+# Codecov configuration for ChordSketch.
+#
+# Gating model follows the tracker in issue #1846 §Strategy.3:
+#
+#   core              standalone floor 85%
+#   Renderers (group) floor 80%, intra-group skew <= 5%
+#   Bindings (group)  floor 70%, intra-group skew <= 10%
+#   Patch target      70% on new lines
+#
+# Codecov does not natively enforce intra-group skew; the skew clause lives
+# as a reviewer rule in `.claude/rules/renderer-parity.md` and
+# `.claude/rules/fix-propagation.md` and is verified by auto-review, not by
+# this file.
+#
+# Branch protection: Codecov status checks are emitted but NOT yet wired
+# into branch protection required checks. Per tracker §Strategy: "add to
+# branch protection required checks only after two consecutive green main
+# builds at the gate value". That is a one-time human action on GitHub
+# Settings once baselines prove stable.
+
+codecov:
+  notify:
+    # Wait up to Codecov's default before finalising so the coverage.yml
+    # workflow has time to upload.
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...95"
+
+  status:
+    project:
+      # Aggregate guard: the workspace as a whole may drift by at most 1
+      # percentage point between main builds.
+      default:
+        target: auto
+        threshold: 1%
+        informational: false
+
+      core:
+        paths:
+          - crates/core/
+        target: 85%
+        threshold: 1%
+        informational: false
+
+      render-text:
+        paths:
+          - crates/render-text/
+        target: 80%
+        threshold: 1%
+        informational: false
+
+      render-html:
+        paths:
+          - crates/render-html/
+        target: 80%
+        threshold: 1%
+        informational: false
+
+      render-pdf:
+        paths:
+          - crates/render-pdf/
+        target: 80%
+        threshold: 1%
+        informational: false
+
+      # Foreign-language bindings sit at a lower floor because the lines
+      # llvm-cov sees are mostly marshalling — the real public API surface
+      # is exercised via language-runtime integration tests that llvm-cov
+      # does not observe. Raising the floor requires addressing that
+      # observability gap first.
+      ffi:
+        paths:
+          - crates/ffi/
+        target: 70%
+        threshold: 1%
+        informational: false
+
+      napi:
+        paths:
+          - crates/napi/
+        target: 70%
+        threshold: 1%
+        informational: false
+
+      wasm:
+        paths:
+          - crates/wasm/
+        target: 70%
+        threshold: 1%
+        informational: false
+
+    patch:
+      default:
+        target: 70%
+        threshold: 0%
+
+# Excluded from both project and patch metrics so the published numbers
+# reflect hand-written, runtime-reachable code.
+ignore:
+  - "**/target/**"
+  - "**/node_modules/**"
+  - "**/tests/**"
+  - "**/*_test.rs"
+  - "**/build.rs"
+  # Build-time bindgen driver, instrumented at 0% because it is only
+  # invoked during `cargo build`, not at runtime.
+  - "crates/ffi/src/bin/uniffi-bindgen.rs"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

- Adds `codecov.yml` at the repo root with per-crate and per-group
  project floors matching tracker #1846 §Strategy.3.
- Extends `.github/workflows/coverage.yml` to run on PRs so Codecov
  has a diff to comment on.
- Updates three `.claude/rules/` files with the numeric contract that
  Codecov now enforces.

## Numeric contract (locked in by this PR)

| Group | Floor | Max intra-group skew |
|---|---|---|
| `chordsketch-core` | 85% | — |
| Renderers (text / html / pdf) | 80% | 5 pp |
| Bindings (ffi / napi / wasm) | 70% | 10 pp |
| Patch target (new lines) | 70% | — |
| Aggregate workspace threshold | 1% drift | — |

Intra-group skew is not native to Codecov; it's enforced by auto-review
reading the per-crate percentages from the Codecov PR comment.

## Intentionally not in this PR

- **Branch protection update.** Per tracker: \"add to branch protection
  required checks only after two consecutive green main builds at the
  gate value.\" Today's Codecov status checks are emitted but not
  required; after this merges and two subsequent main pushes are green
  at the gated values, a human adds the four status checks to branch
  protection. This PR lands the thresholds; it does not flip the
  enforcement switch.
- **Binding floor reconciliation.** Current NAPI / WASM line coverage
  (as reported by cargo-llvm-cov) hovers around 54% / 62%, below the
  70% group floor. The rationale in `codecov.yml` and
  `fix-propagation.md` explains why the floors stay at 70%: the real
  public API is exercised via JS-boundary tests that llvm-cov cannot
  observe. If the first post-merge main build shows the binding group
  below floor, that's a signal to prioritise the already-tracked
  follow-ups — **not** to lower the floor.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('codecov.yml'))\"` parses
- [x] `bash scripts/check-action-pins.sh .github` — all refs still pinned
- [x] Rules docs render clean in markdown (headers, tables, links valid)
- [ ] After merge: inspect the first push-to-main run of `coverage.yml`
  and the first PR run; confirm Codecov posts a status for each
  configured component and that the aggregate is published

Closes #1992.
Part of #1846.