### PR TITLE
docs: unify tsconfig wasm alias form, trim README CI commentary

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,7 @@ brew install chordsketch
 The Homebrew tap also ships a **Cask** for the ChordSketch
 desktop app (`.app`). See [Desktop application](#desktop-application)
 below for the install snippet and post-install quarantine-flag
-step. The cask is kept in its own section (not under
-`## Installation`) until the first `desktop-v*` release ships
-the DMG to the tap, at which point [#2230](https://github.com/koedame/chordsketch/issues/2230)
-will move it here and add `readme-smoke` coverage.
+step.
 
 ### Scoop (Windows)
 
@@ -154,16 +151,6 @@ xattr -dr com.apple.quarantine /Applications/ChordSketch.app
 Apple Developer ID signing + notarization (so the flag is not
 needed regardless of install path) is tracked in
 [#2075](https://github.com/koedame/chordsketch/issues/2075).
-
-> These two snippets live in `## Desktop application` (not
-> `## Installation`) on purpose. The
-> [`readme-sync.md`](.claude/rules/readme-sync.md) rule couples
-> every `## Installation` command to a smoke job in
-> `.github/workflows/readme-smoke.yml`, and the desktop cask
-> cannot be smoke-installed until the first `desktop-v*` tag
-> publishes the DMG. [#2230](https://github.com/koedame/chordsketch/issues/2230)
-> tracks moving the snippets up and adding cask-install smoke
-> coverage once the cask goes live.
 
 ## Usage
 

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -17,16 +17,12 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    // `@chordsketch/wasm` is mapped WITHOUT the `.js` extension on
-    // purpose. Playground's tsconfig points to
-    // `chordsketch_wasm.js` directly and resolves fine there, but
-    // the same form raises TS7016 ("Could not find a declaration
-    // file") under `moduleResolution: "bundler"` from this deeper
-    // `apps/desktop/` location — reproduced locally on TS 5.9.3.
-    // Root cause is still unexplained; dropping the extension lets
-    // TS pair the alias with the neighbouring
-    // `chordsketch_wasm.d.ts` explicitly. Unification with
-    // playground's form is tracked in #2188.
+    // The `@chordsketch/wasm` alias points at the extension-less
+    // path so `moduleResolution: "bundler"` pairs it with the
+    // neighbouring `chordsketch_wasm.d.ts`. The `.js`-suffix form
+    // raises TS7016 from this nested location under TS 5.9.3; both
+    // `apps/desktop` and `packages/playground` use the same
+    // extension-less form to keep the two tsconfigs symmetric.
     "paths": {
       "@chordsketch/wasm": ["../../packages/npm/web/chordsketch_wasm"],
       "@chordsketch/ui-web": ["../../packages/ui-web/src/index.ts"],

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@chordsketch/wasm": ["../npm/web/chordsketch_wasm.js"],
+      "@chordsketch/wasm": ["../npm/web/chordsketch_wasm"],
       "@chordsketch/ui-web": ["../ui-web/src/index.ts"],
       "@chordsketch/ui-web/style.css": ["../ui-web/src/style.css"]
     }


### PR DESCRIPTION
## Summary

Two small doc / config refinements that were filed as separate issues but share the `tsconfig.json` / README surface and bundle cleanly.

- **#2188 + #2189** — Unify the `@chordsketch/wasm` alias form across `apps/desktop/tsconfig.json` and `packages/playground/tsconfig.json`. Both now resolve the package via the extension-less `chordsketch_wasm` path so `moduleResolution: "bundler"` pairs the alias with the neighbouring `chordsketch_wasm.d.ts`. The `.js`-suffix form raised TS7016 from desktop's nested location on TS 5.9.3; dropping it in playground too keeps the sibling tsconfigs symmetric and retires the asymmetric "WORKAROUND without prefix" that #2189 tracked. The desktop comment was rewritten to describe the resolved state rather than the open question it originally framed.
- **#2234** — Drop the internal-CI-process commentary block from `## Desktop application` in `README.md`. The blockquote exposed `readme-sync.md` coupling + the #2230 pending-move plumbing to every npm / crates.io / PyPI visitor. Both are contributor-facing concerns that belong in `.claude/rules/` and the issue tracker, not in the README that renders on every registry page. The forward reference under `## Installation` was similarly trimmed to a plain one-liner pointing at `#desktop-application`.

## Closed as stale

- **#2197** (unused `editorPane` destructuring) inspected current `main` — the destructured binding is `editorPaneEl`, and it is used at `packages/ui-web/src/index.ts:542` (`editorPaneEl.appendChild(editor.element)`). The issue's diagnosis was either based on a prior version or mistook the `El` suffix; closing as `not planned`.

## Test plan

- [x] `(cd packages/playground && tsc --noEmit)` — clean after the alias change.
- [x] `(cd apps/desktop && npm run build)` — clean (tsc + vite).
- [x] `python3 scripts/extract-readme-commands.py` against the edited README — snapshot unchanged (no `## Installation` / `## Usage` fenced-bash command was touched; the edits were prose-only).

## Review summary

Self-reviewed; no findings.

Closes #2188
Closes #2189
Closes #2234

🤖 Generated with [Claude Code](https://claude.com/claude-code)