### PR TITLE
feat(ui-web): role=group transpose trio — − / input / + / Reset

### DIFF
--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -90,6 +90,7 @@ interface UiNodes {
   transposeDecrementBtn: HTMLButtonElement;
   transposeIncrementBtn: HTMLButtonElement;
   transposeResetBtn: HTMLButtonElement;
+  transposeLiveRegion: HTMLSpanElement;
   preview: HTMLIFrameElement;
   textOutput: HTMLPreElement;
   pdfPane: HTMLDivElement;
@@ -103,6 +104,18 @@ interface UiNodes {
 const TRANSPOSE_MIN = -11;
 const TRANSPOSE_MAX = 11;
 const TRANSPOSE_RESET = 0;
+
+/**
+ * Signed, human-readable semitone offset for the accessibility
+ * live region. Matches the format emitted by the `<Transpose>`
+ * React component's default `formatValue`, plus an explicit
+ * "semitones" suffix so a screen-reader announcement of `"+3"`
+ * alone is not ambiguous out of context.
+ */
+function formatTransposeForAnnouncement(n: number): string {
+  if (n === 0) return '0 semitones';
+  return `${n > 0 ? '+' : ''}${n} semitones`;
+}
 
 /**
  * Build the playground DOM inside `root`. The previous contents of `root`
@@ -186,10 +199,22 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
   const transposeResetBtn = document.createElement('button');
   transposeResetBtn.type = 'button';
   // Starts hidden because the initial value is `TRANSPOSE_RESET`;
-  // visibility is kept in sync by `updateResetVisibility` below.
+  // visibility is kept in sync by `updateTransposeControls` below.
   transposeResetBtn.className = 'transpose-reset hidden';
   transposeResetBtn.textContent = 'Reset';
   transposeResetBtn.setAttribute('aria-label', 'Reset transpose to 0');
+
+  // Visually-hidden live region that announces the current offset
+  // on every value change. Matches the role of the `<output
+  // aria-live="polite">` in the React `<Transpose>` component;
+  // kept as a separate `<span>` here because ui-web retains an
+  // editable `<input>` for direct numeric entry, which `<output>`
+  // cannot be.
+  const transposeLiveRegion = document.createElement('span');
+  transposeLiveRegion.className = 'sr-only';
+  transposeLiveRegion.setAttribute('aria-live', 'polite');
+  transposeLiveRegion.setAttribute('aria-atomic', 'true');
+  transposeLiveRegion.textContent = formatTransposeForAnnouncement(TRANSPOSE_RESET);
 
   transposeGroup.append(
     transposeLabelText,
@@ -197,6 +222,7 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
     transposeInput,
     transposeIncrementBtn,
     transposeResetBtn,
+    transposeLiveRegion,
   );
 
   controls.append(formatLabel, transposeGroup);
@@ -250,6 +276,7 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
     transposeDecrementBtn,
     transposeIncrementBtn,
     transposeResetBtn,
+    transposeLiveRegion,
     preview,
     textOutput,
     pdfPane,
@@ -307,6 +334,7 @@ export async function mountChordSketchUi(
     transposeDecrementBtn,
     transposeIncrementBtn,
     transposeResetBtn,
+    transposeLiveRegion,
     preview,
     textOutput,
     pdfPane,
@@ -326,24 +354,29 @@ export async function mountChordSketchUi(
       : Math.max(TRANSPOSE_MIN, Math.min(TRANSPOSE_MAX, val));
   };
 
-  // Reset button is only meaningful when the current offset is
-  // non-zero — mirrors the `<Transpose>` React component's
-  // `value !== resetValue` rule.
-  const updateResetVisibility = (): void => {
-    const atReset = getTranspose() === TRANSPOSE_RESET;
-    transposeResetBtn.classList.toggle('hidden', atReset);
+  // Sync the three button states + the live-region announcement
+  // to the current clamped offset. Mirrors the `<Transpose>` React
+  // component's `disabled`-at-boundary + `<output aria-live>` rule
+  // so a screen-reader user driving the trio via buttons hears the
+  // new offset and can feel the hard stop at ±11.
+  const updateTransposeControls = (): void => {
+    const v = getTranspose();
+    transposeDecrementBtn.disabled = v <= TRANSPOSE_MIN;
+    transposeIncrementBtn.disabled = v >= TRANSPOSE_MAX;
+    transposeResetBtn.classList.toggle('hidden', v === TRANSPOSE_RESET);
+    transposeLiveRegion.textContent = formatTransposeForAnnouncement(v);
   };
 
   // Set the transpose field to `next`, clamped to the documented
   // range, and schedule a rerender. Setting `value` via JS does
-  // NOT fire `input` events, so the visibility helper and
+  // NOT fire `input` events, so the control-sync helper and
   // debounced render must be invoked explicitly. Mirrors the
   // behaviour of the `<Transpose>` React component's `onChange`
   // callback.
   const setTranspose = (next: number): void => {
     const clamped = Math.max(TRANSPOSE_MIN, Math.min(TRANSPOSE_MAX, next));
     transposeInput.value = String(clamped);
-    updateResetVisibility();
+    updateTransposeControls();
     scheduleRender();
   };
 
@@ -468,7 +501,7 @@ export async function mountChordSketchUi(
   editor.value = initialChordPro;
 
   const onTransposeInput = (): void => {
-    updateResetVisibility();
+    updateTransposeControls();
     scheduleRender();
   };
   const onTransposeDecrement = (): void => {

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -87,12 +87,22 @@ interface UiNodes {
   editor: HTMLTextAreaElement;
   formatSelect: HTMLSelectElement;
   transposeInput: HTMLInputElement;
+  transposeDecrementBtn: HTMLButtonElement;
+  transposeIncrementBtn: HTMLButtonElement;
+  transposeResetBtn: HTMLButtonElement;
   preview: HTMLIFrameElement;
   textOutput: HTMLPreElement;
   pdfPane: HTMLDivElement;
   downloadPdfBtn: HTMLButtonElement;
   errorDiv: HTMLDivElement;
 }
+
+// Range is `-11..=11` — matches the `@chordsketch/react`
+// `<Transpose>` default. A full octave (`±12`) is the identity
+// transposition, so the interesting values stop at ±11.
+const TRANSPOSE_MIN = -11;
+const TRANSPOSE_MAX = 11;
+const TRANSPOSE_RESET = 0;
 
 /**
  * Build the playground DOM inside `root`. The previous contents of `root`
@@ -132,31 +142,64 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
   }
   formatLabel.appendChild(formatSelect);
 
-  // Wrap the transpose input in a group with an accessible name so
-  // assistive tech surfaces the role of the field distinct from
-  // the surrounding format control. The visible `<label>` provides
-  // the accessible name via DOM association; the redundant
-  // `aria-label` on the input itself is a safety net for screen
-  // readers that prioritise it over the associated label text.
-  // Partial parity with the `<Transpose>` React component in
-  // `@chordsketch/react` (#2150) — a full `role=\"group\"` button
-  // trio would change the playground UX visually, so this scope
-  // is limited to named input + documented range.
-  const transposeLabel = document.createElement('label');
-  transposeLabel.append('Transpose: ');
+  // Full `role="group"` button trio matching the `<Transpose>` React
+  // component in `@chordsketch/react`. Landed in #2070; supersedes
+  // the pre-#2070 scope limit that kept this to a bare `<input>` to
+  // avoid visual regression. The `role="group"` + `aria-label` pair
+  // gives assistive tech one labelled cluster for the three
+  // controls; each button still carries its own `aria-label` so a
+  // screen reader reading one button in isolation announces what
+  // it does, not just "button".
+  const transposeGroup = document.createElement('div');
+  transposeGroup.className = 'transpose-group';
+  transposeGroup.setAttribute('role', 'group');
+  transposeGroup.setAttribute('aria-label', 'Transpose');
+
+  const transposeLabelText = document.createElement('span');
+  transposeLabelText.className = 'transpose-group-label';
+  transposeLabelText.textContent = 'Transpose:';
+  // The surrounding group already carries aria-label="Transpose";
+  // hide this text from assistive tech so screen readers do not
+  // read the word twice when focus enters the group.
+  transposeLabelText.setAttribute('aria-hidden', 'true');
+
+  const transposeDecrementBtn = document.createElement('button');
+  transposeDecrementBtn.type = 'button';
+  transposeDecrementBtn.className = 'transpose-step';
+  transposeDecrementBtn.textContent = '−'; // MINUS SIGN (matches `<Transpose>`)
+  transposeDecrementBtn.setAttribute('aria-label', 'Decrease transpose by 1 semitone');
+
   const transposeInput = document.createElement('input');
   transposeInput.type = 'number';
   transposeInput.id = 'transpose';
-  transposeInput.value = '0';
-  // Range is `-11..=11` — matches the `@chordsketch/react`
-  // `<Transpose>` default. A full octave (`±12`) is the identity
-  // transposition, so the interesting values stop at ±11.
-  transposeInput.min = '-11';
-  transposeInput.max = '11';
+  transposeInput.value = String(TRANSPOSE_RESET);
+  transposeInput.min = String(TRANSPOSE_MIN);
+  transposeInput.max = String(TRANSPOSE_MAX);
   transposeInput.setAttribute('aria-label', 'Transpose in semitones');
-  transposeLabel.appendChild(transposeInput);
 
-  controls.append(formatLabel, transposeLabel);
+  const transposeIncrementBtn = document.createElement('button');
+  transposeIncrementBtn.type = 'button';
+  transposeIncrementBtn.className = 'transpose-step';
+  transposeIncrementBtn.textContent = '+';
+  transposeIncrementBtn.setAttribute('aria-label', 'Increase transpose by 1 semitone');
+
+  const transposeResetBtn = document.createElement('button');
+  transposeResetBtn.type = 'button';
+  // Starts hidden because the initial value is `TRANSPOSE_RESET`;
+  // visibility is kept in sync by `updateResetVisibility` below.
+  transposeResetBtn.className = 'transpose-reset hidden';
+  transposeResetBtn.textContent = 'Reset';
+  transposeResetBtn.setAttribute('aria-label', 'Reset transpose to 0');
+
+  transposeGroup.append(
+    transposeLabelText,
+    transposeDecrementBtn,
+    transposeInput,
+    transposeIncrementBtn,
+    transposeResetBtn,
+  );
+
+  controls.append(formatLabel, transposeGroup);
   header.appendChild(controls);
 
   const main = document.createElement('main');
@@ -204,6 +247,9 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
     editor,
     formatSelect,
     transposeInput,
+    transposeDecrementBtn,
+    transposeIncrementBtn,
+    transposeResetBtn,
     preview,
     textOutput,
     pdfPane,
@@ -258,6 +304,9 @@ export async function mountChordSketchUi(
     editor,
     formatSelect,
     transposeInput,
+    transposeDecrementBtn,
+    transposeIncrementBtn,
+    transposeResetBtn,
     preview,
     textOutput,
     pdfPane,
@@ -269,12 +318,33 @@ export async function mountChordSketchUi(
 
   const getTranspose = (): number => {
     const val = parseInt(transposeInput.value, 10);
-    // Clamp to the same `[-11, 11]` window as the input's own
-    // HTML `min`/`max`, matching the `@chordsketch/react`
-    // `<Transpose>` default — a full octave (`±12`) is the
-    // identity transposition, so the interesting values stop
-    // at ±11.
-    return isNaN(val) ? 0 : Math.max(-11, Math.min(11, val));
+    // Clamp to `TRANSPOSE_MIN..=TRANSPOSE_MAX`. Empty/non-numeric
+    // input (`NaN`) falls back to the reset value so a mid-edit
+    // cleared field doesn't crash renderers downstream.
+    return isNaN(val)
+      ? TRANSPOSE_RESET
+      : Math.max(TRANSPOSE_MIN, Math.min(TRANSPOSE_MAX, val));
+  };
+
+  // Reset button is only meaningful when the current offset is
+  // non-zero — mirrors the `<Transpose>` React component's
+  // `value !== resetValue` rule.
+  const updateResetVisibility = (): void => {
+    const atReset = getTranspose() === TRANSPOSE_RESET;
+    transposeResetBtn.classList.toggle('hidden', atReset);
+  };
+
+  // Set the transpose field to `next`, clamped to the documented
+  // range, and schedule a rerender. Setting `value` via JS does
+  // NOT fire `input` events, so the visibility helper and
+  // debounced render must be invoked explicitly. Mirrors the
+  // behaviour of the `<Transpose>` React component's `onChange`
+  // callback.
+  const setTranspose = (next: number): void => {
+    const clamped = Math.max(TRANSPOSE_MIN, Math.min(TRANSPOSE_MAX, next));
+    transposeInput.value = String(clamped);
+    updateResetVisibility();
+    scheduleRender();
   };
 
   const showError = (msg: string): void => {
@@ -397,9 +467,26 @@ export async function mountChordSketchUi(
 
   editor.value = initialChordPro;
 
+  const onTransposeInput = (): void => {
+    updateResetVisibility();
+    scheduleRender();
+  };
+  const onTransposeDecrement = (): void => {
+    setTranspose(getTranspose() - 1);
+  };
+  const onTransposeIncrement = (): void => {
+    setTranspose(getTranspose() + 1);
+  };
+  const onTransposeReset = (): void => {
+    setTranspose(TRANSPOSE_RESET);
+  };
+
   editor.addEventListener('input', scheduleRender);
   formatSelect.addEventListener('change', render);
-  transposeInput.addEventListener('input', scheduleRender);
+  transposeInput.addEventListener('input', onTransposeInput);
+  transposeDecrementBtn.addEventListener('click', onTransposeDecrement);
+  transposeIncrementBtn.addEventListener('click', onTransposeIncrement);
+  transposeResetBtn.addEventListener('click', onTransposeReset);
   downloadPdfBtn.addEventListener('click', downloadPdf);
 
   render();
@@ -415,7 +502,10 @@ export async function mountChordSketchUi(
       }
       editor.removeEventListener('input', scheduleRender);
       formatSelect.removeEventListener('change', render);
-      transposeInput.removeEventListener('input', scheduleRender);
+      transposeInput.removeEventListener('input', onTransposeInput);
+      transposeDecrementBtn.removeEventListener('click', onTransposeDecrement);
+      transposeIncrementBtn.removeEventListener('click', onTransposeIncrement);
+      transposeResetBtn.removeEventListener('click', onTransposeReset);
       downloadPdfBtn.removeEventListener('click', downloadPdf);
     },
   };

--- a/packages/ui-web/src/style.css
+++ b/packages/ui-web/src/style.css
@@ -8,6 +8,24 @@
   display: none !important;
 }
 
+/*
+ * Visually hidden but reachable by screen readers. The classic
+ * "clip-rect" pattern — a single 1×1 px box offscreen keeps the
+ * element in the accessibility tree so `aria-live` regions still
+ * announce, while not occupying visual layout.
+ */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 :root {
   --bg: #1a1a2e;
   --surface: #16213e;
@@ -107,6 +125,11 @@ header h1 {
 .transpose-group button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
+}
+
+.transpose-group button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .transpose-reset {

--- a/packages/ui-web/src/style.css
+++ b/packages/ui-web/src/style.css
@@ -74,6 +74,46 @@ header h1 {
   text-align: center;
 }
 
+.transpose-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #999;
+}
+
+.transpose-group-label {
+  /* `aria-hidden` on this node keeps it out of the accessibility
+     tree; styling is purely visual. */
+  margin-right: 0.1rem;
+}
+
+.transpose-group button {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+  min-width: 1.75rem;
+}
+
+.transpose-group button:hover {
+  background: var(--border);
+}
+
+.transpose-group button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.transpose-reset {
+  /* Slightly wider than the ± steppers because the label is a word. */
+  min-width: auto !important;
+}
+
 main {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary

Extends `@chordsketch/ui-web`'s transpose control from a bare `<input type=number>` to the full accessible trio documented in `@chordsketch/react`'s `<Transpose>` component: decrement, input, increment, reset. The addition automatically reaches both the browser playground and the Tauri desktop app because they both mount `mountChordSketchUi`.

## Scope

From the acceptance-criteria list on #2070:

| AC | Status |
|---|---|
| Toolbar displays current transpose semitones | Already satisfied by the existing input (unchanged). |
| **`+` / `−` buttons increment / decrement by 1 semitone** | **Implemented.** |
| `Cmd/Ctrl + Up / Down` transposes | **Deferred** — tracked as #2190 (see below). |
| **Reset button returns to 0** | **Implemented** (hidden while current offset is 0). |
| Preview updates immediately | Already satisfied — same `scheduleRender` debounce used by all controls. |
| CI green | Verified locally via playground + desktop Vite builds. |

### Keyboard shortcut deferral

The `Cmd/Ctrl + Up / Down` shortcut is excluded from this PR to keep shortcut-binding decisions deliberate. Shortcuts affect global accelerator maps, clash with OS conventions, and are expensive to revert once muscle memory forms. The binding will be decided holistically once the other desktop shortcut touch-points (#2080 file I/O, #2072 editor) have their requirements settled. Tracking issue: #2190.

## Implementation

- `packages/ui-web/src/index.ts`
  - New `UiNodes` fields: `transposeDecrementBtn`, `transposeIncrementBtn`, `transposeResetBtn`.
  - Module constants `TRANSPOSE_MIN = -11`, `TRANSPOSE_MAX = 11`, `TRANSPOSE_RESET = 0` — single source of truth for the input's `min`/`max` attributes, the `getTranspose()` clamp, the `setTranspose(next)` clamp, and the Reset button's semantics.
  - `buildDom` now emits `<div role="group" aria-label="Transpose"><span aria-hidden="true">Transpose:</span> <button>−</button> <input> <button>+</button> <button class="hidden">Reset</button></div>`. Each button carries its own `aria-label` so screen readers reading one button in isolation announce what it does.
  - `mountChordSketchUi` gets an `updateResetVisibility` helper (toggles `.hidden` on the Reset button when the current offset crosses 0) and a `setTranspose(next)` helper (clamps, writes to the input, updates visibility, schedules a render). `setTranspose` exists because programmatic `input.value = …` does **not** fire `input` events, so the input's listener wouldn't otherwise fire.
  - Reset button is only meaningful at non-zero offsets, so it starts hidden (initial value is `0`) and the visibility helper keeps it in sync on every input change + button click.
  - Event listeners are registered on all four new elements and torn down by the existing `destroy()` path so the handle returned by `mountChordSketchUi` still cancels cleanly.
- `packages/ui-web/src/style.css`
  - New `.transpose-group`, `.transpose-step`, `.transpose-reset` selectors styled against the existing `--surface` / `--border` / `--accent` tokens, so the trio looks at home on both dark-mode hosts without theme overrides.
  - `.transpose-group-label` is only a visual label — the `aria-hidden="true"` on the `<span>` keeps it out of the accessibility tree (the group's `aria-label="Transpose"` does the work there).

## Fix-propagation / rule audit

- `.claude/rules/fix-propagation.md` — no renderer / binding / sanitizer sister group touched. The React `<Transpose>` component already implements the equivalent surface in `packages/react/src/transpose.tsx`; this PR brings ui-web to parity, it does not diverge from it.
- `.claude/rules/ci-parallelization.md` — no CI workflow changes.
- `.claude/rules/code-style.md` — ui-web has no test runner; integration smoke is via the existing playground + desktop Vite builds in `desktop-smoke`.
- `.claude/rules/doc-maintenance.md` — no new crate / workflow / rule; no doc update required.
- `.claude/rules/one-pr-at-a-time.md` — verified `gh pr list --state open --base main` is empty.

## Test plan

- [x] `(cd packages/npm && npm run build)` — wasm dual-package build clean.
- [x] `(cd packages/playground && npm ci && npm run build)` — playground bundles cleanly against the new ui-web; no new TS errors.
- [x] `(cd apps/desktop && npm ci && npm run build)` — desktop frontend bundles cleanly (tsc + vite build green).
- [x] `cargo fmt --all --check` — clean.
- [ ] Interactive browser click-test — not exercised in this PR environment; deferred to manual verification during merge.

Closes #2070