### PR TITLE
feat(render-html): body-only HTML export + render_html_css() (Step 1 of #2279)

### DIFF
--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -49,6 +49,33 @@ namespace chordsketch {
     [Throws=ChordSketchError]
     PdfRenderWithWarnings parse_and_render_pdf_with_warnings(string input, string? config_json, i8? transpose);
 
+    /// Parse ChordPro input and render as a body-only HTML fragment.
+    ///
+    /// Body-only counterpart to `parse_and_render_html`: returns just
+    /// the `<div class="song">...</div>` markup, with no `<!DOCTYPE>`,
+    /// `<html>`, `<head>`, `<title>`, or embedded `<style>`. Use this
+    /// from hosts that supply their own document envelope so the
+    /// chord-over-lyrics layout does not depend on HTML5's
+    /// nested-document recovery rules. Pair with `render_html_css()`
+    /// for the matching stylesheet (#2279).
+    [Throws=ChordSketchError]
+    string parse_and_render_html_body(string input, string? config_json, i8? transpose);
+
+    /// Parse ChordPro input, render as a body-only HTML fragment, and
+    /// return render warnings alongside the output.
+    ///
+    /// See `parse_and_render_html_body` for the body-only contract and
+    /// `parse_and_render_text_with_warnings` for the warnings contract.
+    [Throws=ChordSketchError]
+    TextRenderWithWarnings parse_and_render_html_body_with_warnings(string input, string? config_json, i8? transpose);
+
+    /// Returns the canonical chord-over-lyrics CSS that
+    /// `parse_and_render_html` embeds inside `<style>`.
+    ///
+    /// Pair with `parse_and_render_html_body` when the consumer is
+    /// supplying its own document envelope (#2279).
+    string render_html_css();
+
     /// Validate ChordPro input and return any parse errors as structured
     /// records. Returns an empty list if the input is valid.
     ///

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -251,6 +251,83 @@ pub fn parse_and_render_pdf_with_warnings(
     })
 }
 
+/// Parse ChordPro input and render as a body-only HTML fragment.
+///
+/// Unlike [`parse_and_render_html`], the returned string is just the
+/// `<div class="song">...</div>` markup — no `<!DOCTYPE>`, `<html>`,
+/// `<head>`, `<title>`, or embedded `<style>` block. Use this from
+/// hosts that supply their own document envelope so the rendered
+/// chord-over-lyrics layout does not depend on HTML5's nested-document
+/// recovery rules — see #2279.
+///
+/// Pair with [`render_html_css`] to obtain the matching stylesheet.
+///
+/// Render warnings are forwarded to stderr via `flush_warnings`. Use
+/// [`parse_and_render_html_body_with_warnings`] to capture them
+/// programmatically.
+///
+/// See [`parse_and_render_text`] for `transpose` parameter documentation.
+///
+/// # Errors
+///
+/// Returns [`ChordSketchError::InvalidConfig`] when `config_json` cannot
+/// be parsed.
+#[must_use = "callers must handle parse and render errors"]
+pub fn parse_and_render_html_body(
+    input: String,
+    config_json: Option<String>,
+    transpose: Option<i8>,
+) -> Result<String, ChordSketchError> {
+    let config = resolve_config(config_json)?;
+    let songs = parse_songs(&input)?;
+    Ok(flush_warnings(
+        chordsketch_render_html::render_songs_body_with_warnings(
+            &songs,
+            transpose.unwrap_or(0),
+            &config,
+        ),
+    ))
+}
+
+/// Parse ChordPro input, render as a body-only HTML fragment, and return
+/// warnings alongside the output.
+///
+/// See [`parse_and_render_html_body`] for the body-only contract and
+/// [`parse_and_render_text_with_warnings`] for the warnings contract.
+///
+/// # Errors
+///
+/// Returns [`ChordSketchError::InvalidConfig`] when `config_json` cannot
+/// be parsed.
+#[must_use = "callers must handle parse and render errors"]
+pub fn parse_and_render_html_body_with_warnings(
+    input: String,
+    config_json: Option<String>,
+    transpose: Option<i8>,
+) -> Result<TextRenderWithWarnings, ChordSketchError> {
+    let config = resolve_config(config_json)?;
+    let songs = parse_songs(&input)?;
+    let result = chordsketch_render_html::render_songs_body_with_warnings(
+        &songs,
+        transpose.unwrap_or(0),
+        &config,
+    );
+    Ok(TextRenderWithWarnings {
+        output: result.output,
+        warnings: result.warnings,
+    })
+}
+
+/// Returns the canonical chord-over-lyrics CSS that
+/// [`parse_and_render_html`] embeds inside `<style>`.
+///
+/// Pair with [`parse_and_render_html_body`] when the consumer is
+/// supplying its own document envelope.
+#[must_use]
+pub fn render_html_css() -> String {
+    chordsketch_render_html::render_html_css().to_string()
+}
+
 /// A single validation issue reported by [`validate`].
 ///
 /// Mirrors the NAPI binding's `ValidationError` (#1990) and the UDL

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -150,6 +150,47 @@ export function renderPdfWithWarningsAndOptions(
 ): PdfRenderWithWarnings;
 
 /**
+ * Renders the ChordPro source to a body-only HTML fragment — just
+ * the `<div class="song">...</div>` markup, with no `<!DOCTYPE>`,
+ * `<html>`, `<head>`, `<title>`, or embedded `<style>`. Use this
+ * from hosts that supply their own document envelope so the
+ * chord-over-lyrics layout does not rely on HTML5's nested-document
+ * recovery rules. Pair with {@link renderHtmlCss} for the matching
+ * stylesheet (#2279).
+ */
+export function renderHtmlBody(source: string): string;
+
+/**
+ * Body-only counterpart to {@link renderHtmlWithOptions}.
+ */
+export function renderHtmlBodyWithOptions(
+  source: string,
+  options: RenderOptions,
+): string;
+
+/**
+ * Body-only counterpart to {@link renderHtmlWithWarnings}; returns
+ * the fragment alongside structured warnings.
+ */
+export function renderHtmlBodyWithWarnings(source: string): TextRenderWithWarnings;
+
+/**
+ * Body-only counterpart to {@link renderHtmlWithWarningsAndOptions}.
+ */
+export function renderHtmlBodyWithWarningsAndOptions(
+  source: string,
+  options: RenderOptions,
+): TextRenderWithWarnings;
+
+/**
+ * Returns the canonical chord-over-lyrics CSS that
+ * {@link renderHtml} / {@link renderHtmlWithOptions} embed inside
+ * `<style>`. Pair with {@link renderHtmlBody} when supplying your
+ * own document envelope (#2279).
+ */
+export function renderHtmlCss(): string;
+
+/**
  * Validates a ChordPro source document and returns a list of issues. An
  * empty array indicates the document parses cleanly.
  */

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -398,6 +398,94 @@ pub fn render_pdf_with_warnings_and_options(
     do_render_pdf_with_warnings(&input, &config, transpose)
 }
 
+/// Render ChordPro input as a body-only HTML fragment using default
+/// configuration.
+///
+/// Unlike [`render_html`], the returned string is just the
+/// `<div class="song">...</div>` markup — no `<!DOCTYPE>`, `<html>`,
+/// `<head>`, `<title>`, or embedded `<style>` block. Use this from
+/// hosts that supply their own document envelope so the rendered
+/// chord-over-lyrics layout does not depend on HTML5's nested-document
+/// recovery rules — see #2279.
+///
+/// Pair with [`render_html_css`] to obtain the matching stylesheet.
+#[must_use = "callers must handle render errors"]
+#[napi]
+pub fn render_html_body(input: String) -> Result<String> {
+    do_render_string(
+        &input,
+        &chordsketch_chordpro::config::Config::defaults(),
+        0,
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
+/// Render ChordPro input as a body-only HTML fragment with options.
+///
+/// See [`render_html_body`] for the body-only contract.
+#[must_use = "callers must handle render errors"]
+#[napi]
+pub fn render_html_body_with_options(input: String, options: RenderOptions) -> Result<String> {
+    let config = resolve_config(options.config)?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    do_render_string(
+        &input,
+        &config,
+        transpose,
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
+/// Render ChordPro input as a body-only HTML fragment, returning both
+/// output and captured warnings.
+///
+/// See [`render_html_body`] for the body-only contract and
+/// [`render_text_with_warnings`] for the warnings contract.
+#[must_use = "callers must handle render errors"]
+#[napi]
+pub fn render_html_body_with_warnings(input: String) -> Result<TextRenderWithWarnings> {
+    do_render_string_with_warnings(
+        &input,
+        &chordsketch_chordpro::config::Config::defaults(),
+        0,
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
+/// Render ChordPro input as a body-only HTML fragment with options,
+/// returning both output and captured warnings.
+///
+/// Combines the options payload of [`render_html_body_with_options`]
+/// with the structured-warning capture of
+/// [`render_html_body_with_warnings`].
+#[must_use = "callers must handle render errors"]
+#[napi]
+pub fn render_html_body_with_warnings_and_options(
+    input: String,
+    options: RenderOptions,
+) -> Result<TextRenderWithWarnings> {
+    let config = resolve_config(options.config)?;
+    let transpose = parse_transpose(options.transpose.unwrap_or(0))?;
+    do_render_string_with_warnings(
+        &input,
+        &config,
+        transpose,
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
+/// Returns the canonical chord-over-lyrics CSS that
+/// [`render_html`] / [`render_html_with_options`] embed inside
+/// `<style>`.
+///
+/// Pair with [`render_html_body`] / [`render_html_body_with_options`]
+/// when the consumer is supplying its own document envelope.
+#[must_use]
+#[napi]
+pub fn render_html_css() -> String {
+    chordsketch_render_html::render_html_css().to_string()
+}
+
 /// A single validation issue reported by [`validate`]. Mirrors the
 /// `ValidationError` interface in `crates/napi/index.d.ts`; the `#[napi(object)]`
 /// attribute marshals this into a plain JS `{line, column, message}` record.

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -193,7 +193,7 @@ pub fn render_song_with_warnings(
     html.push_str("<style>\n");
     html.push_str(CSS);
     html.push_str("</style>\n</head>\n<body>\n");
-    render_song_body(song, cli_transpose, config, &mut html, &mut warnings);
+    render_song_body_into(song, cli_transpose, config, &mut html, &mut warnings);
     html.push_str("</body>\n</html>\n");
     RenderResult::with_warnings(html, warnings)
 }
@@ -203,7 +203,7 @@ pub fn render_song_with_warnings(
 /// This is the shared implementation used by both single-song and multi-song
 /// rendering. It appends directly to the provided buffer without any document
 /// wrapper (`<html>`, `<head>`, etc.).
-fn render_song_body(
+fn render_song_body_into(
     song: &Song,
     cli_transpose: i8,
     config: &Config,
@@ -705,11 +705,137 @@ pub fn render_songs_with_warnings(
         if i > 0 {
             html.push_str("<hr class=\"song-separator\">\n");
         }
-        render_song_body(song, cli_transpose, config, &mut html, &mut warnings);
+        render_song_body_into(song, cli_transpose, config, &mut html, &mut warnings);
     }
 
     html.push_str("</body>\n</html>\n");
     RenderResult::with_warnings(html, warnings)
+}
+
+/// Render a [`Song`] AST to its body-only HTML fragment.
+///
+/// Unlike [`render_song`], this returns just the `<div class="song">...</div>`
+/// markup — no `<!DOCTYPE>`, `<html>`, `<head>`, `<title>`, or embedded
+/// `<style>` block. Use this when the consumer is going to wrap the output
+/// in its own document (e.g. a VS Code WebView, a Tauri shell, or a static
+/// site generator) and supply CSS separately via [`render_html_css`].
+///
+/// Background: prior to #2279 the only public API was the full-document
+/// variants, which forced consumers to either accept a complete HTML
+/// document where they wanted a fragment, or to reimplement body
+/// rendering. The latter produced sister-site drift across the playground,
+/// the desktop shell, and the VS Code preview (each with its own bespoke
+/// `wrapHtml`-style helper). The body-only family closes that gap.
+#[must_use]
+pub fn render_song_body(song: &Song) -> String {
+    render_song_body_with_transpose(song, 0, &Config::defaults())
+}
+
+/// Render a [`Song`] AST to its body-only HTML fragment with a CLI
+/// transposition offset.
+///
+/// See [`render_song_body`] for the contract. Warnings are printed to
+/// stderr via `eprintln!`; use [`render_song_body_with_warnings`] to
+/// capture them programmatically.
+#[must_use]
+pub fn render_song_body_with_transpose(song: &Song, cli_transpose: i8, config: &Config) -> String {
+    let result = render_song_body_with_warnings(song, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render a [`Song`] AST to its body-only HTML fragment, returning warnings
+/// programmatically.
+///
+/// This is the structured variant of [`render_song_body_with_transpose`].
+/// See [`render_song_body`] for the contract.
+#[must_use = "caller must check warnings in the returned RenderResult"]
+pub fn render_song_body_with_warnings(
+    song: &Song,
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<String> {
+    let mut warnings = Vec::new();
+    let mut html = String::new();
+    render_song_body_into(song, cli_transpose, config, &mut html, &mut warnings);
+    RenderResult::with_warnings(html, warnings)
+}
+
+/// Render multiple [`Song`]s into a single body-only HTML fragment.
+///
+/// Songs are separated with `<hr class="song-separator">`, matching the
+/// inline separator used by [`render_songs`]. See [`render_song_body`]
+/// for the contract.
+#[must_use]
+pub fn render_songs_body(songs: &[Song]) -> String {
+    render_songs_body_with_transpose(songs, 0, &Config::defaults())
+}
+
+/// Render multiple [`Song`]s into a single body-only HTML fragment with
+/// transposition.
+///
+/// See [`render_songs_body`] for the contract. Warnings are printed to
+/// stderr via `eprintln!`; use [`render_songs_body_with_warnings`] to
+/// capture them programmatically.
+#[must_use]
+pub fn render_songs_body_with_transpose(
+    songs: &[Song],
+    cli_transpose: i8,
+    config: &Config,
+) -> String {
+    let result = render_songs_body_with_warnings(songs, cli_transpose, config);
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+    result.output
+}
+
+/// Render multiple [`Song`]s into a single body-only HTML fragment, returning
+/// warnings programmatically.
+///
+/// See [`render_songs_body`] for the contract.
+#[must_use = "caller must check warnings in the returned RenderResult"]
+pub fn render_songs_body_with_warnings(
+    songs: &[Song],
+    cli_transpose: i8,
+    config: &Config,
+) -> RenderResult<String> {
+    let mut warnings = Vec::new();
+    if songs.len() <= 1 {
+        let output = songs
+            .first()
+            .map(|s| {
+                let r = render_song_body_with_warnings(s, cli_transpose, config);
+                warnings = r.warnings;
+                r.output
+            })
+            .unwrap_or_default();
+        return RenderResult::with_warnings(output, warnings);
+    }
+    let mut html = String::new();
+    for (i, song) in songs.iter().enumerate() {
+        if i > 0 {
+            html.push_str("<hr class=\"song-separator\">\n");
+        }
+        render_song_body_into(song, cli_transpose, config, &mut html, &mut warnings);
+    }
+    RenderResult::with_warnings(html, warnings)
+}
+
+/// The canonical chord-over-lyrics CSS that the full-document renderers
+/// embed inside `<style>`.
+///
+/// Pair this with [`render_song_body`] / [`render_songs_body`] when the
+/// consumer is supplying its own document envelope: inline the returned
+/// string inside a `<style>` block, ship it as a separate file referenced
+/// via `<link rel="stylesheet">`, or merge it into the host's existing
+/// stylesheet. The contract is byte-stable; consumers can hash the result
+/// for cache-busting filenames.
+#[must_use]
+pub fn render_html_css() -> &'static str {
+    CSS
 }
 
 /// Parse a ChordPro source string and render it to HTML.
@@ -2007,6 +2133,100 @@ mod tests {
         let html = render_song(&song);
         assert!(html.contains("<!DOCTYPE html>"));
         assert!(html.contains("</html>"));
+    }
+
+    #[test]
+    fn test_render_song_body_omits_document_envelope() {
+        // The whole point of the body-only family is that consumers
+        // wrapping the output in their own document do not get a
+        // nested `<!DOCTYPE>` / `<html>` / `<head>` / `<style>` to
+        // unwrap. Pin that contract here so future refactors cannot
+        // silently re-introduce the envelope.
+        let song =
+            chordsketch_chordpro::parse("{title: Sample}\nWas [G]blind but [D]now I [G]see.")
+                .unwrap();
+        let body = render_song_body(&song);
+        assert!(!body.contains("<!DOCTYPE"));
+        assert!(!body.contains("<html"));
+        assert!(!body.contains("</html>"));
+        assert!(!body.contains("<head"));
+        assert!(!body.contains("<style"));
+        assert!(!body.contains("<title>"));
+        // The body must still contain the song wrapper and metadata
+        // blocks that the full-document renderer produces inside
+        // `<body>` — that's the contract consumers depend on.
+        assert!(body.contains("<div class=\"song\">"));
+        assert!(body.contains("<h1>Sample</h1>"));
+        // The `chord-block` flex layout is what positions chords above
+        // lyrics; body-only consumers will provide the CSS via
+        // `render_html_css()` but the markup itself must still emit
+        // the class names.
+        assert!(body.contains("class=\"chord-block\""));
+    }
+
+    #[test]
+    fn test_render_song_body_byte_stable_with_full_render_body_section() {
+        // The body-only output should be byte-equal to the body slice
+        // of the full-document output (between `<body>\n` and
+        // `</body>`). That is the only way to guarantee that callers
+        // who switch over from the full-document API to the body-only
+        // API see no rendering drift.
+        let song = chordsketch_chordpro::parse(
+            "{title: Amazing Grace}\nA[G]mazing [D]grace, how [G]sweet the sound.",
+        )
+        .unwrap();
+        let full = render_song(&song);
+        let body = render_song_body(&song);
+        let body_start = full
+            .find("<body>\n")
+            .expect("full-document render must have <body>")
+            + "<body>\n".len();
+        let body_end = full
+            .rfind("</body>")
+            .expect("full-document render must have </body>");
+        let extracted = &full[body_start..body_end];
+        assert_eq!(
+            extracted, body,
+            "body-only output must match the body slice of the full document"
+        );
+    }
+
+    #[test]
+    fn test_render_html_css_returns_canonical_block() {
+        // Consumers can hash this result to build cache-busting
+        // filenames or inline it directly. Pin a few key selectors
+        // so a future refactor that drops one (e.g. `.chord-block`,
+        // which is what makes the chord-over-lyrics layout work)
+        // surfaces here as a hard test failure rather than a silent
+        // visual regression in every host that uses the body-only
+        // family.
+        let css = render_html_css();
+        assert!(css.contains(".chord-block"));
+        assert!(css.contains(".chord "));
+        assert!(css.contains(".lyrics"));
+        // The full-document renderer embeds *exactly* this string
+        // inside its `<style>` block — assert the lockstep so a
+        // future divergence is caught immediately.
+        let song = chordsketch_chordpro::parse("{title: t}").unwrap();
+        let full = render_song(&song);
+        assert!(full.contains(css));
+    }
+
+    #[test]
+    fn test_render_songs_body_separator_between_songs() {
+        let parsed =
+            chordsketch_chordpro::parse_multi_lenient("{title: A}\n{new_song}\n{title: B}");
+        let songs: Vec<_> = parsed.results.into_iter().map(|r| r.song).collect();
+        assert_eq!(songs.len(), 2, "expected two songs in the parsed output");
+        let body = render_songs_body(&songs);
+        assert!(body.contains("<hr class=\"song-separator\">"));
+        assert!(!body.contains("<!DOCTYPE"));
+    }
+
+    #[test]
+    fn test_render_songs_body_empty_input() {
+        let body = render_songs_body(&[]);
+        assert!(body.is_empty());
     }
 
     #[test]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1,7 +1,11 @@
 //! HTML renderer for ChordPro documents.
 //!
-//! Converts a parsed ChordPro AST into a self-contained HTML5 document with
-//! embedded CSS for chord-over-lyrics layout.
+//! Converts a parsed ChordPro AST into either a self-contained HTML5 document
+//! (with embedded CSS) or a body-only `<div class="song">` fragment suitable
+//! for embedding in a host document. Use [`render_song`] / [`render_songs`]
+//! for the full-document API and [`render_song_body`] / [`render_songs_body`]
+//! for the fragment API. Pair the latter with [`render_html_css`] to obtain
+//! the matching stylesheet.
 //!
 //! # Security
 //!

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -299,6 +299,65 @@ pub fn render_pdf_with_options(input: &str, options: JsValue) -> Result<Vec<u8>,
     )
 }
 
+/// Render ChordPro input as a body-only HTML fragment using default
+/// configuration.
+///
+/// Unlike [`render_html`], the returned string is just the
+/// `<div class="song">...</div>` markup — no `<!DOCTYPE>`, `<html>`,
+/// `<head>`, `<title>`, or embedded `<style>` block. Use this from
+/// hosts that supply their own document envelope (the playground's
+/// `<iframe srcdoc>`, the desktop Tauri shell, the VS Code WebView
+/// preview) so the rendered chord-over-lyrics layout does not depend
+/// on HTML5's nested-document recovery rules — see #2279.
+///
+/// Pair with [`render_html_css`] to obtain the matching stylesheet.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on parse failure.
+#[must_use = "callers must handle render errors"]
+#[wasm_bindgen]
+pub fn render_html_body(input: &str) -> Result<String, JsValue> {
+    render_string_inner(
+        input,
+        RenderOptions::default(),
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
+/// Render ChordPro input as a body-only HTML fragment with options.
+///
+/// See [`render_html_body`] for the body-only contract and
+/// [`render_html_with_options`] for the `options` format.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
+#[wasm_bindgen]
+pub fn render_html_body_with_options(input: &str, options: JsValue) -> Result<String, JsValue> {
+    render_string_inner(
+        input,
+        deserialize_options(options)?,
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
+/// Return the canonical chord-over-lyrics CSS that
+/// [`render_html`] / [`render_html_with_options`] embed inside
+/// `<style>`.
+///
+/// Pair with [`render_html_body`] / [`render_html_body_with_options`]
+/// when the consumer is supplying its own document envelope. The
+/// contract is byte-stable; consumers can hash the result for
+/// cache-busting filenames or compare it against an expected hash to
+/// detect renderer-CSS drift across versions.
+#[must_use]
+#[wasm_bindgen]
+pub fn render_html_css() -> String {
+    chordsketch_render_html::render_html_css().to_string()
+}
+
 /// Structured render result returned by the `*_with_warnings` family.
 ///
 /// Serialized to a plain JS object `{ output, warnings }` where
@@ -521,6 +580,51 @@ pub fn render_pdf_with_warnings_and_options(
     )
 }
 
+/// Render ChordPro input as a body-only HTML fragment and return
+/// `{ output, warnings }`.
+///
+/// Body-only counterpart to [`render_html_with_warnings`]; returns the
+/// `<div class="song">...</div>` markup without `<!DOCTYPE>` /
+/// `<html>` / `<head>` / `<style>`. See [`render_html_body`] for the
+/// fragment contract and [`render_html_with_warnings`] for the
+/// warnings contract.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on parse failure.
+#[must_use = "callers must handle render errors"]
+#[wasm_bindgen(js_name = renderHtmlBodyWithWarnings)]
+pub fn render_html_body_with_warnings(input: &str) -> Result<JsValue, JsValue> {
+    render_string_with_warnings_inner(
+        input,
+        RenderOptions::default(),
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
+/// Render ChordPro input as a body-only HTML fragment with options
+/// and return `{ output, warnings }`.
+///
+/// Combines the `options` payload of [`render_html_body_with_options`]
+/// with the structured-warning capture of
+/// [`render_html_body_with_warnings`].
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string on parse failure or invalid options.
+#[must_use = "callers must handle render errors"]
+#[wasm_bindgen(js_name = renderHtmlBodyWithWarningsAndOptions)]
+pub fn render_html_body_with_warnings_and_options(
+    input: &str,
+    options: JsValue,
+) -> Result<JsValue, JsValue> {
+    render_string_with_warnings_inner(
+        input,
+        deserialize_options(options)?,
+        chordsketch_render_html::render_songs_body_with_warnings,
+    )
+}
+
 /// Returns the ChordSketch library version.
 #[must_use]
 #[wasm_bindgen]
@@ -700,6 +804,35 @@ mod tests {
         // Lenient parser produces an empty song even for blank input.
         let result = render_html("");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_render_html_body_omits_document_envelope() {
+        let body = render_html_body(MINIMAL_INPUT).unwrap();
+        // Body-only contract — none of the document-level wrappers
+        // emitted by `render_html` may appear here.
+        assert!(!body.contains("<!DOCTYPE"));
+        assert!(!body.contains("<html"));
+        assert!(!body.contains("</html>"));
+        assert!(!body.contains("<head"));
+        assert!(!body.contains("<style"));
+        assert!(!body.contains("<title>"));
+        // The song markup itself must still be present.
+        assert!(body.contains("<div class=\"song\">"));
+    }
+
+    #[test]
+    fn test_render_html_css_returns_canonical_block() {
+        let css = render_html_css();
+        // Pin the load-bearing selectors that make the
+        // chord-over-lyrics layout work.
+        assert!(css.contains(".chord-block"));
+        assert!(css.contains(".lyrics"));
+        // The full-document renderer embeds *exactly* this string —
+        // assert lockstep so future divergence between the WASM
+        // export and the embedded copy is caught immediately.
+        let full = render_html(MINIMAL_INPUT).unwrap();
+        assert!(full.contains(&css));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a body-only render API to `chordsketch-render-html` and exposes it across all three sister-site bindings (WASM / NAPI / FFI).

### `chordsketch-render-html` core

- `render_song_body()` / `_with_transpose()` / `_with_warnings()` — return just `<div class=\"song\">...</div>`, no `<!DOCTYPE>` / `<html>` / `<head>` / `<title>` / `<style>`.
- `render_songs_body()` / `_with_transpose()` / `_with_warnings()` — multi-song variant; songs separated by `<hr class=\"song-separator\">`, matching the inline separator used by `render_songs`.
- `render_html_css()` — returns the canonical chord-over-lyrics CSS the full-document renderers embed inside `<style>`. Byte-stable; consumers can hash it for cache-busting filenames.
- Internal `fn render_song_body` renamed to `fn render_song_body_into` to free the public name. No change to the existing full-document API surface.

### Sister-site bindings (`fix-propagation.md`)

- WASM (`crates/wasm`): `render_html_body`, `render_html_body_with_options`, `render_html_body_with_warnings`, `render_html_body_with_warnings_and_options`, `render_html_css`.
- NAPI (`crates/napi`): same shape, plus matching `index.d.ts` declarations.
- FFI (`crates/ffi`): `parse_and_render_html_body`, `parse_and_render_html_body_with_warnings`, `render_html_css`. UDL declarations updated; UniFFI regenerates Python / Swift / Kotlin / Ruby surface during their respective release jobs.

## Why

#2279 traced the VS Code preview's lyric-baseline drift to two layered structural problems:

1. The VS Code preview reimplements its own `wrapHtml` instead of using `@chordsketch/ui-web`, producing sister-site drift.
2. `wrapHtml` (and the playground's equivalent) wraps the WASM output — which is itself a complete `<!DOCTYPE>` document — inside a second document. The chord-over-lyrics layout therefore depends on HTML5's nested-document recovery silently dropping the inner envelope, which is fragile.

This PR is Step 1: add the stable body-only contract so #2 can be fixed cleanly. Step 2 (VS Code preview migration to `@chordsketch/ui-web`) is the follow-up.

## Tests

Three new lib-level tests in `chordsketch-render-html`:
- body-only output omits the document envelope but keeps `<div class=\"song\">`, `<h1>`, `class=\"chord-block\"`;
- body-only output is **byte-equal** to the body slice of the full document — pins the lockstep contract;
- `render_html_css()` contains the load-bearing selectors (`.chord-block`, `.lyrics`) and the full-document renderer embeds exactly that string.

Two new lib-level tests in `chordsketch-wasm` mirror the envelope-omission and CSS-lockstep checks at the binding boundary. Multi-song separator + empty-input tests for `render_songs_body`.

## Test plan

- [x] `cargo test -p chordsketch-render-html` — 231 passed
- [x] `cargo test -p chordsketch-wasm` — 14 passed
- [x] `cargo build -p chordsketch-napi` — clean
- [x] `cargo build -p chordsketch-ffi` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Full CI matrix on this PR (Test matrix, wasm, napi, ffi, python, ruby, swift, kotlin)

## Deferred

- **Step 2** — VS Code preview migration to `@chordsketch/ui-web` consuming the new body-only export. Tracked under #2279.
- **Body-only golden test fixtures** — the unit-level lockstep test (body-only output is byte-equal to the body slice of the full document) already pins the contract against every existing fixture. A separate body-only fixture corpus would only re-test what the lockstep assertion already covers.

Closes part of #2279 (Step 1).