### PR TITLE
feat(wasm,ffi): return structured ValidationError[] from validate() (#2009)

### DIFF
--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -68,9 +68,9 @@ See #1827.
 ### Validation
 
 ```python
-errors = chordsketch.validate(source)  # list[str] — empty if clean
-for msg in errors:
-    print(msg)
+errors = chordsketch.validate(source)  # list[ValidationError] — empty if clean
+for e in errors:
+    print(f"line {e.line}, column {e.column}: {e.message}")
 ```
 
 ### Utility

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -49,12 +49,13 @@ namespace chordsketch {
     [Throws=ChordSketchError]
     PdfRenderWithWarnings parse_and_render_pdf_with_warnings(string input, string? config_json, i8? transpose);
 
-    /// Validate ChordPro input and return any parse errors as strings.
-    /// Returns an empty list if the input is valid.
+    /// Validate ChordPro input and return any parse errors as structured
+    /// records. Returns an empty list if the input is valid.
     ///
     /// Call this before or after rendering to surface parse diagnostics
-    /// that the render functions silently discard.
-    sequence<string> validate(string input);
+    /// that the render functions silently discard. Each entry carries a
+    /// one-based `line`, one-based `column`, and a human-readable message.
+    sequence<ValidationError> validate(string input);
 
     /// Return the ChordSketch library version.
     string version();
@@ -81,6 +82,20 @@ dictionary PdfRenderWithWarnings {
     bytes output;
     /// Warnings captured during the render pass.
     sequence<string> warnings;
+};
+
+/// A single validation issue reported by `validate()`.
+///
+/// Matches the NAPI `ValidationError` interface introduced in #1990 and
+/// tracked for cross-binding consistency in #2009. Line and column are
+/// one-based (editor diagnostic convention).
+dictionary ValidationError {
+    /// One-based line number where the issue was detected.
+    u32 line;
+    /// One-based column number where the issue was detected.
+    u32 column;
+    /// Human-readable description of the issue.
+    string message;
 };
 
 [Error]

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -251,14 +251,40 @@ pub fn parse_and_render_pdf_with_warnings(
     })
 }
 
-/// Validate ChordPro input and return any parse errors as strings.
+/// A single validation issue reported by [`validate`].
+///
+/// Mirrors the NAPI binding's `ValidationError` (#1990) and the UDL
+/// dictionary of the same name in `chordsketch.udl`. Line and column are
+/// one-based; `u32` matches the `u32` declaration in the UDL, which is
+/// what every target language (Python / Kotlin / Swift / Ruby) sees.
+#[derive(Debug)]
+pub struct ValidationError {
+    /// One-based line number where the issue was detected.
+    pub line: u32,
+    /// One-based column number where the issue was detected.
+    pub column: u32,
+    /// Human-readable description of the issue.
+    pub message: String,
+}
+
+/// Validate ChordPro input and return any parse errors as structured
+/// records. Returns an empty list if the input is valid.
 #[must_use]
-pub fn validate(input: String) -> Vec<String> {
+pub fn validate(input: String) -> Vec<ValidationError> {
     let result = chordsketch_core::parse_multi_lenient(&input);
     result
         .results
         .into_iter()
-        .flat_map(|r| r.errors.into_iter().map(|e| e.to_string()))
+        .flat_map(|r| r.errors.into_iter())
+        .map(|e| ValidationError {
+            // `line()` / `column()` are `usize`; clamp overflow at
+            // `u32::MAX` so we never panic on conversion. A source long
+            // enough to exceed `u32::MAX` lines is orders of magnitude
+            // beyond any realistic song file.
+            line: u32::try_from(e.line()).unwrap_or(u32::MAX),
+            column: u32::try_from(e.column()).unwrap_or(u32::MAX),
+            message: e.message,
+        })
         .collect()
 }
 
@@ -353,10 +379,12 @@ mod tests {
             "unclosed chord should produce a parse error"
         );
         assert!(
-            errors[0].contains("unclosed"),
+            errors[0].message.contains("unclosed"),
             "error message should mention 'unclosed', got: {}",
-            errors[0]
+            errors[0].message
         );
+        assert!(errors[0].line >= 1, "line should be one-based");
+        assert!(errors[0].column >= 1, "column should be one-based");
     }
 
     #[test]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -528,25 +528,55 @@ pub fn version() -> String {
     chordsketch_core::version().to_string()
 }
 
-/// Validate ChordPro input and return any parse errors as strings.
+/// A single validation issue reported by [`validate`].
 ///
-/// Returns an empty array if the input is valid. This allows callers to
-/// obtain parse diagnostics without performing a full render.
-///
-/// Return shape: `Vec<String>` — flat pre-formatted error messages.
-/// The FFI binding (`crates/ffi`) returns the same flat form; the NAPI
-/// binding (`crates/napi`) returns structured `ValidationError` records
-/// (`{line, column, message}`) since #1990. Harmonising the WASM and FFI
-/// sides to the structured shape is tracked in #2009.
-#[must_use]
-#[wasm_bindgen]
-pub fn validate(input: &str) -> Vec<String> {
+/// Serialised to a plain JS `{line, column, message}` object via
+/// `serde_wasm_bindgen`. Matches the NAPI / FFI `ValidationError`
+/// declarations after #2009. Line and column are one-based (editor
+/// diagnostic convention).
+#[derive(Serialize)]
+struct ValidationErrorPayload {
+    line: u32,
+    column: u32,
+    message: String,
+}
+
+/// Shared inner helper used by both the wasm-bindgen wrapper and native
+/// unit tests. Keeping this free of any wasm-bindgen imports means
+/// `cargo test -p chordsketch-wasm` runs without hitting the "cannot
+/// call wasm-bindgen imported functions on non-wasm targets" panic that
+/// `serde_wasm_bindgen::to_value` triggers off-target.
+fn validate_inner(input: &str) -> Vec<ValidationErrorPayload> {
     let result = chordsketch_core::parse_multi_lenient(input);
     result
         .results
         .into_iter()
-        .flat_map(|r| r.errors.into_iter().map(|e| e.to_string()))
+        .flat_map(|r| r.errors.into_iter())
+        .map(|e| ValidationErrorPayload {
+            line: u32::try_from(e.line()).unwrap_or(u32::MAX),
+            column: u32::try_from(e.column()).unwrap_or(u32::MAX),
+            message: e.message,
+        })
         .collect()
+}
+
+/// Validate ChordPro input and return any parse errors as structured
+/// records.
+///
+/// Returns a JS array of `{line, column, message}` objects — empty if the
+/// input is valid. Matches the NAPI binding's `ValidationError[]` shape
+/// (#1990) and the FFI binding's `ValidationError` dictionary (#2009).
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string if serialisation fails. In practice,
+/// `serde_wasm_bindgen::to_value` only fails on programmer error, so
+/// this is a defensive return path — callers can treat it as infallible
+/// in normal use.
+#[wasm_bindgen(js_name = validate)]
+pub fn validate(input: &str) -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(&validate_inner(input))
+        .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 #[cfg(test)]
@@ -627,25 +657,37 @@ mod tests {
         assert!(result.is_ok(), "valid RRJSON should parse successfully");
     }
 
+    // Native tests exercise `validate_inner` directly rather than the
+    // wasm-bindgen wrapper, because `serde_wasm_bindgen::to_value` calls
+    // imported JS machinery that does not exist on non-wasm targets.
+    // The wasm-side serialisation and JS-observable shape are covered by
+    // the `wasm_tests` module below (run via `wasm-pack test --node`).
+
     #[test]
     fn test_validate_returns_empty_for_valid_input() {
-        let errors = validate(MINIMAL_INPUT);
+        let errors = validate_inner(MINIMAL_INPUT);
         assert!(errors.is_empty(), "valid input should produce no errors");
     }
 
     #[test]
     fn test_validate_returns_errors_for_bad_input() {
-        // An unclosed chord bracket is always a parse error, even in lenient mode.
-        let errors = validate("{title: Test}\n[G");
+        let errors = validate_inner("{title: Test}\n[G");
         assert!(
             !errors.is_empty(),
             "unclosed chord should produce a parse error"
         );
+        assert!(
+            errors[0].message.contains("unclosed"),
+            "error message should mention 'unclosed', got: {}",
+            errors[0].message
+        );
+        assert!(errors[0].line >= 1, "line should be one-based");
+        assert!(errors[0].column >= 1, "column should be one-based");
     }
 
     #[test]
     fn test_validate_returns_empty_for_empty_input() {
-        let errors = validate("");
+        let errors = validate_inner("");
         assert!(errors.is_empty(), "empty input should produce no errors");
     }
 
@@ -701,7 +743,7 @@ mod tests {
 mod wasm_tests {
     use super::*;
     use js_sys::{Array, Reflect};
-    use wasm_bindgen::JsValue;
+    use wasm_bindgen::{JsCast, JsValue};
     use wasm_bindgen_test::wasm_bindgen_test;
 
     const MINIMAL_INPUT: &str = "{title: Test}\n[C]Hello";
@@ -1040,6 +1082,50 @@ mod wasm_tests {
         Reflect::set(&opts, &"transpose".into(), &JsValue::from(2)).unwrap();
         let result = render_text_with_options(MINIMAL_INPUT, opts.into()).unwrap();
         assert!(result.contains("Test"));
+    }
+
+    // -- validate JS-boundary tests (#2009) ------------------------------
+    //
+    // `validate` now serialises to an array of `{line, column, message}`
+    // objects via `serde_wasm_bindgen`. These tests run in a real JS host
+    // so the returned `JsValue` can be introspected as an array.
+
+    #[wasm_bindgen_test]
+    fn validate_returns_empty_array_for_valid_input() {
+        let result = validate(MINIMAL_INPUT).unwrap();
+        let arr: Array = result.dyn_into().expect("validate should return an array");
+        assert_eq!(arr.length(), 0, "valid input should produce no errors");
+    }
+
+    #[wasm_bindgen_test]
+    fn validate_returns_structured_errors_for_bad_input() {
+        // Unclosed chord bracket produces at least one parse error.
+        let result = validate("{title: Test}\n[G").unwrap();
+        let arr: Array = result.dyn_into().expect("validate should return an array");
+        assert!(
+            arr.length() > 0,
+            "bad input should produce at least one error"
+        );
+
+        let first = arr.get(0);
+        // Each entry is a plain object with line/column/message.
+        let line = Reflect::get(&first, &"line".into()).unwrap();
+        let column = Reflect::get(&first, &"column".into()).unwrap();
+        let message = Reflect::get(&first, &"message".into()).unwrap();
+
+        assert!(
+            line.as_f64().unwrap_or_default() >= 1.0,
+            "line should be one-based"
+        );
+        assert!(
+            column.as_f64().unwrap_or_default() >= 1.0,
+            "column should be one-based"
+        );
+        let msg = message.as_string().unwrap_or_default();
+        assert!(
+            msg.contains("unclosed"),
+            "error message should mention 'unclosed', got: {msg}"
+        );
     }
 
     /// Smoke test that the `start` panic hook function exists and is

--- a/packages/kotlin/README.md
+++ b/packages/kotlin/README.md
@@ -87,8 +87,8 @@ All render functions accept three parameters:
 ### Validation
 
 ```kotlin
-val errors: List<String> = validate(source)  // empty if clean
-errors.forEach { println(it) }
+val errors: List<ValidationError> = validate(source)  // empty if clean
+errors.forEach { println("line ${it.line}, column ${it.column}: ${it.message}") }
 ```
 
 ### Utility

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -126,7 +126,10 @@ interface RenderOptions {
 
 | Function | Input | Output |
 |----------|-------|--------|
-| `validate(input)` | ChordPro string | `string[]` — parse errors (empty if valid) |
+| `validate(input)` | ChordPro string | `ValidationError[]` — parse errors (empty if valid) |
+
+Each `ValidationError` is `{line, column, message}` with one-based line
+and column numbers. Matches the NAPI (`@chordsketch/node`) binding.
 
 ### Utility
 

--- a/packages/playground/src/wasm.d.ts
+++ b/packages/playground/src/wasm.d.ts
@@ -14,7 +14,12 @@ declare module '@chordsketch/wasm' {
     input: string,
     options: { transpose?: number; config?: string },
   ): Uint8Array;
-  export function validate(input: string): string[];
+  export interface ValidationError {
+    line: number;
+    column: number;
+    message: string;
+  }
+  export function validate(input: string): ValidationError[];
   export function version(): string;
   export default function init(): Promise<void>;
 }

--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -75,8 +75,8 @@ All render methods accept three arguments:
 ### Validation
 
 ```ruby
-errors = Chordsketch.validate(source)  # Array<String> — empty if clean
-errors.each { |msg| puts msg }
+errors = Chordsketch.validate(source)  # Array<ValidationError> — empty if clean
+errors.each { |e| puts "line #{e.line}, column #{e.column}: #{e.message}" }
 ```
 
 ### Utility

--- a/packages/swift/README.md
+++ b/packages/swift/README.md
@@ -113,9 +113,9 @@ All render functions accept three parameters:
 ### Validation
 
 ```swift
-let errors: [String] = validate(input: source)  // empty if clean
-for msg in errors {
-    print(msg)
+let errors: [ValidationError] = validate(input: source)  // empty if clean
+for e in errors {
+    print("line \(e.line), column \(e.column): \(e.message)")
 }
 ```
 

--- a/scripts/smoke-test-python.py
+++ b/scripts/smoke-test-python.py
@@ -26,7 +26,21 @@ print("PDF render: OK")
 
 errors = chordsketch.validate("{title: Valid}\n[C]Hello")
 assert isinstance(errors, list)
-print("Validate: OK")
+assert len(errors) == 0
+print("Validate (valid): OK")
+
+# #2009: validate() now returns structured ValidationError records with
+# line/column/message fields. Exercise the bad-input path so the smoke
+# test catches a regression in the UniFFI wire shape, not just the
+# function existing.
+errors = chordsketch.validate("{title: Test}\n[G")
+assert isinstance(errors, list)
+assert len(errors) > 0
+first = errors[0]
+assert first.line >= 1
+assert first.column >= 1
+assert isinstance(first.message, str) and first.message
+print("Validate (broken, structured): OK")
 
 text = chordsketch.parse_and_render_text("{title: Test}\n[C]Hello", "guitar", None)
 assert "Test" in text


### PR DESCRIPTION
Closes #2009. Final cross-binding consistency fix after #1990 landed
structured ValidationError for NAPI.

## Summary

- **WASM**: `validate()` now returns a JS array of `{line, column,
  message}` objects via `serde_wasm_bindgen::to_value`. Native tests
  exercise a new `validate_inner()` helper so they don't hit the
  wasm-bindgen imports that can't run off-target.
- **FFI (UniFFI)**: UDL gains a `ValidationError` dictionary; Rust
  struct + return-type update. Downstream Python / Kotlin / Swift /
  Ruby bindings regenerate automatically with the new shape.
- Docs and smoke tests across all five packages updated to reflect
  the structured shape.

## Breaking change

Wire-level breaking change for WASM and all UniFFI-backed bindings.
No compatibility shim — see commit message for rationale.

## Test plan

- [x] `cargo test --workspace` — all native tests pass (12 in wasm,
  21 in FFI, plus the rest of the workspace)
- [x] `wasm-pack test --node crates/wasm` — 24/24 including 2 new
  validate tests that assert JS array shape, field types, and the
  "unclosed" message content
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p chordsketch-ffi -p chordsketch-wasm --all-targets -- -D warnings` clean
- [x] `packages/npm` rebuild via `node scripts/build.mjs` succeeds
  (outputs gitignored — CI regenerates)
- [ ] Language-binding CI (python.yml / kotlin.yml / swift.yml /
  ruby.yml / wasm.yml) validates the UniFFI-generated bindings pick
  up the new shape correctly; assertions in the existing smoke tests
  are shape-insensitive (only check `isEmpty`), so they should pass
  without further change, and `smoke-test-python.py` adds a new
  shape-aware case on the bad-input path.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`, the NAPI `ValidationError`
fix in #1990 should have propagated to WASM and FFI in the same PR.
This PR closes that gap. NAPI + WASM + FFI now all return the same
`{line, column, message}` shape; the three bindings' public APIs are
consistent again.

Closes #2009.
Part of #1846.