### PR TITLE
feat(desktop): File → Export PDF / HTML via native dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,8 +540,11 @@ name = "chordsketch-desktop"
 version = "0.0.0"
 dependencies = [
  "chordsketch-chordpro",
+ "chordsketch-render-html",
+ "chordsketch-render-pdf",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
 ]
 
 [[package]]
@@ -2793,6 +2796,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3598,6 +3602,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,6 +4401,65 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -88,6 +88,28 @@ the Rust binary against `apps/desktop/dist/`. Bundles land under
 release matrix (signing, notarization, upload to GitHub Releases) is
 tracked under `#2075`, `#2077`, and `#2078`.
 
+## Export flow
+
+`File → Export PDF…` / `Export HTML…` in the native menu route
+through two Tauri commands in `src-tauri/src/main.rs`:
+
+- `export_pdf(path, chordpro, transpose)` → calls
+  `chordsketch-render-pdf::render_songs_with_transpose` directly
+  from Rust (not the WASM module that drives the live preview)
+  and writes the bytes to `path`.
+- `export_html(path, chordpro, transpose)` → mirror of the above
+  against `chordsketch-render-html`.
+
+Going through Rust instead of WASM keeps exported files
+byte-for-byte identical to what the CLI (`chordsketch`) and the
+UniFFI bindings produce, and avoids piping the full rendered
+buffer back across the IPC boundary as JavaScript memory.
+
+The native save dialog is provided by `tauri-plugin-dialog`;
+the capability in `src-tauri/capabilities/default.json` grants
+only `dialog:allow-save` + `dialog:allow-message` — file-open
+lands with `#2080`.
+
 ## Workspace integration
 
 - `apps/desktop/src-tauri` is a workspace member but **excluded from

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "chordsketch-desktop-frontend",
       "version": "0.0.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-dialog": "^2.7.0"
+      },
       "devDependencies": {
         "typescript": "^5.7.0",
         "vite": "^6.0.0"
@@ -803,6 +807,25 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.0.tgz",
+      "integrity": "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,5 +12,9 @@
   "devDependencies": {
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-dialog": "^2.7.0"
   }
 }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ license = "AGPL-3.0-only"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "ChordSketch desktop application (Tauri v2 scaffold)"
+description = "ChordSketch desktop application"
 publish = false
 
 [build-dependencies]
@@ -18,12 +18,15 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 chordsketch-chordpro = { path = "../../../crates/chordpro" }
+chordsketch-render-html = { path = "../../../crates/render-html" }
+chordsketch-render-pdf = { path = "../../../crates/render-pdf" }
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 
-# Promotes `unused_crate_dependencies` to a warning so that the
-# `use chordsketch_chordpro as _;` link in `src/main.rs` is load-bearing.
-# If a future contributor deletes the `use` line without wiring the
-# parser into the editor surface, the build will warn instead of
-# silently dropping the workspace-linkage AC from #2069.
 [lints.rust]
+# Guards against a workspace-linkage regression: if any of the SDK
+# crates above are silently removed from the binary's dependency
+# graph (e.g. all uses of `chordsketch_render_pdf::*` are deleted in
+# a follow-up refactor), the build now warns instead of accepting a
+# dead entry in Cargo.toml. Kept from #2069.
 unused_crate_dependencies = "warn"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,7 +1,12 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Scaffold-tight capability set. The placeholder frontend runs no IPC; granting only the core app + window primitives keeps the default posture narrow so the UI issues (#2071 split-pane, #2074 export dialog, #2080 file I/O) must opt in consciously rather than inherit `core:default`'s event/menu/tray/path surface.",
+  "description": "Narrow capability set. `core:app:default` + `core:window:default` are the baseline from #2069. `dialog:allow-save` + `dialog:allow-message` are added in #2074 so the File → Export handlers can open a native save dialog and show a success/error alert; the broader `dialog:default` (which also grants file-open + confirm + ask) is intentionally NOT granted — open-file lands with #2080 and will extend this capability then.",
   "windows": ["main"],
-  "permissions": ["core:app:default", "core:window:default"]
+  "permissions": [
+    "core:app:default",
+    "core:window:default",
+    "dialog:allow-save",
+    "dialog:allow-message"
+  ]
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,14 +1,63 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-// Proof of workspace wiring (AC of #2069). The editor preview drives
-// the parser in follow-ups (#2071 split-pane editor, #2074 export
-// dialog); until then, `as _` keeps the linkage live so the crate's
-// `[lints.rust] unused_crate_dependencies = "warn"` fires if the link
-// is removed without replacement.
-use chordsketch_chordpro as _;
+use std::fs;
+
+use chordsketch_chordpro::config::Config;
+use chordsketch_chordpro::parse_multi_lenient;
+
+/// Parse the supplied ChordPro source, render every song it contains
+/// with the requested transposition, and write the result to `path`.
+///
+/// Called by the renderer-specific command wrappers below. Extracting
+/// the parse + render pipeline here keeps the two commands
+/// byte-for-byte equivalent apart from the format choice, so a fix
+/// to one (e.g. transpose-clamp behaviour, parse-warnings surface,
+/// error message format) does not drift against the other — see
+/// `.claude/rules/fix-propagation.md` for the sister-site rationale.
+fn render_and_write<R>(path: &str, chordpro: &str, transpose: i8, render: R) -> Result<(), String>
+where
+    R: Fn(&[chordsketch_chordpro::ast::Song], i8, &Config) -> Vec<u8>,
+{
+    let config = Config::defaults();
+    let parse_result = parse_multi_lenient(chordpro);
+    let songs: Vec<_> = parse_result.results.into_iter().map(|r| r.song).collect();
+    let bytes = render(&songs, transpose, &config);
+    fs::write(path, bytes).map_err(|e| format!("Failed to write {path}: {e}"))
+}
+
+/// Renders `chordpro` to PDF with the optional `transpose` offset and
+/// writes the bytes to `path`. The renderer is the in-process
+/// `chordsketch-render-pdf` crate, not the WASM module — satisfies
+/// AC3 of #2074.
+#[tauri::command]
+fn export_pdf(path: String, chordpro: String, transpose: Option<i8>) -> Result<(), String> {
+    render_and_write(
+        &path,
+        &chordpro,
+        transpose.unwrap_or(0),
+        chordsketch_render_pdf::render_songs_with_transpose,
+    )
+}
+
+/// Renders `chordpro` to HTML with the optional `transpose` offset
+/// and writes the string to `path`. As with `export_pdf`, the
+/// renderer is the in-process `chordsketch-render-html` crate.
+#[tauri::command]
+fn export_html(path: String, chordpro: String, transpose: Option<i8>) -> Result<(), String> {
+    render_and_write(
+        &path,
+        &chordpro,
+        transpose.unwrap_or(0),
+        |songs, t, config| {
+            chordsketch_render_html::render_songs_with_transpose(songs, t, config).into_bytes()
+        },
+    )
+}
 
 fn main() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .invoke_handler(tauri::generate_handler![export_pdf, export_html])
         .run(tauri::generate_context!())
         // `expect` is justified: this is process entry — if the Tauri
         // runtime cannot start, there is no application to recover

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -6,8 +6,30 @@ import init, {
   render_text_with_options,
   render_pdf_with_options,
 } from '@chordsketch/wasm';
-import { mountChordSketchUi, type Renderers } from '@chordsketch/ui-web';
+import {
+  mountChordSketchUi,
+  type ChordSketchUiHandle,
+  type Renderers,
+} from '@chordsketch/ui-web';
 import '@chordsketch/ui-web/style.css';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  Menu,
+  MenuItem,
+  PredefinedMenuItem,
+  Submenu,
+} from '@tauri-apps/api/menu';
+import { message, save } from '@tauri-apps/plugin-dialog';
+
+type ExportFormat = 'pdf' | 'html';
+
+const EXPORT_FILTERS: Record<
+  ExportFormat,
+  { name: string; extensions: string[] }
+> = {
+  pdf: { name: 'PDF', extensions: ['pdf'] },
+  html: { name: 'HTML', extensions: ['html', 'htm'] },
+};
 
 // Adapter from the wasm-bindgen export shape to the ui-web `Renderers`
 // interface. Mirrors `packages/playground/src/main.ts` so the desktop
@@ -30,8 +52,131 @@ if (!root) {
   throw new Error('Desktop entry point #app element missing from index.html');
 }
 
-void mountChordSketchUi(root, {
-  renderers,
-  title: 'ChordSketch',
-  documentTitle: 'ChordSketch',
-});
+/**
+ * Drive a File → Export flow: read the editor content + transpose
+ * offset from the UI handle, show the native save dialog, and
+ * invoke the matching Rust command.
+ *
+ * The Rust renderer is used deliberately (not the WASM in the
+ * WebView) — satisfies AC3 of #2074 and means export output is
+ * byte-for-byte consistent with the CLI / FFI builds.
+ */
+async function runExport(
+  handle: ChordSketchUiHandle,
+  format: ExportFormat,
+): Promise<void> {
+  const path = await save({
+    defaultPath: `chordsketch.${format}`,
+    filters: [EXPORT_FILTERS[format]],
+  });
+  if (!path) return; // User cancelled the save dialog.
+
+  try {
+    const transpose = handle.getTranspose();
+    await invoke(format === 'pdf' ? 'export_pdf' : 'export_html', {
+      path,
+      chordpro: handle.getChordPro(),
+      // Only forward a non-zero transpose so the Rust side can
+      // follow the same identity-skip that the WASM adapter uses
+      // in `renderers` above.
+      transpose: transpose === 0 ? null : transpose,
+    });
+    await message(`Exported to ${path}`, {
+      title: 'ChordSketch',
+      kind: 'info',
+    });
+  } catch (err) {
+    await message(err instanceof Error ? err.message : String(err), {
+      title: 'Export failed',
+      kind: 'error',
+    });
+  }
+}
+
+/**
+ * Install a minimal native menu bar that matches platform
+ * conventions (macOS top menu bar / Windows + Linux window menu):
+ *
+ * - ChordSketch → Quit  (anchors the macOS app menu slot so users
+ *   don't lose `⌘Q`; Linux/Windows still render this as the first
+ *   submenu but that's OK)
+ * - File → Export PDF…, Export HTML…, Close Window
+ * - Edit → Undo/Redo/Cut/Copy/Paste/Select All  (Tauri's custom
+ *   app menu replaces the native default, so the clipboard items
+ *   must be reintroduced explicitly or `⌘C`/`⌘V` stop working in
+ *   the `<textarea>` on macOS)
+ */
+async function installAppMenu(handle: ChordSketchUiHandle): Promise<void> {
+  const [
+    quitItem,
+    exportPdfItem,
+    exportHtmlItem,
+    closeWindowItem,
+    undoItem,
+    redoItem,
+    cutItem,
+    copyItem,
+    pasteItem,
+    selectAllItem,
+    editMenuSep,
+  ] = await Promise.all([
+    PredefinedMenuItem.new({ item: 'Quit' }),
+    MenuItem.new({
+      id: 'export-pdf',
+      text: 'Export PDF…',
+      action: () => {
+        void runExport(handle, 'pdf');
+      },
+    }),
+    MenuItem.new({
+      id: 'export-html',
+      text: 'Export HTML…',
+      action: () => {
+        void runExport(handle, 'html');
+      },
+    }),
+    PredefinedMenuItem.new({ item: 'CloseWindow' }),
+    PredefinedMenuItem.new({ item: 'Undo' }),
+    PredefinedMenuItem.new({ item: 'Redo' }),
+    PredefinedMenuItem.new({ item: 'Cut' }),
+    PredefinedMenuItem.new({ item: 'Copy' }),
+    PredefinedMenuItem.new({ item: 'Paste' }),
+    PredefinedMenuItem.new({ item: 'SelectAll' }),
+    PredefinedMenuItem.new({ item: 'Separator' }),
+  ]);
+
+  const appMenu = await Submenu.new({
+    text: 'ChordSketch',
+    items: [quitItem],
+  });
+  const fileMenu = await Submenu.new({
+    text: 'File',
+    items: [exportPdfItem, exportHtmlItem, closeWindowItem],
+  });
+  const editMenu = await Submenu.new({
+    text: 'Edit',
+    items: [
+      undoItem,
+      redoItem,
+      editMenuSep,
+      cutItem,
+      copyItem,
+      pasteItem,
+      selectAllItem,
+    ],
+  });
+
+  const menu = await Menu.new({ items: [appMenu, fileMenu, editMenu] });
+  await menu.setAsAppMenu();
+}
+
+async function bootstrap(): Promise<void> {
+  const handle = await mountChordSketchUi(root as HTMLElement, {
+    renderers,
+    title: 'ChordSketch',
+    documentTitle: 'ChordSketch',
+  });
+  await installAppMenu(handle);
+}
+
+void bootstrap();

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -58,6 +58,23 @@ export interface MountOptions {
  */
 export interface ChordSketchUiHandle {
   destroy(): void;
+  /**
+   * Current contents of the editor. Hosts use this to drive
+   * format-specific export paths that bypass the in-WebView
+   * rendering — e.g. the desktop app's `File → Export PDF / HTML`
+   * menu routes the source through Rust renderers (#2074) instead
+   * of the WASM module, so it needs a way to read what the user
+   * has typed.
+   */
+  getChordPro(): string;
+  /**
+   * Current semitone offset in the transpose control, clamped to
+   * the same `[-11, 11]` window the trio and the `<input>` itself
+   * enforce. Pair with {@link getChordPro} when invoking an
+   * external renderer so the export matches what the preview
+   * shows.
+   */
+  getTranspose(): number;
 }
 
 const RENDER_DEBOUNCE_MS = 300;
@@ -715,6 +732,12 @@ export async function mountChordSketchUi(
       splitter.removeEventListener('pointercancel', onSplitterPointerUp);
       splitter.removeEventListener('keydown', onSplitterKeyDown);
       downloadPdfBtn.removeEventListener('click', downloadPdf);
+    },
+    getChordPro(): string {
+      return editor.value;
+    },
+    getTranspose(): number {
+      return getTranspose();
     },
   };
 }


### PR DESCRIPTION
## Summary

Implements #2074: the desktop app gains a native `File → Export PDF…` / `File → Export HTML…` menu that routes through the Rust renderer crates (`chordsketch-render-pdf`, `chordsketch-render-html`) — **not** the in-WebView WASM — so exported files are byte-for-byte identical to what the CLI and UniFFI bindings produce.

## Scope vs. #2074 ACs

| AC | Status |
|---|---|
| File menu entries for "Export PDF…" and "Export HTML…" | **Implemented** in `installAppMenu` (`apps/desktop/src/main.ts`) via `@tauri-apps/api/menu`. |
| Native save dialog picks destination | **Implemented** via `tauri-plugin-dialog`'s `save()`. |
| Calls `chordsketch-render-pdf` / `chordsketch-render-html` directly (Rust side, not WASM) | **Implemented** — both `export_pdf` and `export_html` commands call `render_songs_with_transpose` on the Rust crate and `fs::write` the bytes. |
| Success toast / error dialog on completion | **Implemented** — `message()` from `tauri-plugin-dialog` shows an info dialog on success, an error dialog on `Result::Err`. Tauri v2 has no toast primitive; the native OK-only dialog is the nearest supported analogue. |
| CI green | Verified locally (`cargo fmt --all --check`, `cargo clippy -p chordsketch-desktop --all-targets -- -D warnings`, Vite build on both playground and desktop). |

## Implementation

### Rust (`apps/desktop/src-tauri/`)
- Cargo.toml: adds `chordsketch-render-html`, `chordsketch-render-pdf`, and `tauri-plugin-dialog@2`. Removes the never-used `serde` placeholder from #2069.
- `main.rs`: `render_and_write` helper factors the parse-and-render pipeline out of the two command bodies (per `.claude/rules/fix-propagation.md` — a fix to one format should not drift against the other). The helper takes a closure that returns `Vec<u8>`, and the HTML wrapper bridges `String → Vec<u8>` via `.into_bytes()` at the call site.
- Commands: `#[tauri::command] export_pdf(path, chordpro, transpose)` and `export_html(path, chordpro, transpose)`. `transpose` is `Option<i8>` so the frontend can omit the identity-case offset.
- Retires the `use chordsketch_chordpro as _;` workspace-linkage placeholder from #2069 — every SDK crate is now directly referenced by the command bodies. `[lints.rust] unused_crate_dependencies = "warn"` stays to guard against future regressions.

### Capability (`src-tauri/capabilities/default.json`)
- Grants only `dialog:allow-save` + `dialog:allow-message`. The broader `dialog:default` (which would also include `open` / `ask` / `confirm`) is intentionally withheld — file-open lands with #2080 and will extend this capability then.

### `@chordsketch/ui-web` (`packages/ui-web/src/index.ts`)
- `ChordSketchUiHandle` gains `getChordPro()` and `getTranspose()` so hosts can feed external renderers with the current editor state. The browser playground ignores them (unchanged); the desktop export flow is the first consumer.

### Desktop frontend (`apps/desktop/src/main.ts`)
- `installAppMenu(handle)` builds a three-submenu bar — `ChordSketch → Quit`, `File → Export PDF… / Export HTML… / Close Window`, `Edit → Undo/Redo/Cut/Copy/Paste/Select All`. `setAsAppMenu` replaces the OS default, so the Edit items must be reintroduced explicitly or `⌘C` / `⌘V` stop working inside the `<textarea>` on macOS.
- `runExport(handle, format)` reads the editor content + transpose via the new readers, calls `save(...)`, invokes the matching Rust command, and posts success / error `message(...)` dialogs.

### Deferred

About / Preferences / Window / Help submenus (macOS app-menu completeness) are tracked in **#2199**. Keyboard shortcut scope remains deferred under #2190 (transpose) and #2194 (pane focus).

## Fix-propagation / rule audit

- `.claude/rules/fix-propagation.md` — `render_and_write` is the canonical site; both command wrappers share the same parse + render path. Adding a third export format later adds one more call, not a fresh copy.
- `.claude/rules/sanitizer-security.md` / `.claude/rules/defensive-inputs.md` — `path` flows through `fs::write` directly (OS-level write). No HTML / ChordPro injection surface introduced here (the user-typed content IS the payload). The capability allow-list keeps the dialog surface minimal.
- `.claude/rules/ci-parallelization.md` — no CI workflow edit. `desktop-smoke` already builds wasm + Vite + `cargo check`; the new Rust deps are transitively covered.
- `.claude/rules/one-pr-at-a-time.md` — no other PRs open against `main`.

## Test plan

- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy -p chordsketch-desktop --all-targets -- -D warnings` — clean (a `redundant_closure` lint on the PDF wrapper was fixed by passing `render_songs_with_transpose` as a function pointer).
- [x] `cargo clippy --workspace --exclude chordsketch-desktop --all-targets -- -D warnings` — clean (ui-web handle additions don't affect Rust crates).
- [x] `(cd packages/playground && npm ci && npm run build)` — playground ignores the handle readers, builds unchanged.
- [x] `(cd apps/desktop && npm ci && npm run build)` — desktop frontend builds (30.9 kB JS, up from 17.5 kB due to `@tauri-apps/api/menu` + `@tauri-apps/plugin-dialog`).
- [ ] Interactive menu click + save-dialog round-trip — deferred to manual verification during merge (no display in this CI environment; `desktop-smoke` already exercises `cargo check` + the full Vite build, so any type / link failure would surface).

Closes #2074