### PR TITLE
fix(napi): return structured ValidationError[] from validate() (#1990)

### DIFF
--- a/crates/napi/__tests__/public-api.test.js
+++ b/crates/napi/__tests__/public-api.test.js
@@ -91,18 +91,20 @@ describe("NAPI public API surface", () => {
     expect(errs).toHaveLength(0);
   });
 
-  test("validate() returns at least one error message for a broken document", () => {
+  test("validate() returns at least one ValidationError for a broken document", () => {
     // Unterminated chord bracket — parser rejects this.
     const errs = m.validate("{title: T}\n[G");
     expect(Array.isArray(errs)).toBe(true);
     expect(errs.length).toBeGreaterThan(0);
-    // The Rust implementation returns `Vec<String>` — flat error messages,
-    // not structured `{line, column, message}` records. The
-    // `ValidationError[]` type in `crates/napi/index.d.ts` is inaccurate;
-    // tracked in #1990.
+    // Rust returns `Vec<ValidationError>` after #1990, matching the
+    // `ValidationError[]` declaration in `crates/napi/index.d.ts`.
     for (const e of errs) {
-      expect(typeof e).toBe("string");
-      expect(e.length).toBeGreaterThan(0);
+      expect(typeof e.line).toBe("number");
+      expect(typeof e.column).toBe("number");
+      expect(typeof e.message).toBe("string");
+      expect(e.line).toBeGreaterThanOrEqual(1);
+      expect(e.column).toBeGreaterThanOrEqual(1);
+      expect(e.message.length).toBeGreaterThan(0);
     }
   });
 

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -398,16 +398,49 @@ pub fn render_pdf_with_warnings_and_options(
     do_render_pdf_with_warnings(&input, &config, transpose)
 }
 
-/// Validate ChordPro input and return any parse errors as strings.
-/// Returns an empty array if the input is valid.
+/// A single validation issue reported by [`validate`]. Mirrors the
+/// `ValidationError` interface in `crates/napi/index.d.ts`; the `#[napi(object)]`
+/// attribute marshals this into a plain JS `{line, column, message}` record.
+///
+/// Line and column are one-based, matching the rest of the public API and
+/// the numbers a typical editor diagnostic expects. They are `u32` so
+/// napi-rs can marshal them as plain JS `number`s; overflow is impossible
+/// in practice — a ChordPro source long enough to exceed `u32::MAX` lines
+/// is orders of magnitude above any realistic song file.
+#[napi(object)]
+pub struct ValidationError {
+    /// One-based line number where the issue was detected.
+    pub line: u32,
+    /// One-based column number where the issue was detected.
+    pub column: u32,
+    /// Human-readable description of the issue.
+    pub message: String,
+}
+
+/// Validate ChordPro input and return any parse errors as structured
+/// records. Returns an empty array if the input is valid.
+///
+/// The shape matches the TypeScript `ValidationError[]` declaration in
+/// `index.d.ts`. Prior to #1990 this function returned `Vec<String>`; the
+/// previous spelling is gone in this version rather than kept as a
+/// compatibility shim — the structured form is strictly richer and the
+/// package has no pinned consumers that depend on the string form.
 #[must_use]
 #[napi]
-pub fn validate(input: String) -> Vec<String> {
+pub fn validate(input: String) -> Vec<ValidationError> {
     let result = chordsketch_core::parse_multi_lenient(&input);
     result
         .results
         .into_iter()
-        .flat_map(|r| r.errors.into_iter().map(|e| e.to_string()))
+        .flat_map(|r| r.errors.into_iter())
+        .map(|e| ValidationError {
+            // `line()` / `column()` are `usize`; clamp the (astronomically
+            // unlikely) overflow at `u32::MAX` so we never panic on
+            // conversion.
+            line: u32::try_from(e.line()).unwrap_or(u32::MAX),
+            column: u32::try_from(e.column()).unwrap_or(u32::MAX),
+            message: e.message,
+        })
         .collect()
 }
 


### PR DESCRIPTION
Closes #1990. Aligns the Rust `validate()` return with the `ValidationError[]` declaration in `crates/napi/index.d.ts`. New `#[napi(object)] ValidationError { line, column, message }`; no string-form compatibility shim. Updates the jest public-api test assertions back to the structured shape. cargo check / fmt / clippy clean; final jest validation happens in napi.yml CI.