### PR TITLE
docs(napi): fix transpose JSDoc to say 'rejected', not 'clamped' (#2011)

### DIFF
--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -13,8 +13,9 @@ export interface RenderOptions {
   /**
    * Semitone transposition offset. Defaults to 0.
    *
-   * Any integer is accepted, but values outside the i8 range (-128..=127)
-   * are clamped before the underlying renderer reduces modulo 12.
+   * Must be within the i8 range (-128..=127); out-of-range values are
+   * rejected with a thrown `Status::InvalidArg` error. The underlying
+   * renderer reduces the accepted value modulo 12.
    */
   transpose?: number;
 


### PR DESCRIPTION
Closes #2011. Comment-only fix in `index.d.ts`.