### PR TITLE
ci: parameterise validate-release-tag with optional prefix

### DIFF
--- a/.github/actions/validate-release-tag/action.yml
+++ b/.github/actions/validate-release-tag/action.yml
@@ -1,12 +1,17 @@
 name: "Validate release tag format"
 description: >
   Validate that a string matches the project's release tag format
-  `v<major>.<minor>.<patch>[-prerelease]`. Rejects tags whose format
-  is malformed before they are interpolated into downstream shell or
-  `gh` CLI invocations. Paired with routing `inputs.tag` and
+  `[prefix]v<major>.<minor>.<patch>[-prerelease]`. Rejects tags whose
+  format is malformed before they are interpolated into downstream
+  shell or `gh` CLI invocations. Paired with routing `inputs.tag` and
   `github.event.release.tag_name` through `env:` so user-controlled
   values never reach YAML expression interpolation in a `run:` body
   without first being format-validated. See #1797.
+
+  The optional `prefix` input lets tag-triggered workflows on
+  per-product namespaces (e.g. `desktop-v<...>` for the desktop app,
+  #2078) share this composite rather than carrying an inline regex
+  that would silently diverge from the CLI form (#2224).
 inputs:
   tag:
     description: >
@@ -15,6 +20,15 @@ inputs:
       github.ref_name so all three entry points are covered. See the
       workflow callers of this action for the exact expression.
     required: true
+  prefix:
+    description: >
+      Optional product-namespace prefix required before the leading
+      `v` (e.g. `desktop-` so `desktop-v0.1.0` is accepted). Empty by
+      default, which preserves the historical CLI tag form. The
+      prefix MUST NOT contain regex metacharacters; it is spliced
+      into an ERE pattern literally.
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -22,14 +36,21 @@ runs:
       shell: bash
       env:
         TAG: ${{ inputs.tag }}
+        PREFIX: ${{ inputs.prefix }}
       run: |
         set -euo pipefail
         if [ -z "$TAG" ]; then
           echo "Rejecting empty release tag (workflow must supply inputs.tag, github.event.release.tag_name, or run on a tag push)." >&2
           exit 1
         fi
-        if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
+        # Splice the prefix literally — the composite contract
+        # documents that callers MUST NOT pass a prefix containing
+        # regex metacharacters. Within this repo every caller uses a
+        # hardcoded string literal (`desktop-` today), so we do not
+        # rescan the prefix for metachars at run-time.
+        REGEX="^${PREFIX}v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$"
+        if ! printf '%s' "$TAG" | grep -Eq "$REGEX"; then
           echo "Rejecting malformed release tag: $TAG" >&2
-          echo "Expected format: v<major>.<minor>.<patch>[-<prerelease>]" >&2
+          echo "Expected format: ${PREFIX}v<major>.<minor>.<patch>[-<prerelease>]" >&2
           exit 1
         fi

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -53,24 +53,12 @@ jobs:
     name: Validate tag format
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Validate
-        env:
-          TAG: ${{ inputs.tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-          if [ -z "$TAG" ]; then
-            echo "Rejecting empty release tag." >&2
-            exit 1
-          fi
-          # Accept `desktop-v<major>.<minor>.<patch>[-prerelease]`.
-          # A dedicated regex (not the generic
-          # `.github/actions/validate-release-tag` helper) because
-          # the desktop namespace adds the `desktop-` prefix.
-          if ! printf '%s' "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
-            echo "Rejecting malformed desktop release tag: $TAG" >&2
-            echo "Expected format: desktop-v<major>.<minor>.<patch>[-<prerelease>]" >&2
-            exit 1
-          fi
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ inputs.tag || github.ref_name }}
+          prefix: desktop-
 
   build:
     name: Build (${{ matrix.platform.label }})
@@ -276,14 +264,10 @@ jobs:
         # Guard against the `release` job running without the
         # `validate` job's format check (e.g. a future refactor
         # that drops the `needs:`).
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if ! printf '%s' "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
-            echo "Rejecting malformed desktop release tag: $TAG" >&2
-            exit 1
-          fi
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.tag.outputs.tag }}
+          prefix: desktop-
 
       - name: Flatten artefacts + generate SHA256SUMS
         shell: bash
@@ -395,14 +379,10 @@ jobs:
         # Same defense-in-depth as the `release` job — `needs:
         # [release]` already serialises on a validated tag, but
         # a future refactor could break that ordering.
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if ! printf '%s' "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
-            echo "Rejecting malformed desktop release tag: $TAG" >&2
-            exit 1
-          fi
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+          prefix: desktop-
 
       - name: Download SHA256SUMS
         env:
@@ -517,14 +497,10 @@ jobs:
           echo "version=${TAG#desktop-v}" >> "$GITHUB_OUTPUT"
 
       - name: Re-validate tag format
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if ! printf '%s' "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
-            echo "Rejecting malformed desktop release tag: $TAG" >&2
-            exit 1
-          fi
+        uses: ./.github/actions/validate-release-tag
+        with:
+          tag: ${{ steps.tag.outputs.tag }}
+          prefix: desktop-
 
       - name: Download release signatures
         env:


### PR DESCRIPTION
## Summary

Generalise `.github/actions/validate-release-tag/action.yml` so `desktop-release.yml` can share its format-validation logic instead of carrying an inline regex per the `desktop-` tag namespace.

- Composite grows an optional `prefix:` input (default empty — preserves the historical `v<major>.<minor>.<patch>[-prerelease]` shape for every current caller). Non-empty values splice into the regex as `^<prefix>v<major>.<minor>.<patch>[-prerelease]$`. Prefix is spliced literally; the contract documents that callers MUST NOT pass regex metacharacters. Every in-repo caller passes a hardcoded string.
- `desktop-release.yml` drops four inline regex sites in favour of `uses: ./.github/actions/validate-release-tag` with `prefix: desktop-` — the initial `validate` job plus three `Re-validate tag format` defense-in-depth checks in the `release`, `update-cask`, and `publish-updater-manifest` jobs.
- The `validate` job gains a `actions/checkout@...` step so the composite path resolves inside the runner workspace. All other callers already check out the repo.
- `release.yml`, `post-release.yml`, `kotlin.yml`, `swift.yml`, `docker.yml`, `napi.yml`, `chocolatey-retry.yml`, `release-verify.yml` omit `prefix:` and inherit the empty default, so their behaviour is unchanged.

## Out of scope

The prerelease-suffix detector added by #2242 (`^desktop-v[0-9]+\.[0-9]+\.[0-9]+-` guarding `gh release create --prerelease`) is deliberately left inline in the `Create Release` step. That regex is a *feature detector*, not a *format validator*, and generalising it into the composite would conflate two different responsibilities.

## Test plan

- [x] Local smoke-test of the spliced regex against 10 positive/negative cases (including prefix presence/absence, `desktop-v2.10.1-rc.2`, empty input, malformed `desktop-v` stub). All expected accepts/rejects hold.
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on both modified files — parses clean.
- [ ] Exercising all four desktop re-validate sites against a real `desktop-v*` tag push is out of reach until the first desktop release is cut. The `validate` job itself is the gate that fires on every tag push; the three `Re-validate` steps are defense-in-depth for the case where a future refactor drops the `needs:` edges.

## Review summary

Self-reviewed; no findings.

Closes #2224

🤖 Generated with [Claude Code](https://claude.com/claude-code)