### PR TITLE
fix(ui-web): apply viewport flex chain to mount root

### DIFF
--- a/packages/ui-web/README.md
+++ b/packages/ui-web/README.md
@@ -74,6 +74,22 @@ handle.destroy();
 `destroy()` is idempotent. Hosts that mount once and never unmount
 (today's browser playground) may safely ignore the return value.
 
+## Host-page contract
+
+`mountChordSketchUi` adds the `.chordsketch-ui-root` class to the
+supplied `root` element and styles it as a `100vh` flex column. The
+host therefore needs to provide:
+
+- A `<body>` (and any wrapping containers) without their own
+  conflicting `height` or `display` rules — the `100vh` on the mount
+  root is self-sufficient and does not depend on parent sizing.
+- A reset that zeroes `body` margin (the bundled `style.css` already
+  applies `* { margin: 0; padding: 0; box-sizing: border-box; }`).
+
+Both the browser playground (`packages/playground/index.html`) and
+the desktop Tauri shell (`apps/desktop/index.html`) satisfy this with
+a single `<div id="app"></div>`; no host-specific CSS is required.
+
 ## Visual contract
 
 The DOM structure built by `mountChordSketchUi` is **structurally

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -914,6 +914,10 @@ export async function mountChordSketchUi(
       // `clearSplitterDragState` is idempotent when no drag is in
       // progress, so it is safe to call unconditionally (#2196).
       clearSplitterDragState();
+      // Remove the class added by `buildDom` so the host can reuse
+      // `root` for non-ChordSketch content without inheriting the
+      // viewport-filling flex layout.
+      root.classList.remove('chordsketch-ui-root');
     },
     getChordPro(): string {
       return editor.getValue();

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -299,6 +299,11 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
   // or steal cookies. We do allow popups so anchor clicks (e.g. from
   // {link} or chord-diagram image maps) can open in a new tab. See #1058.
   root.innerHTML = '';
+  // Apply the viewport-filling flex chain to `root` rather than `body`
+  // so the layout works when the host wraps the mount root in a
+  // non-body container (the playground's `<div id="app">`). See #2280
+  // and `.chordsketch-ui-root` in `style.css`.
+  root.classList.add('chordsketch-ui-root');
 
   const header = document.createElement('header');
   const h1 = document.createElement('h1');

--- a/packages/ui-web/src/style.css
+++ b/packages/ui-web/src/style.css
@@ -41,6 +41,19 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: var(--bg);
   color: var(--text);
+}
+
+/*
+ * The flex/height chain lives on the mount root rather than `body` so
+ * hosts can put `mountChordSketchUi` into any element without first
+ * styling `<body>`. Pre-#2280, these rules were on `body`, which broke
+ * the layout whenever the host wrapped the mount root in a non-body
+ * container (the playground's `<div id="app">`): the body's flex
+ * context applied to the wrapper, not to the `<header>` / `<main>`
+ * children one level deeper, so `main { flex: 1 }` had no parent
+ * height to fill. `buildDom` adds this class to the supplied `root`.
+ */
+.chordsketch-ui-root {
   height: 100vh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

Move `height: 100vh; display: flex; flex-direction: column; overflow: hidden` from `body` onto a new `.chordsketch-ui-root` class that `buildDom` adds to the host-supplied mount root.

## Why

The CSS lived on `body`, but `mountChordSketchUi` builds `<header>` / `<main>` inside the host-supplied root (the playground's `<div id="app">`). The body's flex context applied to `#app`, which had no height of its own, so the descendant `<main>` had no parent height to fill and the app collapsed to content height — the playground at https://chordsketch.koeda.me/ showed a blank gap below the editor + preview.

Hoisting the chain onto a class that the library adds to `root` makes the layout self-sufficient and works regardless of whether the host wraps the mount in a non-body container. The desktop Tauri shell consumes the same `<div id="app">` mount contract, so it picks up the fix automatically.

The host-page contract is now documented in `packages/ui-web/README.md`.

## Test plan

Built `packages/playground` with the change and exercised it via Playwright at three viewport sizes:

| Viewport | Root height | `<main>` bottom | Document overflow | Notes |
|---|---|---|---|---|
| 1280×800 | 800 | 800 | none | desktop two-column, splitter visible |
| 600×700 | 700 | 700 | none | mobile column, splitter hidden, panes ≈ 40/60 |
| 1600×1000 | 1000 | 1000 | none | window-resize behaviour |

Also verified the resulting CSS class is on `<div id="app">` post-mount and that body styles (font / background / color) still apply.

Closes #2280