### PR TITLE
feat(react): <Transpose> control + useTranspose hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   download. `<PdfExport>` sets `disabled` + `aria-busy` while the
   render is in flight and forwards `onExported` / `onError`
   callbacks alongside all standard `<button>` attributes. (#2041)
+- `@chordsketch/react`: `<Transpose>` control + `useTranspose`
+  hook. Accessible `−` / readout / `+` / reset UI with per-button
+  `aria-label`s, an `<output aria-live="polite">` indicator, and
+  `+` / `-` / `0` keyboard shortcuts while focus is inside.
+  `useTranspose` returns `{ value, increment, decrement, reset,
+  setValue }` with configurable `initial` / `min` / `max` bounds
+  (default `-11`…`+11`); every setter clamps into range and
+  `setValue` normalises `NaN` to `min` so direct binding to a
+  numeric input is safe. Baseline styles under
+  `@chordsketch/react/styles.css` use transparent backgrounds and
+  `currentColor` so the control inherits the host theme. (#2044)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Additionally, these non-Rust packages exist:
 | `@chordsketch/wasm` | `packages/npm` | npm package, **dual build** (browser ESM + Node.js CJS) with TypeScript types |
 | `@chordsketch/node` | `crates/napi` | Native Node.js addon via napi-rs, multi-package prebuilt layout (main resolver + 5 platform packages). See `docs/releasing.md` §napi distribution. |
 | `@chordsketch/ui-web` | `packages/ui-web` | Framework-agnostic editor + preview UI shared by playground and the upcoming Tauri desktop app (private workspace package, not published) |
-| `@chordsketch/react` | `packages/react` | React component library (pre-release — `<PdfExport>` + `usePdfExport` shipped in #2041; `<ChordSheet>` / `<ChordEditor>` / `<Transpose>` / `<ChordDiagram>` pending). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. |
+| `@chordsketch/react` | `packages/react` | React component library (pre-release — `<PdfExport>` + `usePdfExport` shipped in #2041, `<Transpose>` + `useTranspose` in #2044; `<ChordSheet>` / `<ChordEditor>` / `<ChordDiagram>` pending). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. |
 | Playground | `packages/playground` | Vite-based browser host that mounts `@chordsketch/ui-web` against `@chordsketch/wasm` |
 | Python (`chordsketch`) | `crates/ffi` | Python package via UniFFI + maturin |
 | Swift (`ChordSketch`) | `packages/swift` | Swift package with XCFramework |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,9 +10,9 @@ files, powered by [`@chordsketch/wasm`](https://www.npmjs.com/package/@chordsket
 > **Status:** pre-release. The component surface is landing
 > incrementally under issues
 > [#2041](https://github.com/koedame/chordsketch/issues/2041)–[#2045](https://github.com/koedame/chordsketch/issues/2045).
-> Currently shipped: `<PdfExport>` + `usePdfExport` (#2041).
-> Still pending: `<ChordSheet>`, `<ChordEditor>`,
-> `<Transpose>` + `useTranspose`, `<ChordDiagram>`.
+> Currently shipped: `<PdfExport>` + `usePdfExport` (#2041),
+> `<Transpose>` + `useTranspose` (#2044).
+> Still pending: `<ChordSheet>`, `<ChordEditor>`, `<ChordDiagram>`.
 
 ## Installation
 
@@ -87,6 +87,45 @@ forwarded to the underlying WASM renderer:
 <PdfExport source={source} filename="song-up-2.pdf" options={{ transpose: 2 }} />
 await exportPdf(source, 'ukulele-preset.pdf', { config: 'ukulele' });
 ```
+
+### `<Transpose>` — accessible transposition control
+
+```tsx
+import { Transpose, useTranspose } from '@chordsketch/react';
+
+export function Controls() {
+  const { value, setValue } = useTranspose();
+  return <Transpose value={value} onChange={setValue} />;
+}
+```
+
+The component renders a `−` / current-value readout / `+` trio
+plus a Reset button that appears only when the offset is non-zero.
+Buttons carry per-direction `aria-label`s (`"Transpose up one
+semitone"`, etc.), the readout is an `<output>` with `aria-live="polite"`
+so screen readers announce changes, and the wrapper listens for
+`+` / `-` / `0` keys while focus is inside so keyboard users can
+step without mouse hits. Values are clamped into `[min, max]`
+(defaults `-11`…`+11`) in both the controlled mode and via the
+hook's own `setValue`.
+
+### `useTranspose` — state helper for custom UIs
+
+```tsx
+import { useTranspose } from '@chordsketch/react';
+
+const { value, increment, decrement, reset, setValue } = useTranspose({
+  initial: 0,
+  min: -11,
+  max: 11,
+});
+```
+
+All update functions clamp into `[min, max]`. `reset()` returns
+to the initial value, not necessarily zero. `increment` /
+`decrement` accept an optional step; `setValue` accepts any
+number (including `NaN`, which collapses to `min`) so direct
+binding to a numeric input is safe.
 
 ### Version
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -145,13 +145,15 @@ The returned string matches `package.json`'s `version` field.
   build config — they are resolved by the consumer's bundler rather
   than bundled in. This keeps the published package small and lets
   consumers upgrade those dependencies on their own cadence.
-- **CSS under `./styles.css`** (currently empty) is the canonical
-  stylesheet import path for future components:
+- **CSS under `./styles.css`** is the canonical stylesheet import
+  path — opt in from the host application:
   ```ts
   import '@chordsketch/react/styles.css';
   ```
-  The export is reserved in `package.json` so the first component
-  PR can land the stylesheet without a breaking path change.
+  Rules are minimal and use `currentColor` / transparent
+  backgrounds so the components inherit the host theme. Every
+  selector carries a `chordsketch-*` prefix to avoid colliding
+  with host styles.
 
 ## Links
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,7 +4,6 @@
 // Components land incrementally. Remaining surface:
 //   - #2042: <ChordSheet>
 //   - #2043: <ChordEditor>
-//   - #2044: <Transpose> + useTranspose
 //   - #2045: <ChordDiagram>
 
 import packageJson from '../package.json' with { type: 'json' };
@@ -15,6 +14,12 @@ export {
   type PdfExportOptions,
   type UsePdfExportResult,
 } from './use-pdf-export';
+export { Transpose, type TransposeProps } from './transpose';
+export {
+  useTranspose,
+  type UseTransposeOptions,
+  type UseTransposeResult,
+} from './use-transpose';
 
 /**
  * The running version of `@chordsketch/react`. Returns the string

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1,9 +1,48 @@
 /*
  * @chordsketch/react — component stylesheet.
  *
- * This is the scaffolding commit (#2040). The file is intentionally
- * empty — real rules for `<ChordSheet>` / `<ChordEditor>` / etc.
- * land with each component PR (#2041–#2045). Keeping the file
- * present lets consumers pin the `./styles.css` import path now
- * and have it resolve without error on every component release.
+ * Rules here are minimal defaults designed to be easily overridden
+ * by consumer CSS. Every selector uses the `chordsketch-*` prefix
+ * to avoid colliding with host styles; nothing here uses `!important`
+ * or hard-coded colour values that would clash with dark/light
+ * themes.
  */
+
+.chordsketch-transpose {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: inherit;
+}
+
+.chordsketch-transpose__label {
+  font-size: 0.85em;
+  opacity: 0.7;
+}
+
+.chordsketch-transpose__value {
+  min-width: 2.5ch;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.chordsketch-transpose__button {
+  min-width: 2rem;
+  padding: 0.25rem 0.5rem;
+  font: inherit;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  color: inherit;
+}
+
+.chordsketch-transpose__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.chordsketch-transpose__button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}

--- a/packages/react/src/transpose.tsx
+++ b/packages/react/src/transpose.tsx
@@ -137,7 +137,9 @@ export function Transpose({
         type="button"
         onClick={handleDecrement}
         disabled={decrementDisabled}
-        aria-label="Transpose down one semitone"
+        aria-label={
+          step === 1 ? 'Transpose down one semitone' : `Transpose down ${step} semitones`
+        }
         className="chordsketch-transpose__button chordsketch-transpose__button--decrement"
       >
         −
@@ -153,7 +155,9 @@ export function Transpose({
         type="button"
         onClick={handleIncrement}
         disabled={incrementDisabled}
-        aria-label="Transpose up one semitone"
+        aria-label={
+          step === 1 ? 'Transpose up one semitone' : `Transpose up ${step} semitones`
+        }
         className="chordsketch-transpose__button chordsketch-transpose__button--increment"
       >
         +

--- a/packages/react/src/transpose.tsx
+++ b/packages/react/src/transpose.tsx
@@ -113,6 +113,11 @@ export function Transpose({
     <div
       {...divProps}
       role="group"
+      // `aria-label` has to be a string; fall back to the literal
+      // `"Transpose"` if the caller passed a ReactNode label (e.g.
+      // `<span>🎵</span>`) so the group still has an accessible
+      // name. Consumers who want a different accessible name can
+      // pass an explicit `aria-label` through divProps, which wins.
       aria-label={
         typeof divProps['aria-label'] === 'string'
           ? divProps['aria-label']

--- a/packages/react/src/transpose.tsx
+++ b/packages/react/src/transpose.tsx
@@ -1,0 +1,168 @@
+import type { HTMLAttributes, KeyboardEvent } from 'react';
+import { useCallback } from 'react';
+
+/** Props accepted by {@link Transpose}. */
+export interface TransposeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  /** Current semitone offset (controlled mode). */
+  value: number;
+  /** Fired when the user clicks a button or presses a keyboard shortcut. */
+  onChange: (next: number) => void;
+  /** Minimum offset the buttons will emit. Defaults to `-11`. */
+  min?: number;
+  /** Maximum offset the buttons will emit. Defaults to `+11`. */
+  max?: number;
+  /** Step size for `+` / `−` buttons. Defaults to `1`. */
+  step?: number;
+  /**
+   * Optional label shown inline with the buttons. Defaults to
+   * `"Transpose"`. Pass `null` to omit the visible label; the
+   * component still exposes `aria-label` on the wrapper.
+   */
+  label?: React.ReactNode;
+  /** Format the semitone indicator. Defaults to signed integer. */
+  formatValue?: (value: number) => React.ReactNode;
+}
+
+function defaultFormat(value: number): string {
+  if (value === 0) return '0';
+  return value > 0 ? `+${value}` : `${value}`;
+}
+
+/**
+ * Accessible transposition control: a − button, a current-value
+ * readout, a + button, and a reset button (only rendered when the
+ * offset is non-zero). Keyboard support on the wrapper: `+` / `=`
+ * step up, `-` / `_` step down, `0` resets to zero.
+ *
+ * The component is **controlled** — pass `value` and `onChange`.
+ * Wire up `useTranspose()` next to it if you want the internal
+ * state helper.
+ *
+ * ```tsx
+ * const { value, setValue } = useTranspose();
+ * <Transpose value={value} onChange={setValue} />
+ * ```
+ */
+export function Transpose({
+  value,
+  onChange,
+  min = -11,
+  max = 11,
+  step = 1,
+  label = 'Transpose',
+  formatValue = defaultFormat,
+  className,
+  ...divProps
+}: TransposeProps): JSX.Element {
+  const clamp = useCallback(
+    (next: number): number => {
+      if (next < min) return min;
+      if (next > max) return max;
+      return next;
+    },
+    [min, max],
+  );
+
+  const handleDecrement = useCallback(() => {
+    onChange(clamp(value - step));
+  }, [onChange, clamp, value, step]);
+
+  const handleIncrement = useCallback(() => {
+    onChange(clamp(value + step));
+  }, [onChange, clamp, value, step]);
+
+  const handleReset = useCallback(() => {
+    onChange(0);
+  }, [onChange]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>): void => {
+      // Keyboard shortcuts fire only when the wrapper or one of its
+      // descendants has focus, so they don't interfere with form
+      // fields elsewhere on the page.
+      switch (event.key) {
+        case '+':
+        case '=':
+          event.preventDefault();
+          handleIncrement();
+          break;
+        case '-':
+        case '_':
+          event.preventDefault();
+          handleDecrement();
+          break;
+        case '0':
+          if (value !== 0) {
+            event.preventDefault();
+            handleReset();
+          }
+          break;
+        default:
+          // Let arrow keys and tab key bubble as usual — they
+          // already move focus between the individual buttons.
+          break;
+      }
+    },
+    [handleIncrement, handleDecrement, handleReset, value],
+  );
+
+  const decrementDisabled = value <= min;
+  const incrementDisabled = value >= max;
+
+  return (
+    <div
+      {...divProps}
+      role="group"
+      aria-label={
+        typeof divProps['aria-label'] === 'string'
+          ? divProps['aria-label']
+          : typeof label === 'string'
+            ? label
+            : 'Transpose'
+      }
+      className={['chordsketch-transpose', className].filter(Boolean).join(' ')}
+      onKeyDown={handleKeyDown}
+    >
+      {label !== null ? (
+        <span className="chordsketch-transpose__label" aria-hidden="true">
+          {label}
+        </span>
+      ) : null}
+      <button
+        type="button"
+        onClick={handleDecrement}
+        disabled={decrementDisabled}
+        aria-label="Transpose down one semitone"
+        className="chordsketch-transpose__button chordsketch-transpose__button--decrement"
+      >
+        −
+      </button>
+      <output
+        className="chordsketch-transpose__value"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {formatValue(value)}
+      </output>
+      <button
+        type="button"
+        onClick={handleIncrement}
+        disabled={incrementDisabled}
+        aria-label="Transpose up one semitone"
+        className="chordsketch-transpose__button chordsketch-transpose__button--increment"
+      >
+        +
+      </button>
+      {value !== 0 ? (
+        <button
+          type="button"
+          onClick={handleReset}
+          aria-label="Reset transposition to zero"
+          className="chordsketch-transpose__button chordsketch-transpose__button--reset"
+        >
+          Reset
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/react/src/use-transpose.ts
+++ b/packages/react/src/use-transpose.ts
@@ -1,0 +1,101 @@
+import { useCallback, useState } from 'react';
+
+/** Value returned by {@link useTranspose}. */
+export interface UseTransposeResult {
+  /** Current semitone offset (clamped into `[min, max]`). */
+  value: number;
+  /**
+   * Increase the offset by `step` (default 1). Clamped to `max`.
+   * Calls are idempotent at the clamp boundary.
+   */
+  increment: (step?: number) => void;
+  /**
+   * Decrease the offset by `step` (default 1). Clamped to `min`.
+   * Calls are idempotent at the clamp boundary.
+   */
+  decrement: (step?: number) => void;
+  /** Reset the offset back to its initial value. */
+  reset: () => void;
+  /**
+   * Set the offset to an explicit value, clamped into the supplied
+   * range. Useful for slider / input bindings.
+   */
+  setValue: (next: number) => void;
+}
+
+/** Options accepted by {@link useTranspose}. */
+export interface UseTransposeOptions {
+  /**
+   * Starting semitone offset. Clamped into `[min, max]` before it
+   * is adopted as the initial value. Defaults to 0.
+   */
+  initial?: number;
+  /**
+   * Minimum semitone offset the hook will ever return. Defaults
+   * to `-11` (one semitone short of a full octave down — a full
+   * octave is the identity, so `-12` and `0` render the same
+   * chords).
+   */
+  min?: number;
+  /**
+   * Maximum semitone offset the hook will ever return. Defaults
+   * to `+11`.
+   */
+  max?: number;
+}
+
+/**
+ * Clamps `n` to `[min, max]`. Also normalises `NaN` → `min` so a
+ * caller that passes a parsed input box does not leak an invalid
+ * numeric value into the render path.
+ */
+function clamp(n: number, min: number, max: number): number {
+  if (Number.isNaN(n)) return min;
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}
+
+/**
+ * State helper for transposition controls. Use when you want to
+ * wire your own UI (slider, number input, etc.). The sibling
+ * {@link Transpose} component builds a button + indicator pair on
+ * top of the same helper.
+ *
+ * ```ts
+ * const { value, increment, decrement, reset } = useTranspose({ initial: 2 });
+ * // `value` is always in [-11, +11] by default.
+ * ```
+ */
+export function useTranspose(options: UseTransposeOptions = {}): UseTransposeResult {
+  const { initial = 0, min = -11, max = 11 } = options;
+  const initialClamped = clamp(initial, min, max);
+  const [value, setRawValue] = useState<number>(initialClamped);
+
+  const setValue = useCallback(
+    (next: number): void => {
+      setRawValue(clamp(next, min, max));
+    },
+    [min, max],
+  );
+
+  const increment = useCallback(
+    (step = 1): void => {
+      setRawValue((prev) => clamp(prev + step, min, max));
+    },
+    [min, max],
+  );
+
+  const decrement = useCallback(
+    (step = 1): void => {
+      setRawValue((prev) => clamp(prev - step, min, max));
+    },
+    [min, max],
+  );
+
+  const reset = useCallback((): void => {
+    setRawValue(initialClamped);
+  }, [initialClamped]);
+
+  return { value, increment, decrement, reset, setValue };
+}

--- a/packages/react/tests/transpose.test.tsx
+++ b/packages/react/tests/transpose.test.tsx
@@ -1,0 +1,153 @@
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { Transpose, useTranspose } from '../src/index';
+
+describe('useTranspose', () => {
+  test('initial defaults to 0', () => {
+    const { result } = renderHook(() => useTranspose());
+    expect(result.current.value).toBe(0);
+  });
+
+  test('initial value is clamped into [min, max]', () => {
+    const { result } = renderHook(() => useTranspose({ initial: 999, min: -5, max: 5 }));
+    expect(result.current.value).toBe(5);
+  });
+
+  test('initial NaN collapses to min', () => {
+    const { result } = renderHook(() =>
+      useTranspose({ initial: Number.NaN, min: -5, max: 5 }),
+    );
+    expect(result.current.value).toBe(-5);
+  });
+
+  test('increment/decrement step by 1 by default', () => {
+    const { result } = renderHook(() => useTranspose());
+    act(() => result.current.increment());
+    act(() => result.current.increment());
+    act(() => result.current.decrement());
+    expect(result.current.value).toBe(1);
+  });
+
+  test('increment accepts a custom step', () => {
+    const { result } = renderHook(() => useTranspose());
+    act(() => result.current.increment(3));
+    expect(result.current.value).toBe(3);
+  });
+
+  test('clamps at the max / min boundary and stays idempotent there', () => {
+    const { result } = renderHook(() => useTranspose({ min: 0, max: 2 }));
+    act(() => result.current.increment());
+    act(() => result.current.increment());
+    act(() => result.current.increment()); // clamps
+    act(() => result.current.increment()); // still clamped
+    expect(result.current.value).toBe(2);
+    act(() => result.current.decrement(99));
+    expect(result.current.value).toBe(0);
+  });
+
+  test('setValue clamps the supplied value', () => {
+    const { result } = renderHook(() => useTranspose({ min: -3, max: 3 }));
+    act(() => result.current.setValue(10));
+    expect(result.current.value).toBe(3);
+    act(() => result.current.setValue(-10));
+    expect(result.current.value).toBe(-3);
+  });
+
+  test('reset returns to the initial value (not zero when initial was non-zero)', () => {
+    const { result } = renderHook(() => useTranspose({ initial: 2 }));
+    act(() => result.current.increment(5));
+    expect(result.current.value).toBe(7);
+    act(() => result.current.reset());
+    expect(result.current.value).toBe(2);
+  });
+});
+
+describe('<Transpose>', () => {
+  test('renders current value with a + sign for positive values', () => {
+    render(<Transpose value={3} onChange={vi.fn()} />);
+    expect(screen.getByRole('group', { name: 'Transpose' })).toBeTruthy();
+    expect(screen.getByText('+3')).toBeTruthy();
+  });
+
+  test('renders without a + for zero and a − for negatives', () => {
+    const { rerender } = render(<Transpose value={0} onChange={vi.fn()} />);
+    expect(screen.getByText('0')).toBeTruthy();
+    rerender(<Transpose value={-2} onChange={vi.fn()} />);
+    expect(screen.getByText('-2')).toBeTruthy();
+  });
+
+  test('clicking + / − fires onChange with the clamped next value', () => {
+    const onChange = vi.fn();
+    render(<Transpose value={10} onChange={onChange} max={11} min={-11} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Transpose up one semitone' }));
+    expect(onChange).toHaveBeenLastCalledWith(11);
+    fireEvent.click(screen.getByRole('button', { name: 'Transpose down one semitone' }));
+    expect(onChange).toHaveBeenLastCalledWith(9);
+  });
+
+  test('increment button is disabled at max, decrement button disabled at min', () => {
+    const { rerender } = render(<Transpose value={11} onChange={vi.fn()} max={11} min={-11} />);
+    const upButton = screen.getByRole('button', { name: 'Transpose up one semitone' });
+    expect(upButton.hasAttribute('disabled')).toBe(true);
+    rerender(<Transpose value={-11} onChange={vi.fn()} max={11} min={-11} />);
+    const downButton = screen.getByRole('button', { name: 'Transpose down one semitone' });
+    expect(downButton.hasAttribute('disabled')).toBe(true);
+  });
+
+  test('reset button appears only when value is non-zero', () => {
+    const { rerender } = render(<Transpose value={0} onChange={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Reset transposition to zero' })).toBeNull();
+    rerender(<Transpose value={3} onChange={vi.fn()} />);
+    const reset = screen.getByRole('button', { name: 'Reset transposition to zero' });
+    expect(reset).toBeTruthy();
+  });
+
+  test('reset button click fires onChange with 0', () => {
+    const onChange = vi.fn();
+    render(<Transpose value={3} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reset transposition to zero' }));
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  test('keyboard shortcuts: + / - / 0 fire onChange', () => {
+    const onChange = vi.fn();
+    render(<Transpose value={2} onChange={onChange} />);
+    const group = screen.getByRole('group');
+    fireEvent.keyDown(group, { key: '+' });
+    expect(onChange).toHaveBeenLastCalledWith(3);
+    fireEvent.keyDown(group, { key: '-' });
+    expect(onChange).toHaveBeenLastCalledWith(1);
+    fireEvent.keyDown(group, { key: '0' });
+    expect(onChange).toHaveBeenLastCalledWith(0);
+    // Unrelated keys do not fire onChange.
+    onChange.mockClear();
+    fireEvent.keyDown(group, { key: 'a' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('keyboard 0 on a zero-value input is a no-op (does not spuriously fire onChange)', () => {
+    const onChange = vi.fn();
+    render(<Transpose value={0} onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('group'), { key: '0' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('forwards unknown props to the wrapper div', () => {
+    render(<Transpose value={0} onChange={vi.fn()} data-testid="t" className="custom" />);
+    const group = screen.getByTestId('t');
+    expect(group.className).toContain('chordsketch-transpose');
+    expect(group.className).toContain('custom');
+  });
+
+  test('custom formatValue controls the indicator text', () => {
+    render(
+      <Transpose
+        value={2}
+        onChange={vi.fn()}
+        formatValue={(v) => `${v} st`}
+      />,
+    );
+    expect(screen.getByText('2 st')).toBeTruthy();
+  });
+});

--- a/packages/react/tests/transpose.test.tsx
+++ b/packages/react/tests/transpose.test.tsx
@@ -150,4 +150,10 @@ describe('<Transpose>', () => {
     );
     expect(screen.getByText('2 st')).toBeTruthy();
   });
+
+  test('aria-labels reflect the actual step size when step != 1', () => {
+    render(<Transpose value={0} onChange={vi.fn()} step={2} />);
+    expect(screen.getByRole('button', { name: 'Transpose up 2 semitones' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Transpose down 2 semitones' })).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Second component for \`@chordsketch/react\`, landing on top of the
#2041 PDF-export surface. Adds an accessible transposition
control and the state helper it sits on top of.

### What changed

- **\`useTranspose\` hook** — returns
  \`{ value, increment, decrement, reset, setValue }\` with
  configurable \`initial\` / \`min\` / \`max\` bounds (default
  \`-11\`…\`+11\`). Every setter clamps into range; \`setValue\`
  normalises \`NaN\` → \`min\` so direct binding to a numeric input
  does not leak invalid numerics into the render path.
  \`reset()\` returns to the clamped initial value, not zero.
- **\`<Transpose>\` component** — controlled
  \`<Transpose value onChange min max step label formatValue>\`
  rendering \`−\` / readout / \`+\` / reset. Per-button
  \`aria-label\`s, wrapper exposed as \`role=\"group\"\` with
  \`aria-label=\"Transpose\"\` (overridable); the readout is an
  \`<output aria-live=\"polite\" aria-atomic=\"true\">\` so screen
  readers announce value changes; \`+\` / \`=\` / \`-\` / \`_\` /
  \`0\` keyboard shortcuts on the wrapper step the value when
  focus is inside. Reset button only renders when
  \`value !== 0\`. Boundary buttons \`disabled\` when \`value\` is
  at \`min\` / \`max\`. Unknown props forward to the wrapper div.
- **Baseline CSS** under \`@chordsketch/react/styles.css\` uses
  \`currentColor\` / transparent backgrounds so the control
  inherits the host theme. First non-empty content for that
  reserved stylesheet path (reserved by #2040).
- **Exports** in \`src/index.ts\`: \`Transpose\`, \`TransposeProps\`,
  \`useTranspose\`, \`UseTransposeOptions\`, \`UseTransposeResult\`.
- **Tests** — 18 vitest cases covering hook clamping / step /
  reset / boundary idempotence, component default / negative /
  zero rendering, click dispatch with clamping, disabled state
  at boundaries, reset visibility toggle, keyboard shortcuts
  (\`+\`, \`-\`, \`0\`, unrelated-key no-op, \`0\` no-op when
  already zero), prop forwarding, and \`formatValue\` override.
- **README / CHANGELOG / CLAUDE.md** updated for the new surface.

## Test plan

- [x] \`npm run typecheck\` in \`packages/react/\` — passes.
- [x] \`npm test\` — 27 tests across 3 files, all green (was 9
  after #2143; this PR adds 18).
- [x] \`npm run build\` — ESM 6.88 KB, CJS 7.13 KB, types 9.40 KB
  per format; \`styles.css\` now carries real rules.
- [x] \`python3 scripts/extract-readme-commands.py --check\` exits
  0 (top-level README untouched).

## Scope

- Remaining components (\`<ChordSheet>\` / \`<ChordEditor>\` /
  \`<ChordDiagram>\`) land in #2042 / #2043 / #2045.
- Follow-up issue #2144 (ui-web \`triggerDownload\` try/finally
  gap from the #2143 review) is unrelated to this change.

Closes #2044