### PR TITLE
feat(ui-web): add destroy() handle and unknown-format guard

### DIFF
--- a/packages/ui-web/README.md
+++ b/packages/ui-web/README.md
@@ -58,6 +58,22 @@ same shape.
 | `title` | `ChordSketch Playground` | Shown in the header bar. |
 | `documentTitle` | (unchanged) | When set, also overrides `document.title` on mount. |
 
+### Cleanup
+
+`mountChordSketchUi` returns a `Promise<ChordSketchUiHandle>`. The
+handle's `destroy()` method cancels the pending render-debounce
+timer and detaches the event listeners attached during mount:
+
+```ts
+const handle = await mountChordSketchUi(root, { renderers });
+// ...later, when the host is unmounting (Tauri WebView reset, tab
+// switch, Vite HMR, etc.):
+handle.destroy();
+```
+
+`destroy()` is idempotent. Hosts that mount once and never unmount
+(today's browser playground) may safely ignore the return value.
+
 ## Visual contract
 
 The DOM structure built by `mountChordSketchUi` is **structurally

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -47,6 +47,19 @@ export interface MountOptions {
   documentTitle?: string;
 }
 
+/**
+ * Handle returned by {@link mountChordSketchUi}. Hosts that need to tear
+ * the UI down (e.g. a Tauri WebView reset, a tab switch in a desktop
+ * shell, a Vite HMR replacement) call `destroy()` to cancel the pending
+ * debounce timer and remove the event listeners attached during mount.
+ *
+ * Hosts that mount once and never unmount (the browser playground today)
+ * may safely ignore the return value.
+ */
+export interface ChordSketchUiHandle {
+  destroy(): void;
+}
+
 const RENDER_DEBOUNCE_MS = 300;
 
 const HTML_FRAME_TEMPLATE = (body: string): string => `<!DOCTYPE html>
@@ -201,17 +214,19 @@ function formatError(e: unknown): string {
 }
 
 /**
- * Mount the ChordSketch playground UI into `root`. Returns a Promise that
- * resolves once the renderer backend is initialised and the first render
- * has been run. Rejects if `renderers.init()` rejects (the host is
- * responsible for surfacing that to the user, e.g. via console).
+ * Mount the ChordSketch playground UI into `root`. Returns a handle whose
+ * `destroy()` method cancels any pending render debounce and detaches the
+ * event listeners added during mount; resolves once the renderer backend
+ * is initialised and the first render has been run. Rejects if
+ * `renderers.init()` rejects (the host is responsible for surfacing that
+ * to the user, e.g. via console).
  *
  * Calling `mountChordSketchUi` replaces the contents of `root`.
  */
 export async function mountChordSketchUi(
   root: HTMLElement,
   options: MountOptions,
-): Promise<void> {
+): Promise<ChordSketchUiHandle> {
   const {
     renderers,
     initialChordPro = SAMPLE_CHORDPRO,
@@ -291,6 +306,13 @@ export async function mountChordSketchUi(
       } else if (format === 'pdf') {
         showPane('pdf');
         hideError();
+      } else {
+        // Forward-safety guard: `formatSelect.value` is typed as `string`
+        // by the DOM, so adding a new <option> in `buildDom` without a
+        // matching arm here would silently no-op (blank pane, no error).
+        // Surfacing the unknown value as an error makes that mismatch
+        // visible at development time. Filed via #2130.
+        showError(`Unknown format selected: ${format}`);
       }
     } catch (e) {
       showError(formatError(e));
@@ -344,4 +366,20 @@ export async function mountChordSketchUi(
   downloadPdfBtn.addEventListener('click', downloadPdf);
 
   render();
+
+  let destroyed = false;
+  return {
+    destroy(): void {
+      if (destroyed) return;
+      destroyed = true;
+      if (debounceTimer !== null) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      editor.removeEventListener('input', scheduleRender);
+      formatSelect.removeEventListener('change', render);
+      transposeInput.removeEventListener('input', scheduleRender);
+      downloadPdfBtn.removeEventListener('click', downloadPdf);
+    },
+  };
 }


### PR DESCRIPTION
## Summary

Two follow-ups filed during review of #2128. Touches only
\`packages/ui-web/\` (\`src/index.ts\` + \`README.md\`) and is therefore
qualifies for the docs-only-style scope of \`one-pr-at-a-time.md\`'s
parallel carve-out (no Rust, no \`.github/\`, no \`Cargo.*\`).

- **#2129** — \`mountChordSketchUi\` now returns
  \`Promise<ChordSketchUiHandle>\`. The handle's idempotent
  \`destroy()\` cancels the pending render-debounce timer and
  detaches every event listener attached during mount. The browser
  playground ignores the return value (it never unmounts today); the
  upcoming Tauri desktop host (#2069) needs the cleanup path for
  WebView resets, tab switches, and Vite HMR replacement. Added a
  \"Cleanup\" subsection to the README documenting the pattern.
- **#2130** — \`render()\` now has an explicit \`else\` arm that
  calls \`showError\` with the offending value.
  \`formatSelect.value\` is typed as \`string\` by the DOM, so a
  future \`buildDom\` change that adds an \`<option>\` without a
  matching arm in \`render()\` would otherwise silently no-op (blank
  pane, no error). The guard surfaces the mismatch at development
  time; a short comment names the original defect class so a
  future reader does not mistake the arm for dead code.

## Backwards compatibility

\`mountChordSketchUi\`'s return-type change (\`Promise<void>\` →
\`Promise<ChordSketchUiHandle>\`) is forward-compatible — every
existing call site \`await\`s the function for its side effects, so
the new return value is harmlessly discarded. Both
\`packages/playground/src/main.ts\` (production) and the README
example continue to compile and behave identically.

## Test plan

- [x] \`npx tsc --noEmit\` in \`packages/playground/\` passes against
  the updated sources.
- [x] Diff scope: only \`packages/ui-web/{src/index.ts, README.md}\`.
  No \`Cargo.*\`, no \`.github/\`, no Rust.
- [x] Existing playground behaviour preserved end-to-end: the new
  return value is discarded by \`packages/playground/src/main.ts\`'s
  \`void mountChordSketchUi(...)\` call site, and the \`else\` arm
  cannot fire today because \`buildDom\` only emits the three
  matching \`<option>\` values.

Closes #2129
Closes #2130