### PR TITLE
fix(desktop): install live Tauri updater pubkey

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
       "endpoints": [
         "https://raw.githubusercontent.com/koedame/chordsketch/desktop-updater-manifest/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcxNTQwOTE1RDg2RjQzRTIKUldUaVEyL1lGUWxVY1htOWh2ZFNQejJoSkdYZEc1YVp2SUd4V1diOTVVK2pnS2FudFJkL3AvYkwK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU3QTU1RTdBQjcwOUE4MTYKUldRV3FBbTNlbDZsNTdCTzBNVE1xdUVvQmM2T0xoL1BSSVhYZlZrNXdtM21oSFZSL0diR2pUbVIK"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Replace the orphan pubkey committed in #2235 (`71540915D86F43E2`) with the one whose matching private key now lives in the `TAURI_SIGNING_PRIVATE_KEY` repo secret (`E7A55E7AB709A816`).

## Why

The first desktop release (`desktop-v0.3.0`, to be cut immediately after this PR) would fail at the `cargo tauri build -c '{"bundle":{"createUpdaterArtifacts":true}}'` step with "A public key has been found, but no private key in `TAURI_SIGNING_PRIVATE_KEY`" — the secret for the committed pubkey was never persisted in #2235. Without a matching private key, no `.sig` files would be produced and the `publish-updater-manifest` job would also fail.

This PR aligns the in-tree pubkey with the actual secret.

## Backwards-compat

None required. No `desktop-v*` tag has ever been cut; no installed client trusts the orphan pubkey. The first-ever `desktop-v0.3.0` release using the new pair is verifiable out of the box.

## Test plan

- [x] `python3 -c "import json; json.load(open('apps/desktop/src-tauri/tauri.conf.json'))"` — JSON valid.
- [x] Pubkey value visually matches the `Your public key was generated successfully:` line printed by the `cargo tauri signer generate` run that produced the secret.
- [ ] End-to-end verify-on-tag: `desktop-v0.3.0` tag push runs `cargo tauri build` with the secret's private key; Tauri's build step pairs it against this pubkey — if they match, the `.sig` files ship; if they don't, the build fails loudly before any release is published (fail-closed).

## Review summary

Self-reviewed; no findings. Single-field JSON edit with no code path affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)