### PR TITLE
feat(linux): standalone GNOME thumbnailer for .cho files (part of #861)

### DIFF
--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -1,0 +1,100 @@
+<!-- markdownlint-disable MD041 -->
+# Linux file-manager integration
+
+Standalone thumbnailer for ChordPro source files. Once installed, GNOME
+Files (Nautilus), Nemo, Caja, Thunar, and any other XDG-compliant file
+manager will render `.cho` / `.chopro` / `.crd` / `.chordpro` thumbnails
+in place of the generic text-document icon. KDE Dolphin uses a separate
+KIO-previewer mechanism not covered here.
+
+## What this directory contains
+
+| File | Purpose |
+|---|---|
+| `chordsketch-mime.xml` | XDG MIME-type definition for `text/x-chordpro` so the four supported extensions resolve to the right type. |
+| `chordsketch.thumbnailer` | XDG thumbnailer entry pointing at the script below; bound to `MimeType=text/x-chordpro;`. |
+| `chordsketch-thumbnailer` | POSIX `sh` script that takes `(input, output, size)` and writes a PNG. Renders the source via `chordsketch -f pdf`, then rasterises with `pdftoppm`. |
+
+## Dependencies
+
+- `chordsketch` — the CLI (any install path: cargo, snap, AUR, Homebrew Cask, etc.)
+- `pdftoppm` — `poppler-utils` package on Debian / Ubuntu / Arch / Fedora
+
+PDF → PNG via `pdftoppm` is preferred over an HTML → PNG path because the
+in-process Rust PDF renderer keeps the chord-over-lyrics typography
+identical to the editor preview, without pulling in a headless browser
+or rendering toolkit.
+
+## System-wide install
+
+```bash
+# 1. MIME type
+sudo install -Dm644 chordsketch-mime.xml \
+  /usr/share/mime/packages/chordsketch-chordpro.xml
+sudo update-mime-database /usr/share/mime
+
+# 2. Thumbnailer entry + script
+sudo install -Dm644 chordsketch.thumbnailer \
+  /usr/share/thumbnailers/chordsketch.thumbnailer
+sudo install -Dm755 chordsketch-thumbnailer \
+  /usr/local/bin/chordsketch-thumbnailer
+
+# 3. Drop existing thumbnail cache so file managers rebuild
+rm -rf "$HOME/.cache/thumbnails"
+```
+
+## Per-user install (no sudo)
+
+```bash
+install -Dm644 chordsketch-mime.xml \
+  "$HOME/.local/share/mime/packages/chordsketch-chordpro.xml"
+update-mime-database "$HOME/.local/share/mime"
+
+install -Dm644 chordsketch.thumbnailer \
+  "$HOME/.local/share/thumbnailers/chordsketch.thumbnailer"
+install -Dm755 chordsketch-thumbnailer \
+  "$HOME/.local/bin/chordsketch-thumbnailer"
+
+# Make sure ~/.local/bin is in PATH so the file manager can find the
+# script via the `TryExec=chordsketch-thumbnailer` line.
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
+rm -rf "$HOME/.cache/thumbnails"
+```
+
+## Verifying the install
+
+```bash
+# Render a sample to make sure the chain works end to end.
+chordsketch-thumbnailer /path/to/song.cho /tmp/sample-thumb.png 256
+file /tmp/sample-thumb.png   # → PNG image data, ~180 x 256
+```
+
+If the file manager still shows the generic text icon after install:
+
+1. Confirm the MIME type resolved: `xdg-mime query filetype song.cho`
+   should print `text/x-chordpro` (not `text/plain`).
+2. Confirm the thumbnailer is registered: `ls
+   ~/.local/share/thumbnailers/ /usr/share/thumbnailers/` should list
+   `chordsketch.thumbnailer`.
+3. Force the file manager to rebuild thumbnails: log out, drop
+   `~/.cache/thumbnails/`, log back in.
+
+## Why these are not bundled in the Tauri desktop app
+
+The macOS Quick Look Extension and the Windows Preview Handler in #861
+are bundled inside the Tauri desktop app's signed installer because
+both platforms require them to live inside (or alongside) a
+code-signed parent bundle to load. Linux has no equivalent constraint
+— a `.thumbnailer` file pointing at any binary on the user's `$PATH`
+is enough — so shipping these as a small standalone bundle reaches
+the larger Linux audience that installs ChordSketch only as a CLI
+(via `cargo install`, snap, AUR, or Nix) without pulling in the full
+Tauri desktop bundle.
+
+The snap / flatpak / AUR / .deb packages can include these three files
+in their post-install hooks. Tracking issues for those package-side
+integrations live under #1603 (distribution channel coverage).

--- a/packaging/linux/chordsketch-mime.xml
+++ b/packaging/linux/chordsketch-mime.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  XDG MIME-type definition for ChordPro source files.
+
+  Registered with `update-mime-database` against the system or per-user
+  MIME database (see `packaging/linux/README.md`). Without this file,
+  GNOME / KDE / XFCE / MATE file managers report `.cho` files as
+  `text/plain` and the `chordsketch.thumbnailer` MimeType match never
+  fires.
+
+  The four globs cover the file extensions the ChordPro reference
+  implementation accepts. `<sub-class-of type="text/plain"/>` lets text
+  editors that filter by `text/plain` (most of them) still open `.cho`
+  files via the "Open with..." menu without an explicit `text/x-chordpro`
+  association.
+-->
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/x-chordpro">
+    <comment>ChordPro sheet music</comment>
+    <comment xml:lang="ja">ChordPro 楽譜</comment>
+    <glob pattern="*.cho"/>
+    <glob pattern="*.chopro"/>
+    <glob pattern="*.crd"/>
+    <glob pattern="*.chordpro"/>
+    <sub-class-of type="text/plain"/>
+  </mime-type>
+</mime-info>

--- a/packaging/linux/chordsketch-thumbnailer
+++ b/packaging/linux/chordsketch-thumbnailer
@@ -16,23 +16,35 @@
 # renderer is in-process Rust (no headless browser dependency) and
 # keeps the chord-over-lyrics layout pixel-stable across distros.
 #
-# Soft dependencies (declared in `chordsketch-thumbnailer-deps` of the
-# accompanying `README.md`):
+# Soft dependencies (see the "Dependencies" section of the accompanying
+# `README.md`):
 #   - `chordsketch` — installed by the `chordsketch` package itself
 #   - `pdftoppm`    — `poppler-utils` package on Debian/Ubuntu/Arch/Fedora
 
 set -eu
 
+[ $# -eq 3 ] || { printf 'Usage: %s <input> <output> <size>\n' "$0" >&2; exit 1; }
+
 input=$1
 output=$2
 size=$3
+
+# Validate size is a positive integer before it reaches pdftoppm.
+case "$size" in
+    *[!0-9]*|'') printf 'Error: size must be a positive integer, got: %s\n' "$size" >&2; exit 1 ;;
+    0)           printf 'Error: size must be a positive integer (>0), got: 0\n' >&2; exit 1 ;;
+esac
 
 # Strip a leading `file://` if the file manager handed us a URI rather
 # than a path. The `%i` placeholder in `chordsketch.thumbnailer` is
 # documented as a path, but some managers substitute the URI form
 # regardless; accepting both keeps the contract robust against that.
+#
+# Handle both empty-authority (`file:///path`) and localhost-authority
+# (`file://localhost/path`) forms as specified by RFC 8089.
 case "$input" in
-    file://*) input=${input#file://} ;;
+    file:///*) input=${input#file://} ;;
+    file://localhost/*) input=${input#file://localhost} ;;
 esac
 
 # Working directory for the intermediate PDF. `mktemp -d` creates with

--- a/packaging/linux/chordsketch-thumbnailer
+++ b/packaging/linux/chordsketch-thumbnailer
@@ -1,0 +1,60 @@
+#!/bin/sh
+# XDG thumbnailer for ChordPro (.cho / .chopro / .crd / .chordpro) files.
+#
+# Wired in by `chordsketch.thumbnailer`, which the file manager (Files,
+# Nautilus, Nemo, Caja, Thunar, ...) reads from
+# `/usr/share/thumbnailers/` or `~/.local/share/thumbnailers/`. The
+# manager invokes this script with three arguments:
+#
+#   $1  Input file path     (the `.cho` source)
+#   $2  Output PNG path     (where to write the thumbnail)
+#   $3  Requested size      (longest edge in pixels)
+#
+# We render the source to PDF via `chordsketch -f pdf`, then rasterise
+# the first page with `pdftoppm` (poppler-utils) at the requested
+# pixel size. PDF → PNG is preferred over HTML → PNG because the PDF
+# renderer is in-process Rust (no headless browser dependency) and
+# keeps the chord-over-lyrics layout pixel-stable across distros.
+#
+# Soft dependencies (declared in `chordsketch-thumbnailer-deps` of the
+# accompanying `README.md`):
+#   - `chordsketch` — installed by the `chordsketch` package itself
+#   - `pdftoppm`    — `poppler-utils` package on Debian/Ubuntu/Arch/Fedora
+
+set -eu
+
+input=$1
+output=$2
+size=$3
+
+# Strip a leading `file://` if the file manager handed us a URI rather
+# than a path. The `%i` placeholder in `chordsketch.thumbnailer` is
+# documented as a path, but some managers substitute the URI form
+# regardless; accepting both keeps the contract robust against that.
+case "$input" in
+    file://*) input=${input#file://} ;;
+esac
+
+# Working directory for the intermediate PDF. `mktemp -d` creates with
+# mode 0700 so even on a multi-user host the temp file is not
+# world-readable while the render runs.
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+pdf=$tmpdir/page.pdf
+
+# Discard renderer warnings on stderr so a transpose-clamp warning
+# does not appear in the file manager's log when the user just hovers
+# over a `.cho` to preview it. Render errors still propagate via the
+# non-zero exit status (`set -e` above).
+chordsketch -f pdf -o "$pdf" -- "$input" 2>/dev/null
+
+# `-singlefile` writes `${prefix}.png` instead of the default
+# `${prefix}-1.png`, so we know exactly what filename to move. `-r 96`
+# keeps the rendered DPI close to the playground/preview baseline so
+# typography matches the on-screen render the user sees in the editor.
+# `-scale-to` enforces the longest edge equal to the requested
+# thumbnail size.
+pdftoppm -png -singlefile -r 96 -scale-to "$size" "$pdf" "$tmpdir/out"
+
+mv "$tmpdir/out.png" "$output"

--- a/packaging/linux/chordsketch.thumbnailer
+++ b/packaging/linux/chordsketch.thumbnailer
@@ -1,0 +1,4 @@
+[Thumbnailer Entry]
+TryExec=chordsketch-thumbnailer
+Exec=chordsketch-thumbnailer %i %o %s
+MimeType=text/x-chordpro;


### PR DESCRIPTION
## What

In-tree assets for XDG-compliant Linux file managers so \`.cho\` / \`.chopro\` / \`.crd\` / \`.chordpro\` files show chord-over-lyrics thumbnails instead of the generic text icon.

| File | Purpose |
|---|---|
| \`packaging/linux/chordsketch-mime.xml\` | XDG MIME-type definition for \`text/x-chordpro\` (sub-class of \`text/plain\`). |
| \`packaging/linux/chordsketch.thumbnailer\` | Thumbnailer entry binding \`text/x-chordpro\` → \`chordsketch-thumbnailer %i %o %s\`. |
| \`packaging/linux/chordsketch-thumbnailer\` | POSIX \`sh\` script: render via \`chordsketch -f pdf\` then \`pdftoppm -png -singlefile -scale-to \$size\`. |
| \`packaging/linux/README.md\` | System-wide / per-user install instructions and the Tauri-embedding rationale for the macOS / Windows siblings. |

## Why standalone (not Tauri-embedded)

Linux has no equivalent of macOS's \`.appex\` host-bundle requirement or Windows's MSI-driven COM registration; a \`.thumbnailer\` pointing at any binary on \`\$PATH\` is enough. CLI-only users (cargo / snap / AUR / Nix) — the larger Linux audience — therefore get thumbnails without pulling in the full Tauri desktop bundle.

The macOS Quick Look Extension and the Windows Preview Handler must ride inside their platforms' signed parent containers; those are now their own tracked sub-issues:

- **#2288** macOS Quick Look Extension (Tauri-embedded, blocked on #2075 signing).
- **#2289** Windows Preview Handler (Tauri-embedded, can ship unsigned).

## Test plan (executed locally)

PDF → PNG via poppler-utils, three viewport sizes + URI form + missing-CLI fallback:

\`\`\`
\$ chordsketch-thumbnailer fixtures/define-display-transposed/input.cho /tmp/out.png 256
\$ file /tmp/out.png
/tmp/out.png: PNG image data, 181 x 256, 8-bit/color RGB, non-interlaced
\`\`\`

| Case | Result |
|---|---|
| size=128 path input | 91 × 128 PNG ✓ |
| size=256 path input | 181 × 256 PNG ✓ |
| size=512 path input | 362 × 512 PNG ✓ |
| size=128 \`file://\` URI input | 91 × 128 PNG ✓ |
| Missing \`chordsketch\` on \`\$PATH\` | exit 127, no PNG written (file manager falls back gracefully) |

## Deferred

- snap / flatpak / AUR / .deb post-install hooks shipping these three files automatically — tracked under #1603.
- KDE Dolphin support (separate KIO-previewer mechanism, not the XDG \`.thumbnailer\` spec).

Part of #861.