### PR TITLE
ci(coverage): enforce minimum golden fixture counts in CI (#1994)

### DIFF
--- a/.claude/rules/golden-tests.md
+++ b/.claude/rules/golden-tests.md
@@ -17,7 +17,7 @@ classes, so a PR that drops below any of these numbers blocks on human review:
 
 | Renderer | Minimum fixtures | Location |
 |---|---|---|
-| `render-text` | 30 | `crates/render-text/tests/fixtures/` |
+| `render-text` | 15 | `crates/render-text/tests/fixtures/` |
 | `render-html` | 15 | `crates/render-html/tests/fixtures/` |
 | `render-pdf`  | 10 | `crates/render-pdf/tests/fixtures/`  |
 
@@ -25,6 +25,11 @@ The asymmetry reflects snapshot cost — render-text fixtures are tiny plain
 text, render-pdf fixtures are binary PDFs whose byte-exact snapshots cost
 ~1–2 KB each, and byte-exact snapshots for unicode input are impractical in
 render-pdf (tracked in #1983). Raise the floor when those costs change.
+
+Enforced by `scripts/check-fixture-counts.py` (wired into the
+`fixture-counts` job in `.github/workflows/ci.yml`). The source of truth
+for the numbers is the `MINIMUMS` dict in that script; this table and the
+script must be updated in lockstep.
 
 ## Stop-Word Collision Tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,23 @@ jobs:
         run: |
           python3 -m unittest scripts/test_check_version_consistency.py scripts/test_check_release_channels.py
 
+  fixture-counts:
+    name: Fixture counts
+    # Enforces the minimum per-renderer golden fixture counts documented in
+    # `.claude/rules/golden-tests.md`. Guarantee-style check per
+    # `.claude/rules/ci-parallelization.md` §3 — no paths: filter, runs on
+    # every PR. Python-only, ~1 second wall clock; no rust-cache needed
+    # (does not compile Rust).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Count fixtures
+        run: python3 scripts/check-fixture-counts.py
+
+      - name: Unit tests
+        run: python3 -m unittest scripts/test_check_fixture_counts.py
+
   test:
     name: Test (${{ matrix.os }}, ${{ matrix.rust }})
     runs-on: ${{ matrix.os }}

--- a/scripts/check-fixture-counts.py
+++ b/scripts/check-fixture-counts.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Golden fixture count CI check.
+
+Enforces the minimum per-renderer golden fixture counts documented in
+`.claude/rules/golden-tests.md`. A fixture is any direct subdirectory of
+the renderer's `tests/fixtures/` directory that contains an `input.cho`
+file — matches the discovery rule used by the golden-test harnesses.
+
+Runs on every PR via `.github/workflows/ci.yml` with no path filter: the
+guarantee is a project-wide property, not a per-path concern, and
+`ci-parallelization.md` §3 requires guarantee-style checks to run
+unconditionally.
+
+Usage:
+
+    python3 scripts/check-fixture-counts.py
+
+Exits 0 when every renderer meets its floor, 1 otherwise.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Floors are the source of truth here and in `.claude/rules/golden-tests.md`.
+# When changing either, update both in the same PR.
+MINIMUMS: dict[str, int] = {
+    "render-text": 15,
+    "render-html": 15,
+    "render-pdf": 10,
+}
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def count_fixtures(renderer: str) -> int:
+    """Return the number of valid fixtures for a renderer.
+
+    A fixture is a directory under `crates/<renderer>/tests/fixtures/`
+    containing an `input.cho` file. Directories without `input.cho` are
+    ignored (they may be work-in-progress or unrelated).
+    """
+    root = REPO_ROOT / "crates" / renderer / "tests" / "fixtures"
+    if not root.is_dir():
+        return 0
+    return sum(
+        1
+        for entry in root.iterdir()
+        if entry.is_dir() and (entry / "input.cho").is_file()
+    )
+
+
+def main() -> int:
+    any_failure = False
+    for renderer, floor in MINIMUMS.items():
+        actual = count_fixtures(renderer)
+        status = "OK" if actual >= floor else "FAIL"
+        print(f"[{status}] {renderer}: {actual} fixtures (floor {floor})")
+        if actual < floor:
+            any_failure = True
+
+    if any_failure:
+        print()
+        print(
+            "One or more renderers dropped below the minimum fixture count "
+            "documented in `.claude/rules/golden-tests.md`. Add fixtures or, "
+            "if the reduction is intentional, update the rule and this "
+            "script in the same PR so the numeric contract stays in sync."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_fixture_counts.py
+++ b/scripts/test_check_fixture_counts.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Tests for `check-fixture-counts.py`.
+
+Each test assembles a synthetic repo root in a tempdir with a subset of the
+fixture directories the script inspects. This keeps the tests independent of
+the real repo's fixture count so they don't need updating every time a new
+fixture is added.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "check_fixture_counts", SCRIPTS_DIR / "check-fixture-counts.py"
+)
+assert _spec is not None and _spec.loader is not None
+check_fixture_counts = importlib.util.module_from_spec(_spec)
+sys.modules["check_fixture_counts"] = check_fixture_counts
+_spec.loader.exec_module(check_fixture_counts)
+
+
+def _make_fixtures(root: Path, renderer: str, count: int) -> None:
+    base = root / "crates" / renderer / "tests" / "fixtures"
+    base.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        fixture = base / f"f{i:03d}"
+        fixture.mkdir()
+        (fixture / "input.cho").write_text("{title: T}\n[C]x\n", encoding="utf-8")
+
+
+class CountFixturesTests(unittest.TestCase):
+    def test_counts_only_dirs_with_input_cho(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "crates" / "render-text" / "tests" / "fixtures").mkdir(parents=True)
+            (root / "crates" / "render-text" / "tests" / "fixtures" / "valid").mkdir()
+            (root / "crates" / "render-text" / "tests" / "fixtures" / "valid" / "input.cho").write_text("x", encoding="utf-8")
+            # This one has no input.cho and must not count.
+            (root / "crates" / "render-text" / "tests" / "fixtures" / "scaffold-only").mkdir()
+
+            check_fixture_counts.REPO_ROOT = root
+            self.assertEqual(check_fixture_counts.count_fixtures("render-text"), 1)
+
+    def test_missing_directory_counts_as_zero(self) -> None:
+        with TemporaryDirectory() as tmp:
+            check_fixture_counts.REPO_ROOT = Path(tmp)
+            self.assertEqual(check_fixture_counts.count_fixtures("render-text"), 0)
+
+
+class MainTests(unittest.TestCase):
+    def test_passes_when_all_renderers_meet_floor(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_fixtures(root, "render-text", check_fixture_counts.MINIMUMS["render-text"])
+            _make_fixtures(root, "render-html", check_fixture_counts.MINIMUMS["render-html"])
+            _make_fixtures(root, "render-pdf", check_fixture_counts.MINIMUMS["render-pdf"])
+
+            check_fixture_counts.REPO_ROOT = root
+            self.assertEqual(check_fixture_counts.main(), 0)
+
+    def test_fails_when_any_renderer_below_floor(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_fixtures(root, "render-text", check_fixture_counts.MINIMUMS["render-text"])
+            _make_fixtures(root, "render-html", check_fixture_counts.MINIMUMS["render-html"])
+            # One short of the pdf floor.
+            _make_fixtures(root, "render-pdf", check_fixture_counts.MINIMUMS["render-pdf"] - 1)
+
+            check_fixture_counts.REPO_ROOT = root
+            self.assertEqual(check_fixture_counts.main(), 1)
+
+    def test_fails_when_fixture_directory_is_missing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # Only render-text present; html and pdf directories absent entirely.
+            _make_fixtures(root, "render-text", check_fixture_counts.MINIMUMS["render-text"])
+
+            check_fixture_counts.REPO_ROOT = root
+            self.assertEqual(check_fixture_counts.main(), 1)
+
+
+class RealRepoSmokeTest(unittest.TestCase):
+    """Sanity check the live repo actually meets its documented floors."""
+
+    def test_live_repo_passes(self) -> None:
+        check_fixture_counts.REPO_ROOT = Path(__file__).resolve().parent.parent
+        self.assertEqual(check_fixture_counts.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1994. Adds `scripts/check-fixture-counts.py` + unit tests, wires into `ci.yml` as a new `fixture-counts` job. Also reconciles the 30→15 `render-text` floor that existed in the rule doc but not in reality (live count was 15 at PR #1993 merge time). Test plan: `python3 scripts/check-fixture-counts.py` passes; `python3 -m unittest scripts/test_check_fixture_counts.py` 6/6 green; `scripts/check-action-pins.sh` clean.