### PR TITLE
feat(desktop): file open / save / save-as / recents + dirty guard

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -88,6 +88,28 @@ the Rust binary against `apps/desktop/dist/`. Bundles land under
 release matrix (signing, notarization, upload to GitHub Releases) is
 tracked under `#2075`, `#2077`, and `#2078`.
 
+## File I/O
+
+`File → Open…`, `File → Save`, `File → Save As…`, and `File →
+Open Recent` (last 10 files, persisted in `localStorage`) route
+through two Tauri commands in `src-tauri/src/main.rs`:
+
+- `open_file(path)` → reads the UTF-8 source at `path`, enforces
+  `MAX_OPEN_SIZE_BYTES` (10 MiB) before the full read so a stray
+  2 GB binary selected in the picker fails fast instead of
+  wedging the WebView, and returns the string to the frontend.
+- `save_file(path, content)` → `std::fs::write` the given content
+  to the chosen path.
+
+The title bar shows a `•` prefix while the in-memory buffer has
+drifted from the last-saved content; closing the window with a
+dirty buffer prompts "Unsaved changes — Quit without saving?"
+before destroying the window.
+
+Keyboard shortcuts (`⌘/Ctrl + O`, `⌘/Ctrl + S`, `⌘/Ctrl + Shift +
+S`) are tracked under #2206; the menu items drive the same flow
+via click for now.
+
 ## Export flow
 
 `File → Export PDF…` / `Export HTML…` in the native menu route
@@ -105,10 +127,13 @@ byte-for-byte identical to what the CLI (`chordsketch`) and the
 UniFFI bindings produce, and avoids piping the full rendered
 buffer back across the IPC boundary as JavaScript memory.
 
-The native save dialog is provided by `tauri-plugin-dialog`;
-the capability in `src-tauri/capabilities/default.json` grants
-only `dialog:allow-save` + `dialog:allow-message` — file-open
-lands with `#2080`.
+Native dialogs are provided by `tauri-plugin-dialog`. The
+capability in `src-tauri/capabilities/default.json` grants
+`dialog:allow-open` + `dialog:allow-save` + `dialog:allow-ask`
++ `dialog:allow-message`; the wider `dialog:default` (which also
+includes `confirm`) is still withheld, and the `fs:*` permissions
+are intentionally absent — the Rust commands above handle all
+filesystem access.
 
 ## Workspace integration
 

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,12 +1,14 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Narrow capability set. `core:app:default` + `core:window:default` are the baseline from #2069. `dialog:allow-save` + `dialog:allow-message` are added in #2074 so the File → Export handlers can open a native save dialog and show a success/error alert; the broader `dialog:default` (which also grants file-open + confirm + ask) is intentionally NOT granted — open-file lands with #2080 and will extend this capability then.",
+  "description": "Narrow capability set. `core:app:default` + `core:window:default` are the baseline from #2069. `dialog:allow-save` + `dialog:allow-message` land in #2074 (Export flow). `dialog:allow-open` + `dialog:allow-ask` land in #2080 (File → Open and the Quit-unsaved prompt). The custom Rust commands (`open_file`, `save_file`) handle the actual filesystem access, so `fs:*` is intentionally not granted — this keeps untrusted WebView code unable to read or write arbitrary paths without a user-initiated dialog.",
   "windows": ["main"],
   "permissions": [
     "core:app:default",
     "core:window:default",
     "dialog:allow-save",
-    "dialog:allow-message"
+    "dialog:allow-open",
+    "dialog:allow-message",
+    "dialog:allow-ask"
   ]
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use std::fs;
+use std::fs::File;
+use std::io::{BufReader, Read};
 use std::path::Path;
 
 use chordsketch_chordpro::config::Config;
@@ -63,22 +65,33 @@ fn export_html(path: String, chordpro: String, transpose: Option<i8>) -> Result<
 }
 
 /// Reads the ChordPro source at `path` and returns it as a UTF-8
-/// string to the frontend. Enforces `MAX_OPEN_SIZE_BYTES` before the
-/// full read so a stray 2 GB binary selected in the file picker
-/// fails fast with a readable error, rather than a multi-minute
-/// WebView hang while `editor.value = "…"` digests the payload.
+/// string to the frontend. Enforces `MAX_OPEN_SIZE_BYTES` during a
+/// single opened-handle read so a stray 2 GB binary selected in the
+/// file picker fails fast with a readable error, rather than a
+/// multi-minute WebView hang.
+///
+/// Uses `File::open` + `BufReader::take(MAX + 1)` so the size
+/// check is TOCTOU-safe per `.claude/rules/defensive-inputs.md`
+/// ("Never check a resource then act on it in separate steps. Use
+/// atomic operations… Prefer passing already-opened handles"). A
+/// separate `metadata()`-then-`read_to_string()` pair leaves a race
+/// window where a co-process can grow the file past the limit
+/// after the stat but before the read.
 #[tauri::command]
 fn open_file(path: String) -> Result<String, String> {
     let p = Path::new(&path);
-    let meta = fs::metadata(p).map_err(|e| format!("Failed to stat {path}: {e}"))?;
-    if meta.len() > MAX_OPEN_SIZE_BYTES {
-        return Err(format!(
-            "File is too large ({} bytes; limit {} bytes)",
-            meta.len(),
-            MAX_OPEN_SIZE_BYTES,
-        ));
+    let file = File::open(p).map_err(|e| format!("Failed to open {path}: {e}"))?;
+    // `take(MAX + 1)` lets us distinguish "exactly at the limit" (OK)
+    // from "over the limit" (reject) in a single read.
+    let mut reader = BufReader::new(file).take(MAX_OPEN_SIZE_BYTES + 1);
+    let mut buf = String::new();
+    reader
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("Failed to read {path}: {e}"))?;
+    if buf.len() as u64 > MAX_OPEN_SIZE_BYTES {
+        return Err(format!("File is too large (> {MAX_OPEN_SIZE_BYTES} bytes)"));
     }
-    fs::read_to_string(p).map_err(|e| format!("Failed to read {path}: {e}"))
+    Ok(buf)
 }
 
 /// Writes `content` to `path`, overwriting any existing file. Used

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,9 +1,17 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use std::fs;
+use std::path::Path;
 
 use chordsketch_chordpro::config::Config;
 use chordsketch_chordpro::parse_multi_lenient;
+
+/// Max ChordPro source size the editor will open from disk. 10 MiB
+/// comfortably fits the largest hymnal transcriptions in the test
+/// corpus (hundreds of songs concatenated) while rejecting anything
+/// big enough to wedge the `<textarea>` on modest hardware. Lets the
+/// command fail fast with a readable error instead of a WebView hang.
+const MAX_OPEN_SIZE_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Parse the supplied ChordPro source, render every song it contains
 /// with the requested transposition, and write the result to `path`.
@@ -54,10 +62,43 @@ fn export_html(path: String, chordpro: String, transpose: Option<i8>) -> Result<
     )
 }
 
+/// Reads the ChordPro source at `path` and returns it as a UTF-8
+/// string to the frontend. Enforces `MAX_OPEN_SIZE_BYTES` before the
+/// full read so a stray 2 GB binary selected in the file picker
+/// fails fast with a readable error, rather than a multi-minute
+/// WebView hang while `editor.value = "…"` digests the payload.
+#[tauri::command]
+fn open_file(path: String) -> Result<String, String> {
+    let p = Path::new(&path);
+    let meta = fs::metadata(p).map_err(|e| format!("Failed to stat {path}: {e}"))?;
+    if meta.len() > MAX_OPEN_SIZE_BYTES {
+        return Err(format!(
+            "File is too large ({} bytes; limit {} bytes)",
+            meta.len(),
+            MAX_OPEN_SIZE_BYTES,
+        ));
+    }
+    fs::read_to_string(p).map_err(|e| format!("Failed to read {path}: {e}"))
+}
+
+/// Writes `content` to `path`, overwriting any existing file. Used
+/// by the File → Save / Save As menu items; the frontend is
+/// responsible for dialog-driven destination selection so this
+/// command does no extra validation beyond the IO error surface.
+#[tauri::command]
+fn save_file(path: String, content: String) -> Result<(), String> {
+    fs::write(&path, content).map_err(|e| format!("Failed to write {path}: {e}"))
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
-        .invoke_handler(tauri::generate_handler![export_pdf, export_html])
+        .invoke_handler(tauri::generate_handler![
+            export_pdf,
+            export_html,
+            open_file,
+            save_file,
+        ])
         .run(tauri::generate_context!())
         // `expect` is justified: this is process entry — if the Tauri
         // runtime cannot start, there is no application to recover

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -166,42 +166,54 @@ async function runOpen(
   }
 }
 
-async function runSave(handle: ChordSketchUiHandle): Promise<void> {
+async function runSave(
+  handle: ChordSketchUiHandle,
+  rebuildMenu: MenuRebuilder,
+): Promise<void> {
   if (!currentPath) {
-    await runSaveAs(handle);
+    await runSaveAs(handle, rebuildMenu);
     return;
   }
   await writeCurrent(handle, currentPath);
 }
 
-async function runSaveAs(handle: ChordSketchUiHandle): Promise<void> {
+async function runSaveAs(
+  handle: ChordSketchUiHandle,
+  rebuildMenu: MenuRebuilder,
+): Promise<void> {
   const picked = await save({
     defaultPath: currentPath ?? `${UNTITLED_LABEL.toLowerCase()}.cho`,
     filters: CHORDPRO_FILTERS,
   });
   if (!picked) return;
-  await writeCurrent(handle, picked);
+  // Gate the `currentPath` / `pushRecent` updates on the actual
+  // write succeeding — a partial failure previously left the UI
+  // pointing at an unwritten path, so the next `runSave` would
+  // silently retry the failing write instead of reopening Save As.
+  const ok = await writeCurrent(handle, picked);
+  if (!ok) return;
   currentPath = picked;
   pushRecent(picked);
-  // Title reflects the new filename; rebuild the Open Recent menu
-  // so the just-saved path shows up at the top.
+  await rebuildMenu();
   await updateWindowTitle(handle);
 }
 
 async function writeCurrent(
   handle: ChordSketchUiHandle,
   path: string,
-): Promise<void> {
+): Promise<boolean> {
   const content = handle.getChordPro();
   try {
     await invoke('save_file', { path, content });
     lastSavedContent = content;
     await updateWindowTitle(handle);
+    return true;
   } catch (err) {
     await message(err instanceof Error ? err.message : String(err), {
       title: 'Save failed',
       kind: 'error',
     });
+    return false;
   }
 }
 
@@ -332,14 +344,14 @@ async function buildAppMenu(
       id: 'file-save',
       text: 'Save',
       action: () => {
-        void runSave(handle);
+        void runSave(handle, rebuildMenu);
       },
     }),
     MenuItem.new({
       id: 'file-save-as',
       text: 'Save As…',
       action: () => {
-        void runSaveAs(handle);
+        void runSaveAs(handle, rebuildMenu);
       },
     }),
     MenuItem.new({

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -19,9 +19,20 @@ import {
   PredefinedMenuItem,
   Submenu,
 } from '@tauri-apps/api/menu';
-import { message, save } from '@tauri-apps/plugin-dialog';
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { ask, message, open, save } from '@tauri-apps/plugin-dialog';
 
 type ExportFormat = 'pdf' | 'html';
+
+const DEFAULT_WINDOW_TITLE = 'ChordSketch';
+const UNTITLED_LABEL = 'Untitled';
+const MAX_RECENTS = 10;
+const RECENTS_STORAGE_KEY = 'chordsketch-desktop-recent-files';
+
+const CHORDPRO_FILTERS = [
+  { name: 'ChordPro', extensions: ['cho', 'chopro', 'crd', 'chordpro'] },
+  { name: 'All files', extensions: ['*'] },
+];
 
 const EXPORT_FILTERS: Record<
   ExportFormat,
@@ -30,6 +41,13 @@ const EXPORT_FILTERS: Record<
   pdf: { name: 'PDF', extensions: ['pdf'] },
   html: { name: 'HTML', extensions: ['html', 'htm'] },
 };
+
+// Mutable desktop-app session state. Kept in module scope so the
+// menu handlers and the `onChordProChange` callback can update them
+// without plumbing the state through every async boundary.
+let currentPath: string | null = null;
+let lastSavedContent = '';
+let recents: string[] = [];
 
 // Adapter from the wasm-bindgen export shape to the ui-web `Renderers`
 // interface. Mirrors `packages/playground/src/main.ts` so the desktop
@@ -50,6 +68,141 @@ const renderers: Renderers = {
 const root = document.getElementById('app');
 if (!root) {
   throw new Error('Desktop entry point #app element missing from index.html');
+}
+
+// ---- Recents persistence -------------------------------------------------
+
+function loadRecents(): string[] {
+  try {
+    const raw = window.localStorage.getItem(RECENTS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((x): x is string => typeof x === 'string' && x.length > 0)
+      .slice(0, MAX_RECENTS);
+  } catch {
+    // Malformed JSON or inaccessible localStorage — fall back to an
+    // empty list. A bad write from a future version cannot brick the
+    // menu; the list simply resets.
+    return [];
+  }
+}
+
+function persistRecents(list: string[]): void {
+  try {
+    window.localStorage.setItem(RECENTS_STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // Persistence failure is a convenience loss, not a correctness
+    // failure. See the parallel note in `vite.config.ts`'s split-pane
+    // persistence (#2071).
+  }
+}
+
+function pushRecent(path: string): void {
+  // Move-to-front with dedupe, then clamp to the max entry count.
+  recents = [path, ...recents.filter((p) => p !== path)].slice(0, MAX_RECENTS);
+  persistRecents(recents);
+}
+
+// ---- Dirty-state + title helpers -----------------------------------------
+
+function basename(path: string): string {
+  const m = path.match(/[^/\\]+$/);
+  return m ? m[0] : path;
+}
+
+function isDirty(handle: ChordSketchUiHandle): boolean {
+  return handle.getChordPro() !== lastSavedContent;
+}
+
+async function updateWindowTitle(handle: ChordSketchUiHandle): Promise<void> {
+  const label = currentPath ? basename(currentPath) : UNTITLED_LABEL;
+  const prefix = isDirty(handle) ? '• ' : '';
+  await getCurrentWebviewWindow().setTitle(
+    `${prefix}${label} — ${DEFAULT_WINDOW_TITLE}`,
+  );
+}
+
+// ---- File operations -----------------------------------------------------
+
+async function runOpen(
+  handle: ChordSketchUiHandle,
+  rebuildMenu: () => Promise<void>,
+  path?: string,
+): Promise<void> {
+  let target = path ?? null;
+  if (!target) {
+    const picked = await open({
+      multiple: false,
+      directory: false,
+      filters: CHORDPRO_FILTERS,
+    });
+    if (typeof picked === 'string') target = picked;
+    if (!target) return; // User cancelled.
+  }
+
+  if (isDirty(handle)) {
+    const confirmed = await ask(
+      'You have unsaved changes. Open another file and discard them?',
+      { title: 'Discard unsaved changes?', kind: 'warning' },
+    );
+    if (!confirmed) return;
+  }
+
+  try {
+    const content = await invoke<string>('open_file', { path: target });
+    handle.setChordPro(content);
+    currentPath = target;
+    lastSavedContent = content;
+    pushRecent(target);
+    await rebuildMenu();
+    await updateWindowTitle(handle);
+  } catch (err) {
+    await message(err instanceof Error ? err.message : String(err), {
+      title: 'Open failed',
+      kind: 'error',
+    });
+  }
+}
+
+async function runSave(handle: ChordSketchUiHandle): Promise<void> {
+  if (!currentPath) {
+    await runSaveAs(handle);
+    return;
+  }
+  await writeCurrent(handle, currentPath);
+}
+
+async function runSaveAs(handle: ChordSketchUiHandle): Promise<void> {
+  const picked = await save({
+    defaultPath: currentPath ?? `${UNTITLED_LABEL.toLowerCase()}.cho`,
+    filters: CHORDPRO_FILTERS,
+  });
+  if (!picked) return;
+  await writeCurrent(handle, picked);
+  currentPath = picked;
+  pushRecent(picked);
+  // Title reflects the new filename; rebuild the Open Recent menu
+  // so the just-saved path shows up at the top.
+  await updateWindowTitle(handle);
+}
+
+async function writeCurrent(
+  handle: ChordSketchUiHandle,
+  path: string,
+): Promise<void> {
+  const content = handle.getChordPro();
+  try {
+    await invoke('save_file', { path, content });
+    lastSavedContent = content;
+    await updateWindowTitle(handle);
+  } catch (err) {
+    await message(err instanceof Error ? err.message : String(err), {
+      title: 'Save failed',
+      kind: 'error',
+    });
+  }
 }
 
 /**
@@ -82,7 +235,7 @@ async function runExport(
       transpose: transpose === 0 ? null : transpose,
     });
     await message(`Exported to ${path}`, {
-      title: 'ChordSketch',
+      title: DEFAULT_WINDOW_TITLE,
       kind: 'info',
     });
   } catch (err) {
@@ -93,25 +246,72 @@ async function runExport(
   }
 }
 
+// ---- Menu assembly -------------------------------------------------------
+
+type MenuRebuilder = () => Promise<void>;
+
 /**
- * Install a minimal native menu bar that matches platform
- * conventions (macOS top menu bar / Windows + Linux window menu):
- *
- * - ChordSketch → Quit  (anchors the macOS app menu slot so users
- *   don't lose `⌘Q`; Linux/Windows still render this as the first
- *   submenu but that's OK)
- * - File → Export PDF…, Export HTML…, Close Window
- * - Edit → Undo/Redo/Cut/Copy/Paste/Select All  (Tauri's custom
- *   app menu replaces the native default, so the clipboard items
- *   must be reintroduced explicitly or `⌘C`/`⌘V` stop working in
- *   the `<textarea>` on macOS)
+ * Build (or rebuild) the Open Recent submenu. Recreated from scratch
+ * because Tauri v2's `Submenu` is immutable once assembled — no
+ * `append`/`remove` API on the JS side at time of writing.
  */
-async function installAppMenu(handle: ChordSketchUiHandle): Promise<void> {
+async function buildRecentsSubmenu(
+  handle: ChordSketchUiHandle,
+  rebuildMenu: MenuRebuilder,
+): Promise<Submenu> {
+  const items: (MenuItem | PredefinedMenuItem)[] = [];
+  if (recents.length === 0) {
+    items.push(
+      await MenuItem.new({
+        id: 'recents-empty',
+        text: 'No recent files',
+        enabled: false,
+      }),
+    );
+  } else {
+    for (let i = 0; i < recents.length; i += 1) {
+      const path = recents[i] as string;
+      items.push(
+        await MenuItem.new({
+          id: `recent-${i}`,
+          text: basename(path),
+          action: () => {
+            void runOpen(handle, rebuildMenu, path);
+          },
+        }),
+      );
+    }
+    items.push(await PredefinedMenuItem.new({ item: 'Separator' }));
+    items.push(
+      await MenuItem.new({
+        id: 'recents-clear',
+        text: 'Clear Recents',
+        action: () => {
+          recents = [];
+          persistRecents(recents);
+          void rebuildMenu();
+        },
+      }),
+    );
+  }
+  return Submenu.new({ text: 'Open Recent', items });
+}
+
+async function buildAppMenu(
+  handle: ChordSketchUiHandle,
+  rebuildMenu: MenuRebuilder,
+): Promise<Menu> {
   const [
     quitItem,
+    openItem,
+    saveItem,
+    saveAsItem,
     exportPdfItem,
     exportHtmlItem,
     closeWindowItem,
+    fileSepA,
+    fileSepB,
+    fileSepC,
     undoItem,
     redoItem,
     cutItem,
@@ -121,6 +321,27 @@ async function installAppMenu(handle: ChordSketchUiHandle): Promise<void> {
     editMenuSep,
   ] = await Promise.all([
     PredefinedMenuItem.new({ item: 'Quit' }),
+    MenuItem.new({
+      id: 'file-open',
+      text: 'Open…',
+      action: () => {
+        void runOpen(handle, rebuildMenu);
+      },
+    }),
+    MenuItem.new({
+      id: 'file-save',
+      text: 'Save',
+      action: () => {
+        void runSave(handle);
+      },
+    }),
+    MenuItem.new({
+      id: 'file-save-as',
+      text: 'Save As…',
+      action: () => {
+        void runSaveAs(handle);
+      },
+    }),
     MenuItem.new({
       id: 'export-pdf',
       text: 'Export PDF…',
@@ -136,6 +357,9 @@ async function installAppMenu(handle: ChordSketchUiHandle): Promise<void> {
       },
     }),
     PredefinedMenuItem.new({ item: 'CloseWindow' }),
+    PredefinedMenuItem.new({ item: 'Separator' }),
+    PredefinedMenuItem.new({ item: 'Separator' }),
+    PredefinedMenuItem.new({ item: 'Separator' }),
     PredefinedMenuItem.new({ item: 'Undo' }),
     PredefinedMenuItem.new({ item: 'Redo' }),
     PredefinedMenuItem.new({ item: 'Cut' }),
@@ -145,13 +369,26 @@ async function installAppMenu(handle: ChordSketchUiHandle): Promise<void> {
     PredefinedMenuItem.new({ item: 'Separator' }),
   ]);
 
+  const recentsSubmenu = await buildRecentsSubmenu(handle, rebuildMenu);
+
   const appMenu = await Submenu.new({
-    text: 'ChordSketch',
+    text: DEFAULT_WINDOW_TITLE,
     items: [quitItem],
   });
   const fileMenu = await Submenu.new({
     text: 'File',
-    items: [exportPdfItem, exportHtmlItem, closeWindowItem],
+    items: [
+      openItem,
+      recentsSubmenu,
+      fileSepA,
+      saveItem,
+      saveAsItem,
+      fileSepB,
+      exportPdfItem,
+      exportHtmlItem,
+      fileSepC,
+      closeWindowItem,
+    ],
   });
   const editMenu = await Submenu.new({
     text: 'Edit',
@@ -166,17 +403,65 @@ async function installAppMenu(handle: ChordSketchUiHandle): Promise<void> {
     ],
   });
 
-  const menu = await Menu.new({ items: [appMenu, fileMenu, editMenu] });
-  await menu.setAsAppMenu();
+  return Menu.new({ items: [appMenu, fileMenu, editMenu] });
 }
 
+/**
+ * Install (or reinstall) the native menu bar. A rebuild happens
+ * whenever the Open Recent list changes; `setAsAppMenu` replaces
+ * the current menu atomically.
+ */
+async function installAppMenu(handle: ChordSketchUiHandle): Promise<void> {
+  const rebuildMenu: MenuRebuilder = async () => {
+    const menu = await buildAppMenu(handle, rebuildMenu);
+    await menu.setAsAppMenu();
+  };
+  await rebuildMenu();
+}
+
+// ---- Close-requested prompt ---------------------------------------------
+
+async function registerCloseGuard(handle: ChordSketchUiHandle): Promise<void> {
+  const webview = getCurrentWebviewWindow();
+  await webview.onCloseRequested(async (event) => {
+    if (!isDirty(handle)) return;
+    event.preventDefault();
+    const confirmed = await ask(
+      'You have unsaved changes. Quit without saving?',
+      { title: 'Unsaved changes', kind: 'warning' },
+    );
+    if (confirmed) {
+      await webview.destroy();
+    }
+  });
+}
+
+// ---- Bootstrap -----------------------------------------------------------
+
 async function bootstrap(): Promise<void> {
+  recents = loadRecents();
+
   const handle = await mountChordSketchUi(root as HTMLElement, {
     renderers,
-    title: 'ChordSketch',
-    documentTitle: 'ChordSketch',
+    title: DEFAULT_WINDOW_TITLE,
+    documentTitle: DEFAULT_WINDOW_TITLE,
+    onChordProChange: () => {
+      // `updateWindowTitle` is async but fire-and-forget here —
+      // the title only needs to update eventually, and racing
+      // successive calls is fine because each reads `isDirty`
+      // and the mutable state at call time.
+      void updateWindowTitle(handle);
+    },
   });
+
+  // The ui-web mount seeds the editor with `SAMPLE_CHORDPRO` — capture
+  // that as the initial "saved" state so a pristine launch doesn't
+  // show the dirty indicator.
+  lastSavedContent = handle.getChordPro();
+
   await installAppMenu(handle);
+  await registerCloseGuard(handle);
+  await updateWindowTitle(handle);
 }
 
 void bootstrap();

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -766,9 +766,17 @@ export async function mountChordSketchUi(
     },
     setChordPro(value: string): void {
       editor.value = value;
+      // Cancel any debounce pending from pre-load keystrokes (e.g.
+      // paste-then-Open): without this, the stale timer fires ~300 ms
+      // later and re-renders the freshly loaded content again —
+      // idempotent but wasteful.
+      if (debounceTimer !== null) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
       // Immediate render (not `scheduleRender`) because programmatic
       // loads are discrete events — users expect the preview to
-      // reflect the loaded file without a 300ms debounce delay.
+      // reflect the loaded file without a 300 ms debounce delay.
       render();
     },
   };

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -45,6 +45,15 @@ export interface MountOptions {
   title?: string;
   /** Document `<title>` to set on mount. If omitted, the document title is left alone. */
   documentTitle?: string;
+  /**
+   * Fires synchronously on every editor input event, before the
+   * render debounce. Hosts use this for dirty-tracking in the
+   * desktop app (#2080) — comparing the current value to the last
+   * saved content to decide whether the title bar should show a
+   * "modified" indicator. The browser playground has no concept
+   * of unsaved state and simply omits the callback.
+   */
+  onChordProChange?: (value: string) => void;
 }
 
 /**
@@ -75,6 +84,16 @@ export interface ChordSketchUiHandle {
    * shows.
    */
   getTranspose(): number;
+  /**
+   * Replace the editor contents with `value`, triggering an
+   * immediate render. Used by the desktop app's `File → Open`
+   * flow after reading a file off disk (#2080). Does NOT fire
+   * the {@link MountOptions.onChordProChange} callback — a
+   * programmatic load is not a user edit, and the host is
+   * responsible for resetting its own dirty-tracking state at
+   * the same time it calls this.
+   */
+  setChordPro(value: string): void;
 }
 
 const RENDER_DEBOUNCE_MS = 300;
@@ -387,6 +406,7 @@ export async function mountChordSketchUi(
     pdfFilename = 'chordsketch-output.pdf',
     title = 'ChordSketch Playground',
     documentTitle,
+    onChordProChange,
   } = options;
 
   if (documentTitle !== undefined) {
@@ -682,6 +702,11 @@ export async function mountChordSketchUi(
 
   editor.value = initialChordPro;
 
+  const onEditorInput = (): void => {
+    onChordProChange?.(editor.value);
+    scheduleRender();
+  };
+
   const onTransposeInput = (): void => {
     updateTransposeControls();
     scheduleRender();
@@ -696,7 +721,7 @@ export async function mountChordSketchUi(
     setTranspose(TRANSPOSE_RESET);
   };
 
-  editor.addEventListener('input', scheduleRender);
+  editor.addEventListener('input', onEditorInput);
   formatSelect.addEventListener('change', render);
   transposeInput.addEventListener('input', onTransposeInput);
   transposeDecrementBtn.addEventListener('click', onTransposeDecrement);
@@ -720,7 +745,7 @@ export async function mountChordSketchUi(
         clearTimeout(debounceTimer);
         debounceTimer = null;
       }
-      editor.removeEventListener('input', scheduleRender);
+      editor.removeEventListener('input', onEditorInput);
       formatSelect.removeEventListener('change', render);
       transposeInput.removeEventListener('input', onTransposeInput);
       transposeDecrementBtn.removeEventListener('click', onTransposeDecrement);
@@ -738,6 +763,13 @@ export async function mountChordSketchUi(
     },
     getTranspose(): number {
       return getTranspose();
+    },
+    setChordPro(value: string): void {
+      editor.value = value;
+      // Immediate render (not `scheduleRender`) because programmatic
+      // loads are discrete events — users expect the preview to
+      // reflect the loaded file without a 300ms debounce delay.
+      render();
     },
   };
 }


### PR DESCRIPTION
## Summary

Implements #2080 for the desktop app: native File → Open…, Save, Save As…, Open Recent (last 10, persisted), plus a dirty-indicator in the window title and a Quit-with-unsaved-changes confirmation. All filesystem access goes through two new Tauri commands in `main.rs`, not the `fs:*` plugin, so the WebView cannot touch disk without a user-initiated dialog.

## Scope vs. #2080 ACs

| AC | Status |
|---|---|
| `Cmd/Ctrl + O` opens a file picker | **Deferred** → #2206 |
| `Cmd/Ctrl + S` saves (Save As if no current path) | **Deferred** → #2206 |
| `Cmd/Ctrl + Shift + S` always Save As | **Deferred** → #2206 |
| `File → Open Recent` submenu with last 10 files | **Implemented** — move-to-front dedupe, clamp to `MAX_RECENTS = 10`, ends with "Clear Recents" when non-empty. |
| Recents persisted in platform-appropriate app-data path | **Implemented** via `localStorage["chordsketch-desktop-recent-files"]`. `localStorage` is the Tauri-v2-agnostic persistence surface; per-platform `app-data` would need the `path` + `fs` plugins, which this PR intentionally does NOT pull in (see capability scoping below). |
| Dirty indicator in title bar when buffer has unsaved changes | **Implemented** — `•` prefix via `getCurrentWebviewWindow().setTitle(...)`, driven by a new `onChordProChange` callback in ui-web. |
| Prompt on quit if unsaved | **Implemented** via `webview.onCloseRequested` → `event.preventDefault()` + `ask(...)` → `webview.destroy()`. |
| CI green | Verified locally. |

### Shortcut deferral

The three `Cmd/Ctrl + …` bindings from the original AC are tracked under #2206. The menu items drive the same underlying commands via click for now. Rationale matches the previous deferrals (#2190, #2194): global accelerator-map decisions live in one namespace and should be settled together, not piecemeal.

### Recents storage choice

`localStorage` ≠ the "platform-appropriate app-data path" the AC literal asks for. The trade-off: reaching the platform-canonical path (`~/Library/Application Support/...` on macOS, `%APPDATA%\...` on Windows, `~/.config/...` on Linux) needs `tauri-plugin-path` + `tauri-plugin-fs`, which materially widens the capability surface for a 10-entry list of paths. Kept in `localStorage` for now; if a future requirement needs cross-install sharing (e.g. preferences), this can move to the Tauri app-data path as a focused follow-up without breaking the menu.

## Implementation

### Rust (`apps/desktop/src-tauri/src/main.rs`)
- `open_file(path) -> Result<String, String>` — stats the path, enforces `MAX_OPEN_SIZE_BYTES = 10 MiB` (`meta.len() > MAX_OPEN_SIZE_BYTES` check BEFORE `read_to_string`), then returns the UTF-8 contents. Size-check-first lets the command fail fast on a 2 GB stray binary.
- `save_file(path, content) -> Result<(), String>` — thin `fs::write` wrapper.
- Both registered via `tauri::generate_handler!`; commands expose exactly two new IPC entry points and no FS shell.

### Capability (`src-tauri/capabilities/default.json`)
- Adds `dialog:allow-open` and `dialog:allow-ask` on top of the #2074 `save` + `message` grants.
- `dialog:default` (which also includes `confirm`) stays unlisted; `fs:*` stays unlisted entirely. The Rust commands are the only filesystem reach the WebView has.

### `@chordsketch/ui-web` (`packages/ui-web/src/index.ts`)
- `MountOptions.onChordProChange?: (value: string) => void` — fires on every editor `input` event, before the 300 ms render debounce. Playground omits it; desktop uses it for dirty tracking.
- `ChordSketchUiHandle.setChordPro(value: string): void` — replaces the editor content and calls `render()` immediately (programmatic loads are discrete; the debounce is for keystrokes). Does NOT fire `onChordProChange` — a load is not a user edit, and the host resets its own dirty-tracking state at the same call site.

### Desktop frontend (`apps/desktop/src/main.ts`)
- Module-scope mutables: `currentPath`, `lastSavedContent`, `recents`.
- `runOpen` — if the buffer is dirty, `ask()` to confirm discard; invoke `open_file`; `handle.setChordPro`; reset `lastSavedContent` to the loaded value; `pushRecent`; rebuild menu; update title.
- `runSave` / `runSaveAs` / `writeCurrent` — symmetric to the Export flow from #2074.
- `buildRecentsSubmenu` / `buildAppMenu` — whole-menu rebuild whenever `recents` changes, because Tauri v2's JS `Submenu` is immutable after construction. `installAppMenu` closes over `rebuildMenu` and passes it down.
- `registerCloseGuard` — `preventDefault` + `ask` if dirty; `webview.destroy()` on confirm (bypasses the guard's preventDefault on the natural second close event).

## Fix-propagation / rule audit

- `.claude/rules/fix-propagation.md` — `render_and_write` from #2074 stays the canonical site; open/save are new functionality and have no sister. `save_file` is the in-repo sibling of `export_pdf`/`export_html`'s internal `fs::write` calls; all three use the same `map_err(|e| format!("Failed to write {path}: {e}"))` format.
- `.claude/rules/defensive-inputs.md` — `open_file` validates size at the boundary; `save_file` relies on `fs::write`'s `io::Error` (acceptable per `defensive-inputs.md` "range checks" guidance; destination path already came from a user-consented dialog).
- `.claude/rules/sanitizer-security.md` — user-supplied `chordpro` does not reach any HTML/DOM context through this PR; it just flows from `editor.value` back to disk verbatim.
- `.claude/rules/code-style.md` "Silent Fallback" — `loadRecents` and `persistRecents` catch localStorage errors; both carry comments explaining why (Safari private mode, parallel to #2071's split-pane persistence).
- `.claude/rules/ci-parallelization.md` — no CI workflow edit; `desktop-smoke` exercises the new Rust commands via `cargo check` and the frontend TS via `vite build`.
- `.claude/rules/one-pr-at-a-time.md` — no other PR open against main.

## Test plan

- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy --workspace --exclude chordsketch-desktop --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p chordsketch-desktop --all-targets -- -D warnings` — clean.
- [x] `(cd packages/npm && npm run build)` — wasm dual-package build clean.
- [x] `(cd packages/playground && npm ci && npm run build)` — playground unchanged (17.6 kB JS).
- [x] `(cd apps/desktop && npm ci && npm run build)` — desktop frontend builds (51.2 kB JS, up from 30.9 kB due to `@tauri-apps/api/webviewWindow` + the new file/menu logic).
- [ ] Interactive File → Open / Save / Save As / Open Recent / Clear Recents / Quit-unsaved flows — deferred to manual verification during merge (no display in this CI environment; `desktop-smoke` already exercises `cargo check` + the Vite build, so any type/link failure would surface).

Closes #2080