### PR TITLE
feat(chordpro): add settings.strict and missing-{key} warning (#2292)

### DIFF
--- a/crates/chordpro/src/config.rs
+++ b/crates/chordpro/src/config.rs
@@ -814,7 +814,13 @@ const DEFAULT_CONFIG: &str = r#"{
         columns: 1,
         suppress_empty_chords: true,
         lyrics_only: false,
-        transpose: 0
+        transpose: 0,
+        // Strict mode. When true, render-time validators (currently the
+        // missing-{key} check, see render_result::validate_strict_key) emit
+        // warnings for spec violations that are otherwise silent. Default is
+        // false, matching ChordPro R6.100.0 (which flipped its own default
+        // from true to false in the same release).
+        strict: false
     },
 
     // PDF rendering

--- a/crates/chordpro/src/config.rs
+++ b/crates/chordpro/src/config.rs
@@ -1043,6 +1043,7 @@ mod tests {
         let config = Config::defaults();
         assert_eq!(config.get_path("settings.columns"), &Value::Number(1.0));
         assert_eq!(config.get_path("settings.transpose"), &Value::Number(0.0));
+        assert_eq!(config.get_path("settings.strict"), &Value::Bool(false));
     }
 
     #[test]

--- a/crates/chordpro/src/render_result.rs
+++ b/crates/chordpro/src/render_result.rs
@@ -6,6 +6,7 @@
 //! three maintenance points for the same logic (issue #1874).
 
 use crate::ast::{CapoValidation, Metadata};
+use crate::config::Config;
 
 /// Maximum number of warnings any renderer accumulates for a single
 /// render pass (issue #1833). Without a cap, a pathological input such
@@ -56,6 +57,26 @@ pub fn validate_capo(metadata: &Metadata, warnings: &mut Vec<String>) {
                 format!("{{capo}} value {raw:?} is not a valid integer; ignored"),
             );
         }
+    }
+}
+
+/// Validate strict-mode requirements at the render boundary and push a
+/// warning when `settings.strict` is true and the song does not declare a
+/// `{key}` directive (ChordPro R6.100.0).
+///
+/// Renderers call this helper alongside [`validate_capo`] so the warning
+/// message is byte-identical across output formats — a user who pipes the
+/// same `.cho` file to text, HTML, and PDF sees the same warning regardless
+/// of which renderer they chose.
+pub fn validate_strict_key(metadata: &Metadata, config: &Config, warnings: &mut Vec<String>) {
+    if config.get_path("settings.strict").as_bool() != Some(true) {
+        return;
+    }
+    if metadata.key.is_none() {
+        push_warning(
+            warnings,
+            "song does not declare a {key} directive (settings.strict)",
+        );
     }
 }
 
@@ -185,5 +206,52 @@ mod tests {
         validate_capo(&md, &mut v);
         assert_eq!(v.len(), 1);
         assert!(v[0].contains("foo") && v[0].contains("not a valid integer"));
+    }
+
+    // -- validate_strict_key (R6.100.0) -----------------------------------
+
+    fn config_with_strict(strict: bool) -> Config {
+        Config::defaults()
+            .with_define(&format!("settings.strict={strict}"))
+            .expect("defining settings.strict must succeed")
+    }
+
+    #[test]
+    fn test_validate_strict_key_default_off_emits_nothing() {
+        let mut v = Vec::<String>::new();
+        let md = Metadata::default();
+        validate_strict_key(&md, &Config::defaults(), &mut v);
+        assert!(
+            v.is_empty(),
+            "default config has settings.strict=false; no warning expected"
+        );
+    }
+
+    #[test]
+    fn test_validate_strict_key_strict_off_with_missing_key_emits_nothing() {
+        let mut v = Vec::<String>::new();
+        let md = Metadata::default();
+        validate_strict_key(&md, &config_with_strict(false), &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_validate_strict_key_strict_on_with_missing_key_warns() {
+        let mut v = Vec::<String>::new();
+        let md = Metadata::default();
+        validate_strict_key(&md, &config_with_strict(true), &mut v);
+        assert_eq!(v.len(), 1);
+        assert!(v[0].contains("{key}") && v[0].contains("settings.strict"));
+    }
+
+    #[test]
+    fn test_validate_strict_key_strict_on_with_present_key_emits_nothing() {
+        let mut v = Vec::<String>::new();
+        let md = Metadata {
+            key: Some("C".to_string()),
+            ..Metadata::default()
+        };
+        validate_strict_key(&md, &config_with_strict(true), &mut v);
+        assert!(v.is_empty());
     }
 }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -26,7 +26,9 @@ use chordsketch_chordpro::canonical_chord_name;
 use chordsketch_chordpro::config::Config;
 use chordsketch_chordpro::escape::escape_xml as escape;
 use chordsketch_chordpro::inline_markup::{SpanAttributes, TextSpan};
-use chordsketch_chordpro::render_result::{RenderResult, push_warning, validate_capo};
+use chordsketch_chordpro::render_result::{
+    RenderResult, push_warning, validate_capo, validate_strict_key,
+};
 use chordsketch_chordpro::resolve_diagrams_instrument;
 use chordsketch_chordpro::transpose::transpose_chord;
 
@@ -235,6 +237,7 @@ fn render_song_body_into(
     html.push_str("<div class=\"song\">\n");
 
     validate_capo(&song.metadata, warnings);
+    validate_strict_key(&song.metadata, config, warnings);
     render_metadata(&song.metadata, html);
 
     // Tracks whether a multi-column div is currently open.
@@ -3022,6 +3025,56 @@ Verse text\n\
         assert!(
             !result.warnings.iter().any(|w| w.contains("capo")),
             "valid {{capo: 5}} should not warn; got {:?}",
+            result.warnings
+        );
+    }
+
+    // -- settings.strict missing-{key} warning (R6.100.0, #2291) ----------
+
+    #[test]
+    fn test_strict_off_with_missing_key_is_silent() {
+        let song = chordsketch_chordpro::parse("{title: T}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("settings.strict")),
+            "default settings.strict=false must not warn on missing {{key}}; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_strict_on_with_missing_key_warns() {
+        let song = chordsketch_chordpro::parse("{title: T}").unwrap();
+        let cfg = Config::defaults()
+            .with_define("settings.strict=true")
+            .unwrap();
+        let result = render_song_with_warnings(&song, 0, &cfg);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("{key}") && w.contains("settings.strict")),
+            "expected missing-{{key}} warning under settings.strict; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_strict_on_with_present_key_is_silent() {
+        let song = chordsketch_chordpro::parse("{title: T}\n{key: G}").unwrap();
+        let cfg = Config::defaults()
+            .with_define("settings.strict=true")
+            .unwrap();
+        let result = render_song_with_warnings(&song, 0, &cfg);
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("settings.strict")),
+            "settings.strict warning must not fire when {{key}} is present; got {:?}",
             result.warnings
         );
     }

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -17,7 +17,9 @@ use chordsketch_chordpro::canonical_chord_name;
 use chordsketch_chordpro::config::Config;
 use chordsketch_chordpro::inline_markup::TextSpan;
 use chordsketch_chordpro::notation::NotationKind;
-use chordsketch_chordpro::render_result::{RenderResult, push_warning, validate_capo};
+use chordsketch_chordpro::render_result::{
+    RenderResult, push_warning, validate_capo, validate_strict_key,
+};
 use chordsketch_chordpro::resolve_diagrams_instrument;
 use chordsketch_chordpro::transpose::transpose_chord;
 
@@ -677,6 +679,7 @@ fn render_song_into_doc(
     );
 
     validate_capo(&song.metadata, warnings);
+    validate_strict_key(&song.metadata, config, warnings);
 
     // Title
     if let Some(title) = &song.metadata.title {
@@ -5291,6 +5294,56 @@ mod jpeg_tests {
         assert!(
             !result.warnings.iter().any(|w| w.contains("capo")),
             "valid {{capo: 5}} should not warn; got {:?}",
+            result.warnings
+        );
+    }
+
+    // -- settings.strict missing-{key} warning (R6.100.0, #2291) ----------
+
+    #[test]
+    fn test_strict_off_with_missing_key_is_silent() {
+        let song = chordsketch_chordpro::parse("{title: T}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("settings.strict")),
+            "default settings.strict=false must not warn on missing {{key}}; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_strict_on_with_missing_key_warns() {
+        let song = chordsketch_chordpro::parse("{title: T}").unwrap();
+        let cfg = Config::defaults()
+            .with_define("settings.strict=true")
+            .unwrap();
+        let result = render_song_with_warnings(&song, 0, &cfg);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("{key}") && w.contains("settings.strict")),
+            "expected missing-{{key}} warning under settings.strict; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_strict_on_with_present_key_is_silent() {
+        let song = chordsketch_chordpro::parse("{title: T}\n{key: G}").unwrap();
+        let cfg = Config::defaults()
+            .with_define("settings.strict=true")
+            .unwrap();
+        let result = render_song_with_warnings(&song, 0, &cfg);
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("settings.strict")),
+            "settings.strict warning must not fire when {{key}} is present; got {:?}",
             result.warnings
         );
     }

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -6,7 +6,9 @@
 use chordsketch_chordpro::ast::{CommentStyle, DirectiveKind, Line, LyricsLine, Song};
 use chordsketch_chordpro::config::Config;
 use chordsketch_chordpro::notation::NotationKind;
-use chordsketch_chordpro::render_result::{RenderResult, push_warning, validate_capo};
+use chordsketch_chordpro::render_result::{
+    RenderResult, push_warning, validate_capo, validate_strict_key,
+};
 use chordsketch_chordpro::resolve_diagrams_instrument;
 use chordsketch_chordpro::transpose::transpose_chord;
 use unicode_width::UnicodeWidthStr;
@@ -127,6 +129,7 @@ fn render_song_impl(
     let mut auto_diagrams_instrument: Option<String> = None;
 
     validate_capo(&song.metadata, warnings);
+    validate_strict_key(&song.metadata, _config, warnings);
     render_metadata(&song.metadata, &mut output);
 
     for line in &song.lines {
@@ -1585,6 +1588,56 @@ mod delegate_tests {
         assert!(
             !result.warnings.iter().any(|w| w.contains("capo")),
             "valid {{capo: 5}} should not warn; got {:?}",
+            result.warnings
+        );
+    }
+
+    // -- settings.strict missing-{key} warning (R6.100.0, #2291) ----------
+
+    #[test]
+    fn test_strict_off_with_missing_key_is_silent() {
+        let song = chordsketch_chordpro::parse("{title: T}").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("settings.strict")),
+            "default settings.strict=false must not warn on missing {{key}}; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_strict_on_with_missing_key_warns() {
+        let song = chordsketch_chordpro::parse("{title: T}").unwrap();
+        let cfg = Config::defaults()
+            .with_define("settings.strict=true")
+            .unwrap();
+        let result = render_song_with_warnings(&song, 0, &cfg);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("{key}") && w.contains("settings.strict")),
+            "expected missing-{{key}} warning under settings.strict; got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_strict_on_with_present_key_is_silent() {
+        let song = chordsketch_chordpro::parse("{title: T}\n{key: G}").unwrap();
+        let cfg = Config::defaults()
+            .with_define("settings.strict=true")
+            .unwrap();
+        let result = render_song_with_warnings(&song, 0, &cfg);
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("settings.strict")),
+            "settings.strict warning must not fire when {{key}} is present; got {:?}",
             result.warnings
         );
     }

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -83,9 +83,9 @@ fn render_song_impl(
     warnings: &mut Vec<String>,
 ) -> String {
     // Apply song-level config overrides ({+config.KEY: VALUE} directives).
-    // The effective config is not yet consumed by the text renderer but is
-    // computed here for consistency with the HTML and PDF renderers, and will
-    // be used when text-specific config settings are added.
+    // The effective config is used for diagram instrument selection and
+    // strict-mode validation (validate_strict_key), consistent with the
+    // HTML and PDF renderers.
     let song_overrides = song.config_overrides();
     let song_config;
     let _config = if song_overrides.is_empty() {


### PR DESCRIPTION
## What

Add the `settings.strict` config knob (default `false`) introduced by ChordPro upstream R6.100.0, plus a new render-time validator that warns when a song does not declare a `{key}` directive while strict mode is enabled.

* `crates/chordpro/src/config.rs` — extend the `settings` block in `DEFAULT_CONFIG` with `strict: false` (matches the new upstream default).
* `crates/chordpro/src/render_result.rs` — introduce `validate_strict_key(metadata, config, warnings)`, sitting next to `validate_capo` so every renderer consumes one source of truth and emits a byte-identical warning.
* `crates/render-{text,html,pdf}/src/lib.rs` — call the helper at the same point each renderer already calls `validate_capo` (sister-site parity per `.claude/rules/renderer-parity.md`).

## Why

ChordPro R6.100.0 release notes:
> * With `setting.strict`: Issue a warning when a song does not have a valid key (e.g., is missing a `{key}` directive).
> * Change default for `settings.strict` to false.

chordsketch had no `settings.strict` knob at all. Adding it with default `false` matches the new upstream default while opting users in to the warning only when they explicitly set `settings.strict=true` (via `chordsketch --define settings.strict=true …` or a config file / song-level override).

This is sub-issue **#2292** of the R6.100.0 tracking umbrella **#2291**.

## Test plan

- [x] `cargo test --workspace` — all suites green (4 new helper tests in `render_result`, 3 new wiring tests per renderer × 3 renderers = 9 cross-format parity tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

### Sister-site audit (`.claude/rules/fix-propagation.md`)

The new validator is a sister-site change across the **renderer** group. All three renderers received the call in the same place and the same wiring tests; the helper itself lives in the shared `chordsketch_chordpro::render_result` module so the warning text cannot drift across formats.

## Deferred

None.

Closes #2292
Part of #2291