### PR TITLE
ci: desktop-build+release nits and ci-parallelization §2 update

### DIFF
--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -46,6 +46,8 @@ YAML noise.
 
 **Intentionally omitted (infrequent — cache expires before next run):**
 - `release.yml` — ~every 10 days on version tags
+- `desktop-release.yml` — fires on `desktop-v*` tag pushes; expected
+  cadence comparable to `release.yml` and below the 7-day cache TTL
 - `npm-publish.yml` — a few times per month
 - `extended-tests.yml` — dispatch-only, rarely invoked
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -33,7 +33,16 @@ on:
       - "packages/npm/**"
       - "packages/tree-sitter-chordpro/**"
       - "packages/ui-web/**"
-      - "crates/**"
+      # Only the three crates `chordsketch-desktop` depends on —
+      # `chordpro`, `render-html`, `render-pdf`. Changes to sibling
+      # crates (`lsp`, `ffi`, `napi`, `wasm`, `cli`,
+      # `convert-musicxml`) never affect the desktop bundle, so they
+      # MUST not trigger the 4-cell macOS/Windows/Linux matrix.
+      # Extending this list requires a matching edit to
+      # `apps/desktop/src-tauri/Cargo.toml`'s `[dependencies]`.
+      - "crates/chordpro/**"
+      - "crates/render-html/**"
+      - "crates/render-pdf/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/desktop-build.yml"
@@ -43,7 +52,16 @@ on:
       - "packages/npm/**"
       - "packages/tree-sitter-chordpro/**"
       - "packages/ui-web/**"
-      - "crates/**"
+      # Only the three crates `chordsketch-desktop` depends on —
+      # `chordpro`, `render-html`, `render-pdf`. Changes to sibling
+      # crates (`lsp`, `ffi`, `napi`, `wasm`, `cli`,
+      # `convert-musicxml`) never affect the desktop bundle, so they
+      # MUST not trigger the 4-cell macOS/Windows/Linux matrix.
+      # Extending this list requires a matching edit to
+      # `apps/desktop/src-tauri/Cargo.toml`'s `[dependencies]`.
+      - "crates/chordpro/**"
+      - "crates/render-html/**"
+      - "crates/render-pdf/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/desktop-build.yml"
@@ -125,7 +143,12 @@ jobs:
           shared-key: desktop-build-${{ matrix.platform.target }}
 
       - name: Install Tauri system dependencies (Linux)
-        if: matrix.platform.runner == 'ubuntu-latest'
+        # `runner.os` is a stable context value ('Linux' / 'macOS'
+        # / 'Windows') independent of the mutable GitHub runner
+        # label alias (`ubuntu-latest`). Using it here shields the
+        # gate from a future Ubuntu LTS bump that renames the alias
+        # (#2220).
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -116,15 +116,20 @@ jobs:
         with:
           targets: wasm32-unknown-unknown, ${{ matrix.platform.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          # Target-triple per-matrix-cell. Separate shared-key
-          # from `desktop-build.yml`'s cache so release builds do
-          # not invalidate PR-smoke caches (and vice versa).
-          shared-key: desktop-release-${{ matrix.platform.target }}
+      # NOTE: no Swatinem/rust-cache here. Per
+      # `.claude/rules/ci-parallelization.md` §2, this workflow
+      # fires on `desktop-v*` tag pushes — expected cadence
+      # comparable to the CLI `release.yml` (well under once per
+      # 7 days). GitHub Actions evicts cache entries after 7 days
+      # of inactivity, so the cache expires between runs. Adding
+      # rust-cache delivers no wall-clock benefit and only adds
+      # YAML noise. Do not add one back without updating the rule.
 
       - name: Install Tauri system dependencies (Linux)
-        if: matrix.platform.runner == 'ubuntu-latest'
+        # See the parallel gate in `desktop-build.yml`: `runner.os`
+        # is the stable context value, surviving a future Ubuntu
+        # LTS alias rename (#2220).
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Three small refinements against the desktop-bundle CI surface and the rule file that governs the rust-cache decision for tag-triggered workflows. All filed as separate issues during review of #2222; bundled together since they touch overlapping files (`desktop-build.yml`, `desktop-release.yml`, `.claude/rules/ci-parallelization.md`).

- **#2221** — Narrow `desktop-build.yml`'s `crates/**` paths filter to only the three crates `chordsketch-desktop` actually depends on (`chordpro`, `render-html`, `render-pdf`). Sibling crates (`lsp`, `ffi`, `napi`, `wasm`, `cli`, `convert-musicxml`) were previously triggering the 4-cell matrix on every change despite never affecting the desktop bundle. Extending this list requires a matching edit to `apps/desktop/src-tauri/Cargo.toml`'s `[dependencies]`, so the filter can't silently drift.
- **#2220** — Replace `if: matrix.platform.runner == 'ubuntu-latest'` with `if: runner.os == 'Linux'` on the `Install Tauri system dependencies (Linux)` step in both `desktop-build.yml` and `desktop-release.yml`. `runner.os` is a stable context value independent of the mutable runner-label alias; the previous form would have silently skipped the apt-get install on a future Ubuntu LTS bump that renames `ubuntu-latest`, leaving the Linux cell to fail mid-build on a missing `libwebkit2gtk-4.1-dev`.
- **#2228** — Drop `Swatinem/rust-cache` from `desktop-release.yml`. The workflow fires on `desktop-v*` tag pushes at a cadence comparable to the CLI `release.yml` — well below GitHub Actions' 7-day cache-eviction TTL, so the cache expires between runs and the step is pure YAML noise. Updated `.claude/rules/ci-parallelization.md` §2's "Intentionally omitted" list to include `desktop-release.yml` alongside `release.yml`, so a future contributor auditing the rule finds the decision documented rather than an unexplained omission.

## Closed as stale

- **#2219** (pin `tauri-cli` to a concrete version) inspected `main` — `desktop-build.yml:155` already pins `tauri-cli@2.10.1`, and the rationale comment spells out why the semver-range form fails (`taiki-e/install-action` does not accept operators). Closing as `not planned`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on both touched workflow files — parses clean.
- [ ] End-to-end desktop-release tag push — no `desktop-v*` tag is cut during this PR's lifecycle, so the cache-deletion behaviour in `desktop-release.yml` can't be exercised via CI against the tag pipeline itself. The `desktop-build.yml` changes are exercised on every PR that touches `apps/desktop/` (this PR does not, so no self-test).

## Review summary

Self-reviewed; no findings.

Closes #2220
Closes #2221
Closes #2228

🤖 Generated with [Claude Code](https://claude.com/claude-code)