### PR TITLE
docs(contributing): describe Merge Queue as speculative-merge, not rebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,11 @@ npm run dev
 
 5. **Open a PR** with `Closes #N` in the description. PRs are squash-merged.
 6. **Click "Merge when ready"** (or run `gh pr merge --merge-queue`).
-   `main` is protected by GitHub Merge Queue: the queue rebases your
-   PR onto the current tip of `main`, runs CI once against that
-   speculative merge commit, and lands the PR if CI passes. You do
-   not need to manually update or rebase your branch before
+   `main` is protected by GitHub Merge Queue: the queue creates a
+   temporary speculative merge commit combining your PR branch with
+   the current tip of `main`, runs CI once against that commit, and
+   lands the PR if CI passes. Your branch history is not rewritten;
+   you do not need to manually update or rebase your branch before
    merging — the queue does it for you.
 
 CI runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`


### PR DESCRIPTION
## Summary

Pure docs-only fix to \`CONTRIBUTING.md\` step 6. Touches a single
file and four lines.

The original prose mixed two operations:

> the queue **rebases** your PR onto the current tip of \`main\`,
> runs CI once against that **speculative merge commit**

GitHub Merge Queue does not rebase the PR branch — it builds a
temporary speculative merge commit combining the PR branch with
\`main\`. The contributor's branch history is unchanged. The new
text describes that explicitly.

\`pr-workflow.md\` and \`one-pr-at-a-time.md\` (both updated in
#2123) already use \"speculative merge commit\" throughout, so this
PR brings \`CONTRIBUTING.md\` into alignment.

## Test plan

- [x] Diff scope: \`CONTRIBUTING.md\` only.
- [x] No Rust, workflow, CHANGELOG, or other docs changes.
- [x] The trailing sentence (\"you do not need to manually update or
  rebase your branch\") deliberately keeps \"rebase\" — from the
  contributor's perspective they specifically do not need to perform
  a rebase, so that wording is correct.

Closes #2125