### PR TITLE
fix(ci): desktop-release.yml duplicate env: key blocks tag trigger

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -457,6 +457,15 @@ jobs:
           VERSION: ${{ steps.tag.outputs.version }}
           TAG: ${{ steps.tag.outputs.tag }}
           REPO: ${{ github.repository }}
+          # `gh release view` inside this step reads the release
+          # body the `release` job just created. Previously this
+          # was set in a second `env:` block at the bottom of the
+          # step, which GitHub Actions rejects as duplicate-key —
+          # Python's PyYAML tolerates it (second key overwrites),
+          # so `python3 -c 'yaml.safe_load(...)'` passes locally
+          # while `actions/workflows/.../dispatches` returns
+          # `HTTP 422: 'env' is already defined`. Merged here.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -513,8 +522,6 @@ jobs:
           # broken template expansion cannot ship.
           jq . latest.json > /dev/null
           cat latest.json
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish latest.json to desktop-updater-manifest branch
         env:


### PR DESCRIPTION
## Summary

The "Build latest.json" step in `desktop-release.yml` has two `env:` blocks — one at the top of the step (setting VERSION/TAG/REPO) and another at the bottom (setting GH_TOKEN). GitHub Actions' workflow parser rejects this with `HTTP 422: 'env' is already defined`, so the workflow silently refuses to run on tag pushes.

Discovered when `desktop-v0.3.0` tag push produced zero workflow runs. Manual `gh workflow run desktop-release.yml --ref desktop-v0.3.0` returned the real error.

## Why it wasn't caught earlier

PyYAML's `yaml.safe_load` tolerates duplicate keys (second overwrites first), so every release-PR sanity check `python3 -c 'yaml.safe_load(...)'` passed. GitHub's parser is stricter — `'env' is already defined` is a hard reject.

The dup was introduced in #2235 (auto-updater landing) and survived every subsequent edit through #2256 because the lenient check never flagged it.

## Fix

Merge the two `env:` blocks into one at the top of the step. `GH_TOKEN` now lives alongside the other three vars with a comment describing its purpose. No runtime behaviour change — all four env vars were already being set; they just need to share one block per GitHub's strict YAML rules.

## Verification

Local strict-duplicate check passes after the fix:

```python
class L(yaml.SafeLoader): pass
def _nodup(l, node, deep=False):
    m = {}
    for k,v in node.value:
        kk = l.construct_object(k, deep=deep)
        if kk in m: raise ValueError(f"dup {kk!r} line {k.start_mark.line+1}")
        m[kk] = l.construct_object(v, deep=deep)
    return m
L.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _nodup)
yaml.load(open("..."), L)
# → no error
```

## Impact on `desktop-v0.3.0` release

The tag was pushed; no workflow fired; no installers exist; no release page was created. After this PR merges, I will delete + re-push the tag to re-trigger `desktop-release.yml` (the workflow definition at the tag ref will then be the fixed one).

## Test plan

- [x] PyYAML lenient check passes (baseline).
- [x] Strict-duplicate-key check passes.
- [ ] End-to-end: re-push `desktop-v0.3.0` after this PR merges; `desktop-release.yml` should now register and start.

## Review summary

Self-reviewed; no findings. Mechanical YAML fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)