### PR TITLE
fix(ui-web): append download anchor to body before click (Firefox)

### DIFF
--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -207,8 +207,15 @@ export function triggerDownload(bytes: Uint8Array, filename: string): void {
     // Firefox) for `click()` to actually dispatch the download event.
     // Removing the element after the click keeps the DOM clean.
     document.body.appendChild(a);
-    a.click();
-    a.remove();
+    try {
+      a.click();
+    } finally {
+      // Inner `finally` — remove the anchor even if `click()`
+      // throws, so an adversarial / unusual browser state does
+      // not leak the DOM node. The outer `finally` still revokes
+      // the object URL after removal.
+      a.remove();
+    }
   } finally {
     URL.revokeObjectURL(url);
   }

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -356,7 +356,18 @@ export async function mountChordSketchUi(
         const a = document.createElement('a');
         a.href = url;
         a.download = pdfFilename;
-        a.click();
+        // Appending to the document is required in some browsers
+        // (notably Firefox) for `click()` to actually dispatch
+        // the download event. Removing the element after the
+        // click keeps the DOM clean. Mirrors the
+        // `triggerDownload` helper in
+        // `packages/react/src/use-pdf-export.ts`. (#2179)
+        document.body.appendChild(a);
+        try {
+          a.click();
+        } finally {
+          a.remove();
+        }
       } finally {
         // Revoke inside `finally` so a throwing `a.click()`
         // (adversarial / unusual browser state) does not leak


### PR DESCRIPTION
## Summary

Closes #2179. The playground's PDF download used a transient
anchor without appending it to \`document.body\`, so Firefox's
click-dispatch guard silently dropped the download event.

The React package's \`triggerDownload\` helper
(\`packages/react/src/use-pdf-export.ts\`) already does the
\`appendChild\` → \`click\` → \`remove\` dance and documents why;
this PR mirrors it in \`packages/ui-web/src/index.ts\` with an
additional inner \`try/finally\` so a throwing \`click()\` still
removes the anchor before the outer \`finally\` revokes the
object URL.

## Test plan

- [x] \`npx tsc --noEmit\` in \`packages/playground/\` — passes.
- [x] Fix-propagation sister-site (\`packages/react/src/use-pdf-export.ts\`) already has the same pattern.
- [ ] Manual playground check in Firefox once deployed.

Closes #2179