### PR TITLE
ci(readme-smoke): cover desktop cask + move snippet into Installation

### DIFF
--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -165,7 +165,7 @@ This keeps §5 applied to every macOS-bearing workflow while
 preserving the "always run to completion" guarantee for the release
 pipeline.
 
-Covered macOS-bearing workflows as of 2026-04-27:
+Covered macOS-bearing workflows as of 2026-04-26:
 
 - **PR-scoped cancel-in-progress** (main §5 shape): `ci.yml`,
   `swift.yml`, `python.yml`, `ruby.yml`, `kotlin.yml`, `napi.yml`,

--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -165,11 +165,11 @@ This keeps §5 applied to every macOS-bearing workflow while
 preserving the "always run to completion" guarantee for the release
 pipeline.
 
-Covered macOS-bearing workflows as of 2026-04-24:
+Covered macOS-bearing workflows as of 2026-04-27:
 
 - **PR-scoped cancel-in-progress** (main §5 shape): `ci.yml`,
   `swift.yml`, `python.yml`, `ruby.yml`, `kotlin.yml`, `napi.yml`,
-  `github-action-ci.yml`, `desktop-build.yml`.
+  `github-action-ci.yml`, `desktop-build.yml`, `readme-smoke.yml`.
 - **`cancel-in-progress: false`** (release/tag-triggered variant):
   `release.yml`, `post-release.yml`, `desktop-release.yml`.
 

--- a/.github/snapshots/readme-commands.txt
+++ b/.github/snapshots/readme-commands.txt
@@ -1,6 +1,7 @@
 [Installation] npm install @chordsketch/wasm
 [Installation] brew tap koedame/tap
 [Installation] brew install chordsketch
+[Installation] brew install --cask chordsketch
 [Installation] scoop bucket add koedame https://github.com/koedame/scoop-bucket
 [Installation] scoop install chordsketch
 [Installation] winget install koedame.chordsketch

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -358,6 +358,41 @@ jobs:
       - name: Render smoke
         uses: ./.github/actions/cli-render-smoke
 
+  homebrew-cask:
+    name: Homebrew Cask (macOS)
+    # The cask installs `ChordSketch.app` into `/Applications/`, so the
+    # smoke test has to run on a real macOS host. Linux + ubuntu-latest
+    # have no `/Applications` and `brew install --cask` is macOS-only.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Tap and install cask
+        run: |
+          set -euo pipefail
+          brew tap koedame/tap
+          brew install --cask chordsketch
+          # Verify the app bundle landed where the README promises.
+          if [ ! -d /Applications/ChordSketch.app ]; then
+            echo "::error::ChordSketch.app missing from /Applications after cask install" >&2
+            exit 1
+          fi
+          # Sanity-check the bundle metadata so a broken DMG (wrong SHA,
+          # truncated bundle, missing Info.plist) fails the job rather
+          # than silently passing on the directory check alone.
+          VERSION=$(/usr/bin/defaults read \
+            /Applications/ChordSketch.app/Contents/Info.plist \
+            CFBundleShortVersionString)
+          if [ -z "$VERSION" ]; then
+            echo "::error::CFBundleShortVersionString missing from Info.plist" >&2
+            exit 1
+          fi
+          echo "Installed ChordSketch.app version: $VERSION"
+          # `brew info --cask` exits non-zero if the cask manifest is
+          # malformed, giving a second independent signal beyond the
+          # install-and-bundle-check above.
+          brew info --cask chordsketch
+
   scoop:
     name: Scoop (Windows)
     runs-on: windows-latest
@@ -603,6 +638,7 @@ jobs:
       - cargo-install
       - source-build
       - homebrew
+      - homebrew-cask
       - scoop
       - winget
       - chocolatey

--- a/README.md
+++ b/README.md
@@ -58,10 +58,15 @@ JavaScript/TypeScript.
 
 ### Homebrew (macOS / Linux)
 
-CLI (formula):
+Add the tap (required for both the CLI formula and the desktop cask):
 
 ```bash
 brew tap koedame/tap
+```
+
+CLI (formula):
+
+```bash
 brew install chordsketch
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,21 @@ JavaScript/TypeScript.
 
 ### Homebrew (macOS / Linux)
 
+CLI (formula):
+
 ```bash
 brew tap koedame/tap
 brew install chordsketch
 ```
 
-The Homebrew tap also ships a **Cask** for the ChordSketch
-desktop app (`.app`). See [Desktop application](#desktop-application)
-below for the install snippet and post-install quarantine-flag
-step.
+[Desktop app](#desktop-application) (cask, macOS only):
+
+```bash
+brew install --cask chordsketch
+```
+
+The cask installs `ChordSketch.app` into `/Applications/`; Homebrew
+clears the Gatekeeper quarantine flag automatically on install.
 
 ### Scoop (Windows)
 
@@ -126,19 +132,8 @@ cargo install --path crates/cli
 
 ChordSketch also ships a native desktop editor (Tauri v2) with
 live ChordPro preview, syntax highlighting, transpose, file
-open/save, and PDF / HTML export.
-
-Once the first `desktop-v*` release ships, install via the
-Homebrew Cask in `koedame/tap`:
-
-```bash
-brew tap koedame/tap
-brew install --cask chordsketch
-```
-
-The cask installs `ChordSketch.app` into `/Applications/`.
-Homebrew automatically clears the Gatekeeper quarantine flag
-during install, so the app launches directly.
+open/save, and PDF / HTML export. Install via the Homebrew cask
+under `### Homebrew (macOS / Linux)` above.
 
 If you instead download the `.dmg` directly from a GitHub
 Release (bypassing Homebrew), macOS Gatekeeper will block the


### PR DESCRIPTION
## What

- Move `brew install --cask chordsketch` from the dedicated `## Desktop application` section into `### Homebrew (macOS / Linux)` under `## Installation`, alongside the existing formula snippet.
- Add a `homebrew-cask` job to `.github/workflows/readme-smoke.yml` that runs on `macos-latest` and exercises `brew install --cask chordsketch` end-to-end.
- Wire the new job into `report-failure.needs` so auto-managed tracking issues fire on cask regressions.
- Refresh `.github/snapshots/readme-commands.txt`.
- Append `readme-smoke.yml` to the PR-scoped cancel-in-progress list in `.claude/rules/ci-parallelization.md` (§5) because the workflow now runs a `macos-latest` job under the 5-job ceiling.

## Why

`desktop-v0.3.0` shipped on 2026-04-25 with unsigned DMGs, and the `update-cask` job in `desktop-release.yml` committed `Casks/chordsketch.rb` to `koedame/homebrew-tap` — so `brew install --cask chordsketch` is now reliably installable for end users. The previous gating note in `## Desktop application` ("Once the first `desktop-v*` release ships…") is stale, and the cask snippet belongs in the same install table as every other channel.

`.claude/rules/readme-sync.md` requires every advertised install command to be exercised by `readme-smoke.yml` against a real install. The new `homebrew-cask` job satisfies that contract for the cask path.

## Smoke job design

Three independent failure signals so a wrong-SHA / truncated-bundle / malformed-manifest regression cannot pass silently:

1. `brew install --cask chordsketch` — Homebrew validates SHA256 itself; a wrong SHA in `Casks/chordsketch.rb` fails this step.
2. `[ -d /Applications/ChordSketch.app ]` — guards against a successful download that did not extract a usable bundle.
3. `defaults read /Applications/ChordSketch.app/Contents/Info.plist CFBundleShortVersionString` — guards against a bundle that arrives without a usable `Info.plist`.
4. `brew info --cask chordsketch` — independent manifest-validity check after install.

## Test plan

- [x] `python3 scripts/extract-readme-commands.py --check` passes against the refreshed snapshot.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/readme-smoke.yml'))"` passes.
- [ ] On this PR, the new `Homebrew Cask (macOS)` job runs end-to-end against the live tap and is green.

Closes #2230