### PR TITLE
ci: close ci-parallelization §5 gaps + fix runner-capacity comments

### DIFF
--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -155,8 +155,10 @@ Covered macOS-bearing workflows as of 2026-04-22:
 `ffi.yml` and `vscode-extension.yml` carry concurrency blocks too,
 but they are Linux-only — their groups guard against redundant
 `ubuntu-latest` builds on PR rebase / force-push, not the macOS
-5-job ceiling. Their concurrency is a §1 fan-in-discipline measure,
-not a §5 requirement.
+5-job ceiling. They are not required by §5; their presence is a
+defense-in-depth measure against stale-run pileups on Linux
+capacity and is orthogonal to the macOS-cap motivation documented
+here.
 
 When adding a new workflow that touches macOS, append its group name
 to the appropriate bucket above in the same PR that introduces the

--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -106,11 +106,11 @@ event so that `main` pushes, tag pushes, `workflow_dispatch`, and
 rebases cancel stale runs.
 
 Use this exact group-key pattern — `github.event.pull_request.number
-|| github.ref` — for all newly added workflows. Pattern-A keys such
-as `github.head_ref || github.run_id` cancel correctly too, but the
-`head_ref || run_id` form lives alongside the canonical shape in two
-older files for historical reasons and SHOULD be migrated when those
-files are touched for any other reason.
+|| github.ref` — for all newly added workflows. Every existing
+workflow in this repo uses this canonical shape; the older
+`github.head_ref || github.run_id` form is no longer present and
+MUST NOT be reintroduced when adding or modifying a `concurrency:`
+block.
 
 **Why:** GitHub-hosted runners are capped at 5 concurrent macOS jobs
 on the Free / Pro / Team plans
@@ -136,7 +136,7 @@ These workflows therefore use a minimal variant:
 
 ```yaml
 concurrency:
-  group: release-${{ github.ref }}              # or post-release-${{ ... }}
+  group: release-${{ inputs.tag || github.ref }}  # or post-release-${{ ... }}
   cancel-in-progress: false
 ```
 

--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -105,6 +105,13 @@ event so that `main` pushes, tag pushes, `workflow_dispatch`, and
 `release` events always run to completion — only PR force-pushes /
 rebases cancel stale runs.
 
+Use this exact group-key pattern — `github.event.pull_request.number
+|| github.ref` — for all newly added workflows. Pattern-A keys such
+as `github.head_ref || github.run_id` cancel correctly too, but the
+`head_ref || run_id` form lives alongside the canonical shape in two
+older files for historical reasons and SHOULD be migrated when those
+files are touched for any other reason.
+
 **Why:** GitHub-hosted runners are capped at 5 concurrent macOS jobs
 on the Free / Pro / Team plans
 (https://docs.github.com/en/actions/reference/actions-limits). When a
@@ -114,10 +121,45 @@ run starts behind it in the 5-job queue. Without cancel-in-progress,
 N pushes to one PR produce N parallel macOS pipelines competing for
 the same ceiling.
 
-Covered workflows as of 2026-04-22: `ci.yml`, `swift.yml`,
-`python.yml`, `ruby.yml`, `kotlin.yml`, `napi.yml`, `ffi.yml`,
-`vscode-extension.yml`. When adding a new workflow that touches
-macOS, append its group name here in the same PR that introduces the
+### Release/tag-triggered workflows
+
+`release.yml` and `post-release.yml` are macOS-bearing but NEVER
+participate in PR force-push cancellation (they are triggered by tag
+pushes or by `release.types=[published]`). The PR-scoped
+cancel-in-progress expression is therefore irrelevant; what matters
+is that a second tag push or a re-dispatched `workflow_dispatch`
+MUST NOT cancel a release that is already in flight — a partial
+release with only some platform archives would silently degrade
+every downstream install path.
+
+These workflows therefore use a minimal variant:
+
+```yaml
+concurrency:
+  group: release-${{ github.ref }}              # or post-release-${{ ... }}
+  cancel-in-progress: false
+```
+
+This keeps §5 applied to every macOS-bearing workflow while
+preserving the "always run to completion" guarantee for the release
+pipeline.
+
+Covered macOS-bearing workflows as of 2026-04-22:
+
+- **PR-scoped cancel-in-progress** (main §5 shape): `ci.yml`,
+  `swift.yml`, `python.yml`, `ruby.yml`, `kotlin.yml`, `napi.yml`,
+  `github-action-ci.yml`.
+- **`cancel-in-progress: false`** (release/tag-triggered variant):
+  `release.yml`, `post-release.yml`.
+
+`ffi.yml` and `vscode-extension.yml` carry concurrency blocks too,
+but they are Linux-only — their groups guard against redundant
+`ubuntu-latest` builds on PR rebase / force-push, not the macOS
+5-job ceiling. Their concurrency is a §1 fan-in-discipline measure,
+not a §5 requirement.
+
+When adding a new workflow that touches macOS, append its group name
+to the appropriate bucket above in the same PR that introduces the
 workflow.
 
 ## 6. Workflow frequency is a first-class design input

--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -17,8 +17,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: check-action-pins-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  group: check-action-pins-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check-action-pins:

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -21,8 +21,8 @@ on:
 
 # Cancel stale PR runs when a new commit is pushed to the same PR so
 # that rebase / force-push does not leave two parallel FFI builds
-# competing for the macOS 5-job concurrency cap (via the Linux leg
-# chain). `main` pushes, tag pushes, and `workflow_dispatch` /
+# contending for Linux runner capacity (every job here is
+# `ubuntu-latest`). `main` pushes, tag pushes, and `workflow_dispatch` /
 # `release` events are not grouped with PRs and run to completion.
 concurrency:
   group: ffi-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/github-action-ci.yml
+++ b/.github/workflows/github-action-ci.yml
@@ -16,7 +16,7 @@ on:
 
 # Cancel previous runs on the same PR when new commits land.
 concurrency:
-  group: github-action-ci-${{ github.head_ref || github.run_id }}
+  group: github-action-ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -10,6 +10,16 @@ on:
         required: true
         type: string
 
+# Post-release runs key off an already-published GitHub Release (or a
+# manual dispatch of a specific tag) and fan out to external package
+# registries. Cancelling one mid-flight would leave some ecosystems
+# updated and others not. Declare a concurrency group so the workflow
+# conforms to `.claude/rules/ci-parallelization.md` §5, but keep
+# `cancel-in-progress: false` so no partial rollouts are possible.
+concurrency:
+  group: post-release-${{ github.event.release.tag_name || inputs.tag || github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -28,9 +28,10 @@ on:
   pull_request:
 
 # Cancel previous runs on the same PR when new commits land. Daily cron
-# and release runs use a unique run_id and are never cancelled.
+# and release runs fall through to `github.ref` and are never cancelled
+# (cancel-in-progress is gated on `pull_request` events).
 concurrency:
-  group: readme-smoke-${{ github.head_ref || github.run_id }}
+  group: readme-smoke-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,17 @@ on:
         required: true
         type: string
 
+# Tag-triggered releases never receive force-pushes and MUST NOT be
+# cancelled mid-flight (the partial-release failure mode described on
+# the `build` job below would silently degrade downstream channels).
+# Declare a concurrency group so the workflow is still covered by
+# `.claude/rules/ci-parallelization.md` §5, but with
+# `cancel-in-progress: false` so tag pushes and workflow_dispatch runs
+# always run to completion.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 # `cancel-in-progress: false` so tag pushes and workflow_dispatch runs
 # always run to completion.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -26,9 +26,9 @@ on:
 
 # Cancel stale PR runs when a new commit is pushed to the same PR so
 # that rebase / force-push does not leave two parallel extension
-# builds competing for the macOS 5-job concurrency cap. `main` pushes,
-# tag pushes, and `workflow_dispatch` / `release` events are not
-# grouped with PRs and run to completion.
+# builds contending for Linux runner capacity (every job here is
+# `ubuntu-latest`). `main` pushes, tag pushes, and `workflow_dispatch`
+# / `release` events are not grouped with PRs and run to completion.
 concurrency:
   group: vscode-extension-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

Closes three review-time findings from #2108, plus a sister-site
completion:

- **#2109** — `release.yml` and `post-release.yml` are macOS-bearing
  (so covered by `ci-parallelization.md` §5 "MUST declare a
  concurrency block") but previously had none. Add one with
  `cancel-in-progress: false` — partial releases where one platform
  archive is cancelled mid-flight would silently degrade every
  downstream channel, so tag-triggered / release-dispatched runs
  MUST always run to completion. Document the `false` variant in §5
  as a new subsection. \`release.yml\` keys on \`inputs.tag ||
  github.ref\` so a \`workflow_dispatch\` of one tag does not share a
  group with an in-flight run of another.

- **#2110** — \`ffi.yml\` and \`vscode-extension.yml\` concurrency
  comments attributed the cancel-in-progress behaviour to the "macOS
  5-job concurrency cap". Both workflows are Linux-only. Rewrite both
  comments to reference Linux runner capacity instead. The
  concurrency groups themselves were correct and remain unchanged.

- **#2111** — three workflows (\`readme-smoke.yml\`,
  \`github-action-ci.yml\`, \`check-action-pins.yml\`) still used the
  pre-#2108 key pattern \`github.head_ref || github.run_id\`. Migrate
  them all to the canonical \`github.event.pull_request.number ||
  github.ref\` shape so every workflow in the repo uses the one
  documented in §5. Both patterns are semantically correct; the
  change eliminates the inconsistency.

- **Bonus cleanup** — the §5 covered-workflows list is split into two
  buckets (PR-scoped vs. release-variant), adds \`github-action-ci.yml\`
  (a macOS-bearing workflow previously missing from the list), and
  explicitly notes that \`ffi.yml\` / \`vscode-extension.yml\` are
  Linux-only defense-in-depth concurrency (outside §5's macOS-cap
  scope).

## Sister-site audit (per \`fix-propagation.md\`)

- Concurrency-block presence checked across every \`.github/workflows/*.yml\`
  that contains a \`macos-*\` runner: \`ci.yml\`, \`swift.yml\`, \`python.yml\`,
  \`ruby.yml\`, \`kotlin.yml\`, \`napi.yml\`, \`github-action-ci.yml\`,
  \`release.yml\`, \`post-release.yml\` — all nine now have one. This
  matches the 9-workflow list in \`one-pr-at-a-time.md\`.
- Comment text referencing macOS capacity cross-checked against the
  runner list of each Linux-only workflow — only \`ffi.yml\` and
  \`vscode-extension.yml\` carried the incorrect attribution; both
  corrected.
- Key-pattern migration verified by grepping for
  \`github.head_ref || github.run_id\` across \`.github/workflows/\`:
  **zero remaining matches** after the change (including
  \`check-action-pins.yml\`, which was added to the migration during
  review).

## Test plan

- [x] \`python3 -c 'import yaml; [yaml.safe_load(open(f)) for f in ...]'\`
  on every edited workflow — all parse cleanly.
- [x] No Rust/crate changes; local \`cargo fmt/clippy/test\` unaffected.
- [x] CI on this PR exercises the new concurrency groups on the
  workflows that run against PRs.

Closes #2109
Closes #2110
Closes #2111