### PR TITLE
feat(react): <PdfExport> button + usePdfExport hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only exported symbol. CI workflow `.github/workflows/react.yml`
   covers typecheck, vitest smoke, and a build-artefact integrity
   check. (#2040)
+- `@chordsketch/react`: `<PdfExport>` button + `usePdfExport` hook.
+  Lazy-loads `@chordsketch/wasm` on first call, caches the
+  initialised module for subsequent calls, renders to PDF via
+  `render_pdf` / `render_pdf_with_options`, and triggers a browser
+  download. `<PdfExport>` sets `disabled` + `aria-busy` while the
+  render is in flight and forwards `onExported` / `onError`
+  callbacks alongside all standard `<button>` attributes. (#2041)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Additionally, these non-Rust packages exist:
 | `@chordsketch/wasm` | `packages/npm` | npm package, **dual build** (browser ESM + Node.js CJS) with TypeScript types |
 | `@chordsketch/node` | `crates/napi` | Native Node.js addon via napi-rs, multi-package prebuilt layout (main resolver + 5 platform packages). See `docs/releasing.md` §napi distribution. |
 | `@chordsketch/ui-web` | `packages/ui-web` | Framework-agnostic editor + preview UI shared by playground and the upcoming Tauri desktop app (private workspace package, not published) |
-| `@chordsketch/react` | `packages/react` | React component library (scaffold — component surface #2041–#2045 pending). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. |
+| `@chordsketch/react` | `packages/react` | React component library (pre-release — `<PdfExport>` + `usePdfExport` shipped in #2041; `<ChordSheet>` / `<ChordEditor>` / `<Transpose>` / `<ChordDiagram>` pending). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. |
 | Playground | `packages/playground` | Vite-based browser host that mounts `@chordsketch/ui-web` against `@chordsketch/wasm` |
 | Python (`chordsketch`) | `crates/ffi` | Python package via UniFFI + maturin |
 | Swift (`ChordSketch`) | `packages/swift` | Swift package with XCFramework |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,14 +7,12 @@
 React component library for rendering [ChordPro](https://www.chordpro.org/)
 files, powered by [`@chordsketch/wasm`](https://www.npmjs.com/package/@chordsketch/wasm).
 
-> **Status:** scaffold only. The component surface
-> (`<ChordSheet>`, `<ChordEditor>`, `<Transpose>`, `<ChordDiagram>`,
-> `<PdfExport>`) lands in issues
+> **Status:** pre-release. The component surface is landing
+> incrementally under issues
 > [#2041](https://github.com/koedame/chordsketch/issues/2041)–[#2045](https://github.com/koedame/chordsketch/issues/2045).
-> Until those issues close, the only export is `version()` — the
-> package exists so its npm name is reserved, its publish pipeline
-> is proven, and downstream consumers can pin against it ahead of
-> the component release.
+> Currently shipped: `<PdfExport>` + `usePdfExport` (#2041).
+> Still pending: `<ChordSheet>`, `<ChordEditor>`,
+> `<Transpose>` + `useTranspose`, `<ChordDiagram>`.
 
 ## Installation
 
@@ -30,17 +28,74 @@ npm install '@chordsketch/react@VERSION' react
 itself — the host does not need to install it separately. `react`
 is a **peer dependency** (React 18 or newer).
 
-## Usage (scaffold)
+## Usage
+
+### `<PdfExport>` — one-click PDF download
+
+```tsx
+import { PdfExport } from '@chordsketch/react';
+
+const source = `{title: Amazing Grace}
+{key: G}
+
+[G]Amazing [G7]grace, how [C]sweet the [G]sound`;
+
+export function SaveButton() {
+  return (
+    <PdfExport source={source} filename="amazing-grace.pdf">
+      Download PDF
+    </PdfExport>
+  );
+}
+```
+
+While the render is in flight the button is `disabled` and
+`aria-busy="true"` so assistive tech surfaces the loading state.
+`onExported(filename)` and `onError(err)` callbacks are available
+for imperative handlers (analytics, toasts). All the standard
+`<button>` attributes (`className`, `style`, `type` override,
+`id`, …) are forwarded.
+
+### `usePdfExport` — hook for bespoke UIs
+
+```tsx
+import { usePdfExport } from '@chordsketch/react';
+
+export function SaveDropdownItem({ source }: { source: string }) {
+  const { exportPdf, loading, error } = usePdfExport();
+  return (
+    <>
+      <button onClick={() => exportPdf(source, 'song.pdf')} disabled={loading}>
+        {loading ? 'Preparing…' : 'Save as PDF'}
+      </button>
+      {error ? <p role="alert">{error.message}</p> : null}
+    </>
+  );
+}
+```
+
+The hook lazy-loads `@chordsketch/wasm` on first call and caches
+the initialised module for subsequent calls, so repeated exports
+do not re-run WASM init.
+
+### Transposition
+
+Both the component and the hook accept a third `options` argument
+forwarded to the underlying WASM renderer:
+
+```tsx
+<PdfExport source={source} filename="song-up-2.pdf" options={{ transpose: 2 }} />
+await exportPdf(source, 'ukulele-preset.pdf', { config: 'ukulele' });
+```
+
+### Version
 
 ```ts
 import { version } from '@chordsketch/react';
-
-console.log(version()); // "0.0.0" (pre-release)
+console.log(version());
 ```
 
-Once the components land the API will grow; the package's `main`
-entry point will remain the stable surface so this import path
-continues to work.
+The returned string matches `package.json`'s `version` field.
 
 ## Design
 

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
         "jsdom": "^25.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1109,6 +1110,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@vitest/expect": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "jsdom": "^25.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,20 +1,20 @@
 // @chordsketch/react — React component library for ChordPro rendering
 // backed by @chordsketch/wasm.
 //
-// This is the scaffolding commit (#2040). Components land in
-// subsequent PRs:
-//   - #2041: <PdfExport>
+// Components land incrementally. Remaining surface:
 //   - #2042: <ChordSheet>
 //   - #2043: <ChordEditor>
 //   - #2044: <Transpose> + useTranspose
 //   - #2045: <ChordDiagram>
-//
-// The only export at this point is `version()`, a minimal symbol so
-// the build pipeline produces a non-empty module and downstream
-// consumers can pin against a stable entry point before the
-// component surface lands.
 
 import packageJson from '../package.json' with { type: 'json' };
+
+export { PdfExport, type PdfExportProps } from './pdf-export';
+export {
+  usePdfExport,
+  type PdfExportOptions,
+  type UsePdfExportResult,
+} from './use-pdf-export';
 
 /**
  * The running version of `@chordsketch/react`. Returns the string

--- a/packages/react/src/pdf-export.tsx
+++ b/packages/react/src/pdf-export.tsx
@@ -1,0 +1,103 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { useCallback } from 'react';
+
+import {
+  type PdfExportOptions,
+  type WasmLoader,
+  usePdfExport,
+} from './use-pdf-export';
+
+/** Props accepted by the {@link PdfExport} button. */
+export interface PdfExportProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onError'> {
+  /** ChordPro source to render. */
+  source: string;
+  /**
+   * Filename suggested to the browser when the download anchor is
+   * clicked. Defaults to `chordsketch-output.pdf` to match the
+   * playground (`packages/ui-web/src/index.ts`) default.
+   */
+  filename?: string;
+  /** Semitone transposition / config preset forwarded to the renderer. */
+  options?: PdfExportOptions;
+  /**
+   * Button label. Defaults to `"Export PDF"`. Pass a component tree
+   * (e.g. an icon + label) for richer styling.
+   */
+  children?: ReactNode;
+  /**
+   * Optional success callback, fired after the download is
+   * initiated. Useful for analytics / toasts.
+   */
+  onExported?: (filename: string) => void;
+  /**
+   * Optional error callback, fired when `exportPdf` rejects. The
+   * error is also surfaced via the internal `useState` so consumers
+   * can render it from their own state if they prefer; this
+   * callback is a convenience for imperative handlers
+   * (e.g. `toast.error(...)`).
+   */
+  onError?: (error: Error) => void;
+  /**
+   * Test-only WASM loader override. Consumers never need to
+   * supply this — the production default lazy-loads
+   * `@chordsketch/wasm`. Hidden behind `@internal` so it does not
+   * surface in the public API docs.
+   *
+   * @internal
+   */
+  wasmLoader?: WasmLoader;
+}
+
+/**
+ * Button that renders `source` to PDF via `@chordsketch/wasm` and
+ * triggers a browser download on click. While the render is in
+ * flight the button is set `disabled` and `aria-busy="true"` so
+ * assistive tech surfaces the loading state.
+ *
+ * ```tsx
+ * <PdfExport source={chordpro} filename="song.pdf">
+ *   Download PDF
+ * </PdfExport>
+ * ```
+ *
+ * For a bespoke UI (e.g. a dropdown menu that exports PDF as one
+ * option), use {@link usePdfExport} directly instead.
+ */
+export function PdfExport({
+  source,
+  filename = 'chordsketch-output.pdf',
+  options,
+  children = 'Export PDF',
+  onExported,
+  onError,
+  wasmLoader,
+  disabled,
+  ...buttonProps
+}: PdfExportProps): JSX.Element {
+  const { exportPdf, loading } = usePdfExport(wasmLoader);
+
+  const handleClick = useCallback(() => {
+    exportPdf(source, filename, options).then(
+      () => onExported?.(filename),
+      // `exportPdf` rejects after updating its internal `error`
+      // state, so onError is purely a convenience hook; swallow
+      // the rejection here to avoid the React "unhandled promise
+      // rejection" warning for consumers that rely on the state
+      // rather than a callback.
+      (err: Error) => onError?.(err),
+    );
+  }, [exportPdf, source, filename, options, onExported, onError]);
+
+  return (
+    <button
+      type="button"
+      {...buttonProps}
+      onClick={handleClick}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -93,9 +93,22 @@ const defaultLoader: WasmLoader = () =>
  * await exportPdf(chordproSource, 'song.pdf');
  * ```
  *
+ * ### Cache scope
+ *
+ * Each mounted hook owns its own renderer cache — two
+ * `usePdfExport()` consumers in the same app will each call
+ * `import('@chordsketch/wasm')` on first use. Dynamic ESM imports
+ * and `@chordsketch/wasm`'s own `init()` both dedupe internally,
+ * so this is a measurement-level concern (one extra
+ * microtask-scoped dynamic import resolution), not a correctness
+ * concern. Apps that want a single shared renderer can hoist the
+ * hook into a context provider.
+ *
  * @param loader Optional WASM loader — pass a stub in tests. Do not
  *   supply one in production; the default loads `@chordsketch/wasm`
- *   lazily.
+ *   lazily. The loader does not have to be stable across renders —
+ *   the hook reads the latest reference via a ref so inline
+ *   loaders do not invalidate `exportPdf`'s identity.
  */
 export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportResult {
   const [loading, setLoading] = useState(false);
@@ -107,6 +120,15 @@ export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportRe
   // not a state transition.
   const rendererRef = useRef<PdfRenderer | null>(null);
 
+  // The loader is captured in a ref rather than a useCallback
+  // dependency so that a caller who passes an inline loader
+  // expression does not invalidate `exportPdf`'s identity on every
+  // render. The value is read only on the cache miss (first call),
+  // and `rendererRef` encodes the single-init contract, so using
+  // the latest value committed to the ref is sufficient.
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+
   const exportPdf = useCallback(
     async (
       source: string,
@@ -117,11 +139,16 @@ export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportRe
       setError(null);
       try {
         if (rendererRef.current === null) {
-          const mod = await loader();
+          const mod = await loaderRef.current();
           // `init()` is a no-op on the Node.js build of
           // `@chordsketch/wasm` (the module auto-loads in Node) and
           // required on the browser build. Calling it
-          // unconditionally keeps the hook runtime-agnostic.
+          // unconditionally keeps the hook runtime-agnostic. The
+          // Node build still exports `default` as a no-op init
+          // stub — see `packages/npm/node/chordsketch_wasm.js`.
+          // If a future `@chordsketch/wasm` refactor drops that
+          // export, this call will throw on Node and the hook will
+          // surface the error via `error` state on first use.
           await mod.default();
           rendererRef.current = mod;
         }
@@ -139,7 +166,7 @@ export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportRe
         setLoading(false);
       }
     },
-    [loader],
+    [],
   );
 
   return { exportPdf, loading, error };

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -1,0 +1,171 @@
+import { useCallback, useRef, useState } from 'react';
+
+// The `@chordsketch/wasm` surface is loaded lazily (browser build
+// requires `await init()` before the first render call). Importing
+// via a dynamic `import()` keeps the React bundle free of the WASM
+// glue code until a consumer actually triggers an export.
+//
+// The narrow type declared here is deliberately structural rather
+// than a direct re-export from `@chordsketch/wasm` — typing it with
+// the real module shape would pull the WASM package into the
+// library's build graph, which defeats the lazy-loading point. The
+// shape is pinned to the subset that `exportPdf` actually touches
+// (`default`, `render_pdf`, `render_pdf_with_options`) so the
+// contract with the WASM API is still explicit at the boundary.
+interface PdfRenderer {
+  default: () => Promise<unknown>;
+  render_pdf: (input: string) => Uint8Array;
+  render_pdf_with_options: (
+    input: string,
+    options: { transpose?: number; config?: string },
+  ) => Uint8Array;
+}
+
+/** Extra options forwarded to the underlying WASM PDF renderer. */
+export interface PdfExportOptions {
+  /**
+   * Semitone transposition offset, reduced modulo 12 by the
+   * renderer. Omitted or zero → no transposition is applied.
+   */
+  transpose?: number;
+  /**
+   * Configuration preset name (e.g. `"guitar"`, `"ukulele"`) or an
+   * inline RRJSON configuration string.
+   */
+  config?: string;
+}
+
+/** Value returned by {@link usePdfExport}. */
+export interface UsePdfExportResult {
+  /**
+   * Render the given ChordPro `source` to PDF and trigger a browser
+   * download using `filename` as the suggested name. Resolves when
+   * the download has been initiated (the anchor element clicked);
+   * **rejects** if the WASM init or render call throws. The same
+   * error is written to the `error` state before the promise
+   * settles, so UIs that prefer state-driven rendering can ignore
+   * the rejection (e.g. `exportPdf(...).catch(() => {})`) and
+   * render from `error` instead.
+   */
+  exportPdf: (
+    source: string,
+    filename: string,
+    options?: PdfExportOptions,
+  ) => Promise<void>;
+  /**
+   * `true` between the moment `exportPdf` starts and the moment it
+   * settles (resolve or reject). Use for spinners / disabled button
+   * states; the state resets on every call, so UIs do not need to
+   * debounce.
+   */
+  loading: boolean;
+  /**
+   * The error thrown by the most recent `exportPdf` call, or `null`
+   * if the last call succeeded or no call has been made yet. Set
+   * before the returned promise rejects so error-rendering UIs
+   * observe the value synchronously via React's state update.
+   */
+  error: Error | null;
+}
+
+/**
+ * Injected renderer factory, for tests. Production callers never
+ * need to supply this — the default points at
+ * `@chordsketch/wasm`. Tests pass a hand-rolled stub that returns
+ * a deterministic byte string without loading a real WASM binary.
+ *
+ * @internal
+ */
+export type WasmLoader = () => Promise<PdfRenderer>;
+
+const defaultLoader: WasmLoader = () =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  import('@chordsketch/wasm') as Promise<PdfRenderer>;
+
+/**
+ * React hook that produces a `Promise<void>`-returning `exportPdf`
+ * function together with `loading` / `error` state. The WASM module
+ * is loaded at most once per hook instance and reused across calls.
+ *
+ * ```ts
+ * const { exportPdf, loading, error } = usePdfExport();
+ * // later:
+ * await exportPdf(chordproSource, 'song.pdf');
+ * ```
+ *
+ * @param loader Optional WASM loader — pass a stub in tests. Do not
+ *   supply one in production; the default loads `@chordsketch/wasm`
+ *   lazily.
+ */
+export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  // Cache the initialised renderer across invocations so repeated
+  // exports do not re-run WASM init. `useRef` is appropriate (not
+  // `useState`) because the value is plain cache that does not need
+  // to drive re-renders — writing to `.current` is a side effect,
+  // not a state transition.
+  const rendererRef = useRef<PdfRenderer | null>(null);
+
+  const exportPdf = useCallback(
+    async (
+      source: string,
+      filename: string,
+      options?: PdfExportOptions,
+    ): Promise<void> => {
+      setLoading(true);
+      setError(null);
+      try {
+        if (rendererRef.current === null) {
+          const mod = await loader();
+          // `init()` is a no-op on the Node.js build of
+          // `@chordsketch/wasm` (the module auto-loads in Node) and
+          // required on the browser build. Calling it
+          // unconditionally keeps the hook runtime-agnostic.
+          await mod.default();
+          rendererRef.current = mod;
+        }
+        const renderer = rendererRef.current;
+        const bytes =
+          options !== undefined && (options.transpose !== undefined || options.config !== undefined)
+            ? renderer.render_pdf_with_options(source, options)
+            : renderer.render_pdf(source);
+        triggerDownload(bytes, filename);
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loader],
+  );
+
+  return { exportPdf, loading, error };
+}
+
+/**
+ * Turn a PDF byte array into a downloaded file. Exported for tests
+ * that want to assert on the download side of the flow without
+ * going through the WASM renderer.
+ *
+ * @internal
+ */
+export function triggerDownload(bytes: Uint8Array, filename: string): void {
+  const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    // Appending to the document is required in some browsers (notably
+    // Firefox) for `click()` to actually dispatch the download event.
+    // Removing the element after the click keeps the DOM clean.
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/packages/react/tests/pdf-export.test.tsx
+++ b/packages/react/tests/pdf-export.test.tsx
@@ -188,6 +188,29 @@ describe('<PdfExport>', () => {
     expect(button.getAttribute('aria-busy')).toBeNull();
   });
 
+  test('options prop is forwarded to the renderer', async () => {
+    const stub = makeStubRenderer();
+
+    render(
+      <PdfExport
+        source="{title: Hi}"
+        filename="hi.pdf"
+        options={{ transpose: 5, config: 'ukulele' }}
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export PDF' }));
+
+    await waitFor(() =>
+      expect(stub.render_pdf_with_options).toHaveBeenCalledWith('{title: Hi}', {
+        transpose: 5,
+        config: 'ukulele',
+      }),
+    );
+    expect(stub.render_pdf).not.toHaveBeenCalled();
+  });
+
   test('calls onError when the render rejects', async () => {
     const boom = new Error('render kaboom');
     const stub = makeStubRenderer();

--- a/packages/react/tests/pdf-export.test.tsx
+++ b/packages/react/tests/pdf-export.test.tsx
@@ -1,0 +1,207 @@
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PdfExport, usePdfExport } from '../src/index';
+import type { WasmLoader } from '../src/use-pdf-export';
+
+const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // "%PDF" magic bytes
+
+interface StubRenderer {
+  default: ReturnType<typeof vi.fn>;
+  render_pdf: ReturnType<typeof vi.fn>;
+  render_pdf_with_options: ReturnType<typeof vi.fn>;
+}
+
+function makeStubRenderer(): StubRenderer {
+  return {
+    default: vi.fn(async () => undefined),
+    render_pdf: vi.fn(() => PDF_BYTES),
+    render_pdf_with_options: vi.fn(() => PDF_BYTES),
+  };
+}
+
+function makeLoader(stub: StubRenderer): WasmLoader {
+  // The `usePdfExport` hook accepts any loader returning a
+  // structurally compatible renderer; casting here is safe because
+  // the stub implements the narrow surface the hook touches.
+  return vi.fn(async () => stub as unknown as Awaited<ReturnType<WasmLoader>>);
+}
+
+function installBlobUrlStubs(): { create: ReturnType<typeof vi.fn>; revoke: ReturnType<typeof vi.fn> } {
+  // jsdom does not implement URL.createObjectURL; stub it so
+  // triggerDownload's blob flow runs.
+  const create = vi.fn(() => 'blob:fake');
+  const revoke = vi.fn();
+  Object.defineProperty(URL, 'createObjectURL', { value: create, configurable: true });
+  Object.defineProperty(URL, 'revokeObjectURL', { value: revoke, configurable: true });
+  return { create, revoke };
+}
+
+describe('usePdfExport', () => {
+  let blobStubs: ReturnType<typeof installBlobUrlStubs>;
+
+  beforeEach(() => {
+    blobStubs = installBlobUrlStubs();
+  });
+
+  test('exportPdf renders, downloads, and cleans up', async () => {
+    const stub = makeStubRenderer();
+    const { result } = renderHook(() => usePdfExport(makeLoader(stub)));
+
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click');
+
+    await act(async () => {
+      await result.current.exportPdf('{title: Test}\n[C]Hello', 'song.pdf');
+    });
+
+    expect(stub.default).toHaveBeenCalledTimes(1);
+    expect(stub.render_pdf).toHaveBeenCalledWith('{title: Test}\n[C]Hello');
+    expect(stub.render_pdf_with_options).not.toHaveBeenCalled();
+    expect(blobStubs.create).toHaveBeenCalledTimes(1);
+    expect(blobStubs.revoke).toHaveBeenCalledWith('blob:fake');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    // Anchor is removed after click — no stray <a> left in the DOM.
+    expect(document.querySelectorAll('a[download]')).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('options are forwarded to render_pdf_with_options when transpose is set', async () => {
+    const stub = makeStubRenderer();
+    const { result } = renderHook(() => usePdfExport(makeLoader(stub)));
+
+    await act(async () => {
+      await result.current.exportPdf('{title: T}', 'song.pdf', { transpose: 2 });
+    });
+
+    expect(stub.render_pdf).not.toHaveBeenCalled();
+    expect(stub.render_pdf_with_options).toHaveBeenCalledWith('{title: T}', { transpose: 2 });
+  });
+
+  test('WASM module is loaded exactly once across repeated calls', async () => {
+    const stub = makeStubRenderer();
+    const loader = makeLoader(stub);
+    const { result } = renderHook(() => usePdfExport(loader));
+
+    await act(async () => {
+      await result.current.exportPdf('a', 'a.pdf');
+      await result.current.exportPdf('b', 'b.pdf');
+      await result.current.exportPdf('c', 'c.pdf');
+    });
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(stub.default).toHaveBeenCalledTimes(1);
+    expect(stub.render_pdf).toHaveBeenCalledTimes(3);
+  });
+
+  test('render failure surfaces through error state and promise rejection', async () => {
+    const boom = new Error('parse failed');
+    const stub = makeStubRenderer();
+    stub.render_pdf.mockImplementation(() => {
+      throw boom;
+    });
+    const { result } = renderHook(() => usePdfExport(makeLoader(stub)));
+
+    // The `exportPdf` rejection is caught here; the state update it
+    // schedules still lands on the React tree, but act() completes
+    // before the failing promise propagates so we have to assert
+    // against the post-commit state via waitFor.
+    await act(async () => {
+      await result.current.exportPdf('bad', 'bad.pdf').catch((e: unknown) => {
+        expect(e).toBe(boom);
+      });
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(boom));
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe('<PdfExport>', () => {
+  beforeEach(() => {
+    installBlobUrlStubs();
+  });
+
+  test('renders a button and downloads on click', async () => {
+    const stub = makeStubRenderer();
+    const onExported = vi.fn();
+
+    render(
+      <PdfExport
+        source="{title: Hi}"
+        filename="hi.pdf"
+        onExported={onExported}
+        wasmLoader={makeLoader(stub)}
+      >
+        Save as PDF
+      </PdfExport>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Save as PDF' });
+    expect(button.hasAttribute('disabled')).toBe(false);
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(stub.render_pdf).toHaveBeenCalled());
+    await waitFor(() => expect(onExported).toHaveBeenCalledWith('hi.pdf'));
+    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(button.getAttribute('aria-busy')).toBeNull();
+  });
+
+  test('disables itself and sets aria-busy while rendering', async () => {
+    const stub = makeStubRenderer();
+    // Hold the render open so the button is observed mid-flight.
+    let resolveRender!: () => void;
+    stub.render_pdf.mockImplementation(() => {
+      // render_pdf is synchronous in the real API; the hold is
+      // simulated by having `default()` (init) await a pending
+      // promise instead, so the button observes `loading=true`
+      // before render_pdf fires.
+      return PDF_BYTES;
+    });
+    let releaseInit!: () => void;
+    stub.default.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseInit = resolve;
+        }),
+    );
+    resolveRender = () => releaseInit();
+
+    render(<PdfExport source="x" filename="x.pdf" wasmLoader={makeLoader(stub)} />);
+    const button = screen.getByRole('button', { name: 'Export PDF' });
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button.hasAttribute('disabled')).toBe(true));
+    expect(button.getAttribute('aria-busy')).toBe('true');
+
+    resolveRender();
+    await waitFor(() => expect(button.hasAttribute('disabled')).toBe(false));
+    expect(button.getAttribute('aria-busy')).toBeNull();
+  });
+
+  test('calls onError when the render rejects', async () => {
+    const boom = new Error('render kaboom');
+    const stub = makeStubRenderer();
+    stub.render_pdf.mockImplementation(() => {
+      throw boom;
+    });
+    const onError = vi.fn();
+
+    render(
+      <PdfExport source="x" filename="x.pdf" onError={onError} wasmLoader={makeLoader(stub)} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export PDF' }));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(boom));
+  });
+});

--- a/packages/react/tests/setup.ts
+++ b/packages/react/tests/setup.ts
@@ -1,0 +1,10 @@
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// `@testing-library/react` mounts components into a shared `document.body`.
+// Without explicit cleanup the body accumulates nodes across tests in the
+// same file, which turns `getByRole('button')` into an ambiguous match.
+// Running `cleanup()` after every test restores the single-root invariant.
+afterEach(() => {
+  cleanup();
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: false,
+    setupFiles: ['./tests/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary

First component in \`@chordsketch/react\`, landing on top of the
#2040 scaffold. Exports a ChordPro source to PDF via the
\`@chordsketch/wasm\` \`render_pdf\` /
\`render_pdf_with_options\` surface and triggers a browser
download.

Two exports so both use cases are covered without code duplication:

- **\`<PdfExport source filename options …>Export PDF</PdfExport>\`**
  — drop-in button. Sets \`disabled\` + \`aria-busy\` during render,
  forwards every standard \`<button>\` attribute, exposes
  \`onExported(filename)\` and \`onError(err)\` callbacks.
- **\`usePdfExport(loader?)\` hook** — returns
  \`{ exportPdf(source, filename, options?), loading, error }\`.
  The WASM module is dynamically imported on first call (so the
  package does not drag the WASM bundle into the consumer's entry
  chunk) and cached via \`useRef\` across calls.

## What changed

- \`packages/react/src/use-pdf-export.ts\` — the hook and an
  \`@internal\` \`triggerDownload\` helper (Blob → anchor click →
  object-URL revoke).
- \`packages/react/src/pdf-export.tsx\` — the button, built on the
  hook.
- \`packages/react/src/index.ts\` — re-exports the component and the
  hook alongside \`PdfExportProps\`, \`PdfExportOptions\`, and
  \`UsePdfExportResult\`.
- \`packages/react/tests/pdf-export.test.tsx\` — vitest + jsdom +
  \`@testing-library/react\`. 8 tests cover: end-to-end flow,
  options forwarding, single WASM init across repeated calls,
  error propagation via \`error\` state + rejection, button click,
  \`aria-busy\`/\`disabled\` toggles mid-render, and the \`onError\`
  callback firing.
- \`packages/react/tests/setup.ts\` — runs \`cleanup()\` between
  tests so \`getByRole('button')\` stays unambiguous across cases.
- \`packages/react/vitest.config.ts\` — points at the setup file.
- \`packages/react/package.json\` — adds \`@types/react-dom\` to
  devDeps.
- \`packages/react/README.md\` — status upgraded from \"scaffold\"
  to \"pre-release\"; adds component and hook usage sections.
- \`CHANGELOG.md\` — \"Added\" bullet under \`[Unreleased]\`.
- \`CLAUDE.md\` — workspace row updated to reflect shipped vs
  pending components.

## Test plan

- [x] \`npm run typecheck\` in \`packages/react/\` — passes.
- [x] \`npm test\` — 8 tests, all green:
  - \`usePdfExport\` renders/downloads/cleans up
  - options forwarded to \`render_pdf_with_options\` when
    \`transpose\` is set
  - WASM module loaded exactly once across repeated calls
  - render failure surfaces through both promise rejection and
    \`error\` state
  - \`<PdfExport>\` button click triggers download and calls
    \`onExported\`
  - \`<PdfExport>\` sets \`disabled\` + \`aria-busy=\"true\"\`
    mid-render, clears both on completion
  - \`<PdfExport>\` calls \`onError\` when the render rejects
- [x] \`npm run build\` — tsup emits ESM (2.75 KB), CJS (2.84 KB),
  and \`.d.ts\`/\`.d.cts\` (5.29 KB each). \`styles.css\` still
  copies through for the reserved import path.
- [x] \`python3 scripts/extract-readme-commands.py --check\` exits
  0 (top-level README untouched).

## Scope

- Components #2042–#2045 are separate PRs.
- No changes to the publish pipeline — the package still needs its
  initial manual \`npm publish\` (per #2040's deferral and the
  memory note on granular-token limits for creating new
  \`@chordsketch/*\` packages).

Closes #2041