### PR TITLE
Update Swift Package.swift to v0.3.0

### DIFF
--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "chordsketchFFI",
-            url: "https://github.com/koedame/chordsketch/releases/download/v0.2.2/chordsketch-xcframework.zip",
-            checksum: "1c0116fd5c942533f9d76ee4534dca1457fa8a078b18eda411770a02d76e4934"
+            url: "https://github.com/koedame/chordsketch/releases/download/v0.3.0/chordsketch-xcframework.zip",
+            checksum: "6d0bbc9bb9f98987b16b3dc28d27578b5163384c886ca7dfcd97bdb06ddc82f2"
         ),
         .target(
             name: "ChordSketch",


### PR DESCRIPTION
## What

Updates `packages/swift/Package.swift`'s `.binaryTarget` to point to
the `v0.3.0` xcframework asset and pin its SHA256.

- **Tag**: `v0.3.0`
- **Asset**: `chordsketch-xcframework.zip`
- **SHA256**: `6d0bbc9bb9f98987b16b3dc28d27578b5163384c886ca7dfcd97bdb06ddc82f2`

## Why

Auto-generated by `post-release.yml`'s `update-swift-package` job
after the Swift workflow uploaded the xcframework to the release.
Without this update, `swift package add https://github.com/koedame/chordsketch.git`
against the new tag would fail with an invalid checksum error.

See #1062.