### PR TITLE
docs(rules): behaviour→behavior, PR-formatting heading, in-progress flip

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -14,7 +14,7 @@
 ## Test Quality
 
 - Every test must make at least one meaningful assertion that would fail if the
-  tested behaviour regressed. Empty tests or tests that only assert `true` are
+  tested behavior regressed. Empty tests or tests that only assert `true` are
   not acceptable.
 - Tests must cover both the happy path and the error / edge-case paths.
 - When adding a test for a bug fix, the test must fail without the fix applied.

--- a/.claude/rules/evidence-based-claims.md
+++ b/.claude/rules/evidence-based-claims.md
@@ -5,7 +5,7 @@ and unilateral judgments that are not grounded in verifiable data.
 "I think", "probably", "should be around X" are signals to stop and
 measure, not to ship the number as a fact.
 
-## Prohibited behaviours
+## Prohibited behaviors
 
 - **Fabricated durations** — "CI takes 15-20 minutes", "this should
   build in a minute", "the deploy usually takes a while". If the

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -39,13 +39,46 @@ bug should close all linked issues.
 ## Workflow Lifecycle
 
 1. Create Issue with labels.
-2. Create worktree + branch from latest `main`.
-3. Implement (commits reference issue: `Part of #N` or `Closes #N`).
-4. Open PR (title references issue, body has `Closes #N`).
-5. CI -> auto-review (severity classification) -> human merge.
+2. Move the issue to **In Progress** on the [chordsketch project board](https://github.com/orgs/koedame/projects/1)
+   at the moment work actually starts — i.e. the first commit or worktree
+   creation, not at planning time. Issues still sitting in Todo while a
+   PR exists against them are a signal that this step was skipped.
+3. Create worktree + branch from latest `main`.
+4. Implement (commits reference issue: `Part of #N` or `Closes #N`).
+5. Open PR (title references issue, body has `Closes #N`).
+6. CI -> auto-review (severity classification) -> human merge.
    See [Pull Request Workflow](pr-workflow.md) for details. Bots do not merge in
    this repo; a human inspects the check rollup and performs the squash merge.
-6. Cleanup worktree.
+7. After merge, the project-board automation moves the issue to Done via
+   the linked `Closes #N`; no manual status flip is needed.
+8. Cleanup worktree.
+
+### Updating Project Board Status
+
+The board's Status field has three options: **Todo**, **In Progress**, **Done**.
+Use `gh` to flip an issue to In Progress:
+
+```bash
+# 1. Resolve the issue's project-item ID.
+ITEM_ID=$(gh api graphql -f query='
+  { repository(owner: "koedame", name: "chordsketch") {
+      issue(number: '"$N"') { projectItems(first: 5) { nodes { id } } } } }
+  ' --jq '.data.repository.issue.projectItems.nodes[0].id')
+
+# 2. Set Status = In Progress.
+gh api graphql -f query='
+  mutation {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: "PVT_kwDOBCeHxM4BTI0L"
+      itemId: "'"$ITEM_ID"'"
+      fieldId: "PVTSSF_lADOBCeHxM4BTI0LzhAd1Rw"
+      value: { singleSelectOptionId: "47fc9ee4" }
+    }) { projectV2Item { id } } }'
+```
+
+The single-select option IDs are stable: `f75ad846` = Todo,
+`47fc9ee4` = In Progress, `98236657` = Done. Batch multiple issues by
+iterating over a list of numbers.
 
 ## Closing an Issue Without Implementing It
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -49,8 +49,11 @@ bug should close all linked issues.
 6. CI -> auto-review (severity classification) -> human merge.
    See [Pull Request Workflow](pr-workflow.md) for details. Bots do not merge in
    this repo; a human inspects the check rollup and performs the squash merge.
-7. After merge, the project-board automation moves the issue to Done via
-   the linked `Closes #N`; no manual status flip is needed.
+7. After merge, either the project-board's built-in
+   "Auto-add PR / Auto-close" workflow moves the issue to Done via the
+   linked `Closes #N`, or — if that workflow is not enabled — flip the
+   Status to Done manually with the same `gh` snippet below, using
+   option ID `98236657`.
 8. Cleanup worktree.
 
 ### Updating Project Board Status

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -65,7 +65,7 @@ Previously-reviewed code that was not flagged is considered accepted. If a revie
 later discovers a blocking issue in previously-accepted code, it should be filed as a
 separate issue — not raised in the delta review.
 
-### PR Formatting
+### PR Formatting and Commit Messages
 
 - PR titles should be concise and written in imperative mood (e.g., "Add chord
   transposition support").


### PR DESCRIPTION
## Summary

Pure docs-only updates to `.claude/rules/*`. Qualifies for the
`one-pr-at-a-time.md` docs-only parallel-eligibility carve-out.

- **#2102** — normalize \`behaviour(s)\` → \`behavior(s)\` in
  \`evidence-based-claims.md\` (heading) and \`code-style.md\` (pre-existing
  inconsistency in the Test Quality section).
- **#2103** — rename the \`### PR Formatting\` heading in \`pr-workflow.md\`
  to \`### PR Formatting and Commit Messages\` so the section's full scope
  (since #2101) is visible to anyone searching for commit-message
  guidance.
- **Workflow lifecycle** — add an explicit step to
  \`issue-workflow.md\` for flipping the project-board Status to
  **In Progress** the moment work actually starts (first commit /
  worktree creation), and include a reusable \`gh api graphql\` snippet
  that records the stable project ID (\`PVT_kwDOBCeHxM4BTI0L\`), Status
  field ID, and single-select option IDs so the flip can be scripted.

## Test plan

- [x] Only touches \`.claude/rules/*.md\`; no Rust or workflow changes.
- [x] \`grep -n behaviour .claude/rules/\` returns nothing after the change.
- [x] \`grep -n 'PR Formatting' .claude/rules/pr-workflow.md\` points at the
  updated heading.

Closes #2102
Closes #2103