### PR TITLE
docs(transpose): rename test_transpose_flat_preserves_flat_spelling

### DIFF
--- a/crates/core/src/transpose.rs
+++ b/crates/core/src/transpose.rs
@@ -271,10 +271,11 @@ mod tests {
     }
 
     #[test]
-    fn test_transpose_flat_preserves_flat_spelling() {
+    fn test_transpose_bb_up_2_to_c() {
         let detail = parse_chord("Bb").unwrap();
         let t = transpose_detail(&detail, 2);
-        // Bb (10) + 2 = 0 = C
+        // Bb (10) + 2 = 0 = C (natural — no accidental; flat spelling is
+        // not preserved here because C has no flat form).
         assert_eq!(t.root, Note::C);
         assert_eq!(t.root_accidental, None);
     }


### PR DESCRIPTION
## What

Rename `test_transpose_flat_preserves_flat_spelling` to
`test_transpose_bb_up_2_to_c` in `crates/core/src/transpose.rs`, and
expand the inline comment so the new name and the assertion agree.

## Why

The old test name claims flat spelling is preserved, but the assertion
shows `Bb + 2 = C` with `root_accidental = None` — i.e. natural, not a
flat. A reader who skims only the name would mis-learn the semantics.
The rename states the arithmetic directly; the expanded comment
documents that C has no flat form so there is nothing to preserve.

The sibling `test_transpose_flat_to_flat` (Eb + 2 = F, also natural)
has the same naming defect but was not covered by #2085; leaving it
alone here to keep the PR focused on the issue's scope.

## Test results

- `cargo test -p chordsketch-core transpose` — 31 tests pass, including
  the renamed `test_transpose_bb_up_2_to_c`
- `cargo fmt --check` — clean

## Review summary

Pure rename + comment expansion. No production code changed, no
behavioural change. No other references to the old name exist in the
workspace (verified via grep).

Closes #2085