### PR TITLE
test(vscode-extension): read PREVIEW_VIEW_TYPE from bundle (#2026)

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -20,11 +20,13 @@ import { startLspClient, stopLspClient } from './lsp.js';
 import { startLspClientSafely } from './lsp-activation.js';
 import { notifyDocumentChanged, disposeAll, registerPreviewSerializer } from './preview.js';
 // Re-exported so the integration-test harness can reach
-// `createPreviewSerializer` through the bundled `dist/extension.js` —
-// the serializer object returned to VS Code by
-// `registerWebviewPanelSerializer` is otherwise unreachable from tests.
-// See `test/integration/serializer.test.ts` for the round-trip test.
-export { createPreviewSerializer } from './preview.js';
+// `createPreviewSerializer` and the `PREVIEW_VIEW_TYPE` string literal
+// through the bundled `dist/extension.js` — the serializer object
+// returned to VS Code by `registerWebviewPanelSerializer` is otherwise
+// unreachable from tests, and the view-type string must be identical to
+// the one used by the running extension so the serializer actually
+// fires on the fabricated panel. See `test/integration/serializer.test.ts`.
+export { createPreviewSerializer, PREVIEW_VIEW_TYPE } from './preview.js';
 import { registerOpenPreview, registerOpenPreviewToSide, registerTransposeUp, registerTransposeDown, registerConvertTo, resetCommandSingletons } from './commands.js';
 
 /**

--- a/packages/vscode-extension/test/integration/serializer.test.ts
+++ b/packages/vscode-extension/test/integration/serializer.test.ts
@@ -42,7 +42,11 @@ import * as vscode from "vscode";
 import { activateExtension, fixture } from "./helpers.js";
 
 const EXTENSION_ID = "koedame.chordsketch";
-const PREVIEW_VIEW_TYPE = "chordsketchPreview";
+// Read from the compiled bundle in `suiteSetup` below rather than
+// hard-coding. That way a future rename of `PREVIEW_VIEW_TYPE` in
+// `preview.ts` cannot silently drift the test into creating panels
+// with the old identifier while the serializer binds to the new one.
+let PREVIEW_VIEW_TYPE: string;
 
 /**
  * Build a minimal `ExtensionContext` using the real extension's
@@ -96,6 +100,12 @@ suite("preview panel serializer", () => {
       "function",
       "dist/extension.js must export createPreviewSerializer — check extension.ts re-export and preview.ts factory",
     );
+    assert.equal(
+      typeof previewModule.PREVIEW_VIEW_TYPE,
+      "string",
+      "dist/extension.js must export PREVIEW_VIEW_TYPE — check extension.ts re-export",
+    );
+    PREVIEW_VIEW_TYPE = previewModule.PREVIEW_VIEW_TYPE;
     serializer = previewModule.createPreviewSerializer(fakeContext());
   });
 


### PR DESCRIPTION
Closes #2026. Re-export `PREVIEW_VIEW_TYPE` from `extension.ts`, read it from the compiled bundle in the serializer test so a future rename cannot drift silently. Local run: 10/10 pass on stable + 1.85.0 floor.