### PR TITLE
fix(desktop): enforce size limit on export_pdf / export_html input

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -15,6 +15,16 @@ use chordsketch_chordpro::parse_multi_lenient;
 /// command fail fast with a readable error instead of a WebView hang.
 const MAX_OPEN_SIZE_BYTES: u64 = 10 * 1024 * 1024;
 
+/// Upper bound on the ChordPro source length that `export_pdf` and
+/// `export_html` accept from the WebView. Matches `MAX_OPEN_SIZE_BYTES`
+/// — a user who cannot open a file larger than 10 MiB cannot reach the
+/// export path with one either, so keeping the two limits identical is
+/// the least-surprising contract. Per `.claude/rules/code-style.md`
+/// ("Resource Limits"): the `parse_multi_lenient` + renderer pipeline
+/// has no internal cap, so the boundary check lives here at the Tauri
+/// command entry point.
+const MAX_EXPORT_CHORDPRO_BYTES: usize = 10 * 1024 * 1024;
+
 /// Parse the supplied ChordPro source, render every song it contains
 /// with the requested transposition, and write the result to `path`.
 ///
@@ -30,6 +40,13 @@ where
 {
     if path.is_empty() {
         return Err("Refusing to write: destination path is empty".to_string());
+    }
+    if chordpro.len() > MAX_EXPORT_CHORDPRO_BYTES {
+        return Err(format!(
+            "ChordPro source is too large to export ({} bytes > {} bytes)",
+            chordpro.len(),
+            MAX_EXPORT_CHORDPRO_BYTES
+        ));
     }
     let config = Config::defaults();
     let parse_result = parse_multi_lenient(chordpro);


### PR DESCRIPTION
## Summary

Add `MAX_EXPORT_CHORDPRO_BYTES` (10 MiB, matching `MAX_OPEN_SIZE_BYTES`) to `apps/desktop/src-tauri/src/main.rs` and reject `chordpro` arguments above the threshold at the `render_and_write` boundary. Per `.claude/rules/code-style.md` "Resource Limits": the `parse_multi_lenient` + renderer pipeline has no internal cap, so the boundary check belongs at the Tauri command entry point.

## Why identical to `MAX_OPEN_SIZE_BYTES`

A user who cannot open a file larger than 10 MiB cannot reach the export path with one either — split limits would only confuse. The constant is named separately (`MAX_EXPORT_CHORDPRO_BYTES`) rather than aliased so a future decision to diverge is a single-site change.

## Test plan

- [x] `cargo check -p chordsketch-desktop` — clean.
- [x] `cargo clippy -p chordsketch-desktop -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [ ] Interactive test with a >10 MiB `.cho` file — not run in this session; the desktop smoke suite already exercises the commands with sub-limit input.

## Review summary

Self-reviewed; no findings.

Closes #2204

🤖 Generated with [Claude Code](https://claude.com/claude-code)