### PR TITLE
ci(readme-smoke): gate library-smoke until chordsketch-chordpro publishes

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -461,7 +461,7 @@ jobs:
     # old `chordsketch-core` name until v0.3.0 publishes. The PR
     # branch still exercises the snippet via workspace path-deps and
     # fails hard on API drift. Remove this flag once v0.3.0 is on
-    # crates.io; tracked in #1776-equivalent follow-up.
+    # crates.io; tracked in #2169.
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
       # Checkout is needed even on non-PR runs because the PR branch

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -456,6 +456,13 @@ jobs:
   library-smoke:
     name: Library Usage
     runs-on: ubuntu-latest
+    # Tolerate failure on non-PR runs while the `chordsketch-chordpro`
+    # rename (#2097) is still pre-release — crates.io only hosts the
+    # old `chordsketch-core` name until v0.3.0 publishes. The PR
+    # branch still exercises the snippet via workspace path-deps and
+    # fails hard on API drift. Remove this flag once v0.3.0 is on
+    # crates.io; tracked in #1776-equivalent follow-up.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
       # Checkout is needed even on non-PR runs because the PR branch
       # variant uses workspace path-deps. Cheap on shallow clone.


### PR DESCRIPTION
## Summary

Close #2136. The \`library-smoke\` job has been auto-opening
that issue every day because crates.io does not yet host
\`chordsketch-chordpro\` — the rename from \`chordsketch-core\`
in #2097 reaches the public registry only with the v0.3.0
release. The snippet matches the README; the only broken leg is
the crate-name resolution.

### Fix

Add a conditional \`continue-on-error: \${{ github.event_name
!= 'pull_request' }}\` on the \`library-smoke\` job:

- **PR runs stay fail-closed.** The PR branch already uses
  workspace path-deps (the renamed crate), so any future API
  drift is caught immediately.
- **Non-PR runs (daily schedule, release-event, dispatch)
  tolerate the resolution failure** for the duration of the
  pre-release window.

Follow-up **#2169** tracks removing the flag once
\`chordsketch-chordpro\` publishes to crates.io, and bumping
the \`^0.2\` dep constraint to match. Matches the pattern
already used for Chocolatey (#1776).

## Test plan

- [x] Only \`.github/workflows/readme-smoke.yml\` changes; one
  line added.
- [x] \`library-smoke\` on this PR still runs fail-closed via
  the \`github.event_name == 'pull_request'\` branch of the
  existing \`if\` logic (uses workspace path-deps).
- [x] Next daily scheduled run on \`main\` will observe the new
  \`continue-on-error\` and not auto-open #2136 again.

Closes #2136