### PR TITLE
test(chordpro): CRLF span + transpose rename + hash-prefix debug_assert

### DIFF
--- a/crates/chordpro/src/lexer.rs
+++ b/crates/chordpro/src/lexer.rs
@@ -499,6 +499,24 @@ mod tests {
         assert_eq!(tokens[2].span.end, Position::new(2, 3));
     }
 
+    #[test]
+    fn spans_across_crlf_lines() {
+        let tokens = Lexer::new("AB\r\nCD").tokenize();
+
+        // "AB"
+        assert_eq!(tokens[0].span.start, Position::new(1, 1));
+        assert_eq!(tokens[0].span.end, Position::new(1, 3));
+
+        // \r\n — span mirrors the bare-LF case: the newline token starts at
+        // the CR column on line 1 and ends at column 1 of the next line.
+        assert_eq!(tokens[1].span.start, Position::new(1, 3));
+        assert_eq!(tokens[1].span.end, Position::new(2, 1));
+
+        // "CD"
+        assert_eq!(tokens[2].span.start, Position::new(2, 1));
+        assert_eq!(tokens[2].span.end, Position::new(2, 3));
+    }
+
     // ------------------------------------------------------------------
     // Edge cases
     // ------------------------------------------------------------------

--- a/crates/chordpro/src/parser.rs
+++ b/crates/chordpro/src/parser.rs
@@ -546,7 +546,13 @@ impl Parser {
         // `raw` starts with `#` today. Use `unwrap_or` rather than `expect` so
         // that a future caller re-using this function without that guard
         // degrades to treating the whole line as the comment body instead of
-        // panicking on otherwise valid input.
+        // panicking on otherwise valid input. The `debug_assert!` surfaces a
+        // contract violation loudly in debug builds while still allowing the
+        // release-build fallback above.
+        debug_assert!(
+            raw.starts_with('#'),
+            "parse_hash_comment_line called without '#' prefix"
+        );
         let after_hash = raw.strip_prefix('#').unwrap_or(raw.as_str());
         let text = after_hash.strip_prefix(' ').unwrap_or(after_hash);
 
@@ -1826,14 +1832,14 @@ mod tests {
         );
     }
 
+    // Release-only: in debug builds the `debug_assert!` added for #2096 fires
+    // on this contract violation. The release fallback (treating the whole
+    // line as the comment body) is still live, so this test locks it in on
+    // release profiles. Regression guard for #2082 (a future caller could
+    // re-use this method without the `t.starts_with('#')` gate).
+    #[cfg(not(debug_assertions))]
     #[test]
     fn parse_hash_comment_line_is_resilient_to_missing_hash_prefix() {
-        // Directly invoke parse_hash_comment_line with tokens whose first
-        // text does NOT start with '#', bypassing the dispatch guard in
-        // parse_line. The function must not panic — it falls back to
-        // treating the whole line as the comment body. Regression guard
-        // for #2082 (a future caller could re-use this method without the
-        // `t.starts_with('#')` gate).
         let tokens = Lexer::new("no hash prefix\n").tokenize();
         let mut parser = Parser::new(tokens);
         let line = parser
@@ -1843,6 +1849,17 @@ mod tests {
             line,
             Line::Comment(CommentStyle::Normal, "no hash prefix".to_string()),
         );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "parse_hash_comment_line called without '#' prefix")]
+    fn parse_hash_comment_line_debug_asserts_missing_hash_prefix() {
+        // Counterpart to the release-only resilience test above: debug builds
+        // must surface the contract violation loudly via `debug_assert!`.
+        let tokens = Lexer::new("no hash prefix\n").tokenize();
+        let mut parser = Parser::new(tokens);
+        let _ = parser.parse_hash_comment_line();
     }
 
     // -- Directive classification -------------------------------------------

--- a/crates/chordpro/src/transpose.rs
+++ b/crates/chordpro/src/transpose.rs
@@ -281,10 +281,11 @@ mod tests {
     }
 
     #[test]
-    fn test_transpose_flat_to_flat() {
+    fn test_transpose_eb_up_2_to_f() {
         let detail = parse_chord("Eb").unwrap();
         let t = transpose_detail(&detail, 2);
-        // Eb (3) + 2 = 5 = F
+        // Eb (3) + 2 = 5 = F natural. F has no flat form in standard chord
+        // notation, so the flat accidental is dropped.
         assert_eq!(t.root, Note::F);
         assert_eq!(t.root_accidental, None);
     }


### PR DESCRIPTION
## Summary

Bundles three small `crates/chordpro` follow-ups:

- **#2093** — add `spans_across_crlf_lines` lexer test, mirroring the existing
  bare-LF `spans_across_lines` span assertion.
- **#2095** — rename `test_transpose_flat_to_flat` → `test_transpose_eb_up_2_to_f`
  and clarify in the comment that F has no flat form, so the flat accidental
  is dropped.
- **#2096** — add `debug_assert!(raw.starts_with('#'))` before the `unwrap_or`
  fallback in `parse_hash_comment_line`, per the Silent Fallback section of
  `code-style.md`. This fails loudly on contract violations in debug builds
  while keeping the graceful release fallback intact.

### Note on the resilience test

`parse_hash_comment_line_is_resilient_to_missing_hash_prefix` (added in #2091)
directly invokes the method with non-`#` input and asserts no panic. The
`debug_assert!` added here intentionally fires on that exact contract
violation, so the test is split across the two build profiles:

- `parse_hash_comment_line_is_resilient_to_missing_hash_prefix` — gated on
  `cfg(not(debug_assertions))` so it still locks in the release fallback
  (#2082 regression guard).
- `parse_hash_comment_line_debug_asserts_missing_hash_prefix` — new
  `#[should_panic]` test that runs under `cfg(debug_assertions)` to assert
  the new contract check fires.

This split preserves both the debug contract check and the release fallback
coverage.

## Test plan

- [x] \`cargo test -p chordsketch-chordpro --lib\` — 1096 passed, 0 failed
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -p chordsketch-chordpro --all-targets -- -D warnings\`

Closes #2093
Closes #2095
Closes #2096