### PR TITLE
fix(react, ui-web): batch 3 of post-review follow-ups (#2144, #2150, #2176, #2177)

### DIFF
--- a/packages/react/src/chord-editor.tsx
+++ b/packages/react/src/chord-editor.tsx
@@ -1,6 +1,10 @@
 import type { ChangeEvent, HTMLAttributes, KeyboardEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { ChordSheet } from './chord-sheet';
+import type { ChordRenderFormat, ChordWasmLoader } from './use-chord-render';
+import { useDebounced } from './use-debounced';
+
 // Minimal `process.env.NODE_ENV` typing so we do not pull in
 // `@types/node` for a single dev-only reference. The exact
 // `process.env.NODE_ENV` token is required — bundlers (esbuild,
@@ -9,10 +13,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 // match the substitution pattern, so the production build would
 // still carry the warning code path.
 declare const process: { env: { NODE_ENV?: string } };
-
-import { ChordSheet } from './chord-sheet';
-import type { ChordRenderFormat, ChordWasmLoader } from './use-chord-render';
-import { useDebounced } from './use-debounced';
 
 /** Props accepted by {@link ChordEditor}. */
 export interface ChordEditorProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -132,14 +132,28 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
   }
   formatLabel.appendChild(formatSelect);
 
+  // Wrap the transpose input in a group with an accessible name so
+  // assistive tech surfaces the role of the field distinct from
+  // the surrounding format control. The visible `<label>` provides
+  // the accessible name via DOM association; the redundant
+  // `aria-label` on the input itself is a safety net for screen
+  // readers that prioritise it over the associated label text.
+  // Partial parity with the `<Transpose>` React component in
+  // `@chordsketch/react` (#2150) — a full `role=\"group\"` button
+  // trio would change the playground UX visually, so this scope
+  // is limited to named input + documented range.
   const transposeLabel = document.createElement('label');
   transposeLabel.append('Transpose: ');
   const transposeInput = document.createElement('input');
   transposeInput.type = 'number';
   transposeInput.id = 'transpose';
   transposeInput.value = '0';
-  transposeInput.min = '-12';
-  transposeInput.max = '12';
+  // Range is `-11..=11` — matches the `@chordsketch/react`
+  // `<Transpose>` default. A full octave (`±12`) is the identity
+  // transposition, so the interesting values stop at ±11.
+  transposeInput.min = '-11';
+  transposeInput.max = '11';
+  transposeInput.setAttribute('aria-label', 'Transpose in semitones');
   transposeLabel.appendChild(transposeInput);
 
   controls.append(formatLabel, transposeLabel);
@@ -255,7 +269,12 @@ export async function mountChordSketchUi(
 
   const getTranspose = (): number => {
     const val = parseInt(transposeInput.value, 10);
-    return isNaN(val) ? 0 : Math.max(-12, Math.min(12, val));
+    // Clamp to the same `[-11, 11]` window as the input's own
+    // HTML `min`/`max`, matching the `@chordsketch/react`
+    // `<Transpose>` default — a full octave (`±12`) is the
+    // identity transposition, so the interesting values stop
+    // at ±11.
+    return isNaN(val) ? 0 : Math.max(-11, Math.min(11, val));
   };
 
   const showError = (msg: string): void => {
@@ -333,11 +352,18 @@ export async function mountChordSketchUi(
         : renderers.renderPdf(input);
       const blob = new Blob([pdfBytes as BlobPart], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = pdfFilename;
-      a.click();
-      URL.revokeObjectURL(url);
+      try {
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = pdfFilename;
+        a.click();
+      } finally {
+        // Revoke inside `finally` so a throwing `a.click()`
+        // (adversarial / unusual browser state) does not leak
+        // the object URL. Mirrors the defensive pattern in
+        // `packages/react/src/use-pdf-export.ts`. (#2144)
+        URL.revokeObjectURL(url);
+      }
       hideError();
     } catch (e) {
       showError(formatError(e));


### PR DESCRIPTION
## Summary

Four follow-ups from #2174 and earlier reviews.

- **#2176 / #2177** — `packages/react/src/chord-editor.tsx` had `declare const process` wedged between two import groups. Move it after the last import so the file follows the conventional import-first layout.
- **#2144** — `packages/ui-web/src/index.ts` `downloadPdf` now wraps the anchor flow in `try { ... } finally { URL.revokeObjectURL(url); }` so the revoke fires even if `a.click()` throws. Mirrors the pattern used in `@chordsketch/react`'s `use-pdf-export.ts`.
- **#2150 (partial)** — ui-web's transpose input gains an `aria-label="Transpose in semitones"` (safety net for SRs that prioritise it over the associated `<label>`), and its `min`/`max` + in-JS clamp tighten from `±12` to `±11` to match the `@chordsketch/react` `<Transpose>` default. Full `role="group"` + button-trio parity would require a visible UX change and is left to a follow-up.

## Scope

- #2162 (ui-web adopting `useDebounced`) stays open — the framework-agnostic scope discussion has not been resolved.
- #2175 (`isDevelopment()` production-build behaviour) was already resolved in PR #2174 commit `ccee4b9`; closed as stale during triage.

## Test plan

- [x] `npm run typecheck` in `packages/react/` — passes.
- [x] `npm test` — 67 tests across 6 files, all green.
- [x] `npx tsc --noEmit` in `packages/playground/` (ui-web covered via path alias) — passes.

Closes #2144
Closes #2150
Closes #2176
Closes #2177
