### PR TITLE
chore: put desktop Tauri app into CLI/GUI version lockstep

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsketch-desktop-frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.2",
   "type": "module",
   "description": "Vite frontend for the ChordSketch desktop app; mounts @chordsketch/ui-web inside the Tauri WebView.",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "chordsketch-desktop"
-version = "0.0.0"
+# Kept in lockstep with the SDK workspace version — see
+# `.github/workflows/ci.yml`'s `check-version-consistency` job and
+# `scripts/check-version-consistency.py`. A release PR bumps this
+# line together with every `crates/*/Cargo.toml` and the desktop
+# frontend manifests (`apps/desktop/package.json`,
+# `apps/desktop/src-tauri/tauri.conf.json`).
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 # Application-layer license per CLAUDE.md §License Policy ("future Forum,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ChordSketch",
-  "version": "0.0.0",
+  "version": "0.2.2",
   "identifier": "me.koeda.chordsketch.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -87,6 +87,12 @@ at post-release verification rather than before the tag is cut.
      manifests under `crates/napi/npm/<triple>/package.json`
    - `packages/tree-sitter-chordpro/package.json`
 
+   Desktop (CLI and GUI are always in lockstep — same version number):
+   - `apps/desktop/src-tauri/Cargo.toml` — `package.version`
+   - `apps/desktop/src-tauri/tauri.conf.json` — top-level `"version"`
+     (drives the installer metadata users see in Finder / Explorer)
+   - `apps/desktop/package.json` — `version`
+
    Hardcoded pins in CI:
    - `.github/workflows/readme-smoke.yml` ~line 204:
      `npm install '@chordsketch/wasm@<version>'`

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -336,7 +336,7 @@ def load_desktop_versions(repo_root: Path) -> list[Source]:
         match = re.search(r'"version"\s*:\s*"([^"]+)"', text)
         if match is None:
             raise SystemExit(
-                "apps/desktop/src-tauri/tauri.conf.json: no version field found"
+                f"{tauri_conf}: no version field found"
             )
         sources.append(
             Source(

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -28,6 +28,11 @@ Sources checked:
   8. `packaging/macports/Portfile` — `github.setup … <version> v`
   9. `packaging/nix/package.nix` — `version = "X.Y.Z";`
  10. `packaging/winget/*.yaml` — `PackageVersion: X.Y.Z`
+ 11. `apps/desktop/src-tauri/Cargo.toml` — `package.version`
+ 12. `apps/desktop/src-tauri/tauri.conf.json` — top-level `"version"`
+ 13. `apps/desktop/package.json` — `version`
+     (CLI and GUI are always in lockstep; the three desktop manifests
+     must all agree with the workspace canonical.)
 
 Each source is a (file, field, current_value) triple. The allowlist file has
 the same (file, field, current_value) shape plus a mandatory `tracking_issue`
@@ -291,6 +296,61 @@ def load_napi_platform_package_versions(repo_root: Path) -> list[Source]:
     return sources
 
 
+def load_desktop_versions(repo_root: Path) -> list[Source]:
+    """Collect the three version fields the desktop Tauri app carries.
+
+    The desktop crate lives under `apps/desktop/src-tauri/` (outside the
+    `crates/` tree that `load_crate_versions` scans) and is kept in
+    lockstep with the workspace per the user's release-versioning
+    requirement — CLI and GUI always share the same version number. The
+    Tauri bundle's user-facing version is pulled from
+    `tauri.conf.json`'s `"version"`, which MUST agree with the Rust
+    crate's `Cargo.toml` and with the Vite frontend's `package.json`
+    (otherwise the shipped installer metadata diverges from the binary
+    it packages).
+    """
+    sources: list[Source] = []
+
+    cargo_toml = repo_root / "apps/desktop/src-tauri/Cargo.toml"
+    if cargo_toml.is_file():
+        try:
+            data = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise SystemExit(f"{cargo_toml}: invalid TOML: {exc}")
+        version = data.get("package", {}).get("version")
+        if not isinstance(version, str):
+            raise SystemExit(
+                f"{cargo_toml}: package.version is missing or not a string"
+            )
+        sources.append(
+            Source(
+                file="apps/desktop/src-tauri/Cargo.toml",
+                field="package.version",
+                value=version,
+            )
+        )
+
+    tauri_conf = repo_root / "apps/desktop/src-tauri/tauri.conf.json"
+    if tauri_conf.is_file():
+        text = tauri_conf.read_text(encoding="utf-8")
+        match = re.search(r'"version"\s*:\s*"([^"]+)"', text)
+        if match is None:
+            raise SystemExit(
+                "apps/desktop/src-tauri/tauri.conf.json: no version field found"
+            )
+        sources.append(
+            Source(
+                file="apps/desktop/src-tauri/tauri.conf.json",
+                field="version",
+                value=match.group(1),
+            )
+        )
+
+    sources.append(load_package_json_version(repo_root, "apps/desktop/package.json"))
+
+    return sources
+
+
 def load_all_sources(repo_root: Path) -> list[Source]:
     sources: list[Source] = []
     sources.extend(load_crate_versions(repo_root))
@@ -312,6 +372,9 @@ def load_all_sources(repo_root: Path) -> list[Source]:
     sources.extend(load_macports_version(repo_root))
     sources.extend(load_nix_version(repo_root))
     sources.extend(load_winget_versions(repo_root))
+    # Desktop Tauri app — CLI and GUI are always in lockstep per the
+    # user's release-versioning requirement.
+    sources.extend(load_desktop_versions(repo_root))
     return sources
 
 

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -346,7 +346,11 @@ def load_desktop_versions(repo_root: Path) -> list[Source]:
             )
         )
 
-    sources.append(load_package_json_version(repo_root, "apps/desktop/package.json"))
+    package_json = repo_root / "apps/desktop/package.json"
+    if package_json.is_file():
+        sources.append(
+            load_package_json_version(repo_root, "apps/desktop/package.json")
+        )
 
     return sources
 


### PR DESCRIPTION
## Summary

Align the three version fields the desktop Tauri app carries with the SDK workspace version (`0.2.2`), and teach `scripts/check-version-consistency.py` to enforce the alignment so a future release bump cannot silently leave them at `0.0.0` while the CLI advances.

Responds to user requirement: CLI and GUI should always share one version number — the desktop installer users see in Finder / Explorer should match the `chordsketch --version` output of the CLI binary.

## Fields bumped (`0.0.0` → `0.2.2`)

- `apps/desktop/src-tauri/Cargo.toml` — `package.version`
- `apps/desktop/src-tauri/tauri.conf.json` — top-level `"version"` (drives installer metadata)
- `apps/desktop/package.json` — `version` (private package, but still tracks so the consistency script catches drift)

The `Cargo.toml` change adds a comment pointing at the consistency script so a future contributor understands the lockstep requirement.

## Script enforcement

- New `load_desktop_versions` loader in `scripts/check-version-consistency.py` adds the three fields above as tracked sources. Parses `Cargo.toml` via `tomllib` and the two JSON files via the existing naive regex extractor (matches every other `package.json` in the repo).
- Wired into `load_all_sources`. Docstring "Sources checked" list updated (11–13).
- Negative-tested locally: mutating `tauri.conf.json`'s version produces a clear `ERROR: 1 unallowlisted drift(s)` report pointing at the exact (file, field) pair.

## Docs

`docs/releasing.md` Checklist step 1 gains a new "Desktop (CLI and GUI are always in lockstep — same version number)" subsection listing the three files alongside the existing non-Rust manifests, so release-time edits touch them automatically.

## Test plan

- [x] `python3 scripts/check-version-consistency.py` → `sources checked: 29`, exit 0, all in sync (was 26 before this PR).
- [x] Negative test: temporarily setting `tauri.conf.json` version to `9.9.9` produces an `ERROR` pointing at the exact field; restoring gives OK. See commit message for the observed output.

## Review summary

Self-reviewed; no findings. The version bump from `0.0.0` → `0.2.2` is a cosmetic fix — no Tauri release has ever been cut, so no external consumer has pinned to the old values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)