### PR TITLE
fix(desktop): codemirror highlight+lint polish

### DIFF
--- a/apps/desktop/src/codemirror-editor.ts
+++ b/apps/desktop/src/codemirror-editor.ts
@@ -182,10 +182,11 @@ function highlightPlugin(grammar: LoadedGrammar) {
         // walks every node. Viewport-scoped decorations would be
         // cheaper for very long buffers, but the current chord
         // fixtures comfortably fit the "reparse on every keystroke"
-        // budget, and viewport scoping requires keeping a separate
-        // decoration set per visible range (tracked in #2215 sibling
-        // notes). Keep the call symmetric with `tree.rootNode.text`
-        // so a future caller can't mistakenly assume range scoping.
+        // budget, and viewport scoping requires maintaining a
+        // per-visible-range decoration set — a future optimisation
+        // if large files become a concern. Keep the call symmetric
+        // with `tree.rootNode.text` so a future reader can't
+        // mistakenly assume range scoping is already in place.
         const matches = grammar.query.matches(this.tree.rootNode, {
           startIndex: 0,
           endIndex: view.state.doc.length,
@@ -320,9 +321,10 @@ function publishDiagnostics(
 
 /**
  * Return true iff the EditorState currently has at least one
- * diagnostic set. Short-circuits via throw so the lint iterator
- * stops at the first hit — `forEachDiagnostic` has no built-in
- * break.
+ * diagnostic set. Iterates all existing diagnostics (O(n)) because
+ * `forEachDiagnostic` has no built-in break; this is acceptable since
+ * the function is only called on the error-clearing path where the
+ * new diagnostics list is already empty.
  */
 function hasExistingDiagnostics(view: EditorView): boolean {
   let found = false;

--- a/apps/desktop/src/codemirror-editor.ts
+++ b/apps/desktop/src/codemirror-editor.ts
@@ -22,7 +22,11 @@ import {
   HighlightStyle,
   syntaxHighlighting,
 } from '@codemirror/language';
-import { setDiagnostics, type Diagnostic } from '@codemirror/lint';
+import {
+  forEachDiagnostic,
+  setDiagnostics,
+  type Diagnostic,
+} from '@codemirror/lint';
 import { Compartment, EditorState } from '@codemirror/state';
 import {
   Decoration,
@@ -174,11 +178,14 @@ function highlightPlugin(grammar: LoadedGrammar) {
       buildDecorations(view: EditorView): DecorationSet {
         if (!this.tree) return Decoration.none;
         const builder = new RangeDecorationBuilder();
-        // Range-scoped `QueryOptions` are honoured here so the
-        // highlight query only walks the visible / changed slice
-        // of the tree rather than the entire document on every
-        // keystroke. `tree-sitter`'s query cursor internally
-        // clips matches to `[startIndex, endIndex)`.
+        // Pass the full document extent to the query so tree-sitter
+        // walks every node. Viewport-scoped decorations would be
+        // cheaper for very long buffers, but the current chord
+        // fixtures comfortably fit the "reparse on every keystroke"
+        // budget, and viewport scoping requires keeping a separate
+        // decoration set per visible range (tracked in #2215 sibling
+        // notes). Keep the call symmetric with `tree.rootNode.text`
+        // so a future caller can't mistakenly assume range scoping.
         const matches = grammar.query.matches(this.tree.rootNode, {
           startIndex: 0,
           endIndex: view.state.doc.length,
@@ -274,8 +281,16 @@ function publishDiagnostics(
       walker.gotoParent();
     }
   };
-  visit();
-  walker.delete();
+  try {
+    visit();
+  } finally {
+    // `walker` wraps a WASM `TreeCursor` — skipping `.delete()`
+    // would leak its WASM-side memory for the parser's lifetime.
+    // The finally is unconditional so a thrown `visit()` (e.g. a
+    // future `web-tree-sitter` regression) does not bleed handles
+    // keystroke-by-keystroke (#2214).
+    walker.delete();
+  }
   if (truncated > 0) {
     // Trailing marker so the truncation is visible in the lint
     // gutter, not just silent. `from === to` would be rejected,
@@ -288,10 +303,33 @@ function publishDiagnostics(
       message: `…and ${truncated} more syntax error${truncated === 1 ? '' : 's'} (truncated; fix earlier errors first)`,
     });
   }
+  // Skip the dispatch on the common "valid ChordPro" path where
+  // both the previous and the new diagnostics list are empty.
+  // `@codemirror/lint`'s state field re-runs through every
+  // transaction even when the value is unchanged, so eliminating
+  // the empty-to-empty write halves the per-keystroke transaction
+  // count on the happy path (#2215).
+  if (diagnostics.length === 0 && !hasExistingDiagnostics(view)) {
+    return;
+  }
   view.dispatch(setDiagnostics(view.state, diagnostics));
   // `setDiagnostics` returns a `TransactionSpec` (not a
   // transaction), which `view.dispatch` accepts directly — no
   // extra wrapping needed.
+}
+
+/**
+ * Return true iff the EditorState currently has at least one
+ * diagnostic set. Short-circuits via throw so the lint iterator
+ * stops at the first hit — `forEachDiagnostic` has no built-in
+ * break.
+ */
+function hasExistingDiagnostics(view: EditorView): boolean {
+  let found = false;
+  forEachDiagnostic(view.state, () => {
+    found = true;
+  });
+  return found;
 }
 
 // Base theme that fills the pane and matches the dark surface of


### PR DESCRIPTION
## Summary

Three small correctness and performance nits against `apps/desktop/src/codemirror-editor.ts`. All touch the CodeMirror highlight / lint plugin wrapper and share the same file — bundling so reviewer context is contiguous and there is no ordering-between-PRs risk.

- **#2213** — `buildDecorations` comment claimed the highlight query was "range-scoped to the visible / changed slice", but the call passes `startIndex: 0, endIndex: view.state.doc.length` so it walks the entire tree. Rewritten to match the actual scope and to flag viewport scoping as a future optimisation path rather than the current implementation.
- **#2214** — Wrap the `visit()` traversal inside `publishDiagnostics` in `try/finally` so `walker.delete()` always runs. `walker` is a `TreeCursor` with backing WASM memory that leaks for the parser's lifetime when not explicitly freed; a future `web-tree-sitter` regression (or a bug in any of the node-property reads) would otherwise bleed handles keystroke-by-keystroke.
- **#2215** — Skip the `view.dispatch(setDiagnostics(...))` call on the "valid ChordPro" happy path where both the previous and new diagnostics lists are empty. `@codemirror/lint`'s state field re-runs on every transaction even when the value is unchanged, so the empty-to-empty write is one redundant transaction per keystroke. Uses `forEachDiagnostic` with a boolean flag to probe the existing state — O(1) on the happy path, O(n) on the already-slow error path.

## Why

The three fixes together halve the per-keystroke transaction count on the common case (valid input), plug a latent WASM memory-leak path, and bring the code's self-documentation back in line with its behaviour. Each is small and confined to the same file.

## Test plan

- [x] `(cd apps/desktop && npm run build)` — tsc passes, vite emits `dist/assets/index-DkMBQlY7.js` (469.20 kB / 138.07 kB gzipped).
- [ ] Interactive keystroke benchmark (reduced transaction count on valid input) — requires launching the Tauri dev bundle and instrumenting dispatches; not measured in this session. The tsc build coverage is the CI-visible proxy.

## Review summary

Self-reviewed; no findings.

Closes #2213
Closes #2214
Closes #2215

🤖 Generated with [Claude Code](https://claude.com/claude-code)