### PR TITLE
ci: add merge_group trigger to ci.yml for GitHub Merge Queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  # Fires when a PR enters the GitHub Merge Queue. The queue runs CI
+  # on a speculative merge commit before appending it to main. All
+  # checks listed in branch protection's required_status_checks must
+  # exist in this workflow (or another workflow that also handles
+  # merge_group) for the queue to consider a PR "green" and land it.
+  # The event has no effect until merge queue is enabled on `main` via
+  # repository / branch protection settings; until then this is a
+  # no-op trigger that never fires.
+  merge_group:
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## What

Add \`merge_group:\` to the \`on:\` list of \`.github/workflows/ci.yml\`.
This is the workflow trigger that fires when a PR enters GitHub Merge
Queue and the queue runs CI on a speculative merge commit.

All 8 required status checks on \`main\` branch protection
(\`Format\`, \`Clippy\`, \`Test (ubuntu-latest, stable|1.85.0)\`,
\`Test (macos-latest, stable|1.85.0)\`, \`Test (windows-latest, stable|1.85.0)\`)
are defined in \`ci.yml\`, so this single workflow covers every check
the queue needs to see green before landing a PR.

## Why

Phase 1 of #2107. The \`merge_group\` event is a no-op until merge
queue is enabled on \`main\` via repository / branch protection
settings; adding the trigger now is safe and unlocks the follow-on
work:

1. (This PR) \`merge_group\` trigger in \`ci.yml\` — no behavioural change.
2. (Repo admin step) Enable merge queue on \`main\` via Settings →
   Branches → edit rule → \"Require merge queue\". Cannot be done from
   a PR; requires admin access.
3. (Follow-up PR) Once the queue is confirmed working, retire
   \`.github/workflows/auto-update-branch.yml\` and refresh
   \`.claude/rules/pr-workflow.md\` and
   \`.claude/rules/one-pr-at-a-time.md\` to describe the queue-backed
   merge flow.

Splitting phase 2 out keeps the repo-settings change reversible and
auditable separately from the workflow change.

## Test results

\`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"\` — valid YAML.

No CI run impact on PRs today (the trigger only fires on
\`merge_group\` events, which are not emitted unless the queue is
enabled).

## Review summary

Part of #2107. Intentionally scoped to the no-op trigger addition to
keep blast radius minimal.