### PR TITLE
ci: add concurrency groups with PR-scoped cancel-in-progress to 7 workflows

### DIFF
--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -87,7 +87,40 @@ gh run view <run-id> --json jobs -R koedame/chordsketch
 A PR that says "this makes CI faster" without concrete numbers is not
 reviewable.
 
-## 5. Workflow frequency is a first-class design input
+## 5. Concurrency groups are required on every macOS-bearing workflow
+
+Every workflow that includes a `runs-on: macos-*` job MUST declare a
+top-level `concurrency:` block keyed by the PR number (falling back to
+`github.ref` for non-PR events) and cancel PR runs in-progress.
+Recommended shape:
+
+```yaml
+concurrency:
+  group: <workflow-name>-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+The `cancel-in-progress` expression is gated on the `pull_request`
+event so that `main` pushes, tag pushes, `workflow_dispatch`, and
+`release` events always run to completion — only PR force-pushes /
+rebases cancel stale runs.
+
+**Why:** GitHub-hosted runners are capped at 5 concurrent macOS jobs
+on the Free / Pro / Team plans
+(https://docs.github.com/en/actions/reference/actions-limits). When a
+PR is rebased (or the `auto-update-branch` workflow merges `main`
+into it), the old run continues occupying macOS slots while the new
+run starts behind it in the 5-job queue. Without cancel-in-progress,
+N pushes to one PR produce N parallel macOS pipelines competing for
+the same ceiling.
+
+Covered workflows as of 2026-04-22: `ci.yml`, `swift.yml`,
+`python.yml`, `ruby.yml`, `kotlin.yml`, `napi.yml`, `ffi.yml`,
+`vscode-extension.yml`. When adding a new workflow that touches
+macOS, append its group name here in the same PR that introduces the
+workflow.
+
+## 6. Workflow frequency is a first-class design input
 
 Before adding a cache layer, a matrix split, or any optimization to a workflow,
 verify how often it actually runs:

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -19,6 +19,15 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ffi.yml"
 
+# Cancel stale PR runs when a new commit is pushed to the same PR so
+# that rebase / force-push does not leave two parallel FFI builds
+# competing for the macOS 5-job concurrency cap (via the Linux leg
+# chain). `main` pushes, tag pushes, and `workflow_dispatch` /
+# `release` events are not grouped with PRs and run to completion.
+concurrency:
+  group: ffi-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -28,6 +28,15 @@ on:
         required: false
         type: string
 
+# Cancel stale PR runs when a new commit is pushed to the same PR so
+# that rebase / force-push does not leave two parallel Kotlin builds
+# competing for the macOS 5-job concurrency cap. `main` pushes, tag
+# pushes, and `workflow_dispatch` / `release` events are not grouped
+# with PRs and run to completion.
+concurrency:
+  group: kotlin-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -27,6 +27,15 @@ on:
         required: true
         type: string
 
+# Cancel stale PR runs when a new commit is pushed to the same PR so
+# that rebase / force-push does not leave two parallel napi-rs builds
+# competing for the macOS 5-job concurrency cap. `main` pushes, tag
+# pushes, and `workflow_dispatch` / `release` events are not grouped
+# with PRs and run to completion.
+concurrency:
+  group: napi-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,6 +20,15 @@ on:
       - "Cargo.lock"
       - ".github/workflows/python.yml"
 
+# Cancel stale PR runs when a new commit is pushed to the same PR so
+# that rebase / force-push does not leave two parallel Python builds
+# competing for the macOS 5-job concurrency cap. `main` pushes, tag
+# pushes, and `workflow_dispatch` / `release` events are not grouped
+# with PRs and run to completion.
+concurrency:
+  group: python-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,6 +28,15 @@ on:
         required: false
         type: string
 
+# Cancel stale PR runs when a new commit is pushed to the same PR so
+# that rebase / force-push does not leave two parallel Ruby builds
+# competing for the macOS 5-job concurrency cap. `main` pushes, tag
+# pushes, and `workflow_dispatch` / `release` events are not grouped
+# with PRs and run to completion.
+concurrency:
+  group: ruby-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,6 +28,15 @@ on:
         required: false
         type: string
 
+# Cancel stale PR runs when a new commit is pushed to the same PR so
+# that rebase / force-push does not leave two parallel Swift builds
+# competing for the macOS 5-job concurrency cap. `main` pushes, tag
+# pushes, and `workflow_dispatch` / `release` events are not grouped
+# with PRs and run to completion.
+concurrency:
+  group: swift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -24,6 +24,15 @@ on:
         default: ""
         type: string
 
+# Cancel stale PR runs when a new commit is pushed to the same PR so
+# that rebase / force-push does not leave two parallel extension
+# builds competing for the macOS 5-job concurrency cap. `main` pushes,
+# tag pushes, and `workflow_dispatch` / `release` events are not
+# grouped with PRs and run to completion.
+concurrency:
+  group: vscode-extension-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## What

Add top-level \`concurrency:\` blocks to the seven workflows that currently lack one:
\`swift.yml\`, \`python.yml\`, \`ruby.yml\`, \`kotlin.yml\`, \`napi.yml\`, \`ffi.yml\`, \`vscode-extension.yml\`.

Pattern applied to each:

\`\`\`yaml
concurrency:
  group: <workflow-name>-\${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: \${{ github.event_name == 'pull_request' }}
\`\`\`

The PR-number-scoped group key means unrelated PRs are never lumped together. The event gate on \`cancel-in-progress\` ensures only PR pushes cancel stale runs — \`main\` pushes, tag pushes, \`workflow_dispatch\`, and \`release\` events always run to completion.

Also extends \`.claude/rules/ci-parallelization.md\` with a new §5 that makes this discipline mandatory for any workflow that touches macOS runners, so future additions do not regress.

## Why

GitHub-hosted runners cap concurrent macOS jobs at 5 on the Free / Pro / Team plans (https://docs.github.com/en/actions/reference/actions-limits). A 300-run sample of main-branch CI (collected 2026-04-22) showed:

| Workflow | compute envelope | p50 wall-clock |
|---|---|---|
| Swift Package | ~13 min (longest build leg 552 s + assemble 200 s) | 27.2 min |
| CI | ~5 min (longest test 274 s) | 17.6 min |
| Python Package | similar | 22.9 min |
| Ruby Gem | similar | 19.0 min |
| Kotlin Package | similar | 18.7 min |

The delta between compute and wall-clock is queue wait. When \`auto-update-branch\` rebases an open PR, the old run keeps consuming macOS slots while the new run queues behind it — \`cancel-in-progress\` on PR events eliminates that duplicate cost.

## Test results

- \`python3 -c \"import yaml; [yaml.safe_load(open(f)) for f in glob('.github/workflows/*.yml')]\"\` — all workflow YAML parses cleanly
- The pattern mirrors the existing \`ci.yml\` concurrency block that has been in place for months, adjusted only for the PR-event gate.
- No runtime behaviour change on a clean push (there is nothing to cancel); the effect appears only on force-push / auto-update-branch pushes to a PR.

## Review summary

Closes #2106

Related: \`#2107\` (enable GitHub Merge Queue) depends on this PR landing first so that speculative merge commits rely on cancel-in-progress for the 5-macOS-slot hand-off.