### PR TITLE
ci: extract desktop-build-steps composite action

### DIFF
--- a/.github/actions/desktop-build-steps/action.yml
+++ b/.github/actions/desktop-build-steps/action.yml
@@ -1,0 +1,205 @@
+name: "Desktop bundle build steps"
+description: >
+  Shared install + `cargo tauri build` pipeline for the desktop app,
+  consumed by both `desktop-build.yml` (PR-time smoke across four
+  matrix cells) and `desktop-release.yml` (tag-triggered signed
+  bundles). Covers everything from "Rust toolchain installed" through
+  "native installer written to `target/<triple>/release/bundle/`";
+  callers run their own artefact-collection + upload steps
+  afterwards because the upload shape differs between the two
+  workflows (PR smoke pairs names with matrix-label directories;
+  release flattens into one `release/` directory for `gh release`).
+  Tracked in #2223; rationale for consolidating in
+  `.claude/rules/fix-propagation.md` §Sister-Site Groups.
+inputs:
+  target:
+    description: >
+      Rust target triple (e.g. `x86_64-unknown-linux-gnu`). The
+      toolchain installs this target and `wasm32-unknown-unknown`;
+      `cargo tauri build --target ${target}` uses the value directly.
+    required: true
+  enable-cache:
+    description: >
+      Install `Swatinem/rust-cache` when `"true"`. The CLI
+      `release.yml` and the desktop `desktop-release.yml` both set
+      this to `"false"` per `.claude/rules/ci-parallelization.md` §2
+      (infrequent workflows — cache expires before the next run).
+      PR-smoke callers (`desktop-build.yml`) leave the default
+      `"true"`.
+    required: false
+    default: "true"
+  cache-key-prefix:
+    description: >
+      Prefix for the `rust-cache` `shared-key`; the target triple is
+      appended so the four matrix cells do not thrash. Ignored when
+      `enable-cache` is `"false"`.
+    required: false
+    default: "desktop-build"
+  build-config:
+    description: >
+      Optional JSON blob forwarded to `cargo tauri build -c <...>`.
+      Leave empty for the default build. `desktop-release.yml` passes
+      `{"bundle":{"createUpdaterArtifacts":true}}` to produce the
+      updater `.sig` files (#2076); baking that into
+      `tauri.conf.json` would break PR builds because
+      `TAURI_SIGNING_PRIVATE_KEY` is not available on PR runs.
+    required: false
+    default: ""
+  # --- Signing pass-throughs (populated from repo secrets at the
+  # caller level). All default to empty so the PR-smoke caller
+  # doesn't need to enumerate them. Tauri's build step reads these
+  # env vars directly when present; absent values produce unsigned
+  # bundles, matching the pre-#2075 state.
+  apple-signing-identity:
+    required: false
+    default: ""
+  apple-certificate:
+    required: false
+    default: ""
+  apple-certificate-password:
+    required: false
+    default: ""
+  apple-id:
+    required: false
+    default: ""
+  apple-password:
+    required: false
+    default: ""
+  apple-team-id:
+    required: false
+    default: ""
+  windows-certificate:
+    required: false
+    default: ""
+  windows-certificate-password:
+    required: false
+    default: ""
+  tauri-signing-private-key:
+    required: false
+    default: ""
+  tauri-signing-private-key-password:
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      with:
+        targets: wasm32-unknown-unknown, ${{ inputs.target }}
+
+    - name: Configure rust-cache
+      if: inputs.enable-cache == 'true'
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        # Target-triple in the shared-key so the four matrix
+        # cells do not thrash the cache against each other (per
+        # the worked example in
+        # `.claude/rules/ci-parallelization.md` §2).
+        # `apps/desktop/src-tauri` inherits the workspace target
+        # dir from the root `Cargo.toml`, so the default
+        # `workspaces: . -> target` is correct — no override.
+        shared-key: ${{ inputs.cache-key-prefix }}-${{ inputs.target }}
+
+    - name: Install Tauri system dependencies (Linux)
+      # `runner.os` is a stable context value ('Linux' / 'macOS' /
+      # 'Windows') independent of the mutable GitHub runner label
+      # alias — survives an Ubuntu LTS bump (#2220).
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libwebkit2gtk-4.1-dev \
+          libgtk-3-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev \
+          build-essential \
+          pkg-config \
+          file
+
+    - name: Install wasm-pack
+      uses: ./.github/actions/install-wasm-pack
+
+    - name: Install Tauri CLI
+      # `taiki-e/install-action` prebuilds the Tauri CLI so this
+      # finishes in seconds, vs. ~2 min for `cargo install`. Pin
+      # to a concrete version because `install-action` does NOT
+      # accept semver operators (caret/tilde) — see the upstream
+      # error "install-action does not support semver operators:
+      # '^2'". Bump this line when Tauri CLI cuts a new release
+      # we want to pick up.
+      uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2
+      with:
+        tool: tauri-cli@2.10.1
+
+    - name: Setup Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: "22"
+        cache: npm
+        cache-dependency-path: |
+          apps/desktop/package-lock.json
+          packages/tree-sitter-chordpro/package-lock.json
+
+    - name: Build @chordsketch/wasm (dual-package layout)
+      # Produces `packages/npm/web/chordsketch_wasm.js` — the file
+      # Vite's alias in `apps/desktop/vite.config.ts` resolves to.
+      # `packages/npm` carries no node_modules, so no `npm ci` is
+      # needed here; `scripts/build.mjs` shells out to wasm-pack
+      # directly.
+      shell: bash
+      run: npm run build
+      working-directory: packages/npm
+
+    - name: Install tree-sitter-chordpro grammar deps
+      # `apps/desktop`'s `prebuild` hook (run transitively by
+      # `cargo tauri build`'s `beforeBuildCommand`) invokes
+      # `npx tree-sitter build --wasm` against this package; the
+      # CLI is a devDependency of `packages/tree-sitter-chordpro`.
+      shell: bash
+      run: npm ci
+      working-directory: packages/tree-sitter-chordpro
+
+    - name: Install desktop frontend deps
+      shell: bash
+      run: npm ci
+      working-directory: apps/desktop
+
+    - name: Build Tauri bundle
+      # `cargo tauri build` fires `beforeBuildCommand: "npm run
+      # build"` from `tauri.conf.json`, which in turn runs the
+      # `prebuild` hook (tree-sitter wasm build + web-tree-sitter
+      # runtime copy) and then `tsc && vite build`. Afterwards
+      # the Rust release build packages the app into platform-
+      # native installers under
+      # `apps/desktop/src-tauri/target/release/bundle/`.
+      #
+      # The `-c` flag is forwarded from `inputs.build-config`
+      # when non-empty; an empty input falls through to the
+      # default build. See `desktop-release.yml` for the updater
+      # artefact case.
+      shell: bash
+      working-directory: apps/desktop/src-tauri
+      env:
+        BUILD_CONFIG: ${{ inputs.build-config }}
+        TARGET: ${{ inputs.target }}
+        # Tauri's build step reads these env vars when present;
+        # empty defaults produce unsigned bundles (the pre-#2075
+        # state).
+        APPLE_SIGNING_IDENTITY: ${{ inputs.apple-signing-identity }}
+        APPLE_CERTIFICATE: ${{ inputs.apple-certificate }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ inputs.apple-certificate-password }}
+        APPLE_ID: ${{ inputs.apple-id }}
+        APPLE_PASSWORD: ${{ inputs.apple-password }}
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+        WINDOWS_CERTIFICATE: ${{ inputs.windows-certificate }}
+        WINDOWS_CERTIFICATE_PASSWORD: ${{ inputs.windows-certificate-password }}
+        TAURI_SIGNING_PRIVATE_KEY: ${{ inputs.tauri-signing-private-key }}
+        TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ inputs.tauri-signing-private-key-password }}
+      run: |
+        if [ -n "$BUILD_CONFIG" ]; then
+          cargo tauri build --target "$TARGET" -c "$BUILD_CONFIG"
+        else
+          cargo tauri build --target "$TARGET"
+        fi

--- a/.github/actions/desktop-build-steps/action.yml
+++ b/.github/actions/desktop-build-steps/action.yml
@@ -198,6 +198,31 @@ runs:
         TAURI_SIGNING_PRIVATE_KEY: ${{ inputs.tauri-signing-private-key }}
         TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ inputs.tauri-signing-private-key-password }}
       run: |
+        # Unset any signing-related env vars that the caller passed
+        # as empty strings. GitHub Actions YAML has no way to
+        # conditionally drop a key from a step's `env:` block, so
+        # passing `APPLE_CERTIFICATE: ""` (the default when the
+        # PR-smoke caller does not wire up the secret) still puts
+        # the variable into `cargo tauri build`'s environment — at
+        # which point Tauri's bundler treats the empty value as
+        # "certificate supplied, import it" and calls
+        # `security import`, which fails with "One or more
+        # parameters passed to a function were not valid; failed to
+        # import keychain certificate". Unsetting empty values here
+        # restores the pre-composite behaviour where those env vars
+        # were simply absent on the PR-smoke path, letting Tauri
+        # fall back to unsigned bundles.
+        for v in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE \
+                 APPLE_CERTIFICATE_PASSWORD APPLE_ID \
+                 APPLE_PASSWORD APPLE_TEAM_ID \
+                 WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD \
+                 TAURI_SIGNING_PRIVATE_KEY \
+                 TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+          if [ -z "${!v:-}" ]; then
+            unset "$v"
+          fi
+        done
+
         if [ -n "$BUILD_CONFIG" ]; then
           cargo tauri build --target "$TARGET" -c "$BUILD_CONFIG"
         else

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -122,97 +122,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Desktop bundle build steps
+        # Rust toolchain + rust-cache + Tauri system deps + wasm-pack
+        # + Tauri CLI + Node.js + `npm` ceremony + `cargo tauri
+        # build`. The composite is shared with `desktop-release.yml`
+        # so a bump to any of those tools lands in exactly one place
+        # (#2223).
+        uses: ./.github/actions/desktop-build-steps
         with:
-          targets: wasm32-unknown-unknown, ${{ matrix.platform.target }}
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          # Target-triple in the shared-key so the four matrix
-          # cells do not thrash the cache against each other (per
-          # the worked example in `.claude/rules/ci-parallelization.md`
-          # §2). `apps/desktop/src-tauri` inherits the workspace
-          # target dir from the root `Cargo.toml`, so the default
-          # `workspaces: . -> target` is correct — no override.
-          shared-key: desktop-build-${{ matrix.platform.target }}
-
-      - name: Install Tauri system dependencies (Linux)
-        # `runner.os` is a stable context value ('Linux' / 'macOS'
-        # / 'Windows') independent of the mutable GitHub runner
-        # label alias (`ubuntu-latest`). Using it here shields the
-        # gate from a future Ubuntu LTS bump that renames the alias
-        # (#2220).
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            build-essential \
-            pkg-config \
-            file
-
-      - name: Install wasm-pack
-        uses: ./.github/actions/install-wasm-pack
-
-      - name: Install Tauri CLI
-        # `taiki-e/install-action` prebuilds the Tauri CLI so this
-        # finishes in seconds, vs. ~2 min for `cargo install`.
-        # Pin to a concrete version because `install-action` does
-        # NOT accept semver operators (caret/tilde) — see the
-        # upstream error "install-action does not support semver
-        # operators: '^2'". Bump this line when Tauri CLI cuts a
-        # new release we want to pick up.
-        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2
-        with:
-          tool: tauri-cli@2.10.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: |
-            apps/desktop/package-lock.json
-            packages/tree-sitter-chordpro/package-lock.json
-
-      - name: Build @chordsketch/wasm (dual-package layout)
-        # Produces `packages/npm/web/chordsketch_wasm.js` — the
-        # file Vite's alias in `apps/desktop/vite.config.ts`
-        # resolves to. `packages/npm` carries no node_modules, so
-        # no `npm ci` is needed here; `scripts/build.mjs` shells
-        # out to wasm-pack directly.
-        run: npm run build
-        working-directory: packages/npm
-
-      - name: Install tree-sitter-chordpro grammar deps
-        # `apps/desktop`'s `prebuild` hook (run transitively by
-        # `cargo tauri build`'s `beforeBuildCommand`) invokes
-        # `npx tree-sitter build --wasm` against this package; the
-        # CLI is a devDependency of `packages/tree-sitter-chordpro`.
-        run: npm ci
-        working-directory: packages/tree-sitter-chordpro
-
-      - name: Install desktop frontend deps
-        run: npm ci
-        working-directory: apps/desktop
-
-      - name: Build Tauri bundle (unsigned)
-        # `cargo tauri build` fires `beforeBuildCommand: "npm run
-        # build"` from `tauri.conf.json`, which in turn runs the
-        # `prebuild` hook (tree-sitter wasm build + web-tree-sitter
-        # runtime copy) and then `tsc && vite build`. Afterwards
-        # the Rust release build packages the app into platform-
-        # native installers under
-        # `apps/desktop/src-tauri/target/release/bundle/`.
-        #
-        # `--target` is forwarded to cargo so the shared-key pins
-        # exactly the architecture the matrix cell is building for.
-        run: cargo tauri build --target ${{ matrix.platform.target }}
-        working-directory: apps/desktop/src-tauri
+          target: ${{ matrix.platform.target }}
+          # Full `rust-cache` enabled; PR-smoke fires on every
+          # desktop-touching PR so the cache is warm.
+          enable-cache: "true"
+          cache-key-prefix: desktop-build
 
       - name: List bundle outputs
         # Debug aid — when #2078 (Releases upload) wires the

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -46,6 +46,12 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/desktop-build.yml"
+      # The composite action this workflow consumes; without this
+      # entry a PR that only bumps the composite (e.g. Tauri CLI
+      # version, wasm-pack pin, apt-get list) would NOT trigger
+      # the 4-cell matrix, defeating #2223's purpose of giving
+      # both desktop workflows a single point of truth.
+      - ".github/actions/desktop-build-steps/**"
   pull_request:
     paths:
       - "apps/desktop/**"
@@ -65,6 +71,12 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/desktop-build.yml"
+      # The composite action this workflow consumes; without this
+      # entry a PR that only bumps the composite (e.g. Tauri CLI
+      # version, wasm-pack pin, apt-get list) would NOT trigger
+      # the 4-cell matrix, defeating #2223's purpose of giving
+      # both desktop workflows a single point of truth.
+      - ".github/actions/desktop-build-steps/**"
   workflow_dispatch:
 
 # PR-scoped cancel-in-progress per the §5 shape in

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -98,101 +98,31 @@ jobs:
           # fix for manual re-runs (#2226).
           ref: ${{ inputs.tag || github.ref }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Desktop bundle build steps
+        # Shared composite with `desktop-build.yml` (#2223). Per
+        # `.claude/rules/ci-parallelization.md` §2, tag-triggered
+        # workflows run too infrequently for rust-cache to help;
+        # `enable-cache: "false"` suppresses the cache step.
+        # `build-config` enables updater `.sig` file generation
+        # only for the release pipeline (#2076 rationale in the
+        # composite's doc). Signing secrets are threaded through
+        # the composite's pass-through inputs; absent values ship
+        # unsigned installers (pre-#2075 state).
+        uses: ./.github/actions/desktop-build-steps
         with:
-          targets: wasm32-unknown-unknown, ${{ matrix.platform.target }}
-
-      # NOTE: no Swatinem/rust-cache here. Per
-      # `.claude/rules/ci-parallelization.md` §2, this workflow
-      # fires on `desktop-v*` tag pushes — expected cadence
-      # comparable to the CLI `release.yml` (well under once per
-      # 7 days). GitHub Actions evicts cache entries after 7 days
-      # of inactivity, so the cache expires between runs. Adding
-      # rust-cache delivers no wall-clock benefit and only adds
-      # YAML noise. Do not add one back without updating the rule.
-
-      - name: Install Tauri system dependencies (Linux)
-        # See the parallel gate in `desktop-build.yml`: `runner.os`
-        # is the stable context value, surviving a future Ubuntu
-        # LTS alias rename (#2220).
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            build-essential \
-            pkg-config \
-            file
-
-      - name: Install wasm-pack
-        uses: ./.github/actions/install-wasm-pack
-
-      - name: Install Tauri CLI
-        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2
-        with:
-          tool: tauri-cli@2.10.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: |
-            apps/desktop/package-lock.json
-            packages/tree-sitter-chordpro/package-lock.json
-
-      - name: Build @chordsketch/wasm (dual-package layout)
-        run: npm run build
-        working-directory: packages/npm
-
-      - name: Install tree-sitter-chordpro grammar deps
-        run: npm ci
-        working-directory: packages/tree-sitter-chordpro
-
-      - name: Install desktop frontend deps
-        run: npm ci
-        working-directory: apps/desktop
-
-      - name: Build Tauri bundle
-        # Same `beforeBuildCommand` chain documented in
-        # `desktop-build.yml`. When #2075 lands, the signing env
-        # vars below are populated from repository secrets and
-        # Tauri produces signed artefacts without any workflow
-        # change. Until then, the env vars stay empty and the
-        # build ships unsigned installers.
-        #
-        # `-c '{"bundle":{"createUpdaterArtifacts":true}}'`
-        # enables updater `.sig` file generation only for the
-        # release pipeline. Baking it into `tauri.conf.json`
-        # would break `desktop-build.yml` and `desktop-smoke`
-        # (both run on PRs, where `TAURI_SIGNING_PRIVATE_KEY` is
-        # not available; Tauri fails hard with "A public key
-        # has been found, but no private key" when
-        # createUpdaterArtifacts is true and no private key is
-        # set). See #2076 review for the observed failure.
-        run: |
-          cargo tauri build \
-            --target ${{ matrix.platform.target }} \
-            -c '{"bundle":{"createUpdaterArtifacts":true}}'
-        working-directory: apps/desktop/src-tauri
-        env:
-          # Apple notarization / signing (populated by #2075).
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Windows Authenticode (populated by #2075).
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-          # Tauri updater signing (populated by #2076).
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          target: ${{ matrix.platform.target }}
+          enable-cache: "false"
+          build-config: '{"bundle":{"createUpdaterArtifacts":true}}'
+          apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          apple-certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-password: ${{ secrets.APPLE_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          windows-certificate: ${{ secrets.WINDOWS_CERTIFICATE }}
+          windows-certificate-password: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          tauri-signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          tauri-signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Collect bundles into a flat directory
         # Downstream SHA256SUMS and Release upload want one


### PR DESCRIPTION
## Summary

Consolidate the Rust toolchain + rust-cache + Tauri system-dep install + wasm-pack + Tauri CLI + Node.js + `npm` ceremony + `cargo tauri build` sequence into a single composite at `.github/actions/desktop-build-steps/`. Both `desktop-build.yml` (PR-smoke) and `desktop-release.yml` (tag-triggered signed bundles) now invoke the composite instead of carrying ~90 lines of near-identical inline steps each.

`.claude/rules/fix-propagation.md` §Sister-Site Groups flagged the two inline copies as drift-prone — a future Tauri CLI, wasm-pack, Node version, or Linux system-dep bump landing in one workflow but not the other would silently desynchronise PR-smoke and release builds.

## Composite API

Three input axes cover everything the callers actually differ on:

- **`enable-cache`** — `"true"` for PR smoke (cache is warm), `"false"` for `desktop-release.yml` per `.claude/rules/ci-parallelization.md` §2 (7-day TTL eviction makes cache ineffective for tag-cadence workflows).
- **`build-config`** — optional `-c <JSON>` forwarded to `cargo tauri build`. Release passes `{"bundle":{"createUpdaterArtifacts":true}}` to produce Tauri updater `.sig` files (#2076); baking the flag into `tauri.conf.json` would break PR builds.
- **Ten optional signing pass-through inputs** (`apple-signing-identity`, `tauri-signing-private-key`, etc.). Default empty so the PR-smoke caller does not enumerate them; Tauri's build reads the env vars when present, empty values ship unsigned bundles.

## Why ci.yml's `desktop-smoke` stays unchanged

`desktop-smoke` runs `cargo check` (not `cargo tauri build`), so the composite's final build step does not fit. Converting it would require either another input to skip the `cargo tauri build` step or a separate narrower composite — both more cost than benefit right now. If a future refactor adds a bundle step there, the switch is a one-line edit.

## Why upload stays in the callers

The two workflows diverge on artefact collection:

- `desktop-build.yml` uploads per-matrix-cell using `actions/upload-artifact` with a label-qualified name.
- `desktop-release.yml` copies into a flat `release-artefacts/<label>/` directory + SHA256SUMS + `gh release upload`.

Consolidating those would require more input knobs than it saves, so the composite stops at the `cargo tauri build` line and each workflow handles its own post-processing.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all three touched files — parses clean.
- [x] Behavioural-diff audit: same toolchain SHA, same Linux apt-get list, same `tauri-cli@2.10.1`, same Node `22`, same `cache-dependency-path`, same `shared-key` template preserved via `cache-key-prefix`.
- [ ] End-to-end 4-cell matrix on `desktop-build.yml` fires on this PR (workflow-file edits land on the same branch). `desktop-release.yml` is tag-triggered and cannot be exercised until the next `desktop-v*` tag.

## Review summary

Self-reviewed; no findings.

Closes #2223

🤖 Generated with [Claude Code](https://claude.com/claude-code)