### PR TITLE
fix(ci): gate winget readme-smoke behind retries + soft-fail on schedule

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -384,13 +384,40 @@ jobs:
   winget:
     name: winget (Windows)
     runs-on: windows-latest
+    # `winget install` starts with a source refresh against
+    # Microsoft's CDN; the CDN occasionally returns "Failed in
+    # attempting to update the source: winget" on the hosted
+    # Windows runners. This bubbles up as `CommandNotFoundException`
+    # on the subsequent `chordsketch --version`, which is an infra
+    # flake, not a breakage we can fix in-repo. Soft-fail on
+    # scheduled runs so a single flake does not page the maintainer;
+    # keep fail-fast on PRs so a PR that actually breaks the winget
+    # manifest still surfaces. Filed as #2208.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install via winget
         shell: powershell
         run: |
-          winget install --id koedame.chordsketch --exact --accept-source-agreements --accept-package-agreements --silent
+          # Explicit retry loop for the transient source-refresh
+          # failure documented in #2208. Three attempts with a
+          # 10-second backoff covers the typical CDN blip; the
+          # `continue-on-error` gate above is the final safety net
+          # if all three still fail on a scheduled run.
+          $attempt = 0
+          while ($true) {
+            $attempt++
+            winget install --id koedame.chordsketch --exact `
+              --accept-source-agreements --accept-package-agreements --silent
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -ge 3) {
+              Write-Error "winget install failed after $attempt attempts"
+              exit 1
+            }
+            Write-Host "winget install attempt $attempt failed; retrying in 10s"
+            Start-Sleep -Seconds 10
+          }
           # winget portable installs place command-line aliases in
           # %LOCALAPPDATA%\Microsoft\WinGet\Links\ and adds that directory to
           # the user PATH in the registry — but the current process does not


### PR DESCRIPTION
## Summary

Addresses **#2208** — the scheduled nightly run of the README-install-smoke workflow fired an auto-filed \`priority:high\` bug after the \`winget\` job hit a transient "Failed in attempting to update the source: winget" error against Microsoft's CDN. The install step silently no-op'd, \`chordsketch --version\` then threw \`CommandNotFoundException\`, and \`report-failure\` opened #2208.

Same PR-branch CI runs (seven within the hour on either side) were all green. The failure is a flake at the winget-source-refresh layer, not a regression on our side.

## Fix

Two complementary mitigations, matching the precedent established by \`#2021\` (\`chocolatey\`) and \`#2169\` (\`library-smoke\`):

1. **Retry loop in the install step** — three attempts with a 10-second backoff. Covers one-shot CDN blips.
2. **\`continue-on-error: \${{ github.event_name != 'pull_request' }}\`** — scheduled runs soft-fail so a surviving flake does not page the maintainer; PR runs stay fail-fast.

Follow-up #2216 tracks removing the \`continue-on-error\` gate once scheduled-run winget success becomes durable.

## Fix-propagation / rule audit

- \`.claude/rules/fix-propagation.md\` — no renderer / binding / sanitizer touched. The retry + soft-fail pattern is a \`readme-smoke\` idiom already used for \`chocolatey\` and \`library-smoke\`; consistency improved, not fractured.
- \`.claude/rules/ci-parallelization.md\` — no workflow-wide concurrency change; adds zero new \`needs:\` edges.
- \`.claude/rules/readme-sync.md\` — no \`README.md\` text change, so the snapshot at \`.github/snapshots/readme-commands.txt\` stays aligned.
- \`.claude/rules/root-cause-fixes.md\` — the retry loop attacks the root cause (transient source-refresh failure) directly; the \`continue-on-error\` gate is the documented safety net, not a band-aid masking a real breakage. Both are recorded in the workflow comment with a link to the follow-up #2216 that will remove the gate.
- \`.claude/rules/one-pr-at-a-time.md\` — no other PRs open against \`main\`.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/readme-smoke.yml'))"\` — parses.
- [ ] PR CI — verifies the \`winget (Windows)\` job still runs fail-fast on PRs (i.e. \`continue-on-error\` is \`false\` when \`github.event_name == 'pull_request'\`).
- [ ] Next scheduled run — if it succeeds, the fix cycle closes. If another flake fires, the retry + soft-fail combination keeps \`report-failure\` quiet.

Closes #2208