### PR TITLE
docs(sdk) + napi(types): fix Ruby grouping diagram + add WithWarnings .d.ts

### DIFF
--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -39,6 +39,42 @@ export interface ValidationError {
   message: string;
 }
 
+/**
+ * Structured render result returned by the `*WithWarnings` and
+ * `*WithWarningsAndOptions` families (string outputs).
+ *
+ * Mirrors the `TextRenderWithWarnings` struct in
+ * `crates/napi/src/lib.rs`. Used by both the text and HTML render
+ * variants — the field name is historical (the struct backed text
+ * output first).
+ *
+ * Use these variants when you need warning-driven UI (inline
+ * banners, telemetry aggregation, selective suppression). The plain
+ * `renderText` / `renderHtml` entry points forward warnings to
+ * `process.stderr` instead, which is fine for CLI scripts but
+ * invisible to embedded use.
+ */
+export interface TextRenderWithWarnings {
+  /** Rendered text or HTML output. */
+  output: string;
+  /** Renderer warnings captured during the render pass. */
+  warnings: string[];
+}
+
+/**
+ * Structured render result for the PDF `*WithWarnings` family.
+ *
+ * Mirrors the `PdfRenderWithWarnings` struct in
+ * `crates/napi/src/lib.rs`. See {@link TextRenderWithWarnings} for
+ * the warnings contract.
+ */
+export interface PdfRenderWithWarnings {
+  /** PDF byte stream. */
+  output: Buffer;
+  /** Renderer warnings captured during the render pass. */
+  warnings: string[];
+}
+
 /** Returns the version string baked into the compiled Rust crate. */
 export function version(): string;
 
@@ -66,6 +102,52 @@ export function renderPdf(source: string): Buffer;
  * applied.
  */
 export function renderPdfWithOptions(source: string, options: RenderOptions): Buffer;
+
+/**
+ * Renders to plain text, returning structured warnings alongside the
+ * output. Use this when you need warning-driven UI; the plain
+ * `renderText` forwards warnings to `process.stderr` instead.
+ */
+export function renderTextWithWarnings(source: string): TextRenderWithWarnings;
+
+/**
+ * Renders to HTML, returning structured warnings alongside the
+ * output. See {@link renderTextWithWarnings} for the contract.
+ */
+export function renderHtmlWithWarnings(source: string): TextRenderWithWarnings;
+
+/**
+ * Renders to PDF, returning structured warnings alongside the
+ * Buffer output. See {@link renderTextWithWarnings} for the contract.
+ */
+export function renderPdfWithWarnings(source: string): PdfRenderWithWarnings;
+
+/**
+ * Renders to plain text with rendering options applied, returning
+ * structured warnings alongside the output.
+ */
+export function renderTextWithWarningsAndOptions(
+  source: string,
+  options: RenderOptions,
+): TextRenderWithWarnings;
+
+/**
+ * Renders to HTML with rendering options applied, returning
+ * structured warnings alongside the output.
+ */
+export function renderHtmlWithWarningsAndOptions(
+  source: string,
+  options: RenderOptions,
+): TextRenderWithWarnings;
+
+/**
+ * Renders to PDF with rendering options applied, returning
+ * structured warnings alongside the Buffer output.
+ */
+export function renderPdfWithWarningsAndOptions(
+  source: string,
+  options: RenderOptions,
+): PdfRenderWithWarnings;
 
 /**
  * Validates a ChordPro source document and returns a list of issues. An

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -49,23 +49,23 @@ output. Every other binding is a thin wrapper that exposes the
 **same** Rust API surface in idiomatic form for its host language:
 
 ```
-                ┌──────────────────────────────────────────┐
-                │  chordsketch-chordpro (parser + AST)     │
-                │  chordsketch-render-{text,html,pdf}      │
-                └──────────────────────────────────────────┘
-                                    ▲
-            ┌──────────────┬────────┼────────┬──────────────┐
-            │              │        │        │              │
-       chordsketch     chordsketch- │   chordsketch-     chordsketch-
-       (CLI binary)    wasm         │   napi             ffi (UniFFI)
-                       (browser /   │   (Node.js         │
-                       ESM)         │   native)          ▼
-                                                  ┌──────────────────┐
-                                                  │ Python (PyPI)    │
-                                                  │ Swift (XCFwk)    │
-                                                  │ Kotlin (Maven)   │
-                                                  │ Ruby (RubyGems)  │
-                                                  └──────────────────┘
+           ┌──────────────────────────────────────────┐
+           │  chordsketch-chordpro (parser + AST)     │
+           │  chordsketch-render-{text,html,pdf}      │
+           └──────────────────────────────────────────┘
+                                ▲
+       ┌──────────────┬─────────┴─────┬──────────────┐
+       │              │               │              │
+  chordsketch    chordsketch-    chordsketch-    chordsketch-
+  (CLI binary)   wasm            napi            ffi (UniFFI)
+                 (browser /      (Node.js              │
+                 ESM)            native)               ▼
+                                              ┌──────────────────┐
+                                              │ Python  (PyPI)   │
+                                              │ Swift   (XCFwk)  │
+                                              │ Kotlin  (Maven)  │
+                                              │ Ruby    (Gems)   │
+                                              └──────────────────┘
 ```
 
 `chordsketch-ffi` is the single UniFFI shared library that backs

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -54,14 +54,27 @@ output. Every other binding is a thin wrapper that exposes the
                 │  chordsketch-render-{text,html,pdf}      │
                 └──────────────────────────────────────────┘
                                     ▲
-        ┌──────────────┬────────────┼────────────┬──────────────┐
-        │              │            │            │              │
-   chordsketch     chordsketch-  chordsketch-  chordsketch-   chordsketch
-   (CLI binary)    wasm          napi          ffi (UniFFI)   (Ruby gem
-                   (browser /    (Node.js      → Python /      via UniFFI)
-                   ESM)          native)       Swift /
-                                               Kotlin)
+            ┌──────────────┬────────┼────────┬──────────────┐
+            │              │        │        │              │
+       chordsketch     chordsketch- │   chordsketch-     chordsketch-
+       (CLI binary)    wasm         │   napi             ffi (UniFFI)
+                       (browser /   │   (Node.js         │
+                       ESM)         │   native)          ▼
+                                                  ┌──────────────────┐
+                                                  │ Python (PyPI)    │
+                                                  │ Swift (XCFwk)    │
+                                                  │ Kotlin (Maven)   │
+                                                  │ Ruby (RubyGems)  │
+                                                  └──────────────────┘
 ```
+
+`chordsketch-ffi` is the single UniFFI shared library that backs
+**all four** of the Python, Swift, Kotlin, and Ruby distributions.
+The per-language packages (`pip install chordsketch`,
+`me.koeda:chordsketch`, `gem install chordsketch`, the Swift
+package) each ship a thin language-binding layer on top of the
+same `crates/ffi` artefact — there is no separate `chordsketch-ruby`
+crate.
 
 Because every binding wraps the same parser and renderers, the
 output of `parseAndRenderHtml(input)` (or its language-specific


### PR DESCRIPTION
## Summary

Two follow-ups from the review of #2132, bundled because both
touch the SDK documentation surface.

- **#2133** — \`docs/sdk/README.md\` architecture diagram showed
  Ruby as a separate column adjacent to \`chordsketch-ffi\`,
  visually implying a separate crate. Reflow so all four UniFFI
  consumers (Python, Swift, Kotlin, Ruby) drop out of the single
  \`chordsketch-ffi\` node into one shared box, and add a paragraph
  noting there is no separate \`chordsketch-ruby\` crate.
- **#2134** — \`crates/napi/index.d.ts\` was missing six
  declarations exposed by \`#[napi]\` items in
  \`crates/napi/src/lib.rs\` and documented in
  \`crates/napi/README.md:62-67\`:
  \`renderTextWithWarnings\` / \`renderHtmlWithWarnings\` /
  \`renderPdfWithWarnings\` plus the three
  \`*WithWarningsAndOptions\` variants. Add them, plus the two
  shape interfaces \`TextRenderWithWarnings\` and
  \`PdfRenderWithWarnings\` that mirror the
  \`#[napi(object)]\` Rust structs (PDF variant uses \`Buffer\`).

The \`packages/npm/src/node.ts\` re-export stub mentioned in
#2134's acceptance criteria does not exist in the repo (the
\`@chordsketch/wasm\` npm package ships pure WASM artefacts, not
NAPI re-exports), so the audit there was a no-op.

## Test plan

- [x] Diff scope: \`docs/sdk/README.md\` (diagram + paragraph) and
  \`crates/napi/index.d.ts\` (additions only — no behaviour change,
  no Rust change).
- [x] Every newly declared TS function name verified against
  \`#[napi]\` items in \`crates/napi/src/lib.rs\`
  (renderTextWithWarnings@216, renderHtmlWithWarnings@231,
  renderPdfWithWarnings@246, renderTextWithWarningsAndOptions@352,
  renderHtmlWithWarningsAndOptions@372,
  renderPdfWithWarningsAndOptions@392) and against
  \`crates/napi/README.md\` (lines 62-67).
- [x] \`TextRenderWithWarnings\` / \`PdfRenderWithWarnings\` field
  shapes verified against the \`#[napi(object)]\` structs
  (\`crates/napi/src/lib.rs:166-182\`).

Closes #2133
Closes #2134