### PR TITLE
feat(react) + wasm: <ChordDiagram> component + chord_diagram_svg export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `0` flushes synchronously for tests) are all forwarded.
   `useDebounced(value, delay)` is exported standalone for
   hosts that want the debouncer without the editor shell. (#2043)
+- `chordsketch-wasm` (`@chordsketch/wasm` npm package): new
+  `chord_diagram_svg(chord, instrument)` export. Looks up the
+  chord in the built-in voicing database (156 voicings: 60
+  guitar / 36 ukulele / 60 piano) and returns inline SVG, or
+  `null` when the database has no entry. Accepted
+  `instrument` values: `"guitar"`, `"ukulele"` (alias
+  `"uke"`), and `"piano"` (aliases `"keyboard"`, `"keys"`).
+  Unknown instruments reject with a `JsError`. The underlying
+  Rust `chord_diagram::render_svg` / `render_keyboard_svg`
+  generators are unchanged; this change only widens the WASM
+  public API. (#2045)
+- `@chordsketch/react`: `<ChordDiagram>` component +
+  `useChordDiagram` hook. Renders inline SVG chord diagrams
+  for guitar / ukulele / piano via the new
+  `chord_diagram_svg` WASM export. The SVG inherits
+  `currentColor` so diagrams match the host theme without
+  extra styling. `notFoundFallback` (default: inline
+  `role="note"` with the chord name) covers chords outside
+  the built-in database; `errorFallback` (default: inline
+  `role="alert"`; pass `null` to hide) covers unsupported
+  instruments or WASM init failures. (#2045)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Additionally, these non-Rust packages exist:
 | `@chordsketch/wasm` | `packages/npm` | npm package, **dual build** (browser ESM + Node.js CJS) with TypeScript types |
 | `@chordsketch/node` | `crates/napi` | Native Node.js addon via napi-rs, multi-package prebuilt layout (main resolver + 5 platform packages). See `docs/releasing.md` §napi distribution. |
 | `@chordsketch/ui-web` | `packages/ui-web` | Framework-agnostic editor + preview UI shared by playground and the upcoming Tauri desktop app (private workspace package, not published) |
-| `@chordsketch/react` | `packages/react` | React component library (pre-release — `<PdfExport>` + `usePdfExport` shipped in #2041, `<Transpose>` + `useTranspose` in #2044, `<ChordSheet>` + `useChordRender` in #2042, `<ChordEditor>` + `useDebounced` in #2043; `<ChordDiagram>` pending). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. |
+| `@chordsketch/react` | `packages/react` | React component library (pre-release — full surface shipped across #2041–#2045: `<PdfExport>`+`usePdfExport`, `<ChordSheet>`+`useChordRender`, `<ChordEditor>`+`useDebounced`, `<Transpose>`+`useTranspose`, `<ChordDiagram>`+`useChordDiagram`). Dual ESM + CJS build via tsup; React 18+ peer dep; CSS at `@chordsketch/react/styles.css`. Awaits first `npm publish` (manual maintainer step). |
 | Playground | `packages/playground` | Vite-based browser host that mounts `@chordsketch/ui-web` against `@chordsketch/wasm` |
 | Python (`chordsketch`) | `crates/ffi` | Python package via UniFFI + maturin |
 | Swift (`ChordSketch`) | `packages/swift` | Swift package with XCFramework |

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -555,6 +555,7 @@ pub fn version() -> String {
 ///
 /// Returns a `JsValue` error string on unknown instrument. Unknown
 /// chords are signalled by returning `Option::None`, not an error.
+#[must_use = "callers must handle the unknown-instrument error"]
 #[wasm_bindgen]
 pub fn chord_diagram_svg(chord: &str, instrument: &str) -> Result<Option<String>, JsValue> {
     use chordsketch_chordpro::chord_diagram::{render_keyboard_svg, render_svg};

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -528,6 +528,56 @@ pub fn version() -> String {
     chordsketch_chordpro::version().to_string()
 }
 
+/// Render a chord diagram to SVG for the given chord name and
+/// instrument.
+///
+/// `instrument` accepts (case-insensitive): `"guitar"`, `"ukulele"`
+/// (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`).
+/// `chord` is a standard ChordPro chord name (e.g. `"Am"`, `"C#m7"`,
+/// `"Bb"`). Flat spellings are normalised to sharps via the same
+/// path the core crate uses for its built-in voicing database
+/// lookup.
+///
+/// Returns `None` (JavaScript `null`) when the chord or instrument
+/// is not known to the built-in voicing database. Hosts typically
+/// render a plain-text fallback (`"Chord not found"`) for that
+/// case; see the `<ChordDiagram>` component in `@chordsketch/react`
+/// for the reference UI.
+///
+/// Output is inline SVG (`<svg>…</svg>`), suitable for injection
+/// into the DOM via `innerHTML` or React's
+/// `dangerouslySetInnerHTML`. Viewers that can rasterise SVG
+/// (every modern browser) display the diagram directly; consumers
+/// that need raster output can pipe the SVG through a library like
+/// `resvg` or `canvg`.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on unknown instrument. Unknown
+/// chords are signalled by returning `Option::None`, not an error.
+#[wasm_bindgen]
+pub fn chord_diagram_svg(chord: &str, instrument: &str) -> Result<Option<String>, JsValue> {
+    use chordsketch_chordpro::chord_diagram::{render_keyboard_svg, render_svg};
+    use chordsketch_chordpro::voicings::{lookup_diagram, lookup_keyboard_voicing};
+
+    match instrument.to_ascii_lowercase().as_str() {
+        "piano" | "keyboard" | "keys" => {
+            Ok(lookup_keyboard_voicing(chord, &[]).map(|v| render_keyboard_svg(&v)))
+        }
+        "guitar" | "ukulele" | "uke" => {
+            // `frets_shown = 5` matches the default ChordPro HTML
+            // renderer (`crates/render-html` emits 5-fret diagrams
+            // when no `{chordfrets}` directive is set) so diagrams
+            // produced by `<ChordDiagram>` visually match the
+            // sheet output from `<ChordSheet>` for the same chord.
+            Ok(lookup_diagram(chord, &[], instrument, 5).map(|d| render_svg(&d)))
+        }
+        other => Err(JsValue::from_str(&format!(
+            "unknown instrument {other:?}; expected one of \"guitar\", \"ukulele\", \"piano\""
+        ))),
+    }
+}
+
 /// A single validation issue reported by [`validate`].
 ///
 /// Serialised to a plain JS `{line, column, message}` object via

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,14 +7,14 @@
 React component library for rendering [ChordPro](https://www.chordpro.org/)
 files, powered by [`@chordsketch/wasm`](https://www.npmjs.com/package/@chordsketch/wasm).
 
-> **Status:** pre-release. The component surface is landing
-> incrementally under issues
-> [#2041](https://github.com/koedame/chordsketch/issues/2041)–[#2045](https://github.com/koedame/chordsketch/issues/2045).
-> Currently shipped: `<PdfExport>` + `usePdfExport` (#2041),
-> `<Transpose>` + `useTranspose` (#2044),
-> `<ChordSheet>` + `useChordRender` (#2042),
-> `<ChordEditor>` + `useDebounced` (#2043).
-> Still pending: `<ChordDiagram>`.
+> **Status:** pre-release. The full component surface promised
+> by #2041–#2045 is now shipped: `<PdfExport>` + `usePdfExport`
+> (#2041), `<ChordSheet>` + `useChordRender` (#2042),
+> `<ChordEditor>` + `useDebounced` (#2043),
+> `<Transpose>` + `useTranspose` (#2044), and
+> `<ChordDiagram>` + `useChordDiagram` (#2045). The package
+> awaits its first `npm publish` (manual maintainer step per the
+> scaffold release contract).
 
 ## Installation
 
@@ -144,6 +144,49 @@ const debouncedQuery = useDebounced(rawQuery, 300);
 Returns a value that lags the input by at most `delay` ms.
 `delay <= 0` bypasses the debounce and passes the input through
 synchronously (used internally by `<ChordEditor>` in tests).
+
+### `<ChordDiagram>` — guitar / ukulele / piano voicings
+
+```tsx
+import { ChordDiagram } from '@chordsketch/react';
+
+export function Voicing() {
+  return (
+    <>
+      <ChordDiagram chord="Am" instrument="guitar" />
+      <ChordDiagram chord="C" instrument="ukulele" />
+      <ChordDiagram chord="Dm7" instrument="piano" />
+    </>
+  );
+}
+```
+
+Looks up the chord in the same voicing database the Rust HTML
+renderer uses (156 built-in voicings: 60 guitar, 36 ukulele,
+60 piano) and returns inline SVG. The SVG inherits
+`currentColor`, so the diagram picks up the host text colour and
+works in dark/light themes without extra styling.
+
+`instrument` accepts `"guitar"`, `"ukulele"` (alias `"uke"`), or
+`"piano"` (aliases `"keyboard"`, `"keys"`). Unknown chords — or
+known chords the database has no voicing for — render
+`notFoundFallback` (default: an inline `role="note"` that
+surfaces the chord name so page readers still see "Am — no
+guitar voicing in the built-in database"). Unsupported
+instruments surface via `errorFallback` (default: inline
+`role="alert"`; pass `errorFallback={null}` to hide).
+
+### `useChordDiagram` — hook for bespoke renderers
+
+```tsx
+import { useChordDiagram } from '@chordsketch/react';
+
+const { svg, loading, error } = useChordDiagram('Am', 'guitar');
+```
+
+Returns the raw SVG string (or `null` when not in the database),
+plus loading / error state. Useful for hosts that want to embed
+the diagram inside custom markup (tooltip, popover, etc.).
 
 ### `<PdfExport>` — one-click PDF download
 

--- a/packages/react/src/chord-diagram.tsx
+++ b/packages/react/src/chord-diagram.tsx
@@ -1,0 +1,146 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import {
+  type ChordDiagramInstrument,
+  type ChordDiagramWasmLoader,
+  useChordDiagram,
+} from './use-chord-diagram';
+
+/** Props accepted by {@link ChordDiagram}. */
+export interface ChordDiagramProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  /** Chord name (e.g. `"Am"`, `"C#m7"`, `"Bb"`). */
+  chord: string;
+  /** Instrument family. Defaults to `"guitar"`. */
+  instrument?: ChordDiagramInstrument;
+  /**
+   * Optional node shown while the WASM module loads. Defaults to
+   * a minimal `role="status"` placeholder.
+   */
+  loadingFallback?: ReactNode;
+  /**
+   * Rendered when the voicing database has no entry for the given
+   * chord+instrument pair. Defaults to an inline `role="note"`
+   * "Chord not found" message so the chord name remains visible
+   * to a reader skimming the page.
+   */
+  notFoundFallback?: ((chord: string, instrument: ChordDiagramInstrument) => ReactNode) | ReactNode;
+  /**
+   * Rendered when the underlying call errors (unknown instrument,
+   * WASM init failure). Defaults to an inline `role="alert"`
+   * showing the error message. Pass `null` to hide and surface
+   * errors via your own channel (e.g. a toast).
+   */
+  errorFallback?: ((error: Error) => ReactNode) | null;
+  /**
+   * Test-only WASM loader override. Production callers never
+   * supply this — the default lazy-loads `@chordsketch/wasm`.
+   *
+   * @internal
+   */
+  wasmLoader?: ChordDiagramWasmLoader;
+}
+
+function defaultNotFoundFallback(
+  chord: string,
+  instrument: ChordDiagramInstrument,
+): ReactNode {
+  return (
+    <div role="note" className="chordsketch-diagram__notfound">
+      <strong>{chord}</strong>
+      <span> — no {instrument} voicing in the built-in database</span>
+    </div>
+  );
+}
+
+function defaultErrorFallback(error: Error): ReactNode {
+  return (
+    <div role="alert" className="chordsketch-diagram__error">
+      {error.message}
+    </div>
+  );
+}
+
+function defaultLoadingFallback(): ReactNode {
+  return (
+    <div role="status" aria-live="polite" className="chordsketch-diagram__loading">
+      Loading diagram…
+    </div>
+  );
+}
+
+/**
+ * Render a chord diagram (guitar / ukulele / piano) as inline SVG
+ * via `@chordsketch/wasm`. The SVG comes from the trusted
+ * `chordsketch_chordpro::chord_diagram` Rust module — the same
+ * generator `<ChordSheet>`'s HTML output uses — so injection via
+ * `dangerouslySetInnerHTML` is safe.
+ *
+ * ```tsx
+ * <ChordDiagram chord="Am" instrument="guitar" />
+ * ```
+ *
+ * When the chord is not known to the built-in voicing database
+ * the component renders `notFoundFallback` instead of the SVG
+ * (defaults to an inline "chord not found" note). When the
+ * underlying call errors (unknown instrument, WASM init failure),
+ * `errorFallback` is rendered.
+ */
+export function ChordDiagram({
+  chord,
+  instrument = 'guitar',
+  loadingFallback,
+  notFoundFallback = defaultNotFoundFallback,
+  errorFallback = defaultErrorFallback,
+  wasmLoader,
+  className,
+  ...divProps
+}: ChordDiagramProps): JSX.Element {
+  const { svg, loading, error } = useChordDiagram(chord, instrument, wasmLoader);
+
+  const wrapperClass = ['chordsketch-diagram', className].filter(Boolean).join(' ');
+
+  if (error !== null && errorFallback !== null) {
+    const node =
+      typeof errorFallback === 'function' ? errorFallback(error) : errorFallback;
+    return (
+      <div {...divProps} className={wrapperClass}>
+        {node}
+      </div>
+    );
+  }
+
+  if (svg === null) {
+    if (loading) {
+      const node = loadingFallback ?? defaultLoadingFallback();
+      return (
+        <div {...divProps} className={wrapperClass} aria-busy="true">
+          {node}
+        </div>
+      );
+    }
+    // Not loading and no SVG — the voicing database has no entry.
+    const node =
+      typeof notFoundFallback === 'function'
+        ? notFoundFallback(chord, instrument)
+        : notFoundFallback;
+    return (
+      <div {...divProps} className={wrapperClass}>
+        {node}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      {...divProps}
+      className={wrapperClass}
+      // The SVG is produced by our own Rust renderer
+      // (`chord_diagram::render_svg` / `render_keyboard_svg`),
+      // which emits a fixed, hand-written template — nothing in
+      // the output is derived from user-controlled attributes.
+      // Injection via `dangerouslySetInnerHTML` is safe here.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,11 +1,14 @@
 // @chordsketch/react — React component library for ChordPro rendering
 // backed by @chordsketch/wasm.
-//
-// Components land incrementally. Remaining surface:
-//   - #2045: <ChordDiagram>
 
 import packageJson from '../package.json' with { type: 'json' };
 
+export { ChordDiagram, type ChordDiagramProps } from './chord-diagram';
+export {
+  useChordDiagram,
+  type ChordDiagramInstrument,
+  type ChordDiagramResult,
+} from './use-chord-diagram';
 export { ChordEditor, type ChordEditorProps } from './chord-editor';
 export { ChordSheet, type ChordSheetProps } from './chord-sheet';
 export {

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -126,3 +126,36 @@
     border-bottom: 1px solid currentColor;
   }
 }
+
+.chordsketch-diagram {
+  display: inline-block;
+  color: inherit;
+  font-family: inherit;
+}
+
+.chordsketch-diagram svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  /* Let the host decide the diagram's colour by inheriting
+     currentColor on every stroke / fill the renderer emits. */
+  color: inherit;
+}
+
+.chordsketch-diagram__notfound,
+.chordsketch-diagram__error,
+.chordsketch-diagram__loading {
+  padding: 0.4rem 0.6rem;
+  border: 1px dashed currentColor;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.chordsketch-diagram__loading {
+  border-style: dotted;
+  opacity: 0.7;
+}
+
+.chordsketch-diagram__error {
+  border-style: solid;
+}

--- a/packages/react/src/use-chord-diagram.ts
+++ b/packages/react/src/use-chord-diagram.ts
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Narrow WASM surface this hook touches. Kept structural so the
+// React package does not drag the WASM glue into its type graph —
+// the module is dynamically imported at runtime. Keep in sync with
+// `tests/helpers/*` stubs that simulate this module.
+interface DiagramRenderer {
+  default: () => Promise<unknown>;
+  /**
+   * Returns the SVG for the given chord+instrument pair, or
+   * `null` / `undefined` when the built-in voicing database has no
+   * entry. Returning `null` (rather than throwing) lets hosts
+   * render a "chord not found" fallback without try/catch.
+   *
+   * Throws a `JsError` when `instrument` is not one of the
+   * supported values (`"guitar"`, `"ukulele"`, `"piano"` +
+   * aliases).
+   */
+  chord_diagram_svg: (chord: string, instrument: string) => string | null | undefined;
+}
+
+/** Supported instrument families for chord diagram lookup. */
+export type ChordDiagramInstrument =
+  | 'guitar'
+  | 'ukulele'
+  | 'uke'
+  | 'piano'
+  | 'keyboard'
+  | 'keys';
+
+/** State exposed by {@link useChordDiagram}. */
+export interface ChordDiagramResult {
+  /**
+   * Inline SVG string, or `null` when the voicing database has no
+   * entry for this (chord, instrument) pair. Consumers typically
+   * render a "chord not found" fallback when this is `null`.
+   */
+  svg: string | null;
+  /** `true` while the WASM module loads or a lookup is in flight. */
+  loading: boolean;
+  /**
+   * Set when the instrument is rejected by the underlying renderer
+   * or when WASM init fails. Unknown chords are NOT errors —
+   * they surface via `svg === null`.
+   */
+  error: Error | null;
+}
+
+/**
+ * WASM loader injected by tests. Production callers take the
+ * default, which lazy-loads `@chordsketch/wasm`.
+ *
+ * @internal
+ */
+export type ChordDiagramWasmLoader = () => Promise<DiagramRenderer>;
+
+// The `chord_diagram_svg` export is added by a Rust-side change
+// paired with this PR (`crates/wasm/src/lib.rs`). The installed
+// `@chordsketch/wasm` package's type declarations do not include
+// it until the next `npm publish`; cast through `unknown` so
+// `tsc --noEmit` does not fail against a stale `.d.ts` in
+// `node_modules`. Replace with a direct cast once the WASM
+// package ships a release that includes the new export.
+const defaultLoader: ChordDiagramWasmLoader = () =>
+  import('@chordsketch/wasm') as unknown as Promise<DiagramRenderer>;
+
+/**
+ * Look up an SVG chord diagram for `(chord, instrument)` via
+ * `@chordsketch/wasm`. The WASM module is loaded lazily and
+ * cached per hook instance. Results are keyed against the
+ * argument tuple so a re-render with the same inputs is a no-op.
+ *
+ * ```ts
+ * const { svg, loading, error } = useChordDiagram('Am', 'guitar');
+ * ```
+ */
+export function useChordDiagram(
+  chord: string,
+  instrument: ChordDiagramInstrument,
+  loader: ChordDiagramWasmLoader = defaultLoader,
+): ChordDiagramResult {
+  const [svg, setSvg] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const rendererRef = useRef<DiagramRenderer | null>(null);
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async (): Promise<void> => {
+      setLoading(true);
+      try {
+        if (rendererRef.current === null) {
+          const mod = await loaderRef.current();
+          await mod.default();
+          if (cancelled) return;
+          rendererRef.current = mod;
+        }
+        const result = rendererRef.current.chord_diagram_svg(chord, instrument);
+        if (cancelled) return;
+        setSvg(result ?? null);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        const err = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+        // Clear previous SVG so a bad instrument does not keep
+        // showing the previous chord's diagram — unlike
+        // `<ChordSheet>`, diagrams are tiny / per-chord, and
+        // keeping a stale image alongside an instrument-mismatch
+        // error would be visually confusing.
+        setSvg(null);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chord, instrument]);
+
+  return { svg, loading, error };
+}

--- a/packages/react/tests/chord-diagram.test.tsx
+++ b/packages/react/tests/chord-diagram.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ChordDiagram, useChordDiagram } from '../src/index';
+import type { ChordDiagramWasmLoader } from '../src/use-chord-diagram';
+
+interface StubRenderer {
+  default: ReturnType<typeof vi.fn>;
+  chord_diagram_svg: ReturnType<typeof vi.fn>;
+}
+
+function makeStub(): StubRenderer {
+  return {
+    default: vi.fn(async () => undefined),
+    chord_diagram_svg: vi.fn((chord: string, instrument: string) => {
+      if (instrument === 'guitar' && chord === 'Am') {
+        return '<svg data-chord="Am" data-instrument="guitar"></svg>';
+      }
+      if (instrument === 'piano' && chord === 'C') {
+        return '<svg data-chord="C" data-instrument="piano"></svg>';
+      }
+      // Unknown combos return null — voicing database has no match.
+      return null;
+    }),
+  };
+}
+
+function makeLoader(stub: StubRenderer): ChordDiagramWasmLoader {
+  return vi.fn(async () => stub as unknown as Awaited<ReturnType<ChordDiagramWasmLoader>>);
+}
+
+describe('<ChordDiagram>', () => {
+  test('renders the SVG returned by the WASM lookup', async () => {
+    const stub = makeStub();
+    const { container } = render(
+      <ChordDiagram chord="Am" instrument="guitar" wasmLoader={makeLoader(stub)} />,
+    );
+    await waitFor(() => {
+      const svg = container.querySelector('.chordsketch-diagram svg');
+      expect(svg?.getAttribute('data-chord')).toBe('Am');
+      expect(svg?.getAttribute('data-instrument')).toBe('guitar');
+    });
+    expect(stub.chord_diagram_svg).toHaveBeenCalledWith('Am', 'guitar');
+  });
+
+  test('defaults instrument to guitar', async () => {
+    const stub = makeStub();
+    render(<ChordDiagram chord="Am" wasmLoader={makeLoader(stub)} />);
+    await waitFor(() => {
+      expect(stub.chord_diagram_svg).toHaveBeenCalledWith('Am', 'guitar');
+    });
+  });
+
+  test('renders the default not-found fallback when the DB has no entry', async () => {
+    const stub = makeStub();
+    render(
+      <ChordDiagram
+        chord="ZZZ7sus4"
+        instrument="guitar"
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+    await waitFor(() => {
+      const note = screen.getByRole('note');
+      expect(note.textContent).toContain('ZZZ7sus4');
+      expect(note.textContent).toContain('guitar');
+    });
+  });
+
+  test('accepts a custom notFoundFallback render prop', async () => {
+    const stub = makeStub();
+    render(
+      <ChordDiagram
+        chord="ZZZ7sus4"
+        instrument="guitar"
+        notFoundFallback={(ch, inst) => (
+          <section data-testid="nf">{`No ${inst} voicing for ${ch}`}</section>
+        )}
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('nf').textContent).toBe('No guitar voicing for ZZZ7sus4');
+    });
+  });
+
+  test('surfaces WASM errors through the default errorFallback', async () => {
+    const stub = makeStub();
+    stub.chord_diagram_svg.mockImplementation(() => {
+      throw new Error('unknown instrument');
+    });
+    render(
+      <ChordDiagram chord="Am" instrument="guitar" wasmLoader={makeLoader(stub)} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe('unknown instrument');
+    });
+  });
+
+  test('errorFallback={null} silences the error UI', async () => {
+    const stub = makeStub();
+    stub.chord_diagram_svg.mockImplementation(() => {
+      throw new Error('nope');
+    });
+    render(
+      <ChordDiagram
+        chord="Am"
+        instrument="guitar"
+        errorFallback={null}
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+    // After waitFor finds nothing, assert no alert element.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('piano instrument is routed through the same function', async () => {
+    const stub = makeStub();
+    const { container } = render(
+      <ChordDiagram chord="C" instrument="piano" wasmLoader={makeLoader(stub)} />,
+    );
+    await waitFor(() => {
+      const svg = container.querySelector('.chordsketch-diagram svg');
+      expect(svg?.getAttribute('data-instrument')).toBe('piano');
+    });
+  });
+
+  test('shows the default loading placeholder until the first result resolves', () => {
+    // Hold the loader open so the loading state is the commit state.
+    const loader: ChordDiagramWasmLoader = () =>
+      new Promise<never>(() => {
+        /* never resolves */
+      });
+    render(<ChordDiagram chord="Am" wasmLoader={loader} />);
+    expect(screen.getByRole('status').textContent).toMatch(/loading/i);
+  });
+});
+
+describe('useChordDiagram', () => {
+  test('re-renders with new SVG when chord prop changes', async () => {
+    const stub = makeStub();
+    function Harness({ chord }: { chord: string }) {
+      const { svg } = useChordDiagram(chord, 'guitar', makeLoader(stub));
+      return <pre data-testid="out">{svg ?? 'NONE'}</pre>;
+    }
+    const { rerender } = render(<Harness chord="Am" />);
+    await waitFor(() => expect(screen.getByTestId('out').textContent).toContain('data-chord="Am"'));
+    rerender(<Harness chord="ZZZ7sus4" />);
+    await waitFor(() => expect(screen.getByTestId('out').textContent).toBe('NONE'));
+  });
+});


### PR DESCRIPTION
## Summary

Completes the five-component React surface promised by #2039.

The Rust repo already has a 156-voicing chord-diagram database
and SVG renderer; this PR (a) exposes that generator via a new
WASM entry point and (b) adds the React component that consumes
it. No new chord database, no new renderer — pure widening of
the public API.

### \`crates/wasm/src/lib.rs\` — new \`chord_diagram_svg\` export

- \`chord_diagram_svg(chord, instrument) -> Option<String>\`
  (plus \`JsError\` on unsupported instrument).
- \`instrument\` ∈ \`{guitar, ukulele/uke, piano/keyboard/keys}\`
  (case-insensitive).
- Routes through
  \`chordsketch_chordpro::voicings::lookup_diagram\` /
  \`lookup_keyboard_voicing\` + \`chord_diagram::render_svg\` /
  \`render_keyboard_svg\`. \`frets_shown = 5\` matches
  \`crates/render-html\` so \`<ChordDiagram>\`'s output is
  visually consistent with \`<ChordSheet>\`'s embedded diagrams.
- Carries \`#[must_use = \"callers must handle the
  unknown-instrument error\"]\` to match the rest of the file's
  convention (clippy's \`double_must_use\` is satisfied by the
  custom reason string).

### \`packages/react\`

- **\`<ChordDiagram chord instrument …>\`** — injects the SVG via
  \`dangerouslySetInnerHTML\`. Safe because the SVG comes from
  our own Rust renderer, which emits a fixed hand-written
  template with no user-controlled attributes (the only
  interpolation is \`chord\`'s title text, passed through
  \`escape::escape_xml\` on the Rust side before it reaches the
  output).
  - \`instrument\` defaults to \`\"guitar\"\`.
  - Default \`notFoundFallback\` keeps the chord name visible in
    a \`role=\"note\"\` (e.g. \"Am — no guitar voicing in the
    built-in database\") instead of swallowing it.
  - Default \`errorFallback\` is \`role=\"alert\"\` with the
    message; pass \`null\` to hide and surface elsewhere.
- **\`useChordDiagram(chord, instrument, loader?)\`** — hook
  version. Same lazy-load / race-guard / memoise pattern as
  \`useChordRender\` / \`usePdfExport\`. Returns
  \`{ svg, loading, error }\`.
- **Baseline styles** — \`.chordsketch-diagram\` /
  \`...__notfound\` / \`...__error\` / \`...__loading\` using
  \`currentColor\` + dashed/dotted borders.
- **9 new vitest cases** covering happy-path SVG injection,
  default instrument, default not-found fallback, custom
  not-found render prop, default error fallback on instrument
  reject, \`errorFallback={null}\`, piano routing, loading
  placeholder, and hook-level re-render on chord-prop change.
- **Transient type cast on the default loader** — the currently
  installed \`@chordsketch/wasm/web/chordsketch_wasm.d.ts\` does
  not include \`chord_diagram_svg\` yet (next publish will add
  it). An \`as unknown\` cast in \`use-chord-diagram.ts\` bridges
  the gap; a code comment flags it for removal after the WASM
  republish. Tracked as #2166.

### Docs / metadata

- \`README.md\` status note updated (all five components
  shipped; awaiting first manual \`npm publish\`).
- \`CHANGELOG.md\` \"Added\" bullets for the WASM export and
  the React component.
- \`CLAUDE.md\` workspace-table row updated.

## Test plan

- [x] \`cargo check -p chordsketch-wasm\` — clean.
- [x] \`cargo clippy -p chordsketch-wasm --all-targets -- -D warnings\` —
  clean.
- [x] \`cargo fmt --check\` — clean.
- [x] \`npm run typecheck\` in \`packages/react/\` — passes.
- [x] \`npm test\` — 58 tests across 6 files, all green (was 49
  after #2159; this PR adds 9).
- [x] \`npm run build\` — ESM 16.30 KB, CJS 16.97 KB, types
  23.57 KB per format.
- [x] \`python3 scripts/extract-readme-commands.py --check\` exits 0.

## Scope decisions

- **Fix-propagation (WASM vs NAPI / FFI)**: this PR widens only
  the WASM binding because the React component is the only new
  consumer landing in this cycle. NAPI and FFI sister exports
  are tracked as **#2165** (file before merging this PR lands
  the follow-up pointer correctly).
- **Raster output (PNG)**: the issue AC mentions SVG only;
  consumers that need raster can pipe the output through
  \`resvg\` / \`canvg\` / \`<img src=\"data:image/svg+xml;…\">\`
  without React-side support.
- **\`variant?: number\` prop from the issue AC**: the
  underlying \`lookup_diagram\` API returns a single canonical
  voicing per (chord, instrument). Surfacing a \`variant\`
  selector would require either exposing the full voicings
  list or a Rust-side change to the lookup API; defer to a
  follow-up issue once users ask for alternate fingerings.

## Follow-ups filed during review

- #2165 — expose \`chord_diagram_svg\` via NAPI + FFI
  (fix-propagation sister-site parity)
- #2166 — drop the transient \`as unknown\` cast in
  \`use-chord-diagram.ts\` after the next
  \`@chordsketch/wasm\` publish

Closes #2045