### PR TITLE
ci: add workflow_dispatch-only Chocolatey retry workflow

### DIFF
--- a/.github/workflows/chocolatey-retry.yml
+++ b/.github/workflows/chocolatey-retry.yml
@@ -1,0 +1,99 @@
+name: Chocolatey Retry Push
+
+# Re-runs only the Chocolatey pack-and-push step from post-release.yml.
+#
+# Use this when post-release.yml's `update-chocolatey` job fails (e.g.
+# 403 Forbidden because the previous version is still in Chocolatey
+# community moderation) while the other 7 jobs succeeded. Re-dispatching
+# the whole post-release.yml would duplicate non-idempotent side effects
+# in AUR, Flathub, Snap, CocoaPods, Homebrew, Scoop, and Swift.
+#
+# See #1852 (original v0.2.2 failure) and #2030 (this workflow).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to push to Chocolatey (e.g., v0.2.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  push-chocolatey:
+    name: Retry Chocolatey push
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Determine version
+        id: version
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="$INPUT_TAG"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+
+      - name: Download checksums
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh release download "$TAG" -p checksums.txt
+
+      - name: Generate package
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          SHA_WINDOWS=$(grep "x86_64-pc-windows-msvc" checksums.txt | awk '{print $1}')
+
+          if [[ ! "$SHA_WINDOWS" =~ ^[0-9a-fA-F]{64}$ ]]; then
+            echo "ERROR: missing or invalid SHA256 for x86_64-pc-windows-msvc: '${SHA_WINDOWS}'" >&2
+            exit 1
+          fi
+
+          mkdir -p choco-pkg/tools
+
+          sed \
+            -e "s/{{VERSION}}/${VERSION}/g" \
+            packaging/chocolatey/chordsketch.nuspec.template > choco-pkg/chordsketch.nuspec
+
+          sed \
+            -e "s/{{VERSION}}/${VERSION}/g" \
+            -e "s/{{SHA256_X86_64_PC_WINDOWS_MSVC}}/${SHA_WINDOWS}/g" \
+            packaging/chocolatey/tools/chocolateyInstall.ps1.template > choco-pkg/tools/chocolateyInstall.ps1
+
+          echo "=== chordsketch.nuspec ==="
+          cat choco-pkg/chordsketch.nuspec
+          echo "=== chocolateyInstall.ps1 ==="
+          cat choco-pkg/tools/chocolateyInstall.ps1
+
+      - name: Pack and push
+        shell: pwsh
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if (-not $env:CHOCOLATEY_API_KEY) {
+            Write-Host "CHOCOLATEY_API_KEY secret is not set; skipping Chocolatey push."
+            Write-Host "To enable automatic Chocolatey updates, add the API key"
+            Write-Host "as a repository secret named CHOCOLATEY_API_KEY."
+            exit 0
+          }
+
+          cd choco-pkg
+          choco pack chordsketch.nuspec
+          choco push "chordsketch.$env:VERSION.nupkg" `
+            --source https://push.chocolatey.org/ `
+            --api-key $env:CHOCOLATEY_API_KEY

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -919,6 +919,25 @@ No local Windows machine is needed.
    `.nupkg` from the template and pushing to the Chocolatey Community
    Repository on each release. No manual `choco push` is needed.
 
+#### Retrying a failed Chocolatey push
+
+If `update-chocolatey` fails while the other jobs in `post-release.yml`
+succeed — typical cause is a `403 Forbidden` because the previous
+version is still in community moderation (Chocolatey blocks newer-version
+pushes while the prior version is queued) — use the standalone
+`chocolatey-retry.yml` workflow:
+
+```bash
+gh workflow run chocolatey-retry.yml -R koedame/chordsketch -f tag=vX.Y.Z
+```
+
+This re-runs only the pack-and-push steps and does not re-trigger the
+other 7 post-release jobs (AUR, Flathub, Snap, CocoaPods, Homebrew,
+Scoop, Swift), avoiding duplicate side effects. Wait for the previous
+version's moderation badge on
+`community.chocolatey.org/packages/chordsketch` to read `Ready`
+(approved) before retrying.
+
 ### Snap Store
 
 Set up on 2026-04-15. Automated via `post-release.yml` `update-snap`.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/chocolatey-retry.yml` — a `workflow_dispatch`-only workflow that copies the `update-chocolatey` job's pack-and-push steps from `post-release.yml`.
- Adds a subsection to `docs/releasing.md` documenting when and how to invoke the retry workflow.

## Why

During the v0.2.2 release ([run 24599855735](https://github.com/koedame/chordsketch/actions/runs/24599855735)), `update-chocolatey` failed with `403 Forbidden` from `push.chocolatey.org` — most likely because v0.2.1 was still in community moderation at that moment (Chocolatey blocks newer-version pushes while the prior version is queued).

The other 7 jobs in `post-release.yml` (AUR, Flathub, Snap, CocoaPods, Homebrew, Scoop, Swift) all succeeded. Re-dispatching the full workflow would re-run those jobs, duplicating non-idempotent side effects (AUR git push, Flathub PR creation, Snap revision upload, `pod trunk push`, etc.).

v0.2.1 has since been approved (`Ready` on `community.chocolatey.org/packages/chordsketch`), so the v0.2.2 push should succeed now. Once this PR merges, dispatch with:

```bash
gh workflow run chocolatey-retry.yml -R koedame/chordsketch -f tag=v0.2.2
```

This is also a durable fix: any future release whose prior version is still in moderation at publish time will hit the same 403, and this workflow gives a clean retry path.

## Test plan

- [ ] `python3 -c 'import yaml; yaml.safe_load(...)'` passes (locally verified)
- [ ] Human merges the PR
- [ ] Dispatch `chocolatey-retry.yml` with `tag=v0.2.2` and observe `choco push` success
- [ ] `community.chocolatey.org/packages/chordsketch` shows v0.2.2 (initial status: `Submitted`, later `Ready` after moderation)

## Review summary

- Workflow is `workflow_dispatch` only; will not auto-run on release or PR.
- `permissions: contents: read` mirrors `post-release.yml`.
- `validate-release-tag` action is applied before any shell / `gh` interpolation of the tag input, consistent with #1797.
- Reuses the existing `CHOCOLATEY_API_KEY` secret and templates under `packaging/chocolatey/`.
- No README / smoke-test surface changes (no install method added/changed).

Closes #2030
Relates to #1852

🤖 Generated with [Claude Code](https://claude.com/claude-code)