### PR TITLE
ci(readme-smoke): temporarily skip Chocolatey job (#2021)

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -408,11 +408,13 @@ jobs:
   chocolatey:
     name: Chocolatey (Windows)
     runs-on: windows-latest
-    # Chocolatey package is published automatically by post-release.yml
-    # on each release. On PR runs (before the first release with Chocolatey),
-    # this job will fail because the package does not yet exist on the
-    # Chocolatey Community Repository. That is expected and does not block
-    # the PR. Once the first release lands, this job will start passing.
+    # Temporarily skipped: the chordsketch Chocolatey package is stuck in
+    # community moderation (see #1852), so `choco install chordsketch` has
+    # been failing on every run for an extended period. Re-enable this job
+    # (remove `if: false` and drop `continue-on-error: true` per #1776) once
+    # the package is reliably installable from the Chocolatey Community
+    # Repository. Tracking: #2021.
+    if: false
     continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## What

Skip the `chocolatey` job in `.github/workflows/readme-smoke.yml` via `if: false`.

## Why

`choco install chordsketch` has been failing on every readme-smoke run for weeks (example: https://github.com/koedame/chordsketch/actions/runs/24674581497/job/72155559858). The root cause is upstream: the Chocolatey package is stuck in community moderation (#1852). Although `continue-on-error: true` already kept the job from blocking PRs, the persistent red marker added noise to every run and made real failures harder to spot in the check rollup.

Skip the job entirely until publication is restored. The README section, publishing step in `post-release.yml`, and the existing unskip-tracking issue (#1776) are all preserved untouched.

## Test results

- YAML change is comment + one new `if: false` line; no behavioral change outside CI
- Once merged, the Chocolatey job will appear as "skipped" instead of "failed" in readme-smoke runs
- `report-failure`'s `needs:` still references `chocolatey`; because skipped jobs do not trigger `failure()`, this is a no-op on the tracking-issue logic (Chocolatey-only failures already were not reported while `continue-on-error: true` was set)

## Review summary

Sister-site audit: this change is scoped to a single CI job. `post-release.yml → update-chocolatey` is deliberately left as-is so the publish step still retries on every release — flipping it off would mask progress in #1852.

Refs: #2021, #1776, #1852