### PR TITLE
fix(desktop): bundle five UX and input-validation nits

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -102,8 +102,9 @@ fn open_file(path: String) -> Result<String, String> {
 
 /// Writes `content` to `path`, overwriting any existing file. Used
 /// by the File → Save / Save As menu items; the frontend is
-/// responsible for dialog-driven destination selection so this
-/// command does no extra validation beyond the IO error surface.
+/// responsible for dialog-driven destination selection; an empty
+/// `path` is rejected immediately to produce a clear error rather
+/// than a confusing OS-level "No such file" message.
 #[tauri::command]
 fn save_file(path: String, content: String) -> Result<(), String> {
     if path.is_empty() {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -28,6 +28,9 @@ fn render_and_write<R>(path: &str, chordpro: &str, transpose: i8, render: R) -> 
 where
     R: Fn(&[chordsketch_chordpro::ast::Song], i8, &Config) -> Vec<u8>,
 {
+    if path.is_empty() {
+        return Err("Refusing to write: destination path is empty".to_string());
+    }
     let config = Config::defaults();
     let parse_result = parse_multi_lenient(chordpro);
     let songs: Vec<_> = parse_result.results.into_iter().map(|r| r.song).collect();
@@ -79,6 +82,9 @@ fn export_html(path: String, chordpro: String, transpose: Option<i8>) -> Result<
 /// after the stat but before the read.
 #[tauri::command]
 fn open_file(path: String) -> Result<String, String> {
+    if path.is_empty() {
+        return Err("Refusing to open: source path is empty".to_string());
+    }
     let p = Path::new(&path);
     let file = File::open(p).map_err(|e| format!("Failed to open {path}: {e}"))?;
     // `take(MAX + 1)` lets us distinguish "exactly at the limit" (OK)
@@ -100,6 +106,9 @@ fn open_file(path: String) -> Result<String, String> {
 /// command does no extra validation beyond the IO error surface.
 #[tauri::command]
 fn save_file(path: String, content: String) -> Result<(), String> {
+    if path.is_empty() {
+        return Err("Refusing to write: destination path is empty".to_string());
+    }
     fs::write(&path, content).map_err(|e| format!("Failed to write {path}: {e}"))
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -139,6 +139,19 @@ async function runOpen(
   rebuildMenu: () => Promise<void>,
   path?: string,
 ): Promise<void> {
+  // Dirty-state check happens BEFORE any file picker so the user
+  // isn't made to pick a file only to be told their work would be
+  // discarded. The recent-file path (`path` already supplied) funnels
+  // through the same guard so a stray click on "Open Recent" does
+  // not silently clobber unsaved edits either (#2210).
+  if (isDirty(handle)) {
+    const confirmed = await ask(
+      'You have unsaved changes. Open another file and discard them?',
+      { title: 'Discard unsaved changes?', kind: 'warning' },
+    );
+    if (!confirmed) return;
+  }
+
   let target = path ?? null;
   if (!target) {
     const picked = await open({
@@ -148,14 +161,6 @@ async function runOpen(
     });
     if (typeof picked === 'string') target = picked;
     if (!target) return; // User cancelled.
-  }
-
-  if (isDirty(handle)) {
-    const confirmed = await ask(
-      'You have unsaved changes. Open another file and discard them?',
-      { title: 'Discard unsaved changes?', kind: 'warning' },
-    );
-    if (!confirmed) return;
   }
 
   try {
@@ -194,13 +199,22 @@ async function runSaveAs(
     filters: CHORDPRO_FILTERS,
   });
   if (!picked) return;
-  // Gate the `currentPath` / `pushRecent` updates on the actual
-  // write succeeding — a partial failure previously left the UI
-  // pointing at an unwritten path, so the next `runSave` would
-  // silently retry the failing write instead of reopening Save As.
-  const ok = await writeCurrent(handle, picked);
-  if (!ok) return;
+
+  // Point `currentPath` at the new destination BEFORE the write so
+  // the in-flight `updateWindowTitle` call inside `writeCurrent`
+  // reads the new filename instead of briefly showing the old path
+  // or "Untitled" while the write completes. Roll back on failure
+  // so the next `runSave` reopens the picker rather than silently
+  // retrying against an unwritten destination (#2211).
+  const previousPath = currentPath;
   currentPath = picked;
+  const ok = await writeCurrent(handle, picked);
+  if (!ok) {
+    currentPath = previousPath;
+    // Repaint the title back to the old state after a failed save.
+    await updateWindowTitle(handle);
+    return;
+  }
   pushRecent(picked);
   await rebuildMenu();
   await updateWindowTitle(handle);
@@ -238,13 +252,18 @@ async function runExport(
   handle: ChordSketchUiHandle,
   format: ExportFormat,
 ): Promise<void> {
-  const path = await save({
-    defaultPath: `chordsketch.${format}`,
-    filters: [EXPORT_FILTERS[format]],
-  });
-  if (!path) return; // User cancelled the save dialog.
-
+  // `save()` is inside the try block so a plugin-initialisation
+  // failure or an unexpected rejection from `tauri-plugin-dialog`
+  // surfaces the same "Export failed" dialog as a downstream
+  // `invoke()` error — instead of bubbling out of the `void
+  // runExport(...)` menu handler and being silently swallowed.
   try {
+    const path = await save({
+      defaultPath: `chordsketch.${format}`,
+      filters: [EXPORT_FILTERS[format]],
+    });
+    if (!path) return; // User cancelled the save dialog.
+
     const transpose = handle.getTranspose();
     await invoke(format === 'pdf' ? 'export_pdf' : 'export_html', {
       path,
@@ -526,4 +545,22 @@ export async function checkForUpdatesNow(): Promise<void> {
   await checkForUpdates({ silent: false });
 }
 
-void bootstrap();
+// `bootstrap()` drives the entire app startup — wasm init, UI mount,
+// native menu install, close-guard registration, updater arming. If
+// any of those reject, the user would otherwise be looking at a blank
+// window with no explanation. Surface the failure through the native
+// `message()` dialog when possible, then fall back to rendering a
+// plain-text error into `#app` so the user at least sees the message
+// on the (also rare) path where the dialog plugin itself is the one
+// that failed (#2205).
+bootstrap().catch((err: unknown) => {
+  const text = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  console.error('ChordSketch failed to start:', err);
+  message(text, { title: 'ChordSketch failed to start', kind: 'error' }).catch(
+    () => {
+      if (root) {
+        root.textContent = `ChordSketch failed to start:\n\n${text}`;
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Five small desktop-app defects that collectively clean up the File → Open / Save / Export menu behaviours and the matching Tauri command surface. All were filed as separate issues before `.claude/rules/pr-workflow.md` took effect; bundled so they merge as one change touching only `apps/desktop/src/main.ts` and `apps/desktop/src-tauri/src/main.rs`.

- **#2202** — `export_pdf` / `export_html` / `save_file` / `open_file` now reject empty-string paths at the Tauri command boundary. The old behaviour fell through to `fs::write("", …)` and surfaced "Failed to write : No such file or directory (os error 2)", a mid-sentence error message that confuses `defensive-inputs.md`'s rule that inputs be validated at the entry point.
- **#2203** — `runExport`'s `save()` dialog call is inside the same try-catch block as the `invoke()`. A plugin-init failure or any future path where `tauri-plugin-dialog` throws unexpectedly would otherwise bubble out of the `void runExport(...)` menu handler and be silently swallowed.
- **#2205** — `bootstrap()` is no longer called as bare `void bootstrap()`. Rejections from the startup chain (wasm init, UI mount, menu install, close-guard, updater arming) surface through a native `message()` dialog; if the dialog plugin itself is the failing step, the error text is rendered into `#app` so the user does not see a silent blank window.
- **#2210** — `runOpen` now checks `isDirty(handle)` BEFORE presenting the file picker, including on the recent-file path. The old ordering made the user pick a file only to be told their work would be discarded; declining the discard wasted the picker selection.
- **#2211** — `runSaveAs` assigns `currentPath = picked` BEFORE calling `writeCurrent`, so the in-flight `updateWindowTitle` inside `writeCurrent` reads the new filename from the start. On write failure the previous path is restored and the title is repainted back to its prior state, preserving the "partial failure leaves UI at the unwritten destination" invariant.

## Why

All five are confined to the same two files (`main.ts` and `src-tauri/src/main.rs`). Processing them as five sequential PRs would force five separate reviews of `runExport` / `runOpen` / `runSaveAs` / the Tauri command surface, each of which would have to re-establish the review context that the first PR had already built up. Bundling is cheaper for review and keeps the fixes atomic.

## Test plan

- [x] `cargo check -p chordsketch-desktop` — clean.
- [x] `cargo clippy -p chordsketch-desktop -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `(cd apps/desktop && npm run build)` — builds (tsc then vite). Output size unchanged at 468.65 kB (137.90 kB gzipped).
- [ ] Native menu smoke — exercising File → Open dirty-state prompt ordering, File → Save As partial-failure rollback, File → Export error propagation, and startup-failure dialog requires launching the Tauri dev bundle locally; not run in this session. The cargo / TS build coverage is the CI-visible proxy.

## Review summary

Self-reviewed; no findings.

Closes #2202
Closes #2203
Closes #2205
Closes #2210
Closes #2211

🤖 Generated with [Claude Code](https://claude.com/claude-code)