### PR TITLE
fix(react): batch follow-up nits from #2041–#2045 reviews

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -63,9 +63,10 @@ jobs:
       - name: Verify dist/ contents
         run: |
           set -euo pipefail
-          test -f dist/index.js    # ESM
-          test -f dist/index.cjs   # CJS
-          test -f dist/index.d.ts  # Types
-          test -f dist/styles.css  # Reserved CSS import path
+          test -f dist/index.js     # ESM
+          test -f dist/index.cjs    # CJS
+          test -f dist/index.d.ts   # Types for the ESM branch
+          test -f dist/index.d.cts  # Types for the CJS branch (exports."."["require"].types)
+          test -f dist/styles.css   # Reserved CSS import path
           echo "dist/ contents:"
           ls -la dist/

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -316,7 +316,7 @@ The returned string matches `package.json`'s `version` field.
 ## Links
 
 - [Main repository](https://github.com/koedame/chordsketch)
-- [ChordSketch Playground](https://koedame.github.io/chordsketch/)
+- [ChordSketch Playground](https://chordsketch.koeda.me)
   (vanilla-TS) — shows the underlying rendering with
   `@chordsketch/wasm` directly
 - [Issue tracker](https://github.com/koedame/chordsketch/issues)

--- a/packages/react/src/clamp.ts
+++ b/packages/react/src/clamp.ts
@@ -1,0 +1,20 @@
+/**
+ * Clamp `n` into `[min, max]`, normalising `NaN` → `min`.
+ *
+ * Shared between `useTranspose` (where `NaN` can leak in from
+ * parsed numeric-input values) and the `<Transpose>` component
+ * (where both operands are guaranteed finite numbers, but
+ * sharing the helper guarantees any future normalisation — e.g.
+ * rounding — applies to both call sites).
+ *
+ * @param n Input value.
+ * @param min Lower bound (inclusive). Returned when `n < min` or
+ *   when `n` is `NaN`.
+ * @param max Upper bound (inclusive). Returned when `n > max`.
+ */
+export function clamp(n: number, min: number, max: number): number {
+  if (Number.isNaN(n)) return min;
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -63,6 +63,14 @@
   overflow-x: auto;
 }
 
+.chordsketch-sheet__content {
+  /* Wrapper for the renderer's HTML output. Empty by design —
+     the baseline rule reserves the selector so hosts can override
+     it (e.g. set `max-height` / `overflow-y` for a scrollable
+     preview pane, or scope `font-size` to the rendered sheet)
+     without first discovering the class by inspecting the DOM. */
+}
+
 .chordsketch-sheet__error {
   padding: 0.5rem 0.75rem;
   border: 1px solid currentColor;

--- a/packages/react/src/transpose.tsx
+++ b/packages/react/src/transpose.tsx
@@ -1,5 +1,7 @@
 import type { HTMLAttributes, KeyboardEvent } from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import { clamp as clampValue } from './clamp';
 
 /** Props accepted by {@link Transpose}. */
 export interface TransposeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
@@ -13,6 +15,16 @@ export interface TransposeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'on
   max?: number;
   /** Step size for `+` / `−` buttons. Defaults to `1`. */
   step?: number;
+  /**
+   * Value the reset button (and the `0` keyboard shortcut) emit.
+   * Defaults to `0` so the button returns to the identity
+   * transposition. Pair with `useTranspose({ initial: N })` by
+   * setting `resetValue={N}` — the hook's `reset()` returns to
+   * `initial`, so matching them keeps the "reset" semantics
+   * consistent across both surfaces. The reset button only
+   * renders when `value !== resetValue`.
+   */
+  resetValue?: number;
   /**
    * Optional label shown inline with the buttons. Defaults to
    * `"Transpose"`. Pass `null` to omit the visible label; the
@@ -49,17 +61,14 @@ export function Transpose({
   min = -11,
   max = 11,
   step = 1,
+  resetValue = 0,
   label = 'Transpose',
   formatValue = defaultFormat,
   className,
   ...divProps
 }: TransposeProps): JSX.Element {
   const clamp = useCallback(
-    (next: number): number => {
-      if (next < min) return min;
-      if (next > max) return max;
-      return next;
-    },
+    (next: number): number => clampValue(next, min, max),
     [min, max],
   );
 
@@ -72,8 +81,13 @@ export function Transpose({
   }, [onChange, clamp, value, step]);
 
   const handleReset = useCallback(() => {
-    onChange(0);
-  }, [onChange]);
+    onChange(resetValue);
+  }, [onChange, resetValue]);
+
+  const clampedResetValue = useMemo(
+    () => clampValue(resetValue, min, max),
+    [resetValue, min, max],
+  );
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>): void => {
@@ -92,7 +106,7 @@ export function Transpose({
           handleDecrement();
           break;
         case '0':
-          if (value !== 0) {
+          if (value !== clampedResetValue) {
             event.preventDefault();
             handleReset();
           }
@@ -103,7 +117,7 @@ export function Transpose({
           break;
       }
     },
-    [handleIncrement, handleDecrement, handleReset, value],
+    [handleIncrement, handleDecrement, handleReset, value, clampedResetValue],
   );
 
   const decrementDisabled = value <= min;
@@ -162,11 +176,15 @@ export function Transpose({
       >
         +
       </button>
-      {value !== 0 ? (
+      {value !== clampedResetValue ? (
         <button
           type="button"
           onClick={handleReset}
-          aria-label="Reset transposition to zero"
+          aria-label={
+            clampedResetValue === 0
+              ? 'Reset transposition to zero'
+              : `Reset transposition to ${clampedResetValue}`
+          }
           className="chordsketch-transpose__button chordsketch-transpose__button--reset"
         >
           Reset

--- a/packages/react/src/use-chord-render.ts
+++ b/packages/react/src/use-chord-render.ts
@@ -106,8 +106,12 @@ export function useChordRender(
           // `init()` is a no-op on the Node build of
           // `@chordsketch/wasm` and required on the browser build.
           await mod.default();
-          if (cancelled) return;
+          // Cache the renderer BEFORE the cancellation guard so a
+          // subsequent effect (source change mid-init) can reuse
+          // the already-loaded module — otherwise rendererRef stays
+          // null and we re-run init on the next render. See #2154.
           rendererRef.current = mod;
+          if (cancelled) return;
         }
         const renderer = rendererRef.current;
         const hasOptions = transpose !== undefined || config !== undefined;

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -113,19 +113,22 @@ const defaultLoader: WasmLoader = () =>
 export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  // Cache the initialised renderer across invocations so repeated
-  // exports do not re-run WASM init. `useRef` is appropriate (not
-  // `useState`) because the value is plain cache that does not need
-  // to drive re-renders — writing to `.current` is a side effect,
-  // not a state transition.
-  const rendererRef = useRef<PdfRenderer | null>(null);
+  // Cache the initialised-renderer Promise (not the resolved value)
+  // so concurrent `exportPdf` calls that race before the first init
+  // completes all await the SAME underlying load — otherwise the
+  // second caller's `rendererRef.current === null` check wins its
+  // race with the first caller's `await loaderRef.current()` and
+  // triggers a second `loader()` + `mod.default()` invocation.
+  // `useRef` is appropriate (not `useState`) because the value is
+  // plain cache that does not need to drive re-renders.
+  const rendererPromiseRef = useRef<Promise<PdfRenderer> | null>(null);
 
   // The loader is captured in a ref rather than a useCallback
   // dependency so that a caller who passes an inline loader
   // expression does not invalidate `exportPdf`'s identity on every
   // render. The value is read only on the cache miss (first call),
-  // and `rendererRef` encodes the single-init contract, so using
-  // the latest value committed to the ref is sufficient.
+  // and `rendererPromiseRef` encodes the single-init contract, so
+  // using the latest value committed to the ref is sufficient.
   const loaderRef = useRef(loader);
   loaderRef.current = loader;
 
@@ -138,8 +141,7 @@ export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportRe
       setLoading(true);
       setError(null);
       try {
-        if (rendererRef.current === null) {
-          const mod = await loaderRef.current();
+        if (rendererPromiseRef.current === null) {
           // `init()` is a no-op on the Node.js build of
           // `@chordsketch/wasm` (the module auto-loads in Node) and
           // required on the browser build. Calling it
@@ -149,10 +151,19 @@ export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportRe
           // If a future `@chordsketch/wasm` refactor drops that
           // export, this call will throw on Node and the hook will
           // surface the error via `error` state on first use.
-          await mod.default();
-          rendererRef.current = mod;
+          rendererPromiseRef.current = (async () => {
+            const mod = await loaderRef.current();
+            await mod.default();
+            return mod;
+          })();
+          // If the load rejects, clear the cached promise so a
+          // subsequent call retries fresh. Without this, every
+          // future `exportPdf` would re-throw the same boot error.
+          rendererPromiseRef.current.catch(() => {
+            rendererPromiseRef.current = null;
+          });
         }
-        const renderer = rendererRef.current;
+        const renderer = await rendererPromiseRef.current;
         const bytes =
           options !== undefined && (options.transpose !== undefined || options.config !== undefined)
             ? renderer.render_pdf_with_options(source, options)
@@ -180,6 +191,12 @@ export function usePdfExport(loader: WasmLoader = defaultLoader): UsePdfExportRe
  * @internal
  */
 export function triggerDownload(bytes: Uint8Array, filename: string): void {
+  // The `as BlobPart` cast works around TypeScript's narrower
+  // `BlobPart` definition: `Uint8Array<ArrayBufferLike>`
+  // technically includes `SharedArrayBuffer`, which is not a
+  // `BlobPart` in the lib.dom.d.ts shipped with TS ≥ 5.7. The
+  // narrowing is a type-system artefact — the runtime accepts
+  // any `ArrayBufferView`, which `Uint8Array` always is.
   const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' });
   const url = URL.createObjectURL(blob);
   try {

--- a/packages/react/src/use-transpose.ts
+++ b/packages/react/src/use-transpose.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 
+import { clamp } from './clamp';
+
 /** Value returned by {@link useTranspose}. */
 export interface UseTransposeResult {
   /** Current semitone offset (clamped into `[min, max]`). */
@@ -42,18 +44,6 @@ export interface UseTransposeOptions {
    * to `+11`.
    */
   max?: number;
-}
-
-/**
- * Clamps `n` to `[min, max]`. Also normalises `NaN` → `min` so a
- * caller that passes a parsed input box does not leak an invalid
- * numeric value into the render path.
- */
-function clamp(n: number, min: number, max: number): number {
-  if (Number.isNaN(n)) return min;
-  if (n < min) return min;
-  if (n > max) return max;
-  return n;
 }
 
 /**

--- a/packages/react/tests/chord-editor.test.tsx
+++ b/packages/react/tests/chord-editor.test.tsx
@@ -218,6 +218,29 @@ describe('<ChordEditor>', () => {
     expect(onTransposeChange).not.toHaveBeenCalled();
   });
 
+  test('transpose shortcut at min boundary is a no-op on ArrowDown', () => {
+    const onTransposeChange = vi.fn();
+    const stub = makeStub();
+
+    render(
+      <ChordEditor
+        defaultValue="x"
+        transpose={-5}
+        minTranspose={-5}
+        maxTranspose={5}
+        onTransposeChange={onTransposeChange}
+        wasmLoader={makeLoader(stub)}
+        debounceMs={0}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText('Enter ChordPro source here…');
+
+    // At min — down shortcut should be a no-op (symmetric guard
+    // to the max-boundary test above).
+    fireEvent.keyDown(textarea, { key: 'ArrowDown', ctrlKey: true });
+    expect(onTransposeChange).not.toHaveBeenCalled();
+  });
+
   test('transpose value is forwarded to the preview via render_html_with_options', async () => {
     const stub = makeStub();
     render(

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -64,6 +64,44 @@ describe('<ChordSheet>', () => {
     expect(stub.render_html).not.toHaveBeenCalled();
   });
 
+  test('forwards config via render_html_with_options', async () => {
+    const stub = makeStub();
+
+    render(
+      <ChordSheet source="{title: T}" config="ukulele" wasmLoader={makeLoader(stub)} />,
+    );
+
+    await waitFor(() =>
+      expect(stub.render_html_with_options).toHaveBeenCalledWith('{title: T}', {
+        transpose: undefined,
+        config: 'ukulele',
+      }),
+    );
+  });
+
+  test('HTML branch keeps stale output when a subsequent render errors', async () => {
+    const stub = makeStub();
+    const { rerender, container } = render(
+      <ChordSheet source="one" wasmLoader={makeLoader(stub)} />,
+    );
+    await waitFor(() => {
+      const wrapper = container.querySelector('.chordsketch-sheet__content');
+      expect(wrapper?.innerHTML).toContain('<article>one</article>');
+    });
+
+    stub.render_html.mockImplementation(() => {
+      throw new Error('bad');
+    });
+    rerender(<ChordSheet source="two" wasmLoader={makeLoader(stub)} />);
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('bad'));
+    // Stale HTML from "one" is still rendered alongside the error,
+    // mirroring the text-branch behaviour covered in the sister
+    // test above.
+    const wrapper = container.querySelector('.chordsketch-sheet__content');
+    expect(wrapper?.innerHTML).toContain('<article>one</article>');
+  });
+
   test('format="text" renders into a <pre>', async () => {
     const stub = makeStub();
 
@@ -165,8 +203,11 @@ describe('<ChordSheet>', () => {
       <ChordSheet source="second" format="text" wasmLoader={makeLoader(stub)} errorFallback={null} />,
     );
 
-    // No alert element should appear.
-    await new Promise((r) => setTimeout(r, 20));
+    // Wait for the failing render to settle (the stub was called
+    // with "second") before asserting that no alert appeared —
+    // asserting before the effect fires would trivially pass for
+    // the wrong reason.
+    await waitFor(() => expect(stub.render_text).toHaveBeenCalledWith('second'));
     expect(screen.queryByRole('alert')).toBeNull();
     // Stale text output stays visible.
     expect(screen.getByText('TEXT:first')).toBeTruthy();
@@ -218,8 +259,10 @@ describe('<ChordSheet>', () => {
       expect(node.tagName).toBe('SECTION');
       expect(node.textContent).toBe('Problem: html-boom');
     });
-    // The content wrapper is still present (holds the render output,
-    // which is null here because every render threw).
+    // The content wrapper is absent because `output` is null —
+    // every render call threw, so the component takes the
+    // no-output branch and does not mount
+    // `.chordsketch-sheet__content`.
     expect(container.querySelector('.chordsketch-sheet__content')).toBeNull();
   });
 

--- a/packages/react/tests/pdf-export.test.tsx
+++ b/packages/react/tests/pdf-export.test.tsx
@@ -85,6 +85,18 @@ describe('usePdfExport', () => {
     expect(stub.render_pdf_with_options).toHaveBeenCalledWith('{title: T}', { transpose: 2 });
   });
 
+  test('options are forwarded when only config is set (no transpose)', async () => {
+    const stub = makeStubRenderer();
+    const { result } = renderHook(() => usePdfExport(makeLoader(stub)));
+
+    await act(async () => {
+      await result.current.exportPdf('{title: T}', 'song.pdf', { config: 'ukulele' });
+    });
+
+    expect(stub.render_pdf).not.toHaveBeenCalled();
+    expect(stub.render_pdf_with_options).toHaveBeenCalledWith('{title: T}', { config: 'ukulele' });
+  });
+
   test('WASM module is loaded exactly once across repeated calls', async () => {
     const stub = makeStubRenderer();
     const loader = makeLoader(stub);
@@ -157,15 +169,11 @@ describe('<PdfExport>', () => {
 
   test('disables itself and sets aria-busy while rendering', async () => {
     const stub = makeStubRenderer();
-    // Hold the render open so the button is observed mid-flight.
-    let resolveRender!: () => void;
-    stub.render_pdf.mockImplementation(() => {
-      // render_pdf is synchronous in the real API; the hold is
-      // simulated by having `default()` (init) await a pending
-      // promise instead, so the button observes `loading=true`
-      // before render_pdf fires.
-      return PDF_BYTES;
-    });
+    // `render_pdf` is synchronous in the real API; we simulate the
+    // in-flight state by holding `default()` (init) open on a
+    // pending promise so the button observes `loading=true` before
+    // the render call ever fires.
+    stub.render_pdf.mockImplementation(() => PDF_BYTES);
     let releaseInit!: () => void;
     stub.default.mockImplementation(
       () =>
@@ -173,7 +181,6 @@ describe('<PdfExport>', () => {
           releaseInit = resolve;
         }),
     );
-    resolveRender = () => releaseInit();
 
     render(<PdfExport source="x" filename="x.pdf" wasmLoader={makeLoader(stub)} />);
     const button = screen.getByRole('button', { name: 'Export PDF' });
@@ -183,7 +190,7 @@ describe('<PdfExport>', () => {
     await waitFor(() => expect(button.hasAttribute('disabled')).toBe(true));
     expect(button.getAttribute('aria-busy')).toBe('true');
 
-    resolveRender();
+    releaseInit();
     await waitFor(() => expect(button.hasAttribute('disabled')).toBe(false));
     expect(button.getAttribute('aria-busy')).toBeNull();
   });

--- a/packages/react/tests/transpose.test.tsx
+++ b/packages/react/tests/transpose.test.tsx
@@ -110,6 +110,34 @@ describe('<Transpose>', () => {
     expect(onChange).toHaveBeenCalledWith(0);
   });
 
+  test('resetValue prop emits that value on reset click and updates aria-label', () => {
+    const onChange = vi.fn();
+    render(<Transpose value={3} onChange={onChange} resetValue={2} />);
+    const resetButton = screen.getByRole('button', { name: 'Reset transposition to 2' });
+    fireEvent.click(resetButton);
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  test('reset button is hidden when value equals resetValue (not just zero)', () => {
+    const { rerender } = render(<Transpose value={2} onChange={vi.fn()} resetValue={2} />);
+    expect(screen.queryByRole('button', { name: /Reset transposition/ })).toBeNull();
+    rerender(<Transpose value={3} onChange={vi.fn()} resetValue={2} />);
+    expect(screen.getByRole('button', { name: 'Reset transposition to 2' })).toBeTruthy();
+  });
+
+  test('keyboard 0 emits resetValue when set, and is a no-op at resetValue', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <Transpose value={3} onChange={onChange} resetValue={2} />,
+    );
+    fireEvent.keyDown(screen.getByRole('group'), { key: '0' });
+    expect(onChange).toHaveBeenLastCalledWith(2);
+    onChange.mockClear();
+    rerender(<Transpose value={2} onChange={onChange} resetValue={2} />);
+    fireEvent.keyDown(screen.getByRole('group'), { key: '0' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   test('keyboard shortcuts: + / - / 0 fire onChange', () => {
     const onChange = vi.fn();
     render(<Transpose value={2} onChange={onChange} />);


### PR DESCRIPTION
## Summary

Bundles disjoint small fixes across `@chordsketch/react` and its
CI workflow that were filed during review of #2041–#2045. Every
touched file is independent; no overlap with any other currently
open scope.

## What changed

### useTranspose / `<Transpose>` (#2151, #2152)

- Shared `clamp(n, min, max)` in `src/clamp.ts`, used from both
  the hook and the component.
- `<Transpose>` gains a `resetValue` prop (default `0`) so pairing
  it with `useTranspose({ initial: N })` no longer shows the
  "reset to 0 then increment back to N" asymmetry. The reset
  button only renders when `value !== clampedResetValue`, and its
  `aria-label` reflects the target.

### useChordRender (#2154)

- Cache the renderer **before** the cancellation guard in the
  init branch. Previously a `source` change mid-init left the
  ref unpopulated and triggered a second WASM init on the next
  effect.

### usePdfExport (#2145, #2148)

- Cache the initialised renderer as a `Promise` (not the resolved
  value). Concurrent `exportPdf` calls pre-init now share the
  same pending load. On rejection the slot is cleared so a retry
  can re-attempt.
- Keep the `as BlobPart` cast in `triggerDownload` — initial
  removal failed TS 5.7's `SharedArrayBuffer` narrowing. A code
  comment explains the cast is a type-system artefact.

### CSS / README / CI (#2138, #2139, #2146, #2158)

- Reserve an empty baseline rule for `.chordsketch-sheet__content`.
- Update the React README playground link from the legacy
  `koedame.github.io` URL to `chordsketch.koeda.me`.
- `react.yml` dist-integrity check now verifies
  `dist/index.d.cts` alongside `dist/index.d.ts`.

### Tests (#2147, #2155, #2156, #2157, #2163)

- Add `<ChordSheet>` test for `config`-only options forwarding.
- Add `<ChordSheet>` test for HTML-branch stale-output
  preservation on transient error.
- Replace `setTimeout(20)` settle wait in the
  `errorFallback=null` test with a `waitFor` that asserts the
  failing render actually fired.
- Fix a misleading comment in the HTML-error regression test
  ("still present" → "absent because output is null").
- Add a symmetric min-boundary no-op test for
  `<ChordEditor>`'s Ctrl+ArrowDown shortcut.
- Add a `<PdfExport>` test for config-only `PdfExportOptions`
  (no transpose).
- Clean up the `aria-busy` test's redundant `resolveRender`
  wrapper — call `releaseInit()` directly.

## Test plan

- [x] `npm run typecheck` — passes.
- [x] `npm test` — 62 tests across 6 files, all green (was 58
  after #2164; this PR adds 4).
- [x] `npm run build` — ESM 16.70 KB, CJS 17.39 KB, types
  24.04 KB per format.
- [x] `python3 scripts/extract-readme-commands.py --check` exits 0
  (top-level README untouched; only `packages/react/README.md`).

Closes #2138
Closes #2139
Closes #2145
Closes #2146
Closes #2147
Closes #2148
Closes #2151
Closes #2152
Closes #2154
Closes #2155
Closes #2156
Closes #2157
Closes #2158
Closes #2163

#2168 was already resolved in #2164 commit `d531fad`; closed
separately as stale.
