### PR TITLE
refactor(react): drop unknown bridge cast in chord-diagram loader

### DIFF
--- a/packages/react/src/use-chord-diagram.ts
+++ b/packages/react/src/use-chord-diagram.ts
@@ -54,15 +54,8 @@ export interface ChordDiagramResult {
  */
 export type ChordDiagramWasmLoader = () => Promise<DiagramRenderer>;
 
-// The `chord_diagram_svg` export is added by a Rust-side change
-// paired with this PR (`crates/wasm/src/lib.rs`). The installed
-// `@chordsketch/wasm` package's type declarations do not include
-// it until the next `npm publish`; cast through `unknown` so
-// `tsc --noEmit` does not fail against a stale `.d.ts` in
-// `node_modules`. Replace with a direct cast once the WASM
-// package ships a release that includes the new export.
 const defaultLoader: ChordDiagramWasmLoader = () =>
-  import('@chordsketch/wasm') as unknown as Promise<DiagramRenderer>;
+  import('@chordsketch/wasm') as Promise<DiagramRenderer>;
 
 /**
  * Look up an SVG chord diagram for `(chord, instrument)` via


### PR DESCRIPTION
## What

Replaces the temporary `import('@chordsketch/wasm') as unknown as Promise<DiagramRenderer>` bridge with a direct `as Promise<DiagramRenderer>` cast and removes the accompanying explainer comment.

## Why

The bridge was added in #2164 because `chord_diagram_svg` had landed in `crates/wasm/src/lib.rs` but had not yet been npm-published; `tsc --noEmit` against the stale `node_modules` `.d.ts` would fail without the `unknown` step. `@chordsketch/wasm@0.3.0` is now on the registry and ships `chord_diagram_svg` in its declarations:

```ts
export function chord_diagram_svg(chord: string, instrument: string): string | undefined;
```

`packages/react/package.json` already pins `@chordsketch/wasm` at `^0.3.0`, so the cast can collapse to a single direct cast without a version bump.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 67 tests passed (6 files)

Closes #2166