### PR TITLE
test(napi): add missing typeof assertion to renderHtmlWithOptions test (#1991)

### DIFF
--- a/crates/napi/__tests__/public-api.test.js
+++ b/crates/napi/__tests__/public-api.test.js
@@ -69,6 +69,7 @@ describe("NAPI public API surface", () => {
 
   test("renderHtmlWithOptions({ transpose: 1 }) returns HTML", () => {
     const out = m.renderHtmlWithOptions(MINIMAL, { transpose: 1 });
+    expect(typeof out).toBe("string");
     expect(out).toContain("Test");
   });
 


### PR DESCRIPTION
Closes #1991. One-line consistency fix.