### PR TITLE
refactor(lexer): route CRLF \r advance through advance() helper

### DIFF
--- a/crates/core/src/lexer.rs
+++ b/crates/core/src/lexer.rs
@@ -147,9 +147,8 @@ impl Lexer {
         let is_crlf = self.chars.get(self.pos + 1).map(|&(_, c)| c) == Some('\n');
 
         if is_crlf {
-            // Advance past \r (does NOT bump line — we only bump on \n)
-            self.pos += 1;
-            self.column += 1;
+            // Advance past \r (advance() only bumps line on \n, so \r just bumps column)
+            self.advance(); // consumes '\r'
             // Advance past \n (bumps line)
             self.advance(); // consumes '\n'
             let end = Position::new(self.line, self.column);


### PR DESCRIPTION
## What

Replace the manual `self.pos += 1; self.column += 1` past `\r` inside
`lex_carriage_return` with a second `self.advance()` call, so both
characters of a CRLF sequence are consumed through the same helper.

## Why

`advance()` on `\r` only bumps `column` (line is bumped only on `\n`),
so this is semantically identical today — no behavioural change. The
change removes a parallel position-update path that would drift
silently if `advance()` is ever extended (e.g. to track UTF-16 offsets
for the LSP), as flagged in the #2081 audit.

## Test results

- `cargo test -p chordsketch-core` — 39 unit tests + doctests pass
- `cargo fmt --check` — clean
- `cargo clippy -p chordsketch-core -- -D warnings` — clean

## Review summary

Mechanical single-site refactor. No API change, no behaviour change.

Closes #2084