### PR TITLE
docs(render-html): clarify char-boundary invariant in strip_dangerous_attrs

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1244,8 +1244,15 @@ fn strip_dangerous_attrs(input: &str) -> String {
         } else {
             // Outside a tag — advance one UTF-8 character at a time to
             // preserve multi-byte characters (CJK, emoji, accented, etc.).
+            debug_assert!(
+                input.is_char_boundary(pos),
+                "pos must land on a char boundary; advancing by c.len_utf8() is the invariant"
+            );
             let ch = &input[pos..];
-            let c = ch.chars().next().expect("pos is within bounds");
+            let c = ch
+                .chars()
+                .next()
+                .expect("pos is on a char boundary and within bounds");
             result.push(c);
             pos += c.len_utf8();
         }


### PR DESCRIPTION
## What

Reword the `expect("pos is within bounds")` inside
`strip_dangerous_attrs` to `"pos is on a char boundary and within
bounds"`, and add a `debug_assert!(input.is_char_boundary(pos))`
immediately before the slice.

Note: the #2083 title refers to `sanitize_tag_attrs`, but the single
`expect` with this message actually lives in `strip_dangerous_attrs`
(`crates/render-html/src/lib.rs:1248`). The fix applies there; the
issue will be updated accordingly when merged.

## Why

The real failure mode on this slice is a char-boundary violation, not
an out-of-bounds index — the loop advances `pos` by `c.len_utf8()`, so
landing mid-codepoint is the only way this panics on multi-byte input.
A future bug that advances `pos` by a byte offset instead would
surface a misleading "pos is within bounds" message when the underlying
problem is a char-boundary slice. The `debug_assert!` catches that in
dev builds before the slice panics; the reworded `expect` describes the
invariant accurately in release builds.

## Test results

- `cargo test -p chordsketch-render-html` — 225 tests pass
- `cargo fmt --check` — clean
- `cargo clippy -p chordsketch-render-html -- -D warnings` — clean

## Review summary

Pure documentation / diagnostic improvement. No runtime behaviour change
on the happy path; only the panic message and a debug-only assertion
are added.

Closes #2083