### PR TITLE
docs(sdk): unified per-binding usage guide (render + transpose tasks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ reference and additional examples.
 ## Links
 
 - [ChordPro file format specification](https://www.chordpro.org/chordpro/)
+- [Unified SDK guide (all bindings, task-oriented)](docs/sdk/README.md)
 - [Editor integration guide](docs/editors.md)
 - [Configuration guide](docs/configuration.md)
 - [Versioning and release process](docs/releasing.md)

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,0 +1,93 @@
+# ChordSketch SDK Guide
+
+A unified entry point for using ChordSketch from any language or
+runtime. Pick a starting point that fits how you are integrating:
+
+## I want to do a specific thing
+
+- [Render to HTML, plain text, or PDF](tasks/render.md)
+- [Transpose chords by N semitones](tasks/transpose.md)
+
+Each task page shows the same operation across every binding, so
+you can copy the snippet that matches your stack.
+
+## I know my language already
+
+| Language / runtime | Package | Per-package README (full reference) |
+|---|---|---|
+| Rust | [`chordsketch-chordpro`](https://crates.io/crates/chordsketch-chordpro) (parser/AST) + [`-render-text`](https://crates.io/crates/chordsketch-render-text) / [`-render-html`](https://crates.io/crates/chordsketch-render-html) / [`-render-pdf`](https://crates.io/crates/chordsketch-render-pdf) | [docs.rs/chordsketch-chordpro](https://docs.rs/chordsketch-chordpro) |
+| Browser / Deno / Node ESM | [`@chordsketch/wasm`](https://www.npmjs.com/package/@chordsketch/wasm) | [`packages/npm/README.md`](../../packages/npm/README.md) |
+| Node.js native addon | [`@chordsketch/node`](https://www.npmjs.com/package/@chordsketch/node) | [`crates/napi/README.md`](../../crates/napi/README.md) |
+| Python | [`chordsketch`](https://pypi.org/project/chordsketch/) (UniFFI) | [`crates/ffi/README.md`](../../crates/ffi/README.md) |
+| Swift | [`ChordSketch`](https://swiftpackageindex.com/koedame/chordsketch) (Swift Package + XCFramework) | [`packages/swift/README.md`](../../packages/swift/README.md) |
+| Kotlin / JVM | [`me.koeda:chordsketch`](https://central.sonatype.com/artifact/me.koeda/chordsketch) | [`packages/kotlin/README.md`](../../packages/kotlin/README.md) |
+| Ruby | [`chordsketch`](https://rubygems.org/gems/chordsketch) | [`packages/ruby/README.md`](../../packages/ruby/README.md) |
+| CLI / shell scripts | `chordsketch` binary | [main `README.md` Installation section](../../README.md#installation) + `chordsketch --help` |
+
+The per-package READMEs are L2-quality
+(per [`.claude/rules/package-documentation.md`](../../.claude/rules/package-documentation.md))
+— install command, full API table, options. They are kept current
+with each release, so this guide intentionally does not duplicate
+them for binding-specific details. Cross-link to the relevant task
+page above when you need the same operation across multiple
+bindings (e.g. matching desktop and web renderings).
+
+## I want UI components
+
+The React / Vue / Svelte component packages are tracked under
+[#2039](https://github.com/koedame/chordsketch/issues/2039) and not
+yet released. When they ship they will get their own task pages
+here. For now this guide focuses on the parsing / transposition /
+rendering layer that all UI work builds on.
+
+## How the SDK fits together
+
+ChordSketch is a Rust workspace at the bottom — `chordsketch-chordpro`
+parses ChordPro source into an AST, then the three renderer crates
+(`chordsketch-render-{text,html,pdf}`) walk the AST to produce
+output. Every other binding is a thin wrapper that exposes the
+**same** Rust API surface in idiomatic form for its host language:
+
+```
+                ┌──────────────────────────────────────────┐
+                │  chordsketch-chordpro (parser + AST)     │
+                │  chordsketch-render-{text,html,pdf}      │
+                └──────────────────────────────────────────┘
+                                    ▲
+        ┌──────────────┬────────────┼────────────┬──────────────┐
+        │              │            │            │              │
+   chordsketch     chordsketch-  chordsketch-  chordsketch-   chordsketch
+   (CLI binary)    wasm          napi          ffi (UniFFI)   (Ruby gem
+                   (browser /    (Node.js      → Python /      via UniFFI)
+                   ESM)          native)       Swift /
+                                               Kotlin)
+```
+
+Because every binding wraps the same parser and renderers, the
+output of `parseAndRenderHtml(input)` (or its language-specific
+equivalent) is byte-identical across hosts for any given input.
+PRs that introduce per-binding output drift are caught by the
+fix-propagation rule (`.claude/rules/fix-propagation.md`).
+
+## Status
+
+This guide is being written incrementally. Two task pages are
+landed (render, transpose); they cover every existing binding
+(Rust, WASM, NAPI, CLI, Python, Swift, Kotlin, Ruby). Future
+additions will track new bindings and new operations as they are
+exposed:
+
+- **AST-direct parse + traversal**: only the Rust crate currently
+  exposes the AST as a host object graph; the WASM / NAPI / UniFFI
+  bindings expose the parser only via the `parse_and_render_*`
+  one-shot. When AST-projection lands in those bindings, a
+  `tasks/parse.md` page will be added.
+- **Serialise back to ChordPro**: not currently exposed by any
+  binding. Tracked as part of the v0.3.0 multi-format track
+  (#2050).
+- **Static-site rendering**: an mdBook or Docusaurus build of this
+  guide is deliberately deferred to a follow-up — picking the
+  right static-site tool is its own decision and the Markdown
+  renders cleanly on GitHub today.
+
+If you find a gap, please [file an issue](https://github.com/koedame/chordsketch/issues/new).

--- a/docs/sdk/tasks/render.md
+++ b/docs/sdk/tasks/render.md
@@ -1,0 +1,172 @@
+# Render to HTML, plain text, or PDF
+
+Rendering is the universal SDK operation. Every binding accepts a
+ChordPro string and returns rendered output in one of three formats:
+plain text (chords above lyrics), self-contained HTML5, or A4 PDF.
+
+The output is **byte-identical across every binding** for a given
+input — language choice does not change rendering semantics. PRs
+that introduce per-binding output drift are caught by the
+fix-propagation rule (`.claude/rules/fix-propagation.md`).
+
+## Input
+
+```chordpro
+{title: Amazing Grace}
+{key: G}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound
+```
+
+## Rust
+
+The renderer crates take a `&[Song]` (parsed by
+`chordsketch-chordpro`) plus an optional transpose offset and a
+`Config`. Use the convenience helpers to skip the hand-wired
+config / transpose:
+
+```rust
+use chordsketch_chordpro::parse;
+use chordsketch_render_html::render_song;
+use chordsketch_render_text::render_song as render_text;
+use chordsketch_render_pdf::render_song as render_pdf;
+
+let song = parse(input)?;
+let html: String     = render_song(&song);
+let text: String     = render_text(&song);
+let pdf:  Vec<u8>    = render_pdf(&song);
+```
+
+For multi-song input (`{new_song}` separator) parse with
+`chordsketch_chordpro::parse_multi(input)` and pass the resulting
+`Vec<Song>` to the `render_songs` family.
+
+API reference: [docs.rs/chordsketch-render-html](https://docs.rs/chordsketch-render-html),
+[`-text`](https://docs.rs/chordsketch-render-text),
+[`-pdf`](https://docs.rs/chordsketch-render-pdf).
+
+## `@chordsketch/wasm` (browser / Node ESM)
+
+```ts
+import init, {
+  render_html,
+  render_text,
+  render_pdf,
+} from '@chordsketch/wasm';
+
+await init(); // browser only — Node auto-loads via wasm-pack --target nodejs
+
+const html: string      = render_html(input);
+const text: string      = render_text(input);
+const pdf:  Uint8Array  = render_pdf(input);
+```
+
+The browser build requires `await init()` once before the first
+call; the Node.js build auto-loads synchronously via `require`.
+See [`packages/npm/README.md`](../../../packages/npm/README.md) for
+the runtime-detection details and the dual-package layout.
+
+## `@chordsketch/node` (Node.js native addon)
+
+```ts
+import { render_html, render_text, render_pdf } from '@chordsketch/node';
+
+const html: string  = render_html(input);
+const text: string  = render_text(input);
+const pdf:  Buffer  = render_pdf(input);
+```
+
+`render_pdf` returns a Node.js `Buffer` (vs. `Uint8Array` for the
+WASM build). No `init()` step — the native addon is loaded
+synchronously by `require`. Prebuilt binaries are shipped for the
+five supported platforms (linux-x64-gnu, linux-arm64-gnu,
+darwin-x64, darwin-arm64, win32-x64-msvc); no Rust toolchain
+required to install.
+
+## CLI
+
+The default subcommand reads ChordPro and renders to stdout (or
+`--output FILE`):
+
+```bash
+# HTML to stdout (default)
+chordsketch song.cho
+
+# Plain text
+chordsketch song.cho --format text
+
+# PDF
+chordsketch song.cho --format pdf --output song.pdf
+```
+
+`-` reads from stdin. `--help` lists every option.
+
+## Python
+
+```python
+import chordsketch
+
+html = chordsketch.parse_and_render_html(input, None, None)  # config_json, transpose
+text = chordsketch.parse_and_render_text(input, None, None)
+pdf  = chordsketch.parse_and_render_pdf(input, None, None)   # bytes
+```
+
+The UniFFI-backed bindings (Python / Swift / Kotlin / Ruby) do
+parsing and rendering as a **single** `parse_and_render_*` call —
+the AST is not exposed as a host-language object graph.
+
+## Swift
+
+```swift
+import ChordSketch
+
+let html = try ChordSketch.parseAndRenderHtml(input: input, configJson: nil, transpose: nil)
+let text = try ChordSketch.parseAndRenderText(input: input, configJson: nil, transpose: nil)
+let pdf  = try ChordSketch.parseAndRenderPdf(input: input, configJson: nil, transpose: nil)
+```
+
+UniFFI converts the snake_case Rust function names to camelCase
+Swift names automatically. PDF output is `Data`.
+
+## Kotlin
+
+```kotlin
+import me.koeda.chordsketch.parseAndRenderHtml
+import me.koeda.chordsketch.parseAndRenderText
+import me.koeda.chordsketch.parseAndRenderPdf
+
+val html: String     = parseAndRenderHtml(input, null, null)
+val text: String     = parseAndRenderText(input, null, null)
+val pdf:  ByteArray  = parseAndRenderPdf(input, null, null)
+```
+
+## Ruby
+
+```ruby
+require 'chordsketch'
+
+html = Chordsketch.parse_and_render_html(input, nil, nil)
+text = Chordsketch.parse_and_render_text(input, nil, nil)
+pdf  = Chordsketch.parse_and_render_pdf(input, nil, nil)  # binary string
+```
+
+## Errors
+
+| Binding | Error type | Carries position info? |
+|---|---|---|
+| Rust | `ParseError` (parse) / renderer infallible after parse | yes (`Span` line+column) |
+| WASM / npm | `JsError` thrown | yes (`.line`, `.column` on parse errors) |
+| NAPI / Node native | `Error` thrown | yes |
+| CLI | non-zero exit + stderr | exit 65 (`EX_DATAERR`) on parse error |
+| Python | `ChordSketchError` exception | yes |
+| Swift | `ChordSketchError` enum (`.invalidConfig`, `.noSongsFound`, …) | yes |
+| Kotlin | `ChordSketchException` | yes |
+| Ruby | `Chordsketch::Error` | yes |
+
+To validate input without rendering, use the `validate(input)`
+function exposed by the WASM, NAPI, and UniFFI bindings (returns
+an array of `{line, column, message}` records).
+
+## Next step
+
+[Transpose chords by N semitones](transpose.md) — same input,
+shifted by a configurable number of semitones.

--- a/docs/sdk/tasks/render.md
+++ b/docs/sdk/tasks/render.md
@@ -68,14 +68,16 @@ the runtime-detection details and the dual-package layout.
 ## `@chordsketch/node` (Node.js native addon)
 
 ```ts
-import { render_html, render_text, render_pdf } from '@chordsketch/node';
+import { renderHtml, renderText, renderPdf } from '@chordsketch/node';
 
-const html: string  = render_html(input);
-const text: string  = render_text(input);
-const pdf:  Buffer  = render_pdf(input);
+const html: string  = renderHtml(input);
+const text: string  = renderText(input);
+const pdf:  Buffer  = renderPdf(input);
 ```
 
-`render_pdf` returns a Node.js `Buffer` (vs. `Uint8Array` for the
+NAPI exposes the functions as **camelCase** (napi-rs converts the
+Rust snake_case automatically); the WASM package keeps snake_case.
+`renderPdf` returns a Node.js `Buffer` (vs. `Uint8Array` for the
 WASM build). No `init()` step — the native addon is loaded
 synchronously by `require`. Prebuilt binaries are shipped for the
 five supported platforms (linux-x64-gnu, linux-arm64-gnu,
@@ -88,11 +90,11 @@ The default subcommand reads ChordPro and renders to stdout (or
 `--output FILE`):
 
 ```bash
-# HTML to stdout (default)
+# Plain text — chords above lyrics — is the default format
 chordsketch song.cho
 
-# Plain text
-chordsketch song.cho --format text
+# HTML
+chordsketch song.cho --format html
 
 # PDF
 chordsketch song.cho --format pdf --output song.pdf
@@ -119,25 +121,29 @@ the AST is not exposed as a host-language object graph.
 ```swift
 import ChordSketch
 
-let html = try ChordSketch.parseAndRenderHtml(input: input, configJson: nil, transpose: nil)
-let text = try ChordSketch.parseAndRenderText(input: input, configJson: nil, transpose: nil)
-let pdf  = try ChordSketch.parseAndRenderPdf(input: input, configJson: nil, transpose: nil)
+let html = try parseAndRenderHtml(input: input, configJson: nil, transpose: nil)
+let text = try parseAndRenderText(input: input, configJson: nil, transpose: nil)
+let pdf  = try parseAndRenderPdf(input: input, configJson: nil, transpose: nil)  // [UInt8]
 ```
 
 UniFFI converts the snake_case Rust function names to camelCase
-Swift names automatically. PDF output is `Data`.
+Swift names automatically. PDF output is `[UInt8]` (the
+`bytes` UDL type → Swift's byte sequence, per the Swift package
+README).
 
 ## Kotlin
 
 ```kotlin
-import me.koeda.chordsketch.parseAndRenderHtml
-import me.koeda.chordsketch.parseAndRenderText
-import me.koeda.chordsketch.parseAndRenderPdf
+import uniffi.chordsketch.*
 
 val html: String     = parseAndRenderHtml(input, null, null)
 val text: String     = parseAndRenderText(input, null, null)
 val pdf:  ByteArray  = parseAndRenderPdf(input, null, null)
 ```
+
+The Maven coordinate is `me.koeda:chordsketch` but the package
+namespace UniFFI generates is `uniffi.chordsketch` — that's the
+import path in source.
 
 ## Ruby
 
@@ -151,16 +157,16 @@ pdf  = Chordsketch.parse_and_render_pdf(input, nil, nil)  # binary string
 
 ## Errors
 
-| Binding | Error type | Carries position info? |
+| Binding | Error type | Notes |
 |---|---|---|
-| Rust | `ParseError` (parse) / renderer infallible after parse | yes (`Span` line+column) |
-| WASM / npm | `JsError` thrown | yes (`.line`, `.column` on parse errors) |
-| NAPI / Node native | `Error` thrown | yes |
-| CLI | non-zero exit + stderr | exit 65 (`EX_DATAERR`) on parse error |
-| Python | `ChordSketchError` exception | yes |
-| Swift | `ChordSketchError` enum (`.invalidConfig`, `.noSongsFound`, …) | yes |
-| Kotlin | `ChordSketchException` | yes |
-| Ruby | `Chordsketch::Error` | yes |
+| Rust | `ParseError` (parse) / renderer infallible after parse | Carries `Span` (line + column) |
+| WASM / npm | thrown `JsError` | Render-path errors carry only `.message`. Use `validate(input)` for structured `{line, column, message}` records. |
+| NAPI / Node native | thrown `Error` | Same as WASM: render-path is `.message` only; `validate(input)` returns `ValidationError[]` with `line`, `column`, `message`. |
+| CLI | non-zero exit + stderr | Currently `1` (`ExitCode::FAILURE`) on any error path; the binary does not yet differentiate parse vs. config vs. I/O failures via distinct exit codes. |
+| Python | `chordsketch.ChordSketchError` exception | `.message` |
+| Swift | `ChordSketchError` enum (`.invalidConfig(reason:)`, `.noSongsFound`, …) | `.message`-equivalent on the variant payload |
+| Kotlin | `ChordSketchException` | `.message` |
+| Ruby | `Chordsketch::ChordSketchError` | `.message` |
 
 To validate input without rendering, use the `validate(input)`
 function exposed by the WASM, NAPI, and UniFFI bindings (returns

--- a/docs/sdk/tasks/transpose.md
+++ b/docs/sdk/tasks/transpose.md
@@ -56,13 +56,15 @@ each format (`render_html_with_options` / `render_text_with_options`
 ## `@chordsketch/node`
 
 ```ts
-import { render_html_with_options } from '@chordsketch/node';
+import { renderHtmlWithOptions } from '@chordsketch/node';
 
-const html = render_html_with_options(input, { transpose: 2 });
+const html = renderHtmlWithOptions(input, { transpose: 2 });
 ```
 
-Same options shape as the WASM build. Out-of-range values reject
-with `Status::InvalidArg` (#1826 — previously this binding silently
+NAPI uses **camelCase** function names (napi-rs converts the Rust
+snake_case automatically); the options-object shape is the same as
+the WASM build. Out-of-range values reject with
+`Status::InvalidArg` (#1826 — previously this binding silently
 clamped, which has since been fixed for cross-binding parity).
 
 ## CLI
@@ -87,16 +89,19 @@ html = chordsketch.parse_and_render_html(input, None, 2)
 ```swift
 import ChordSketch
 
-let html = try ChordSketch.parseAndRenderHtml(input: input, configJson: nil, transpose: 2)
+let html = try parseAndRenderHtml(input: input, configJson: nil, transpose: 2)
 ```
 
 ## Kotlin
 
 ```kotlin
-import me.koeda.chordsketch.parseAndRenderHtml
+import uniffi.chordsketch.parseAndRenderHtml
 
 val html = parseAndRenderHtml(input, null, 2)
 ```
+
+The Maven coordinate is `me.koeda:chordsketch` but the import
+path UniFFI generates is `uniffi.chordsketch.*`.
 
 ## Ruby
 
@@ -121,9 +126,16 @@ namespace is required (lowercase rest).
 - **Saturated transpositions**: A few rendering paths emit a
   warning when transposition produces a chord that the renderer
   cannot place faithfully (e.g. extreme accidental spelling).
-  Warnings are surfaced via the `_with_warnings` variants
-  (Rust direct, WASM, NAPI). UniFFI-backed bindings (Python /
-  Swift / Kotlin / Ruby) currently print warnings to stderr.
+  Structured warning capture is available through the
+  `_with_warnings` variants in every binding that exposes them:
+  Rust (`render_*_with_warnings`), WASM
+  (`render_*_with_warnings_and_options`), NAPI
+  (`render*WithWarningsAndOptions`), and UniFFI bindings —
+  Python / Swift / Kotlin / Ruby — via the
+  `parse_and_render_*_with_warnings` variants which return a
+  struct carrying both the rendered output and a `Vec<String>` of
+  warnings. The default (non-`_with_warnings`) entry points
+  forward warnings to stderr.
 
 ## Next step
 

--- a/docs/sdk/tasks/transpose.md
+++ b/docs/sdk/tasks/transpose.md
@@ -1,0 +1,131 @@
+# Transpose chords by N semitones
+
+Every binding accepts a transposition offset (`-128..=127`
+semitones) and shifts every chord in the song by that amount before
+rendering. Internally the offset is reduced modulo 12, so
+`+12 == 0` and `+13 == +1` produce identical output.
+
+The same transposition produces the same rendered output across
+every binding for any given input.
+
+## Input + offset
+
+We will transpose this fragment **up by 2 semitones** (G → A) in
+every snippet:
+
+```chordpro
+{title: Amazing Grace}
+{key: G}
+[G]Amazing [G7]grace, how [C]sweet the [G]sound
+```
+
+Expected: chords become `[A] [A7] [D] [A]`.
+
+## Rust
+
+```rust
+use chordsketch_chordpro::{config::Config, parse};
+use chordsketch_render_html::render_song_with_transpose;
+
+let song = parse(input)?;
+let html: String = render_song_with_transpose(&song, 2, &Config::defaults());
+```
+
+`render_song_with_transpose(&song, 2, &Config::defaults())` is the
+direct API. The `_text` and `_pdf` renderer crates expose the same
+shape (`render_song_with_transpose` returning `String` / `Vec<u8>`).
+
+For multi-song input use `render_songs_with_transpose(&songs, 2, &Config::defaults())`.
+
+## `@chordsketch/wasm`
+
+```ts
+import init, { render_html_with_options } from '@chordsketch/wasm';
+
+await init();
+
+const html = render_html_with_options(input, { transpose: 2 });
+```
+
+`{transpose: number}` accepts integers; values outside
+the `i8` range (`-128..=127`) reject with an error to match the
+other bindings (#1826). The `_with_options` variants exist for
+each format (`render_html_with_options` / `render_text_with_options`
+/ `render_pdf_with_options`).
+
+## `@chordsketch/node`
+
+```ts
+import { render_html_with_options } from '@chordsketch/node';
+
+const html = render_html_with_options(input, { transpose: 2 });
+```
+
+Same options shape as the WASM build. Out-of-range values reject
+with `Status::InvalidArg` (#1826 — previously this binding silently
+clamped, which has since been fixed for cross-binding parity).
+
+## CLI
+
+```bash
+chordsketch song.cho --transpose 2 --format html
+```
+
+`--transpose` accepts any signed 8-bit integer.
+
+## Python
+
+```python
+import chordsketch
+
+# Positional args: input, config_json, transpose
+html = chordsketch.parse_and_render_html(input, None, 2)
+```
+
+## Swift
+
+```swift
+import ChordSketch
+
+let html = try ChordSketch.parseAndRenderHtml(input: input, configJson: nil, transpose: 2)
+```
+
+## Kotlin
+
+```kotlin
+import me.koeda.chordsketch.parseAndRenderHtml
+
+val html = parseAndRenderHtml(input, null, 2)
+```
+
+## Ruby
+
+```ruby
+require 'chordsketch'
+
+html = Chordsketch.parse_and_render_html(input, nil, 2)
+```
+
+The Ruby method signature matches the Python order: `(input,
+config_json, transpose)`. The capital-C `Chordsketch` module
+namespace is required (lowercase rest).
+
+## Range and edge cases
+
+- **Range**: `-128..=127` (`i8`), reduced modulo 12 internally.
+  Out-of-range values reject with an error (Rust: `ParseError`;
+  bindings: their respective error type) — they are not silently
+  clamped. Since #1826 every binding agrees on this contract.
+- **Zero offset**: `transpose = 0` is a no-op and is the default
+  when omitted (`null` / `None` / `nil`).
+- **Saturated transpositions**: A few rendering paths emit a
+  warning when transposition produces a chord that the renderer
+  cannot place faithfully (e.g. extreme accidental spelling).
+  Warnings are surfaced via the `_with_warnings` variants
+  (Rust direct, WASM, NAPI). UniFFI-backed bindings (Python /
+  Swift / Kotlin / Ruby) currently print warnings to stderr.
+
+## Next step
+
+[Render to HTML, plain text, or PDF](render.md) — the underlying
+operation that transposition feeds into.


### PR DESCRIPTION
## Summary

First iteration of the unified SDK guide promised by #2049. Pure
docs-only — no Rust, workflow, Cargo, or per-package README
changes.

This is also the **first PR through the newly enabled GitHub
Merge Queue**, so it doubles as a smoke test of the queue flow
(\"Merge when ready\" button, speculative-merge CI run, etc.).

### What lands

- \`docs/sdk/README.md\` — entry point, binding-selector table,
  architecture diagram (parser/renderer crates → bindings).
- \`docs/sdk/tasks/render.md\` — render to HTML, text, or PDF
  across every existing binding (Rust, WASM, NAPI, CLI, Python,
  Swift, Kotlin, Ruby) with an explicit error-mapping table.
- \`docs/sdk/tasks/transpose.md\` — same coverage for the
  transposition flow, including the \`-128..=127\` range and the
  cross-binding parity behaviour from #1826.
- \`README.md\` — \"Links\" section gains a one-line pointer to
  \`docs/sdk/README.md\`.

### Scope

- **No per-language stub pages.** The per-package READMEs in
  \`packages/{npm,swift,kotlin,ruby}/\` and \`crates/{ffi,napi}/\`
  are already L2-quality per
  \`.claude/rules/package-documentation.md\`. The SDK guide links
  to them rather than duplicate them.
- **Tasks limited to render + transpose** (the operations every
  binding actually exposes today). AST-direct parse is only on
  Rust; serialise-back is not exposed by any binding. The README
  Status section explicitly defers \`tasks/parse.md\` and
  \`tasks/serialise.md\` until those surfaces exist.
- **Static-site render (mdBook / Docusaurus) deferred.** Picking
  the right tool is its own architectural decision; the Markdown
  renders cleanly on GitHub today. Documented in the Status
  section.

### Evidence-based-claims verification

Every API claim in the task pages was verified against the actual
crate sources before commit:

- Rust: \`chordsketch_chordpro::parse(input)\` /
  \`chordsketch_render_*::render_song(&song)\` /
  \`render_song_with_transpose(&song, 2, &Config::defaults())\` —
  exist with the shapes shown.
- WASM / NAPI: \`render_*\` and \`render_*_with_options\` exist.
- UniFFI bindings: \`parse_and_render_*(input, config_json, transpose)\`
  with \`Option<i8>\` transpose.
- CLI: default subcommand renders; \`--format html|text|pdf\` and
  \`--transpose\` are real flags. There is no \`parse\` subcommand
  (the page does not claim one).

## Test plan

- [x] \`python3 scripts/extract-readme-commands.py --check\` exits 0
  — the new \"Unified SDK guide\" link sits outside the
  \`## Installation\` / \`## Usage\` ranges the README-sync
  snapshot tracks.
- [x] No Rust, workflow, or Cargo changes; existing
  \`cargo fmt/clippy/test\` jobs run unchanged.
- [x] Diff scope: only \`README.md\` (one-line link addition) and
  three new files under \`docs/sdk/\`.

Closes #2049