### PR TITLE
ci: harden desktop-release + release tag workflows

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -360,6 +360,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Pin to the tag under release so `workflow_dispatch` re-runs
+          # read `packaging/homebrew/chordsketch-desktop.rb.template`
+          # from the tagged commit rather than the current branch HEAD.
+          # Same source-commit-drift class fixed in the `build` job
+          # (#2226); a future placeholder rename in the template would
+          # otherwise produce a silently-broken cask on re-dispatch.
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Determine version
         id: version

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -102,6 +102,14 @@ jobs:
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Pin to the tag under release so `workflow_dispatch` runs
+          # build from the tagged commit rather than whichever branch
+          # HEAD the user selected as the dispatch ref. `push: tags:`
+          # events already resolve GITHUB_SHA to the tagged commit,
+          # so this `ref:` is a no-op on that path and a correctness
+          # fix for manual re-runs (#2226).
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -289,8 +297,13 @@ jobs:
             -exec cp -v {} release/ \;
           cd release
           # Deterministic sort so the SHA256SUMS file is stable
-          # across runs (same tag → same file content).
-          find . -type f -printf '%f\n' | sort | xargs sha256sum > SHA256SUMS
+          # across runs (same tag → same file content). NUL-delimited
+          # form (`-printf '%f\0'` + `sort -z` + `xargs -0`) so a
+          # future installer filename with whitespace still produces
+          # one-line-per-file output; Tauri's current naming scheme
+          # (`ChordSketch_<version>_<arch>.<ext>`) never contains
+          # spaces, so this is defense-in-depth (#2229).
+          find . -type f -printf '%f\0' | sort -z | xargs -0 sha256sum > SHA256SUMS
           cat SHA256SUMS
 
       - name: Create Release
@@ -305,14 +318,36 @@ jobs:
         # with the CLI, and marking every desktop release "latest"
         # would hide the CLI's own `v*` releases from the landing
         # page.
+        #
+        # Known cosmetic for the very first `desktop-v*` tag:
+        # `--generate-notes` has no prior tag in the desktop
+        # namespace to diff against, so GitHub falls back to
+        # "every merged PR since the repo was created". The note
+        # body will be long; edit manually after the release cuts
+        # if desired. Subsequent desktop tags diff against the
+        # immediately-prior `desktop-v*` and are concise (#2229).
+        #
+        # `--prerelease` is set iff the tag carries a prerelease
+        # suffix (`desktop-v0.1.0-beta.1`, `desktop-v0.2.0-rc.1`).
+        # Without it, a prerelease tag would publish as a
+        # "latest"-eligible release and leak into users' stable
+        # update channels (#2227).
         run: |
           set -euo pipefail
-          gh release create "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$TAG" \
-            --generate-notes \
-            --verify-tag \
-            release/*
+          args=(
+            "$TAG"
+            --repo "$GITHUB_REPOSITORY"
+            --title "$TAG"
+            --generate-notes
+            --verify-tag
+          )
+          # Prerelease suffix is anything after the `MAJOR.MINOR.PATCH`
+          # triplet; the tag format regex (validate job above) already
+          # guarantees the suffix starts with `-` when present.
+          if printf '%s' "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+-'; then
+            args+=(--prerelease)
+          fi
+          gh release create "${args[@]}" release/*
 
   update-cask:
     name: Update Homebrew Cask

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,14 @@ jobs:
             os: windows-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Pin to the tag under release so `workflow_dispatch` runs
+          # build from the tagged commit rather than whichever branch
+          # HEAD the user selected as the dispatch ref. `push: tags:`
+          # events already resolve GITHUB_SHA to the tagged commit,
+          # so this `ref:` is a no-op on that path and a correctness
+          # fix for manual re-runs (#2226).
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         run: |


### PR DESCRIPTION
## Summary

Three small correctness nits against the release-tag workflows surfaced during review of #2222 (`desktop-release.yml` landing) and #2231 (Homebrew cask). Each was filed as its own issue before `.claude/rules/pr-workflow.md` started forbidding review-finding issues; bundled together here so they merge as a single PR touching only two workflow files.

- **#2226** (`workflow_dispatch` source-commit drift): pin `actions/checkout` to `ref: ${{ inputs.tag || github.ref }}` in both `desktop-release.yml`'s and `release.yml`'s build jobs. Without this, a `workflow_dispatch` invocation against a previously-cut tag would rebuild from whichever branch HEAD the user picked as the dispatch ref — publishing installers that no longer match the tag's source.
- **#2227** (prerelease tags publish as GA): `Create Release` now passes `--prerelease` iff the tag carries a suffix after the `MAJOR.MINOR.PATCH` triplet. The validate regex has always accepted `desktop-v0.1.0-beta.1` / `desktop-v0.2.0-rc.1`, but prior to this fix such a tag would ship a stable "latest-eligible" Release — and, as of #2235, leak into Tauri updater clients as if it were a GA build.
- **#2229** (SHA256SUMS null-safety + first-release notes): NUL-delimited `find -printf '%f\0' | sort -z | xargs -0 sha256sum` (defense-in-depth against a future installer filename with whitespace), plus a YAML comment flagging the known-cosmetic `--generate-notes` behaviour on the very first `desktop-v*` tag so a future maintainer does not try to "fix" the oversized notes body.

## Why

All three are latent defects that only trigger on less-common tag operations (re-dispatch, prerelease tag, a future filename with spaces). Landing them ahead of the first `desktop-v*` release — which is the first time #2235's auto-updater will consume a signed manifest — keeps the release pipeline correct under all tag shapes it advertises it accepts.

## Closed as stale (already fixed in `main`)

Two related issues from the same review cycle inspected `main` and found #2231's merge already resolved the reported conditions:

- **#2232** (`update-chocolatey` bypasses the `detect-tag-type` gate): the current `post-release.yml` uses `if: needs.detect-tag-type.outputs.is-desktop != 'true'` + `needs: [detect-tag-type]` on the chocolatey job (line 225–226), same as every other downstream job. The issue's snapshot of the file is pre-#2231.
- **#2233** (unused `arch` declaration in `chordsketch-desktop.rb.template`): the current template has no `arch arm:, intel:` line — on-arm / on-intel blocks hardcode their URL strings directly. Likely removed during #2231's own iteration before merge.

Both will be closed as `not planned` alongside this PR.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('<path>'))"` for both touched workflow files — parses clean.
- [x] Local verification that the `ref:` pinning syntax matches the canonical form already used elsewhere in this repo (e.g. `post-release.yml` line 78 uses the identical `${{ inputs.tag || github.ref }}` expression).
- [ ] End-to-end prerelease-tag smoke — can only be tested on a real `desktop-v*` tag push with a prerelease suffix; the `if printf ... | grep -Eq '^desktop-v...'` guard is tested indirectly by the existing validate regex step which rejects malformed tags before this step runs.

## Review summary

Self-reviewed; no findings.

Closes #2226
Closes #2227
Closes #2229

🤖 Generated with [Claude Code](https://claude.com/claude-code)