### PR TITLE
feat(desktop): surface renderer warnings from File → Export

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use chordsketch_chordpro::config::Config;
 use chordsketch_chordpro::parse_multi_lenient;
+use chordsketch_chordpro::render_result::RenderResult;
 
 /// Max ChordPro source size the editor will open from disk. 10 MiB
 /// comfortably fits the largest hymnal transcriptions in the test
@@ -27,6 +28,8 @@ const MAX_EXPORT_CHORDPRO_BYTES: usize = 10 * 1024 * 1024;
 
 /// Parse the supplied ChordPro source, render every song it contains
 /// with the requested transposition, and write the result to `path`.
+/// Returns the collected render-side warnings so the frontend can
+/// surface them to the user (#2201).
 ///
 /// Called by the renderer-specific command wrappers below. Extracting
 /// the parse + render pipeline here keeps the two commands
@@ -35,11 +38,25 @@ const MAX_EXPORT_CHORDPRO_BYTES: usize = 10 * 1024 * 1024;
 /// error message format) does not drift against the other — see
 /// `.claude/rules/fix-propagation.md` for the sister-site rationale.
 ///
+/// Warning parity with the WASM path (playground / desktop live
+/// preview): both use each renderer's `render_songs_with_warnings`
+/// variant, so the warning messages and ordering are identical across
+/// browser, in-process desktop export, and the CLI (see
+/// `crates/wasm/src/lib.rs` `flush_warnings`). Parser warnings are not
+/// included — `parse_multi_lenient` never returns structured warnings,
+/// only per-line errors that are flushed into the partial AST, and the
+/// CLI/WASM paths do not surface those either.
+///
 /// Trust model: the callers (`export_pdf` / `export_html`) are not
 /// capability-gated; see `save_file`'s doc comment and ADR-0006.
-fn render_and_write<R>(path: &str, chordpro: &str, transpose: i8, render: R) -> Result<(), String>
+fn render_and_write<R>(
+    path: &str,
+    chordpro: &str,
+    transpose: i8,
+    render: R,
+) -> Result<Vec<String>, String>
 where
-    R: Fn(&[chordsketch_chordpro::ast::Song], i8, &Config) -> Vec<u8>,
+    R: Fn(&[chordsketch_chordpro::ast::Song], i8, &Config) -> RenderResult<Vec<u8>>,
 {
     if path.is_empty() {
         return Err("Refusing to write: destination path is empty".to_string());
@@ -54,35 +71,48 @@ where
     let config = Config::defaults();
     let parse_result = parse_multi_lenient(chordpro);
     let songs: Vec<_> = parse_result.results.into_iter().map(|r| r.song).collect();
-    let bytes = render(&songs, transpose, &config);
-    fs::write(path, bytes).map_err(|e| format!("Failed to write {path}: {e}"))
+    let result = render(&songs, transpose, &config);
+    fs::write(path, result.output).map_err(|e| format!("Failed to write {path}: {e}"))?;
+    Ok(result.warnings)
 }
 
 /// Renders `chordpro` to PDF with the optional `transpose` offset and
 /// writes the bytes to `path`. The renderer is the in-process
 /// `chordsketch-render-pdf` crate, not the WASM module — satisfies
-/// AC3 of #2074.
+/// AC3 of #2074. Returns the renderer's captured warnings so the
+/// frontend can surface them in the Export dialog (#2201).
 #[tauri::command]
-fn export_pdf(path: String, chordpro: String, transpose: Option<i8>) -> Result<(), String> {
+fn export_pdf(
+    path: String,
+    chordpro: String,
+    transpose: Option<i8>,
+) -> Result<Vec<String>, String> {
     render_and_write(
         &path,
         &chordpro,
         transpose.unwrap_or(0),
-        chordsketch_render_pdf::render_songs_with_transpose,
+        chordsketch_render_pdf::render_songs_with_warnings,
     )
 }
 
 /// Renders `chordpro` to HTML with the optional `transpose` offset
 /// and writes the string to `path`. As with `export_pdf`, the
 /// renderer is the in-process `chordsketch-render-html` crate.
+/// Returns the renderer's captured warnings so the frontend can
+/// surface them in the Export dialog (#2201).
 #[tauri::command]
-fn export_html(path: String, chordpro: String, transpose: Option<i8>) -> Result<(), String> {
+fn export_html(
+    path: String,
+    chordpro: String,
+    transpose: Option<i8>,
+) -> Result<Vec<String>, String> {
     render_and_write(
         &path,
         &chordpro,
         transpose.unwrap_or(0),
         |songs, t, config| {
-            chordsketch_render_html::render_songs_with_transpose(songs, t, config).into_bytes()
+            let r = chordsketch_render_html::render_songs_with_warnings(songs, t, config);
+            RenderResult::with_warnings(r.output.into_bytes(), r.warnings)
         },
     )
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -240,6 +240,33 @@ async function writeCurrent(
 }
 
 /**
+ * Format the renderer warnings (returned by the Rust export command)
+ * into a human-readable dialog body. The first few warnings are
+ * quoted verbatim; longer lists are truncated with a count so the
+ * dialog stays compact on small laptops. Mirrors the trimming logic
+ * used by the auto-update dialog in `./updater.ts`.
+ */
+const EXPORT_WARNING_LINE_LIMIT = 5;
+function buildExportSummary(path: string, warnings: string[]): string {
+  if (warnings.length === 0) {
+    return `Exported to ${path}`;
+  }
+  const header = `Exported to ${path} with ${warnings.length} warning${
+    warnings.length === 1 ? '' : 's'
+  }:`;
+  if (warnings.length <= EXPORT_WARNING_LINE_LIMIT) {
+    return [header, ...warnings.map((w) => `• ${w}`)].join('\n');
+  }
+  const shown = warnings.slice(0, EXPORT_WARNING_LINE_LIMIT);
+  const hidden = warnings.length - shown.length;
+  return [
+    header,
+    ...shown.map((w) => `• ${w}`),
+    `… and ${hidden} more`,
+  ].join('\n');
+}
+
+/**
  * Drive a File → Export flow: read the editor content + transpose
  * offset from the UI handle, show the native save dialog, and
  * invoke the matching Rust command.
@@ -265,17 +292,27 @@ async function runExport(
     if (!path) return; // User cancelled the save dialog.
 
     const transpose = handle.getTranspose();
-    await invoke(format === 'pdf' ? 'export_pdf' : 'export_html', {
-      path,
-      chordpro: handle.getChordPro(),
-      // Only forward a non-zero transpose so the Rust side can
-      // follow the same identity-skip that the WASM adapter uses
-      // in `renderers` above.
-      transpose: transpose === 0 ? null : transpose,
-    });
-    await message(`Exported to ${path}`, {
+    // The Rust export commands return the renderer's captured
+    // warnings (`render_songs_with_warnings` variant) so we can
+    // surface them next to the success dialog — same set the
+    // playground's live preview logs via `console.warn`. Windowed
+    // `.app` builds have no visible stderr, so without this the
+    // renderer warnings would disappear silently (#2201).
+    const warnings = (await invoke<string[]>(
+      format === 'pdf' ? 'export_pdf' : 'export_html',
+      {
+        path,
+        chordpro: handle.getChordPro(),
+        // Only forward a non-zero transpose so the Rust side can
+        // follow the same identity-skip that the WASM adapter uses
+        // in `renderers` above.
+        transpose: transpose === 0 ? null : transpose,
+      },
+    )) ?? [];
+    const body = buildExportSummary(path, warnings);
+    await message(body, {
       title: DEFAULT_WINDOW_TITLE,
-      kind: 'info',
+      kind: warnings.length > 0 ? 'warning' : 'info',
     });
   } catch (err) {
     await message(err instanceof Error ? err.message : String(err), {


### PR DESCRIPTION
## Summary

Pipe renderer warnings through the File → Export commands into the post-export confirmation dialog so they stop disappearing to `eprintln!` in windowed `.app` bundles. Restores warning parity with the browser playground (which logs to `console.warn` via WASM's `flush_warnings`) and the CLI (stderr).

## Rust side (`apps/desktop/src-tauri/src/main.rs`)

- `render_and_write`'s callback switches from the stderr-flushing `Vec<u8>` variant to `render_songs_with_warnings`, and returns the captured `warnings` field on the success path.
- `export_pdf` / `export_html` change return type from `Result<(), String>` to `Result<Vec<String>, String>`. Callers now receive the warnings array on success; the `Err(String)` failure path is unchanged.
- `export_html` adapts the `RenderResult<String>` → `RenderResult<Vec<u8>>` via `with_warnings(output.into_bytes(), warnings)` so the warnings flow through unchanged.

## Frontend (`apps/desktop/src/main.ts`)

- `runExport` awaits a `string[]` from the invoke.
- New `buildExportSummary` helper formats the dialog body. Empty array → historical `Exported to <path>`. Populated array → count header + bulleted warnings, capped at 5 with a `"… and N more"` tail to keep the dialog compact (mirrors the `formatReleaseNotes` trimming in `updater.ts`).
- Dialog `kind` flips `'info'` → `'warning'` when warnings are present so the icon matches the non-clean result.

## Scope: parser warnings excluded

`parse_multi_lenient` returns per-line `ParseError`s, not structured warnings, and the CLI/WASM surfaces do not forward those either — `flush_warnings` in `crates/wasm/src/lib.rs` handles only `RenderResult.warnings`. Adding a parser-error surface would be a separate change with sister-site impact across CLI and WASM; out of scope for this PR.

## Test plan

- [x] `cargo check -p chordsketch-desktop` — clean.
- [x] `cargo clippy -p chordsketch-desktop -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `(cd apps/desktop && npm run build)` — tsc + vite succeed. Bundle size 469.73 kB / 138.26 kB gzipped (+0.43 kB / +0.15 kB vs prior baseline — the helper function and widened invoke signature).
- [ ] Interactive export of a `.cho` file that triggers renderer warnings (e.g. `{transpose: 99}`, out-of-range `{capo}`) — requires launching the Tauri dev bundle; not run in this session.

## Review summary

Self-reviewed; no findings.

Closes #2201

🤖 Generated with [Claude Code](https://claude.com/claude-code)