### PR TITLE
fix(vscode-extension): body-only render preview, eliminate lyric baseline drift (#2279 Step 2)

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -60,24 +60,27 @@ jobs:
           cache: "npm"
           cache-dependency-path: packages/vscode-extension/package-lock.json
 
-      # Both the web build (for the WebView preview) and the node build (for the
-      # convertTo export command) must be present so esbuild.mjs can:
-      #   - bundle the web JS glue and copy the .wasm binary into dist/webview/
-      #   - copy the node JS and .wasm binary into dist/node/
-      # We restore from the npm registry rather than building from source
-      # so this CI job has no Rust toolchain dependency.
-      - name: Install @chordsketch/wasm (web + node builds)
-        run: |
-          mkdir -p packages/npm
-          cd packages/npm
-          npm pack @chordsketch/wasm@latest 2>/dev/null || true
-          # Unpack into packages/npm/ so esbuild.mjs can find packages/npm/web/ and packages/npm/node/
-          if ls chordsketch-wasm-*.tgz 1>/dev/null 2>&1; then
-            tar xzf chordsketch-wasm-*.tgz --strip-components=1
-            echo "Unpacked @chordsketch/wasm"
-          else
-            echo "WARNING: @chordsketch/wasm not available from registry; WASM preview will be absent in this build."
-          fi
+      # Build @chordsketch/wasm from source rather than fetching @latest
+      # from the npm registry so CI sees the same wasm-bindgen-generated
+      # JS surface that the in-tree `crates/wasm` defines on this commit.
+      # Pre-#2279-Step-2 this step ran `npm pack @chordsketch/wasm@latest`,
+      # which left a publish-lag window where preview.ts could import a
+      # wasm export that existed in `crates/wasm/src/lib.rs` but had not
+      # yet been published to npm — esbuild then bundles a missing-export
+      # reference whose runtime failure is invisible to PR CI.
+      #
+      # The cost is one Rust + wasm-pack build per PR (~2-3 min cold,
+      # ~30s with rust-cache).
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/install-wasm-pack
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Distinct shared-key per workflow + target so vscode-extension's
+          # wasm-pack build does not thrash the cache shared by `wasm.yml`.
+          shared-key: vscode-extension-wasm-pack
+
+      - name: Build @chordsketch/wasm from source (web + node builds)
+        run: node packages/npm/scripts/build.mjs
 
       - name: Install dependencies
         run: npm ci
@@ -212,17 +215,18 @@ jobs:
           cache: "npm"
           cache-dependency-path: packages/vscode-extension/package-lock.json
 
-      - name: Install @chordsketch/wasm (web + node builds)
-        run: |
-          mkdir -p packages/npm
-          cd packages/npm
-          npm pack @chordsketch/wasm@latest 2>/dev/null || true
-          if ls chordsketch-wasm-*.tgz 1>/dev/null 2>&1; then
-            tar xzf chordsketch-wasm-*.tgz --strip-components=1
-            echo "Unpacked @chordsketch/wasm"
-          else
-            echo "WARNING: @chordsketch/wasm not available from registry; WASM preview will be absent in this build."
-          fi
+      # Build @chordsketch/wasm from source on the publish path too —
+      # see the rationale on the same step in the `build` job above.
+      # On a release event the manual `npm publish` of @chordsketch/wasm
+      # may not have happened yet, so `@latest` lags the in-tree source.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/install-wasm-pack
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: vscode-extension-wasm-pack
+
+      - name: Build @chordsketch/wasm from source (web + node builds)
+        run: node packages/npm/scripts/build.mjs
 
       - name: Install dependencies
         run: npm ci

--- a/packages/vscode-extension/esbuild.mjs
+++ b/packages/vscode-extension/esbuild.mjs
@@ -43,10 +43,15 @@ for (const file of ['chordpro.tmLanguage.json', 'language-configuration.json']) 
 }
 
 // Copy the WASM binary for the WebView (browser build).
-// Prefer the installed npm package's web build over the local monorepo build.
-const wasmNpmWeb = path.join(here, 'node_modules', '@chordsketch', 'wasm', 'web', 'chordsketch_wasm_bg.wasm');
+// Prefer the local monorepo build over the installed npm package so a
+// developer (or CI step) that runs `node packages/npm/scripts/build.mjs`
+// against the in-tree `crates/wasm` source picks up new exports
+// immediately, without waiting for a manual `npm publish` cycle. The
+// node_modules copy from `npm install @chordsketch/wasm` remains a
+// fallback for ad-hoc clones where a Rust toolchain is unavailable.
 const wasmLocalWeb = path.join(repoRoot, 'packages', 'npm', 'web', 'chordsketch_wasm_bg.wasm');
-const wasmSrc = fs.existsSync(wasmNpmWeb) ? wasmNpmWeb : wasmLocalWeb;
+const wasmNpmWeb = path.join(here, 'node_modules', '@chordsketch', 'wasm', 'web', 'chordsketch_wasm_bg.wasm');
+const wasmSrc = fs.existsSync(wasmLocalWeb) ? wasmLocalWeb : wasmNpmWeb;
 const wasmDst = path.join(here, 'dist', 'webview', 'chordsketch_wasm_bg.wasm');
 if (fs.existsSync(wasmSrc)) {
   fs.copyFileSync(wasmSrc, wasmDst);
@@ -69,9 +74,11 @@ fs.mkdirSync(nodeDir, { recursive: true });
 fs.writeFileSync(path.join(nodeDir, 'package.json'), JSON.stringify({ type: 'commonjs' }, null, 2) + '\n');
 const wasmNodeFiles = ['chordsketch_wasm.js', 'chordsketch_wasm_bg.wasm'];
 for (const file of wasmNodeFiles) {
-  const npmSrc = path.join(here, 'node_modules', '@chordsketch', 'wasm', 'node', file);
+  // Same precedence rule as the web copy above — local in-tree build
+  // first, npm-published fallback second.
   const localSrc = path.join(repoRoot, 'packages', 'npm', 'node', file);
-  const src = fs.existsSync(npmSrc) ? npmSrc : localSrc;
+  const npmSrc = path.join(here, 'node_modules', '@chordsketch', 'wasm', 'node', file);
+  const src = fs.existsSync(localSrc) ? localSrc : npmSrc;
   if (fs.existsSync(src)) {
     fs.copyFileSync(src, path.join(nodeDir, file));
     console.log(`Copied ${path.relative(here, src)} → dist/node/${file}`);
@@ -95,10 +102,11 @@ const extensionBuild = {
 };
 
 // The WebView bundle imports from the wasm-pack web target's JS glue.
-// Prefer the installed npm package over the local monorepo build.
-const wasmJsNpm = path.join(here, 'node_modules', '@chordsketch', 'wasm', 'web', 'chordsketch_wasm.js');
+// Prefer the local monorepo build over the installed npm package — see
+// the matching comment on the binary copy above for the rationale.
 const wasmJsLocal = path.join(repoRoot, 'packages', 'npm', 'web', 'chordsketch_wasm.js');
-const wasmJsSrc = fs.existsSync(wasmJsNpm) ? wasmJsNpm : wasmJsLocal;
+const wasmJsNpm = path.join(here, 'node_modules', '@chordsketch', 'wasm', 'web', 'chordsketch_wasm.js');
+const wasmJsSrc = fs.existsSync(wasmJsLocal) ? wasmJsLocal : wasmJsNpm;
 
 /** @type {esbuild.BuildOptions} */
 const webviewBuild = {

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -142,10 +142,16 @@ function formatError(e: unknown): string {
 
 /**
  * Canonical chord-over-lyrics CSS exported by `@chordsketch/wasm`.
- * Cached at module load so every render does not pay the WASM
- * round-trip; the value is byte-stable for the lifetime of a build.
+ *
+ * Assigned in {@link main} after `await init()` resolves — wasm-bindgen
+ * exports require WASM memory to be initialised before they are callable,
+ * and module-level evaluation runs before `main()`. Cached (not re-called
+ * on every render) because the value is byte-stable for the lifetime of a
+ * build. `wrapHtml` may only be called after `wasmReady` is `true`, which
+ * is set immediately after this assignment in `main()`, so `wrapHtml` is
+ * guaranteed to see the populated string.
  */
-const CHORDSKETCH_CSS = render_html_css();
+let CHORDSKETCH_CSS = '';
 
 /**
  * Wraps a body-only HTML fragment from `render_html_body_with_options`
@@ -245,8 +251,9 @@ function safeGetState(): PanelState {
  * Renders the given ChordPro source text according to the active view mode
  * and current transpose offset.
  *
- * In HTML mode, `render_html_with_options` is called and the output is loaded
- * into the sandboxed iframe via `srcdoc`. In plain text mode,
+ * In HTML mode, `render_html_body_with_options` is called, the body fragment
+ * is wrapped in a full document by `wrapHtml`, and the result is loaded into
+ * the sandboxed iframe via `srcdoc`. In plain text mode,
  * `render_text_with_options` is called and the output is set as `textContent`
  * of the `<pre>` element (safe — no HTML parsing occurs).
  */
@@ -424,6 +431,14 @@ async function main(): Promise<void> {
   }
 
   loadingEl.style.display = 'none';
+
+  // Cache the canonical chord-over-lyrics CSS now that WASM memory is live.
+  // render_html_css() requires an initialised WASM heap (it allocates a String
+  // in WASM memory and copies bytes across the ABI boundary); calling it before
+  // init() resolves throws a TypeError that prevents the entire module from
+  // loading. The value is byte-stable for the lifetime of a build so a single
+  // call per session is correct.
+  CHORDSKETCH_CSS = render_html_css();
 
   // Unlock the wasmReady guard so renderPreview can now call WASM exports.
   wasmReady = true;

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -12,7 +12,11 @@
  * always `null` for `type="module"` scripts (HTML spec).
  */
 
-import init, { render_html_with_options, render_text_with_options } from '@chordsketch/wasm';
+import init, {
+  render_html_body_with_options,
+  render_html_css,
+  render_text_with_options,
+} from '@chordsketch/wasm';
 
 /** VS Code WebView API acquired from the global injected by the host. */
 declare function acquireVsCodeApi(): {
@@ -137,12 +141,40 @@ function formatError(e: unknown): string {
 }
 
 /**
- * Wraps rendered HTML body content with baseline CSS.
+ * Canonical chord-over-lyrics CSS exported by `@chordsketch/wasm`.
+ * Cached at module load so every render does not pay the WASM
+ * round-trip; the value is byte-stable for the lifetime of a build.
+ */
+const CHORDSKETCH_CSS = render_html_css();
+
+/**
+ * Wraps a body-only HTML fragment from `render_html_body_with_options`
+ * inside a complete document for the preview iframe.
  *
- * Mirrors the `HTML_FRAME_TEMPLATE` helper in `packages/ui-web/src/index.ts`.
- * The rendered HTML from `chordsketch-render-html` contains only the body
- * content (sections, chords-above-lyrics, chord diagrams) without a full
- * document wrapper.
+ * Pre-#2279 this helper bespoke-defined a `<style>` block and then
+ * embedded the WASM output, which itself was already a complete
+ * `<!DOCTYPE>` document — `chord-block` / `lyrics` / `min-height`
+ * styles only survived because of HTML5's nested-document recovery
+ * silently dropping the inner envelope. Once that recovery diverged
+ * from the renderer's expectations, chord-less segments in
+ * chord-bearing lines floated up by ~1 chord-row and the lyrics
+ * baseline drifted (#2279).
+ *
+ * The fix has two parts:
+ *
+ *   1. Use `render_html_body_with_options` so the WASM output is
+ *      *just* the `<div class="song">...</div>` markup — no inner
+ *      document.
+ *   2. Inline `render_html_css()` (the canonical chord-over-lyrics
+ *      CSS) into the wrapper *first*, then layer the VS-Code-specific
+ *      theme overrides on top so they win cascade order.
+ *
+ * The theme block here keeps the preview close to VS Code's body
+ * styling (font, padding, line-height) without re-defining the
+ * load-bearing layout selectors. Removing the bespoke `.chord` color
+ * is intentional — the canonical CSS already covers it; the previous
+ * override was load-bearing only because of the double-wrap and is
+ * not worth preserving.
  */
 function wrapHtml(body: string): string {
   return `<!DOCTYPE html>
@@ -150,17 +182,24 @@ function wrapHtml(body: string): string {
 <head>
 <meta charset="UTF-8">
 <style>
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    padding: 1.5rem;
-    line-height: 1.6;
-    color: #333;
-  }
-  .chord { color: #e94560; font-weight: bold; }
-  h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
-  h2 { font-size: 1.1rem; color: #666; margin-bottom: 1rem; }
-  section { margin-bottom: 1rem; }
-  .song-separator { border-top: 2px solid #ddd; margin: 2rem 0; }
+${CHORDSKETCH_CSS}
+/* VS Code preview theme overrides — applied after the canonical
+   chord-over-lyrics CSS so cascade order keeps the layout intact
+   while these tweaks take precedence on body / heading styles. */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  padding: 1.5rem;
+  line-height: 1.6;
+  color: #333;
+  /* Reset the canonical CSS's max-width centering so the preview
+     panel uses the full WebView column width. */
+  max-width: none;
+  margin: 0;
+}
+h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1.1rem; color: #666; margin-bottom: 1rem; }
+section { margin-bottom: 1rem; }
+.song-separator { border-top: 2px solid #ddd; margin: 2rem 0; }
 </style>
 </head>
 <body>${body}</body>
@@ -240,9 +279,9 @@ function renderPreview(text: string): void {
 
   try {
     if (viewMode === 'html') {
-      const html = render_html_with_options(text, options);
+      const body = render_html_body_with_options(text, options);
       hideError();
-      previewFrame.srcdoc = wrapHtml(html);
+      previewFrame.srcdoc = wrapHtml(body);
       previewFrame.style.display = 'block';
       textFrame.style.display = 'none';
     } else {


### PR DESCRIPTION
## What

Migrates the VS Code preview's WebView script to the body-only HTML export added in #2284 (Step 1), eliminating the double-wrap that caused chord-less segments in chord-bearing lines to drift up by roughly one chord-row.

### `webview/preview.ts`
- Use `render_html_body_with_options` (returns `<div class=\"song\">...</div>` only) and `render_html_css` (canonical chord-over-lyrics CSS) from `@chordsketch/wasm`.
- `wrapHtml` embeds `render_html_css()` *first*, then layers VS-Code-specific theme overrides (font / padding / heading sizes) on top so cascade order keeps the load-bearing `.chord-block` flex column intact.
- Drop the bespoke `.chord` colour override (canonical `#b00` is fine; the previous `#e94560` was load-bearing only because of the double-wrap).
- Cache `render_html_css()` at module load so renders skip the WASM round-trip per call. The byte-stability is pinned by the lockstep test in #2284.

### `esbuild.mjs`
- Flip the `@chordsketch/wasm` source-precedence rule: prefer `packages/npm/web/` (in-tree wasm-pack output) over `node_modules/@chordsketch/wasm/web/` (npm-published copy). Same flip applied to the web bundle, the JS glue alias, and the node CJS file copies. Lets a dev who runs `node packages/npm/scripts/build.mjs` see new exports immediately, without waiting for a manual `npm publish`.

### `.github/workflows/vscode-extension.yml`
- Replace `npm pack @chordsketch/wasm@latest` (in both `build` and `publish` jobs) with a wasm-pack-from-source build via `node packages/npm/scripts/build.mjs`.
- Add `dtolnay/rust-toolchain`, the existing `install-wasm-pack` composite action, and `Swatinem/rust-cache` with the `vscode-extension-wasm-pack` shared-key per `ci-parallelization.md` §2.

## Why

`render_html_with_options` returns a complete `<!DOCTYPE>` document with embedded `<style>` declaring `.chord-block { display: inline-flex; flex-direction: column; }`. The pre-#2279 `wrapHtml` then embedded that complete document inside *another* `<!DOCTYPE>` envelope — the inner `<style>` survived only because of HTML5's nested-document recovery rules. Any environment-specific deviation in that recovery path collapsed `.chord-block` back to default inline flow and the lyrics baseline drifted.

The CI workflow change closes the second hole: `npm pack @chordsketch/wasm@latest` left a publish-lag window where `preview.ts` could import an export that existed in `crates/wasm/src/lib.rs` on the current commit but had not yet been npm-published — esbuild bundled the missing reference silently and the runtime failure was invisible to PR CI.

## Why not full `mountChordSketchUi` migration

The architectural goal in #2279 is to consolidate every preview host onto `@chordsketch/ui-web`'s `mountChordSketchUi`. That is a deeper change than the bug fix requires: the VS Code preview's toolbar (HTML/Text toggle, ±-only transpose, no splitter, `vscode.setState` persistence, `vscode.postMessage` channel) does not match the playground/desktop layout that `mountChordSketchUi` builds. Forcing alignment would regress UX in the preview pane.

Step 2 here ships the **bug fix** by consuming the same body-only export that the eventual `mountChordSketchUi`-based migration will use. The full sister-site consolidation stays open under #2279 once `@chordsketch/ui-web` grows the host-injection points compatible with VS Code's WebView contract.

## Test plan

- [x] `npm run lint` (vscode-extension) — clean
- [x] `npm test` (vscode-extension) — 56 passed
- [x] `npm run build` (vscode-extension) — clean; `dist/webview/preview.js` contains 6 references to the new exports
- [x] `node packages/npm/scripts/build.mjs` — produces both `web/` and `node/` builds with the new exports
- [ ] CI: `vscode-extension.yml` build + publish jobs against this PR
- [ ] Extension-host integration tests (`@vscode/test-cli`)

Closes #2279.