### PR TITLE
feat(napi, ffi): expose chord_diagram_svg sister-binding parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the built-in database; `errorFallback` (default: inline
   `role="alert"`; pass `null` to hide) covers unsupported
   instruments or WASM init failures. (#2045)
+- `chordsketch-napi` (`@chordsketch/node` npm package):
+  `chordDiagramSvg(chord, instrument)` export. Sister of
+  the WASM export added in #2164. Accepted `instrument`
+  values + error semantics match the WASM binding;
+  unknown instruments reject with a napi `Error`
+  (`InvalidArg`). `crates/napi/index.d.ts` carries the new
+  declaration. (#2167)
+- `chordsketch-ffi` (UniFFI): `chord_diagram_svg(chord,
+  instrument)` UDL function. Picked up automatically by the
+  Python (`chordsketch.chord_diagram_svg`), Swift
+  (`ChordSketch.chordDiagramSvg`), Kotlin
+  (`uniffi.chordsketch.chordDiagramSvg`), and Ruby
+  (`Chordsketch.chord_diagram_svg`) bindings. Unknown
+  instrument errors via
+  `ChordSketchError::InvalidConfig`. Five new unit tests
+  exercise the happy path, unknown chord (returns `None`),
+  unsupported instrument (errors), and the
+  `uke` / `keyboard` aliases. (#2167)
 
 ### Changed
 

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -59,6 +59,24 @@ namespace chordsketch {
 
     /// Return the ChordSketch library version.
     string version();
+
+    /// Look up an SVG chord diagram for the given chord name and
+    /// instrument. Mirrors the WASM `chord_diagram_svg` export
+    /// added in #2164 and the NAPI `chordDiagramSvg` export
+    /// added in #2167.
+    ///
+    /// `instrument` accepts (case-insensitive): `"guitar"`,
+    /// `"ukulele"` (alias `"uke"`), or `"piano"` (aliases
+    /// `"keyboard"`, `"keys"`). `chord` is a standard ChordPro
+    /// chord name. Flat spellings are normalised to sharps via
+    /// the same path the core voicing-database lookup uses.
+    ///
+    /// Returns the inline SVG string, or `null` when the
+    /// built-in voicing database has no entry for this
+    /// `(chord, instrument)` pair. Throws `InvalidConfig` when
+    /// the instrument is unsupported.
+    [Throws=ChordSketchError]
+    string? chord_diagram_svg(string chord, string instrument);
 };
 
 /// Structured render result for text / HTML output.

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -294,6 +294,55 @@ pub fn version() -> String {
     chordsketch_chordpro::version().to_string()
 }
 
+/// Look up an SVG chord diagram for the given chord name and
+/// instrument. Mirrors the WASM `chord_diagram_svg` export
+/// added in #2164 and the NAPI `chordDiagramSvg` export added
+/// in #2167.
+///
+/// `instrument` accepts (case-insensitive): `"guitar"`,
+/// `"ukulele"` (alias `"uke"`), or `"piano"` (aliases
+/// `"keyboard"`, `"keys"`). `chord` is a standard ChordPro
+/// chord name. Flat spellings are normalised to sharps via the
+/// same path the core voicing-database lookup uses.
+///
+/// Returns `Ok(Some(svg))` for known `(chord, instrument)`
+/// pairs, `Ok(None)` when the database has no entry, and
+/// `Err(ChordSketchError::InvalidConfig)` when the instrument
+/// is not supported.
+///
+/// # Errors
+///
+/// Returns [`ChordSketchError::InvalidConfig`] when
+/// `instrument` is not one of the supported values.
+#[must_use = "callers must handle the unknown-instrument error"]
+pub fn chord_diagram_svg(
+    chord: String,
+    instrument: String,
+) -> Result<Option<String>, ChordSketchError> {
+    use chordsketch_chordpro::chord_diagram::{render_keyboard_svg, render_svg};
+    use chordsketch_chordpro::voicings::{lookup_diagram, lookup_keyboard_voicing};
+
+    match instrument.to_ascii_lowercase().as_str() {
+        "piano" | "keyboard" | "keys" => {
+            Ok(lookup_keyboard_voicing(&chord, &[]).map(|v| render_keyboard_svg(&v)))
+        }
+        "guitar" | "ukulele" | "uke" => {
+            // `frets_shown = 5` matches the default ChordPro HTML
+            // renderer (`crates/render-html` emits 5-fret diagrams
+            // when no `{chordfrets}` directive is set), keeping
+            // diagrams produced via UniFFI bindings (Python /
+            // Swift / Kotlin / Ruby) visually consistent with
+            // sheets rendered through the same binding.
+            Ok(lookup_diagram(&chord, &[], &instrument, 5).map(|d| render_svg(&d)))
+        }
+        other => Err(ChordSketchError::InvalidConfig {
+            reason: format!(
+                "unknown instrument {other:?}; expected one of \"guitar\", \"ukulele\", \"piano\""
+            ),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -391,6 +440,52 @@ mod tests {
     fn test_version() {
         let v = version();
         assert!(!v.is_empty());
+    }
+
+    #[test]
+    fn test_chord_diagram_svg_known_guitar() {
+        let svg = chord_diagram_svg("Am".to_string(), "guitar".to_string()).unwrap();
+        let svg = svg.expect("Am should be in the built-in guitar voicing database");
+        assert!(svg.contains("<svg"), "expected inline SVG, got: {svg}");
+        assert!(svg.contains("Am"));
+    }
+
+    #[test]
+    fn test_chord_diagram_svg_known_piano() {
+        let svg = chord_diagram_svg("C".to_string(), "piano".to_string()).unwrap();
+        let svg = svg.expect("C should be in the built-in piano voicing database");
+        assert!(svg.contains("<svg"));
+    }
+
+    #[test]
+    fn test_chord_diagram_svg_unknown_chord_returns_none() {
+        // A chord name the database has no voicing for must return
+        // `Ok(None)` rather than an error — hosts pattern-match on
+        // the optional to render a "chord not found" fallback.
+        let svg = chord_diagram_svg("ZZZ7sus4".to_string(), "guitar".to_string()).unwrap();
+        assert!(svg.is_none());
+    }
+
+    #[test]
+    fn test_chord_diagram_svg_unknown_instrument_errors() {
+        let err = chord_diagram_svg("C".to_string(), "theremin".to_string())
+            .expect_err("unsupported instrument should reject");
+        match err {
+            ChordSketchError::InvalidConfig { reason } => {
+                assert!(reason.contains("theremin"), "unexpected reason: {reason}");
+            }
+            _ => panic!("expected InvalidConfig, got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn test_chord_diagram_svg_instrument_aliases() {
+        // `"uke"` should route through the same path as `"ukulele"`.
+        let svg = chord_diagram_svg("Am".to_string(), "uke".to_string()).unwrap();
+        assert!(svg.is_some());
+        // `"keyboard"` should route through the piano branch.
+        let svg = chord_diagram_svg("C".to_string(), "keyboard".to_string()).unwrap();
+        assert!(svg.is_some());
     }
 
     #[test]

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -154,3 +154,20 @@ export function renderPdfWithWarningsAndOptions(
  * empty array indicates the document parses cleanly.
  */
 export function validate(source: string): ValidationError[];
+
+/**
+ * Look up an SVG chord diagram for the given chord name and
+ * instrument. Mirrors the WASM `chord_diagram_svg` export
+ * (#2164).
+ *
+ * `instrument` accepts (case-insensitive): `"guitar"`,
+ * `"ukulele"` (alias `"uke"`), or `"piano"` (aliases
+ * `"keyboard"`, `"keys"`). `chord` is a standard ChordPro
+ * chord name.
+ *
+ * Returns the inline SVG string, or `null` when the built-in
+ * voicing database has no entry for this `(chord, instrument)`
+ * pair. Throws an `Error` (`InvalidArg`) when `instrument` is
+ * not one of the supported values.
+ */
+export function chordDiagramSvg(chord: string, instrument: string): string | null;

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -451,6 +451,52 @@ pub fn version() -> String {
     chordsketch_chordpro::version().to_string()
 }
 
+/// Look up an SVG chord diagram for the given chord name and
+/// instrument, mirroring the WASM `chord_diagram_svg` export
+/// added in #2164.
+///
+/// `instrument` accepts (case-insensitive): `"guitar"`,
+/// `"ukulele"` (alias `"uke"`), or `"piano"` (aliases
+/// `"keyboard"`, `"keys"`). `chord` is a standard ChordPro
+/// chord name. Flat spellings are normalised to sharps via the
+/// same path the core voicing-database lookup uses.
+///
+/// Returns the inline SVG string, or `null` (JavaScript `null`)
+/// when the built-in voicing database has no entry for this
+/// `(chord, instrument)` pair. Hosts typically render a
+/// "chord not found" fallback for that case.
+///
+/// # Errors
+///
+/// Returns a napi `Error` with status `InvalidArg` when
+/// `instrument` is not one of the supported values.
+#[must_use = "callers must handle the unknown-instrument error"]
+#[napi]
+pub fn chord_diagram_svg(chord: String, instrument: String) -> Result<Option<String>> {
+    use chordsketch_chordpro::chord_diagram::{render_keyboard_svg, render_svg};
+    use chordsketch_chordpro::voicings::{lookup_diagram, lookup_keyboard_voicing};
+
+    match instrument.to_ascii_lowercase().as_str() {
+        "piano" | "keyboard" | "keys" => {
+            Ok(lookup_keyboard_voicing(&chord, &[]).map(|v| render_keyboard_svg(&v)))
+        }
+        "guitar" | "ukulele" | "uke" => {
+            // `frets_shown = 5` matches the default ChordPro HTML
+            // renderer (`crates/render-html` emits 5-fret diagrams
+            // when no `{chordfrets}` directive is set), keeping
+            // diagrams produced via NAPI visually consistent with
+            // sheets rendered through the same binding.
+            Ok(lookup_diagram(&chord, &[], &instrument, 5).map(|d| render_svg(&d)))
+        }
+        other => Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "unknown instrument {other:?}; expected one of \"guitar\", \"ukulele\", \"piano\""
+            ),
+        )),
+    }
+}
+
 // Unit tests exercise the underlying rendering and parsing logic directly
 // via chordsketch_chordpro and renderer crates. The napi wrapper functions
 // cannot be tested natively because they depend on the Node.js runtime for


### PR DESCRIPTION
## Summary

Closes the fix-propagation gap from #2164: the WASM binding gained `chord_diagram_svg(chord, instrument)`, but NAPI and FFI/UniFFI did not. Per `.claude/rules/fix-propagation.md` §Bindings, every change to one binding's public API surface must be propagated to all three.

### NAPI (`crates/napi`) — #2167

- New `#[napi]` `chord_diagram_svg(chord, instrument)`. Returns `Result<Option<String>>`: known chord → `Some(svg)`, unknown chord → `None`, unsupported instrument → napi `Error{InvalidArg}`.
- `crates/napi/index.d.ts` updated per the file's own keep-in-sync header rule.

### FFI / UniFFI (`crates/ffi`) — #2165

- New UDL function `string? chord_diagram_svg(string chord, string instrument)` plus matching Rust `pub fn`. Unsupported instruments raise `ChordSketchError::InvalidConfig`.
- Python / Swift / Kotlin / Ruby pick the function up through UniFFI-generated bindings (snake_case for Python/Ruby, camelCase for Swift/Kotlin).

### Tests

5 new unit tests in `crates/ffi/src/lib.rs` cover happy path (guitar + piano), unknown chord (returns `None`), unsupported instrument (errors), and the `uke` / `keyboard` aliases.

## Test plan

- [x] `cargo check -p chordsketch-napi` — clean.
- [x] `cargo clippy -p chordsketch-napi --all-targets -- -D warnings` — clean.
- [x] `cargo test -p chordsketch-ffi` — 26 pass (was 21; +5).
- [x] `cargo clippy -p chordsketch-ffi --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Sister-site audit (per `.claude/rules/fix-propagation.md`)

Bindings group: WASM (#2164) + NAPI (this PR) + FFI/UniFFI (this PR). After this PR all three carry `chord_diagram_svg` with matching semantics. No other bindings exist.

Closes #2165
Closes #2167