### PR TITLE
refactor(parser): make parse_hash_comment_line resilient to broken invariant

### DIFF
--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -516,11 +516,12 @@ impl Parser {
             self.advance();
         }
 
-        // The dispatch guard guarantees `raw` starts with `#` (no leading
-        // whitespace). Strip the `#` and one optional space.
-        let after_hash = raw
-            .strip_prefix('#')
-            .expect("dispatch guard guarantees raw starts with '#'");
+        // The dispatch guard in `parse_line` (`t.starts_with('#')`) guarantees
+        // `raw` starts with `#` today. Use `unwrap_or` rather than `expect` so
+        // that a future caller re-using this function without that guard
+        // degrades to treating the whole line as the comment body instead of
+        // panicking on otherwise valid input.
+        let after_hash = raw.strip_prefix('#').unwrap_or(raw.as_str());
         let text = after_hash.strip_prefix(' ').unwrap_or(after_hash);
 
         Ok(Line::Comment(CommentStyle::Normal, text.to_string()))
@@ -1796,6 +1797,25 @@ mod tests {
         assert!(
             matches!(result[..], [Line::Lyrics(_)]),
             "expected Lyrics, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_hash_comment_line_is_resilient_to_missing_hash_prefix() {
+        // Directly invoke parse_hash_comment_line with tokens whose first
+        // text does NOT start with '#', bypassing the dispatch guard in
+        // parse_line. The function must not panic — it falls back to
+        // treating the whole line as the comment body. Regression guard
+        // for #2082 (a future caller could re-use this method without the
+        // `t.starts_with('#')` gate).
+        let tokens = Lexer::new("no hash prefix\n").tokenize();
+        let mut parser = Parser::new(tokens);
+        let line = parser
+            .parse_hash_comment_line()
+            .expect("parse_hash_comment_line returned Err unexpectedly");
+        assert_eq!(
+            line,
+            Line::Comment(CommentStyle::Normal, "no hash prefix".to_string()),
         );
     }
 


### PR DESCRIPTION
## What

Replace `expect("dispatch guard guarantees raw starts with '#'")` in
`parse_hash_comment_line` with `unwrap_or(raw.as_str())`. Add a unit
test that calls the private method directly with non-`#` input to
prove the graceful fallback.

## Why

The `expect` is sound today because `parse_line` gates the call on
`t.starts_with('#')`. A future caller that re-uses `parse_hash_comment_line`
without that guard would panic on otherwise valid input. The invariant
stays documented in the expanded comment; only the failure mode
changes — panic → degrade to treating the whole line as the comment
body. Aligns with `.claude/rules/defensive-inputs.md` (validate at the
boundary, do not rely on callers).

## Test results

- `cargo test -p chordsketch-core` — all 39 doctests + full unit suite
  pass, including the new
  `parse_hash_comment_line_is_resilient_to_missing_hash_prefix` test
- `cargo fmt --check` — clean
- `cargo clippy -p chordsketch-core --tests -- -D warnings` — clean

## Review summary

Single-site defensive refactor + regression test. No behavioural change
on the happy path (dispatch guard still guarantees `#` prefix today);
only the panic path is replaced with a non-panic fallback.

Closes #2082