### PR TITLE
ci(chocolatey): address review nits and reviewer Guidelines

### DIFF
--- a/.github/workflows/chocolatey-retry.yml
+++ b/.github/workflows/chocolatey-retry.yml
@@ -39,6 +39,8 @@ jobs:
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Validate release tag
+        # Format-validate the resolved tag before downstream `gh` /
+        # shell / checksum-download steps interpolate it. See #1797.
         uses: ./.github/actions/validate-release-tag
         with:
           tag: ${{ steps.version.outputs.tag }}

--- a/packaging/chocolatey/chordsketch.nuspec.template
+++ b/packaging/chocolatey/chordsketch.nuspec.template
@@ -8,10 +8,12 @@
     <authors>koedame</authors>
     <owners>koedame</owners>
     <projectUrl>https://github.com/koedame/chordsketch</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/koedame/chordsketch/main/assets/logo-128.png</iconUrl>
     <licenseUrl>https://github.com/koedame/chordsketch/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/koedame/chordsketch</projectSourceUrl>
+    <packageSourceUrl>https://github.com/koedame/chordsketch/tree/main/packaging/chocolatey</packageSourceUrl>
     <bugTrackerUrl>https://github.com/koedame/chordsketch/issues</bugTrackerUrl>
+    <releaseNotes>https://github.com/koedame/chordsketch/releases</releaseNotes>
     <tags>chordpro music chord parser lyrics renderer cli</tags>
     <summary>ChordPro file format parser and renderer</summary>
     <description>ChordSketch is a Rust implementation of the ChordPro file format. It parses .cho files and renders them to text, HTML, or PDF output. This package installs the chordsketch CLI.</description>


### PR DESCRIPTION
## Summary

Two small Chocolatey-channel quality fixes bundled (per maintainer request — single-PR scope is intentional, both touch the same packaging surface):

1. **`.github/workflows/chocolatey-retry.yml`** — add the inline rationale comment to the `Validate release tag` step, matching every sibling call site in `post-release.yml`. (#2032, Claude review nit on PR #2031)
2. **`packaging/chocolatey/chordsketch.nuspec.template`** — apply the Chocolatey reviewer's Guidelines comments from the 0.2.1 moderation review:
   - Add `<iconUrl>` → `https://raw.githubusercontent.com/koedame/chordsketch/main/assets/logo-128.png` (verified 200 OK)
   - Add `<packageSourceUrl>` → repo path to `packaging/chocolatey/`
   - Add `<releaseNotes>` → `https://github.com/koedame/chordsketch/releases` (URL form so per-version edits are not needed)
   - Drop `<projectSourceUrl>` — it duplicated `<projectUrl>`, and the reviewer's note was "remove the field if not pointing to a distinct source code location"
   - `projectUrl` left at the GitHub repo URL — the playground custom domain `chordsketch.koeda.me` does not currently DNS-resolve (still hosted at `koedame.github.io/chordsketch/`), so changing `projectUrl` to it would be a behaviour regression. (#2034)

Both are non-blocking quality improvements; they will appear on the next release nupkg (0.2.3+). 0.2.2 is already packed and waiting on 0.2.1 moderator approval (see #1852, no action needed).

## Why

- #2032 keeps the "why this step exists" comment consistent across every `validate-release-tag` call site, which is otherwise easy to drop when the template is copied (root cause of this nit).
- #2034 surfaces the package icon on the Chocolatey package page, makes the `packageSourceUrl` link discoverable so users can audit the packaging recipe, and gives reviewers a `releaseNotes` URL — all of which the reviewer flagged as Guidelines (non-blocking quality bar) on 0.2.1.

## Test plan

- [x] `python3 -c 'import xml.etree.ElementTree as ET; ET.parse(...)'` — XML well-formed
- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` — YAML well-formed
- [x] `iconUrl` HTTP HEAD → 200 OK
- [ ] CI green (fmt / clippy / test irrelevant; readme-sync only fires if README changes)
- [ ] Next release nupkg (0.2.3+) shows iconUrl, packageSourceUrl, releaseNotes on the Chocolatey package page

## Review summary

- No README / smoke-test surface changes.
- No code logic changes; documentation/metadata only.
- `projectUrl` deliberately not changed (see why above) — happy to do a follow-up PR once `chordsketch.koeda.me` DNS lands.

Closes #2032
Closes #2034
Relates to #1852

🤖 Generated with [Claude Code](https://claude.com/claude-code)