### PR TITLE
fix(desktop): rename .app.tar.gz per arch + don't make desktop release latest

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -130,10 +130,13 @@ jobs:
         # out the nested `bundle/<type>/` layout so the collected
         # tree is easy to glob.
         shell: bash
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+          ARCH_LABEL: ${{ matrix.platform.label }}
         run: |
           set -euo pipefail
           SRC="target/${{ matrix.platform.target }}/release/bundle"
-          DST="release-artefacts/${{ matrix.platform.label }}"
+          DST="release-artefacts/${ARCH_LABEL}"
           mkdir -p "$DST"
           # macOS: .dmg + .app.tar.gz (+ their .sig). Windows: .msi
           # + .exe (+ .sig). Linux: .deb + .rpm + .AppImage (+ .sig).
@@ -148,6 +151,42 @@ jobs:
                      '*.deb' '*.rpm' '*.AppImage' '*.AppImage.sig'; do
             find "$SRC" -type f -name "$pat" -exec cp -v {} "$DST/" \; || true
           done
+
+          # Tauri 2.10 emits `<ProductName>.app.tar.gz` and
+          # `<ProductName>.app.tar.gz.sig` for the macOS updater
+          # bundle WITHOUT the `_<version>_<arch>` suffix that the
+          # `.dmg` carries. Two macOS cells produce identically-named
+          # files, and the release-flatten step (job `release` below)
+          # then `cp`s both into a single flat `release/` directory,
+          # silently overwriting one cell's bundle with the other's.
+          # The `publish-updater-manifest` job further down expects
+          # `*_<version>_(aarch64|x64).app.tar.gz.sig` per platform
+          # — which never exists on the release. Fix: rename per
+          # cell to match the existing `_<version>_<arch>` convention
+          # before upload-artifact captures the cell. See #2260.
+          if [ "${ARCH_LABEL}" = "macos-aarch64" ] || [ "${ARCH_LABEL}" = "macos-x86_64" ]; then
+            VERSION="${TAG#desktop-v}"
+            case "${ARCH_LABEL}" in
+              macos-aarch64) ARCH=aarch64 ;;
+              macos-x86_64)  ARCH=x64 ;;
+            esac
+            for f in "$DST"/*.app.tar.gz "$DST"/*.app.tar.gz.sig; do
+              [ -e "$f" ] || continue
+              dir=$(dirname "$f")
+              base=$(basename "$f")
+              # Strip everything before `.app.tar.gz` so the rename is
+              # idempotent if Tauri ever starts emitting a versioned
+              # name in a future release — `ChordSketch.app.tar.gz`
+              # and `ChordSketch_<v>_<a>.app.tar.gz` both reduce to
+              # the same target name here.
+              ext="${base#*.app.tar.gz}"  # "" or ".sig"
+              new="ChordSketch_${VERSION}_${ARCH}.app.tar.gz${ext}"
+              if [ "$base" != "$new" ]; then
+                mv -v "$f" "$dir/$new"
+              fi
+            done
+          fi
+
           ls -la "$DST"
 
       - name: Upload cell artefacts
@@ -245,11 +284,21 @@ jobs:
         # `--generate-notes` asks GitHub to auto-build the body
         # from commits + merged PRs between the previous
         # `desktop-v*` tag and this one. `--verify-tag` ensures
-        # the tag actually exists on the remote. `--latest` is
-        # intentionally omitted — desktop releases share the repo
-        # with the CLI, and marking every desktop release "latest"
-        # would hide the CLI's own `v*` releases from the landing
-        # page.
+        # the tag actually exists on the remote.
+        #
+        # `--latest=false` is REQUIRED, not optional. When it is
+        # omitted, `gh release create` defaults to GitHub's
+        # `make_latest=legacy` semver-based picker, which compares
+        # `desktop-v0.3.0`'s semver against the CLI's `v*` tags
+        # and silently promotes the desktop tag to "latest". That
+        # broke `chordsketch-action@v1` for downstream users on
+        # 2026-04-25 because the action's "resolve latest"
+        # endpoint returned `desktop-v0.3.0` and tried to download
+        # CLI binaries from a release that only had desktop
+        # bundles (#2260). Mapping the desktop release out of the
+        # "latest" picker keeps the CLI's `v*` chain authoritative
+        # for the GitHub Releases landing page and for the
+        # `/releases/latest` API.
         #
         # Known cosmetic for the very first `desktop-v*` tag:
         # `--generate-notes` has no prior tag in the desktop
@@ -272,6 +321,7 @@ jobs:
             --title "$TAG"
             --generate-notes
             --verify-tag
+            --latest=false
           )
           # Prerelease suffix is anything after the `MAJOR.MINOR.PATCH`
           # triplet; the tag format regex (validate job above) already


### PR DESCRIPTION
## What

Fixes two bugs in `desktop-release.yml` that surfaced together on
the `desktop-v0.3.0` release:

1. **Tauri 2.10 macOS bundle naming collision.** The Tauri 2.x
   bundle pipeline emits `<ProductName>.app.tar.gz` and
   `<ProductName>.app.tar.gz.sig` for the macOS updater bundle
   without the `_<version>_<arch>` suffix that `.dmg` carries.
   Two macOS matrix cells produce identically-named files; the
   `release` job's flatten step then `cp`s both into a flat
   `release/` directory, silently overwriting one cell's bundle
   with the other's. The `publish-updater-manifest` job's regex
   (`*_${VERSION_RE}_${suffix}.sig` with suffix
   `aarch64.app.tar.gz` / `x64.app.tar.gz`) finds nothing and
   fails with `ERROR: missing signature for platform darwin-aarch64`.

   **Fix:** in the cell-bundle flatten step, detect macOS cells
   by `matrix.platform.label`, derive `arch` (`aarch64` | `x64`)
   and `version` (tag without `desktop-v` prefix), and rename the
   `.app.tar.gz` and `.sig` files in place to
   `ChordSketch_<version>_<arch>.app.tar.gz[.sig]` so they match
   the existing DMG convention and the manifest builder's regex.
   Rename is idempotent — handles a future Tauri release that
   emits a versioned filename natively.

2. **`gh release create` was missing `--latest=false`.** GitHub's
   default `make_latest=legacy` semver-picker compared
   `desktop-v0.3.0`'s semver against the CLI's `v*` tags and
   silently promoted the desktop tag to "latest", breaking
   `chordsketch-action@v1` for downstream users (the action's
   "resolve latest" endpoint returned `desktop-v0.3.0` and the
   404 came from trying to download CLI binaries from a release
   that only carried desktop bundles).

   **Fix:** explicitly pass `--latest=false`. Replace the
   workflow's "intentionally omitted" comment (which was wrong
   about `gh`'s defaults) with the actual rationale.

## Test plan

- [x] `python3 -c "yaml.safe_load(open(f))"` on
      `desktop-release.yml` — clean.
- [ ] Cut a new `desktop-v*` tag after this lands and confirm:
  - GitHub Release lists distinct `ChordSketch_<v>_aarch64.app.tar.gz`
    and `ChordSketch_<v>_x64.app.tar.gz` (plus their `.sig`).
  - `publish-updater-manifest` job succeeds and `latest.json` is
    uploaded with non-empty signatures for all four platforms.
  - `curl https://api.github.com/repos/koedame/chordsketch/releases/latest`
    returns the latest `v*` (CLI) tag, NOT the desktop tag.

## Sister-site audit

`release.yml` (CLI release) is the sister site. Confirmed:
- CLI release artefacts (`chordsketch-x86_64-unknown-linux-gnu.tar.gz`
  etc.) already carry the target triple, no collision risk.
- CLI release explicitly wants to be "latest" by default, so
  the `--latest=false` flag is desktop-specific.

No further sister-site fix needed.

## Closes

#2260

## Out of scope

The `desktop-v0.3.0` release artefact itself remains as-is —
auto-update was documented as inactive in v0.3.0's release notes
during the recovery session. The next `desktop-v*` tag will pick
up this fix and ship a working updater manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)