### PR TITLE
fix(ci): keep TAURI_SIGNING_PRIVATE_KEY_PASSWORD env var on signed path

### DIFF
--- a/.github/actions/desktop-build-steps/action.yml
+++ b/.github/actions/desktop-build-steps/action.yml
@@ -212,16 +212,41 @@ runs:
         # restores the pre-composite behaviour where those env vars
         # were simply absent on the PR-smoke path, letting Tauri
         # fall back to unsigned bundles.
+        #
+        # EXCEPTION: `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` is NOT in
+        # this unset list. The Tauri updater-key generated with
+        # `cargo tauri signer generate --ci --password ""` is
+        # encrypted with an empty-string password (the comment line
+        # reads "rsign encrypted secret key" regardless). At sign
+        # time, Tauri reads the password env var and treats
+        # "unset" as "no password supplied, refuse to decrypt" —
+        # which throws "Wrong password for that key" even though
+        # empty-string is the right password. Leaving the env var
+        # set to the empty string (its `inputs.*` default) lets
+        # Tauri match "empty string password supplied" ↔
+        # "empty string password used at generate". The other eight
+        # vars stay in the unset list because their consumers (Apple
+        # `security import`, Windows Authenticode, Tauri's Apple
+        # notary flow) all interpret empty-string as "configured but
+        # invalid", not as "intentionally blank".
         for v in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE \
                  APPLE_CERTIFICATE_PASSWORD APPLE_ID \
                  APPLE_PASSWORD APPLE_TEAM_ID \
                  WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD \
-                 TAURI_SIGNING_PRIVATE_KEY \
-                 TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+                 TAURI_SIGNING_PRIVATE_KEY; do
           if [ -z "${!v:-}" ]; then
             unset "$v"
           fi
         done
+
+        # If the updater private key is absent (PR-smoke path,
+        # where `TAURI_SIGNING_PRIVATE_KEY` was just unset above),
+        # the password env var is dead weight — also unset it so
+        # Tauri doesn't ingest a phantom password against a
+        # non-existent key.
+        if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+          unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+        fi
 
         if [ -n "$BUILD_CONFIG" ]; then
           cargo tauri build --target "$TARGET" -c "$BUILD_CONFIG"


### PR DESCRIPTION
## Summary

First `desktop-v0.3.0` tag push ([run 24900001058](https://github.com/koedame/chordsketch/actions/runs/24900001058)) failed at the `cargo tauri build` step on 3 of 4 matrix cells with:

```
Error failed to decode secret key: incorrect updater private key password: Wrong password for that key
```

## Root cause

The composite action's signing-env unset loop (introduced in `b98a61e` to prevent empty `APPLE_CERTIFICATE` from triggering `security import` against a phantom cert) was over-aggressive — it also unset `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` when that env var was an empty string.

The updater key is generated with `cargo tauri signer generate --ci --password ""` per ADR-0005 and PR #2235's maintainer setup. That flag produces a key whose secret-key comment reads "rsign encrypted secret key" — the key IS encrypted, using empty-string as the password. At sign time, Tauri matches `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` against the key's encryption password. When the env var is **unset**, Tauri reads it as "no password supplied, cannot decrypt" and throws the error above — even though empty-string is actually the right password.

## Fix

Remove `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` from the unset list so the empty-string default from `inputs.*` flows through to `cargo tauri build` unchanged. Paired with a narrow guard that DOES unset the password env var when `TAURI_SIGNING_PRIVATE_KEY` itself is absent (the PR-smoke path) so we don't feed a phantom password to a build that has no key.

The other eight signing env vars stay in the unset list — their consumers (Apple `security import`, Windows Authenticode, Tauri's Apple notary flow, Tauri's own key loader) interpret empty-string as "configured but invalid". The password var is the lone exception because empty-string IS a legitimate value.

## Test plan

- [x] `python3 -c 'yaml.safe_load(...)'` — clean.
- [ ] End-to-end: after merge, re-push `desktop-v0.3.0` at the fixed commit; expected outcome is a successful 4-cell build + release publish. The empty-password path for the key was previously verified by PR #2235's maintainer setup, and this PR restores the env var flow it relied on.

## Review summary

Self-reviewed; no findings. Mechanical composite action fix with documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)