### PR TITLE
docs(migration): fix Helix wording + word-boundary anchor attribution

### DIFF
--- a/docs/migration/v0.3.md
+++ b/docs/migration/v0.3.md
@@ -26,7 +26,8 @@ think about any step below, please
 | `me.koeda:chordsketch` (Maven Central) | No |
 | `chordsketch` (RubyGems) | No |
 | `chordsketch` (CLI / binary) | No |
-| VS Code / Zed / JetBrains / Helix extensions | No |
+| VS Code / Zed / JetBrains extensions | No |
+| Helix (manual grammar + LSP config) | No |
 
 If you do not depend on `chordsketch-core` from Rust, you do not need
 to do anything.
@@ -70,10 +71,12 @@ find . -name '*.rs' -print0 \
 
 The word-boundary anchors (`\b...\b`) reduce the chance of rewriting
 unrelated identifiers that happen to contain the substring; they do
-not eliminate it (hyphens are non-word characters, so the left-hand
-anchor does not stop a match inside a hypothetical
-`chordsketch-core-extra`). No such sibling crate exists today, but
-review the diff with `git diff` before committing in any case.
+not eliminate it. Hyphens are non-word characters, so the right-hand
+anchor (between `core` and a trailing `-`) still matches, meaning a
+hypothetical `chordsketch-core-extra` would also be rewritten. The
+left anchor *does* correctly prevent matches like
+`mychordsketch-core`. No such sibling crate exists today, but review
+the diff with `git diff` before committing in any case.
 
 After editing:
 
@@ -119,10 +122,16 @@ without modification.
 
 ## Editor extensions
 
-VS Code, Zed, JetBrains, and Helix extensions bundle the
+The VS Code, Zed, and JetBrains extensions bundle the
 `chordsketch-lsp` binary (or route through `chordsketch` directly).
 The LSP protocol surface is unchanged; extension users receive
 v0.3.0 as a transparent update through their editor's marketplace.
+
+Helix is supported via manually configured grammar + LSP settings
+(see `README.md` for the setup snippet) — there is no packaged
+extension. Helix users who have installed `chordsketch-lsp` from a
+release artifact or `cargo install` simply upgrade the binary; the
+LSP protocol surface is unchanged.
 
 ## Rolling back
 

--- a/docs/migration/v0.3.md
+++ b/docs/migration/v0.3.md
@@ -128,10 +128,11 @@ The LSP protocol surface is unchanged; extension users receive
 v0.3.0 as a transparent update through their editor's marketplace.
 
 Helix is supported via manually configured grammar + LSP settings
-(see `README.md` for the setup snippet) — there is no packaged
-extension. Helix users who have installed `chordsketch-lsp` from a
-release artifact or `cargo install` simply upgrade the binary; the
-LSP protocol surface is unchanged.
+(see [`docs/editors.md`](../editors.md) for the `languages.toml`
+snippet) — there is no packaged extension. Helix users who have
+installed `chordsketch-lsp` from a release artifact or
+`cargo install` simply upgrade the binary; the LSP protocol surface
+is unchanged.
 
 ## Rolling back
 


### PR DESCRIPTION
## Summary

Pure docs-only follow-ups to #2119. Touches only
\`docs/migration/v0.3.md\`.

- **#2120**: Helix does not ship a packaged extension — the
  README lists it under manual grammar + LSP configuration. The
  original migration guide grouped it with VS Code / Zed / JetBrains
  as a \"bundled\" extension. Split it into its own matrix row and
  add a dedicated paragraph that describes the manual
  \`chordsketch-lsp\` upgrade path.
- **#2121**: The word-boundary caveat named the wrong anchor as
  the cause of the \`chordsketch-core-extra\` false positive. The
  right-hand \`\\b\` is the one that fires between a word character
  (\`e\`) and a non-word character (\`-\`); the left-hand anchor
  correctly prevents the symmetric \`mychordsketch-core\` case.
  Rewrite the parenthetical to name the correct anchor and
  acknowledge the left anchor does its job.

## Test plan

- [x] Only touches \`docs/migration/v0.3.md\`; no Rust, workflow,
  CHANGELOG, or README changes.
- [x] \`grep -n Helix docs/migration/v0.3.md\` shows Helix only in
  the dedicated matrix row and the dedicated paragraph — no residual
  \"bundle\" phrasing.
- [x] \`grep -n 'left-hand\|right-hand' docs/migration/v0.3.md\`
  shows only the corrected attribution.

Closes #2120
Closes #2121