### PR TITLE
docs(changelog): correct FFI chord_diagram_svg issue reference to #2165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ChordSketchError::InvalidConfig`. Five new unit tests
   exercise the happy path, unknown chord (returns `None`),
   unsupported instrument (errors), and the
-  `uke` / `keyboard` aliases. (#2167)
+  `uke` / `keyboard` aliases. (#2165)
 
 ### Changed
 


### PR DESCRIPTION
## Summary

The `CHANGELOG.md` entry for the `chordsketch-ffi` `chord_diagram_svg` binding cited `(#2167)`, but the FFI work was tracked in issue #2165. Only the NAPI entry should reference `#2167`.

## Test plan

- [x] `git diff` shows a single-character change (`#2167` → `#2165`) on the `chordsketch-ffi` entry only.
- [x] No other CHANGELOG entries or code touched.

Closes #2183