### PR TITLE
feat(react): <ChordEditor> split-pane editor + useDebounced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previous render visible. `aria-busy` is set on the wrapper
   during init and in-flight renders so assistive tech observes
   the loading state. (#2042)
+- `@chordsketch/react`: `<ChordEditor>` component +
+  `useDebounced` hook. Split-pane editor with a plain `<textarea>`
+  (auto-correct / spell-check / auto-capitalise disabled so
+  ChordPro tokens don't trigger browser corrections) and a
+  debounced `<ChordSheet>` live preview on the right. Supports
+  controlled (`value` + `onChange`) and uncontrolled
+  (`defaultValue`) modes. Keyboard shortcuts
+  `Ctrl+ArrowUp` / `Ctrl+ArrowDown` (`Cmd` on macOS) fire
+  `onTransposeChange` with the next value clamped into
+  `[minTranspose, maxTranspose]`, so consumers can bind the
+  editor directly to `useTranspose()` for live transposition
+  without leaving the textarea. `readOnly`, `previewFormat`,
+  `config`, `errorFallback`, and `debounceMs` (default 250 ms;
+  `0` flushes synchronously for tests) are all forwarded.
+  `useDebounced(value, delay)` is exported standalone for
+  hosts that want the debouncer without the editor shell. (#2043)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Additionally, these non-Rust packages exist:
 | `@chordsketch/wasm` | `packages/npm` | npm package, **dual build** (browser ESM + Node.js CJS) with TypeScript types |
 | `@chordsketch/node` | `crates/napi` | Native Node.js addon via napi-rs, multi-package prebuilt layout (main resolver + 5 platform packages). See `docs/releasing.md` §napi distribution. |
 | `@chordsketch/ui-web` | `packages/ui-web` | Framework-agnostic editor + preview UI shared by playground and the upcoming Tauri desktop app (private workspace package, not published) |
-| `@chordsketch/react` | `packages/react` | React component library (pre-release — `<PdfExport>` + `usePdfExport` shipped in #2041, `<Transpose>` + `useTranspose` in #2044, `<ChordSheet>` + `useChordRender` in #2042; `<ChordEditor>` / `<ChordDiagram>` pending). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. |
+| `@chordsketch/react` | `packages/react` | React component library (pre-release — `<PdfExport>` + `usePdfExport` shipped in #2041, `<Transpose>` + `useTranspose` in #2044, `<ChordSheet>` + `useChordRender` in #2042, `<ChordEditor>` + `useDebounced` in #2043; `<ChordDiagram>` pending). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. |
 | Playground | `packages/playground` | Vite-based browser host that mounts `@chordsketch/ui-web` against `@chordsketch/wasm` |
 | Python (`chordsketch`) | `crates/ffi` | Python package via UniFFI + maturin |
 | Swift (`ChordSketch`) | `packages/swift` | Swift package with XCFramework |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,8 +12,9 @@ files, powered by [`@chordsketch/wasm`](https://www.npmjs.com/package/@chordsket
 > [#2041](https://github.com/koedame/chordsketch/issues/2041)–[#2045](https://github.com/koedame/chordsketch/issues/2045).
 > Currently shipped: `<PdfExport>` + `usePdfExport` (#2041),
 > `<Transpose>` + `useTranspose` (#2044),
-> `<ChordSheet>` + `useChordRender` (#2042).
-> Still pending: `<ChordEditor>`, `<ChordDiagram>`.
+> `<ChordSheet>` + `useChordRender` (#2042),
+> `<ChordEditor>` + `useDebounced` (#2043).
+> Still pending: `<ChordDiagram>`.
 
 ## Installation
 
@@ -92,6 +93,51 @@ wire the output into a custom container (e.g. a diff view, a
 multi-pane preview). The renderer is memoised against
 `(source, format, transpose, config)`, so re-renders with
 unchanged inputs do not re-parse.
+
+### `<ChordEditor>` — split-pane edit + live preview
+
+```tsx
+import { ChordEditor, useTranspose } from '@chordsketch/react';
+
+export function Editor() {
+  const { value: transpose, setValue: setTranspose } = useTranspose();
+  return (
+    <ChordEditor
+      defaultValue="{title: My Song}\n[G]Hello"
+      transpose={transpose}
+      onTransposeChange={setTranspose}
+    />
+  );
+}
+```
+
+The left pane is a plain `<textarea>` (spell-check / auto-correct
+disabled so ChordPro tokens don't trigger browser corrections),
+the right pane is a `<ChordSheet>` that re-renders a debounced
+copy of the source (default 250 ms). Supports both controlled
+(`value` + `onChange`) and uncontrolled (`defaultValue`) modes,
+plus keyboard shortcuts **Ctrl+ArrowUp / Ctrl+ArrowDown** (Cmd
+on macOS) to fire `onTransposeChange` — wire that callback to
+the `setValue` from `useTranspose()` to get live transposition
+without leaving the editor.
+
+`readOnly`, `previewFormat="text"` (preview inside `<pre>`
+instead of HTML), `config`, custom `errorFallback`, and
+`minTranspose` / `maxTranspose` bounds for the shortcuts are all
+passed through. Pass `debounceMs={0}` in tests to make the
+preview re-render synchronously.
+
+### `useDebounced` — general-purpose debouncer
+
+```tsx
+import { useDebounced } from '@chordsketch/react';
+
+const debouncedQuery = useDebounced(rawQuery, 300);
+```
+
+Returns a value that lags the input by at most `delay` ms.
+`delay <= 0` bypasses the debounce and passes the input through
+synchronously (used internally by `<ChordEditor>` in tests).
 
 ### `<PdfExport>` — one-click PDF download
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -127,6 +127,12 @@ instead of HTML), `config`, custom `errorFallback`, and
 passed through. Pass `debounceMs={0}` in tests to make the
 preview re-render synchronously.
 
+The textarea receives a default `aria-label="ChordPro editor"`
+so screen-reader users hear an actual name rather than falling
+back to the placeholder (which WAI-ARIA does not treat as an
+accessible name). Override via the `textareaAriaLabel` prop when
+a visible `<label>` provides a better name.
+
 ### `useDebounced` — general-purpose debouncer
 
 ```tsx

--- a/packages/react/src/chord-editor.tsx
+++ b/packages/react/src/chord-editor.tsx
@@ -1,0 +1,193 @@
+import type { ChangeEvent, HTMLAttributes, KeyboardEvent, ReactNode } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { ChordSheet } from './chord-sheet';
+import type { ChordRenderFormat, ChordWasmLoader } from './use-chord-render';
+import { useDebounced } from './use-debounced';
+
+/** Props accepted by {@link ChordEditor}. */
+export interface ChordEditorProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
+  /**
+   * Controlled value. When set, the component does not manage its
+   * own internal state — update `value` from the parent on every
+   * `onChange` firing.
+   */
+  value?: string;
+  /**
+   * Initial value for uncontrolled usage. Ignored when `value` is
+   * supplied. Defaults to the empty string.
+   */
+  defaultValue?: string;
+  /**
+   * Fires on every keystroke with the new editor contents. In
+   * uncontrolled mode the component still manages its own state
+   * internally; this callback is how the host observes edits.
+   */
+  onChange?: (value: string) => void;
+  /**
+   * Semitone transposition offset forwarded to the preview pane.
+   * The editor text itself is never transposed — this affects
+   * only how the preview renders the source.
+   */
+  transpose?: number;
+  /**
+   * Fires when the user hits the transpose keyboard shortcut
+   * (Ctrl / Cmd + Up / Down). The component never mutates
+   * `transpose` directly; wire this callback to your own
+   * transpose state (e.g. from `useTranspose`) to respond.
+   */
+  onTransposeChange?: (next: number) => void;
+  /** Configuration preset name or inline RRJSON forwarded to the preview. */
+  config?: string;
+  /** Preview render format. Defaults to `"html"`. See `<ChordSheet>`. */
+  previewFormat?: ChordRenderFormat;
+  /** Disables editing and focuses the preview as the primary surface. */
+  readOnly?: boolean;
+  /**
+   * Debounce window in milliseconds for the preview re-render.
+   * Defaults to `250` ms. Set to `0` to re-render synchronously
+   * on every keystroke (useful for tests).
+   */
+  debounceMs?: number;
+  /** Placeholder shown when the editor is empty. */
+  placeholder?: string;
+  /**
+   * Optional content rendered while the preview's WASM module
+   * initialises or re-renders. Forwarded to the internal
+   * `<ChordSheet loadingFallback>`.
+   */
+  loadingFallback?: ReactNode;
+  /**
+   * Optional error render prop / null forwarded to the internal
+   * `<ChordSheet errorFallback>`. Defaults to the component's own
+   * inline `role="alert"` fallback.
+   */
+  errorFallback?: ((error: Error) => ReactNode) | null;
+  /** Minimum transpose offset the keyboard shortcuts will emit. Defaults to `-11`. */
+  minTranspose?: number;
+  /** Maximum transpose offset the keyboard shortcuts will emit. Defaults to `11`. */
+  maxTranspose?: number;
+  /**
+   * Test-only WASM loader override forwarded to `<ChordSheet>`.
+   * Production callers never need to supply this.
+   *
+   * @internal
+   */
+  wasmLoader?: ChordWasmLoader;
+}
+
+/**
+ * Split-pane editor + live preview. The editor is a plain
+ * `<textarea>` deliberately — richer surfaces (syntax highlighting
+ * via tree-sitter-chordpro or CodeMirror) can be layered on top
+ * without changing this component's contract, because the public
+ * API only promises a controlled / uncontrolled string value and
+ * an onChange callback. The preview re-renders a debounced copy
+ * of the source via `<ChordSheet>`, so typing does not stall the
+ * UI.
+ *
+ * Supports controlled mode (`value` + `onChange`) and
+ * uncontrolled mode (`defaultValue`). Keyboard shortcuts
+ * `Ctrl+ArrowUp` / `Cmd+ArrowUp` / `Ctrl+ArrowDown` /
+ * `Cmd+ArrowDown` fire `onTransposeChange` with the next value
+ * clamped into `[minTranspose, maxTranspose]`, so a consumer can
+ * bind the component directly to `useTranspose()`.
+ */
+export function ChordEditor({
+  value,
+  defaultValue = '',
+  onChange,
+  transpose = 0,
+  onTransposeChange,
+  config,
+  previewFormat = 'html',
+  readOnly = false,
+  debounceMs = 250,
+  placeholder = 'Enter ChordPro source here…',
+  loadingFallback,
+  errorFallback,
+  minTranspose = -11,
+  maxTranspose = 11,
+  wasmLoader,
+  className,
+  ...divProps
+}: ChordEditorProps): JSX.Element {
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = useState<string>(isControlled ? value : defaultValue);
+  const current = isControlled ? value : internal;
+  const debounced = useDebounced(current, debounceMs);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>): void => {
+      const next = event.target.value;
+      if (!isControlled) {
+        setInternal(next);
+      }
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+
+  const clampedTranspose = useMemo(() => {
+    if (transpose < minTranspose) return minTranspose;
+    if (transpose > maxTranspose) return maxTranspose;
+    return transpose;
+  }, [transpose, minTranspose, maxTranspose]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+      if (!(event.ctrlKey || event.metaKey)) return;
+      if (onTransposeChange === undefined) return;
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        const next = Math.min(maxTranspose, clampedTranspose + 1);
+        if (next !== clampedTranspose) {
+          onTransposeChange(next);
+        }
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        const next = Math.max(minTranspose, clampedTranspose - 1);
+        if (next !== clampedTranspose) {
+          onTransposeChange(next);
+        }
+      }
+    },
+    [clampedTranspose, maxTranspose, minTranspose, onTransposeChange],
+  );
+
+  const wrapperClass = ['chordsketch-editor', className].filter(Boolean).join(' ');
+
+  return (
+    <div {...divProps} className={wrapperClass}>
+      <textarea
+        className="chordsketch-editor__textarea"
+        value={current}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        readOnly={readOnly}
+        placeholder={placeholder}
+        spellCheck={false}
+        // `autoComplete=off` and disabling form-assist attributes
+        // stop browser UI (spell-check underlines, auto-capitalise,
+        // autocorrect prompts) from interfering with ChordPro source
+        // — almost every token in a ChordPro file is either a chord
+        // shorthand or a directive name that fails every English
+        // dictionary check.
+        autoCorrect="off"
+        autoCapitalize="off"
+        autoComplete="off"
+      />
+      <div className="chordsketch-editor__preview">
+        <ChordSheet
+          source={debounced}
+          transpose={clampedTranspose}
+          config={config}
+          format={previewFormat}
+          loadingFallback={loadingFallback}
+          errorFallback={errorFallback}
+          wasmLoader={wasmLoader}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/chord-editor.tsx
+++ b/packages/react/src/chord-editor.tsx
@@ -52,6 +52,14 @@ export interface ChordEditorProps extends Omit<HTMLAttributes<HTMLDivElement>, '
   /** Placeholder shown when the editor is empty. */
   placeholder?: string;
   /**
+   * Accessible name forwarded to the editor textarea as
+   * `aria-label`. Defaults to `"ChordPro editor"`. Placeholders
+   * are not accessible names per WAI-ARIA 1.2 §5.2.8, so the
+   * default is applied even when {@link placeholder} is supplied.
+   * Override when the editor sits next to a visible `<label>`.
+   */
+  textareaAriaLabel?: string;
+  /**
    * Optional content rendered while the preview's WASM module
    * initialises or re-renders. Forwarded to the internal
    * `<ChordSheet loadingFallback>`.
@@ -104,6 +112,7 @@ export function ChordEditor({
   readOnly = false,
   debounceMs = 250,
   placeholder = 'Enter ChordPro source here…',
+  textareaAriaLabel = 'ChordPro editor',
   loadingFallback,
   errorFallback,
   minTranspose = -11,
@@ -166,6 +175,7 @@ export function ChordEditor({
         onKeyDown={handleKeyDown}
         readOnly={readOnly}
         placeholder={placeholder}
+        aria-label={textareaAriaLabel}
         spellCheck={false}
         // `autoComplete=off` and disabling form-assist attributes
         // stop browser UI (spell-check underlines, auto-capitalise,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,11 +2,11 @@
 // backed by @chordsketch/wasm.
 //
 // Components land incrementally. Remaining surface:
-//   - #2043: <ChordEditor>
 //   - #2045: <ChordDiagram>
 
 import packageJson from '../package.json' with { type: 'json' };
 
+export { ChordEditor, type ChordEditorProps } from './chord-editor';
 export { ChordSheet, type ChordSheetProps } from './chord-sheet';
 export {
   useChordRender,
@@ -26,6 +26,7 @@ export {
   type UseTransposeOptions,
   type UseTransposeResult,
 } from './use-transpose';
+export { useDebounced } from './use-debounced';
 
 /**
  * The running version of `@chordsketch/react`. Returns the string

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -74,9 +74,7 @@
 .chordsketch-editor {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1px;
   min-height: 20rem;
-  background: currentColor;
   border: 1px solid currentColor;
   border-radius: 6px;
   overflow: hidden;
@@ -89,9 +87,19 @@
   font-size: 0.9rem;
   line-height: 1.5;
   border: none;
+  /* Separate the textarea from the preview pane with a
+     currentColor divider. Dark-mode consumers get a light
+     divider, light-mode a dark one — the divider inherits the
+     surrounding text colour instead of using a hard-coded hex. */
+  border-right: 1px solid currentColor;
   outline: none;
   resize: none;
-  background: inherit;
+  /* Leave the background transparent so the host decides the
+     editor surface. Setting `background: inherit` here was a
+     subtle bug when the wrapper used a `currentColor` grid-gap
+     trick — it made the textarea background the text colour,
+     which turned dark-mode hosts into text-on-text. */
+  background: transparent;
   color: inherit;
   tab-size: 4;
 }
@@ -104,12 +112,17 @@
 .chordsketch-editor__preview {
   padding: 0.75rem;
   overflow: auto;
-  background: inherit;
+  background: transparent;
 }
 
 @media (max-width: 40rem) {
   .chordsketch-editor {
     grid-template-columns: 1fr;
     grid-template-rows: 1fr 1fr;
+  }
+
+  .chordsketch-editor__textarea {
+    border-right: none;
+    border-bottom: 1px solid currentColor;
   }
 }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -70,3 +70,46 @@
   margin-bottom: 0.5rem;
   font-size: 0.9em;
 }
+
+.chordsketch-editor {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  min-height: 20rem;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.chordsketch-editor__textarea {
+  min-height: 20rem;
+  padding: 0.75rem;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  border: none;
+  outline: none;
+  resize: none;
+  background: inherit;
+  color: inherit;
+  tab-size: 4;
+}
+
+.chordsketch-editor__textarea:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -2px;
+}
+
+.chordsketch-editor__preview {
+  padding: 0.75rem;
+  overflow: auto;
+  background: inherit;
+}
+
+@media (max-width: 40rem) {
+  .chordsketch-editor {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+}

--- a/packages/react/src/use-debounced.ts
+++ b/packages/react/src/use-debounced.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delay`
+ * milliseconds have passed without `value` changing.
+ *
+ * Used by `<ChordEditor>` to avoid re-rendering the
+ * `@chordsketch/wasm`-backed preview on every keystroke. The
+ * returned value lags the input by at most one `delay` window; a
+ * change in `delay` flushes the pending timer so the next update
+ * happens on the new schedule.
+ *
+ * ```ts
+ * const [draft, setDraft] = useState('');
+ * const debounced = useDebounced(draft, 300);
+ * ```
+ *
+ * @param value Latest value from state / props.
+ * @param delay Debounce window in milliseconds. Values ≤ 0 bypass
+ *   the debounce entirely and pass the input through synchronously
+ *   on the next render (no effect tick), useful in tests.
+ */
+export function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    if (delay <= 0) {
+      // No debounce requested — if the state slot has somehow
+      // drifted from `value` (e.g. the component initially mounted
+      // with delay > 0), resync it immediately. The fast-path
+      // return below handles the normal case without going
+      // through the effect at all.
+      if (debounced !== value) {
+        setDebounced(value);
+      }
+      return undefined;
+    }
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+    // `debounced` intentionally excluded — it only matters on the
+    // delay-swap resync, which `delay` change already retriggers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, delay]);
+
+  // Fast-path for `delay <= 0`: return the live input synchronously
+  // on every render so tests (and consumers that want a "flush
+  // now" mode) do not have to wait a microtask for the effect to
+  // fire.
+  if (delay <= 0) {
+    return value;
+  }
+  return debounced;
+}

--- a/packages/react/tests/chord-editor.test.tsx
+++ b/packages/react/tests/chord-editor.test.tsx
@@ -75,6 +75,33 @@ describe('<ChordEditor>', () => {
     expect(textarea.value).toBe('bar');
   });
 
+  test('textarea has a default aria-label that overrides the placeholder-as-name fallback', () => {
+    const stub = makeStub();
+    render(
+      <ChordEditor
+        defaultValue=""
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+    const textarea = screen.getByRole('textbox', { name: 'ChordPro editor' });
+    expect(textarea.tagName).toBe('TEXTAREA');
+  });
+
+  test('textareaAriaLabel prop overrides the default accessible name', () => {
+    const stub = makeStub();
+    render(
+      <ChordEditor
+        defaultValue=""
+        textareaAriaLabel="Lyrics source"
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Lyrics source' });
+    expect(textarea.tagName).toBe('TEXTAREA');
+  });
+
   test('readOnly forwards to the textarea', () => {
     render(
       <ChordEditor

--- a/packages/react/tests/chord-editor.test.tsx
+++ b/packages/react/tests/chord-editor.test.tsx
@@ -1,0 +1,238 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ChordEditor } from '../src/index';
+import type { ChordWasmLoader } from '../src/use-chord-render';
+
+// Reuse the stub shape from the chord-sheet suite — the editor's
+// preview pane is just a `<ChordSheet>` under the hood.
+function makeStub() {
+  return {
+    default: vi.fn(async () => undefined),
+    render_html: vi.fn((src: string) => `<article>${src}</article>`),
+    render_text: vi.fn((src: string) => `TEXT:${src}`),
+    render_html_with_options: vi.fn(
+      (src: string, opts: { transpose?: number }) =>
+        `<article data-t="${opts.transpose ?? 0}">${src}</article>`,
+    ),
+    render_text_with_options: vi.fn(
+      (src: string, opts: { transpose?: number }) => `TEXT+${opts.transpose ?? 0}:${src}`,
+    ),
+  };
+}
+
+function makeLoader(stub: ReturnType<typeof makeStub>): ChordWasmLoader {
+  return vi.fn(async () => stub as unknown as Awaited<ReturnType<ChordWasmLoader>>);
+}
+
+describe('<ChordEditor>', () => {
+  test('uncontrolled mode: renders defaultValue and fires onChange on input', async () => {
+    const stub = makeStub();
+    const onChange = vi.fn();
+
+    render(
+      <ChordEditor
+        defaultValue="start"
+        onChange={onChange}
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      'Enter ChordPro source here…',
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('start');
+
+    fireEvent.change(textarea, { target: { value: 'next' } });
+    expect(onChange).toHaveBeenCalledWith('next');
+    expect(textarea.value).toBe('next');
+  });
+
+  test('controlled mode: value prop wins, host owns state via onChange', () => {
+    function Controlled() {
+      const [v, setV] = useState('foo');
+      return (
+        <>
+          <ChordEditor
+            value={v}
+            onChange={setV}
+            wasmLoader={makeLoader(makeStub())}
+            debounceMs={0}
+          />
+          <div data-testid="observed">{v}</div>
+        </>
+      );
+    }
+    render(<Controlled />);
+    const textarea = screen.getByPlaceholderText(
+      'Enter ChordPro source here…',
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('foo');
+    fireEvent.change(textarea, { target: { value: 'bar' } });
+    expect(screen.getByTestId('observed').textContent).toBe('bar');
+    expect(textarea.value).toBe('bar');
+  });
+
+  test('readOnly forwards to the textarea', () => {
+    render(
+      <ChordEditor
+        defaultValue="frozen"
+        readOnly
+        wasmLoader={makeLoader(makeStub())}
+        debounceMs={0}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(
+      'Enter ChordPro source here…',
+    ) as HTMLTextAreaElement;
+    expect(textarea.readOnly).toBe(true);
+  });
+
+  test('debounced preview only re-renders after the quiet window', async () => {
+    const stub = makeStub();
+    render(
+      <ChordEditor
+        defaultValue=""
+        wasmLoader={makeLoader(stub)}
+        debounceMs={120}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(
+      'Enter ChordPro source here…',
+    ) as HTMLTextAreaElement;
+
+    // Wait for the initial WASM load and empty-input render
+    // so the call counter starts from a predictable baseline.
+    // The initial render uses \`render_html_with_options\`
+    // because \`transpose\` defaults to 0 (a non-undefined value).
+    await waitFor(() =>
+      expect(stub.render_html_with_options).toHaveBeenCalledTimes(1),
+    );
+
+    fireEvent.change(textarea, { target: { value: 'a' } });
+    fireEvent.change(textarea, { target: { value: 'ab' } });
+    fireEvent.change(textarea, { target: { value: 'abc' } });
+
+    // Within ~50 ms no preview re-render has fired — all three
+    // keystrokes are still inside the debounce window.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stub.render_html_with_options).toHaveBeenCalledTimes(1);
+
+    // After the window elapses, exactly one additional render
+    // fires with the final value.
+    await waitFor(
+      () => {
+        const calls = stub.render_html_with_options.mock.calls;
+        const lastSrc = calls.length > 0 ? calls[calls.length - 1]?.[0] : undefined;
+        expect(lastSrc).toBe('abc');
+      },
+      { timeout: 1000 },
+    );
+    // Still exactly 2 total calls (initial + debounced final),
+    // not 4 (one per keystroke) — proves the debounce coalesced.
+    expect(stub.render_html_with_options).toHaveBeenCalledTimes(2);
+  });
+
+  test('Ctrl+ArrowUp / Ctrl+ArrowDown fire onTransposeChange with clamped values', async () => {
+    const onTransposeChange = vi.fn();
+    const stub = makeStub();
+
+    render(
+      <ChordEditor
+        defaultValue="x"
+        transpose={2}
+        onTransposeChange={onTransposeChange}
+        minTranspose={-5}
+        maxTranspose={5}
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText('Enter ChordPro source here…');
+
+    fireEvent.keyDown(textarea, { key: 'ArrowUp', ctrlKey: true });
+    expect(onTransposeChange).toHaveBeenLastCalledWith(3);
+
+    fireEvent.keyDown(textarea, { key: 'ArrowDown', ctrlKey: true });
+    expect(onTransposeChange).toHaveBeenLastCalledWith(1);
+
+    // Cmd key also works for macOS parity.
+    fireEvent.keyDown(textarea, { key: 'ArrowUp', metaKey: true });
+    expect(onTransposeChange).toHaveBeenLastCalledWith(3);
+
+    // Arrow keys without modifier do NOT fire the callback (leave
+    // cursor navigation alone).
+    onTransposeChange.mockClear();
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+    expect(onTransposeChange).not.toHaveBeenCalled();
+  });
+
+  test('transpose shortcut clamps at max / min boundary (no callback fired)', () => {
+    const onTransposeChange = vi.fn();
+    const stub = makeStub();
+
+    render(
+      <ChordEditor
+        defaultValue="x"
+        transpose={5}
+        minTranspose={-5}
+        maxTranspose={5}
+        onTransposeChange={onTransposeChange}
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText('Enter ChordPro source here…');
+
+    // At max — up shortcut should be a no-op.
+    fireEvent.keyDown(textarea, { key: 'ArrowUp', ctrlKey: true });
+    expect(onTransposeChange).not.toHaveBeenCalled();
+  });
+
+  test('transpose value is forwarded to the preview via render_html_with_options', async () => {
+    const stub = makeStub();
+    render(
+      <ChordEditor
+        defaultValue="src"
+        transpose={3}
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+    await waitFor(
+      () =>
+        expect(stub.render_html_with_options).toHaveBeenCalledWith('src', {
+          transpose: 3,
+          config: undefined,
+        }),
+      { timeout: 2000 },
+    );
+  });
+
+  test('previewFormat="text" with default transpose still goes through the with-options variant', async () => {
+    const stub = makeStub();
+    render(
+      <ChordEditor
+        defaultValue="src"
+        previewFormat="text"
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+    // `<ChordEditor>` defaults `transpose` to 0 and forwards it
+    // to the preview. `useChordRender` routes any non-undefined
+    // transpose through `render_text_with_options`, so the plain
+    // `render_text` does not fire here — the check below is on
+    // the options variant.
+    await waitFor(
+      () =>
+        expect(stub.render_text_with_options).toHaveBeenCalledWith('src', {
+          transpose: 0,
+          config: undefined,
+        }),
+      { timeout: 2000 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fourth component for \`@chordsketch/react\`, landing on top of
#2042 (<ChordSheet>). Completes the quick-start surface — a
consumer can now drop \`<ChordEditor>\` into any React app and
get an edit-and-preview UI without writing the debounce /
layout / transpose plumbing themselves.

### What changed

- **\`<ChordEditor>\`** — split-pane editor. Left: plain
  \`<textarea>\` with \`autoCorrect\` / \`autoCapitalize\` /
  \`autoComplete\` / \`spellCheck\` all disabled (ChordPro
  tokens should not trigger browser corrections). Right:
  \`<ChordSheet>\` rendering a debounced copy of the source
  (default 250 ms).
  - Controlled (\`value\` + \`onChange\`) and uncontrolled
    (\`defaultValue\`) modes.
  - \`Ctrl+ArrowUp\` / \`Ctrl+ArrowDown\` (or \`Cmd\` on macOS)
    fire \`onTransposeChange\` with a clamped next value — bind
    to \`useTranspose()\` for a keyboard-driven live transpose.
  - \`readOnly\`, \`previewFormat=\"text\"\`, \`config\`, custom
    \`errorFallback\` / \`loadingFallback\`, \`minTranspose\` /
    \`maxTranspose\` forwarded.
- **\`useDebounced(value, delay)\`** — general-purpose debounce
  hook; \`delay <= 0\` bypasses synchronously.
- **CSS grid layout** in \`styles.css\` (50/50 on wide, stacked
  rows on narrow). Uses \`inherit\` / \`currentColor\`.
- **8 vitest cases** covering uncontrolled / controlled /
  readOnly / debounce quiet-window / Ctrl / Cmd / arrow-without-
  modifier / transpose forwarding / text preview.
- README, CHANGELOG, CLAUDE.md updated.

### Deliberate scope decisions

- **Syntax highlighting** (\`tree-sitter-chordpro\` / Prism) is
  deferred. Both would either pull heavy deps into the published
  bundle (CodeMirror 6, tree-sitter wasm) or require an
  optional-dep pattern. The component's contract (\`value\` +
  \`onChange\` + \`readOnly\`) leaves room for a future PR to
  wrap it in a syntax-highlighted surface without breaking
  consumers.
- **Line numbers / gutter** — same rationale.

## Test plan

- [x] \`npm run typecheck\` — passes.
- [x] \`npm test\` — 47 tests across 5 files, all green (was 39
  after #2153; this PR adds 8).
- [x] \`npm run build\` — ESM 13.07 KB, CJS 13.57 KB, types
  18.93 KB per format.

## Scope

- \`<ChordDiagram>\` (#2045) is the only remaining pre-release
  component.
- No changes to the publish pipeline.

Closes #2043