### PR TITLE
fix(render-pdf): adjacent-dedup ToC entries (#2294)

### DIFF
--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -537,6 +537,22 @@ pub fn render_songs_with_transpose(songs: &[Song], cli_transpose: i8, config: &C
     result.output
 }
 
+/// Push a `(title, page)` tuple into the ToC entry list, skipping the
+/// candidate when it equals the previous entry (adjacent-only dedup).
+///
+/// Mirrors upstream ChordPro `(PDF) Dedup lines in tables of contents
+/// and outlines.` (commit `55398859`, R6.100.0). The Perl implementation
+/// guards `push @{ $song->{body} }, { ... }` with
+/// `unless %prev && $prev{title} eq $title && $prev{pageno} eq $pageno`,
+/// where `%prev` only retains the immediately preceding entry — so a
+/// non-adjacent repeat is intentionally NOT deduped.
+fn push_toc_entry(entries: &mut Vec<(String, usize)>, title: String, page: usize) {
+    let candidate = (title, page);
+    if entries.last() != Some(&candidate) {
+        entries.push(candidate);
+    }
+}
+
 /// Render multiple [`Song`]s into a single PDF, returning warnings programmatically.
 ///
 /// This is the structured variant of [`render_songs_with_transpose`]. Instead
@@ -586,7 +602,7 @@ pub fn render_songs_with_warnings(
             .as_deref()
             .unwrap_or("Untitled")
             .to_string();
-        toc_entries.push((title, start_page));
+        push_toc_entry(&mut toc_entries, title, start_page);
         render_song_into_doc(
             song,
             cli_transpose,
@@ -4774,6 +4790,60 @@ mod toc_tests {
         assert!(bytes.ends_with(b"%%EOF\n"));
         let content = String::from_utf8_lossy(&bytes);
         assert!(content.contains("Table of Contents"));
+    }
+
+    // -- adjacent dedup (R6.100.0, upstream commit 55398859, #2294) -------
+
+    #[test]
+    fn test_push_toc_entry_skips_adjacent_duplicate() {
+        let mut entries = vec![("Song A".to_string(), 1)];
+        push_toc_entry(&mut entries, "Song A".to_string(), 1);
+        assert_eq!(entries, vec![("Song A".to_string(), 1)]);
+    }
+
+    #[test]
+    fn test_push_toc_entry_keeps_different_page() {
+        let mut entries = vec![("Song A".to_string(), 1)];
+        push_toc_entry(&mut entries, "Song A".to_string(), 2);
+        assert_eq!(
+            entries,
+            vec![("Song A".to_string(), 1), ("Song A".to_string(), 2)]
+        );
+    }
+
+    #[test]
+    fn test_push_toc_entry_keeps_different_title() {
+        let mut entries = vec![("Song A".to_string(), 1)];
+        push_toc_entry(&mut entries, "Song B".to_string(), 1);
+        assert_eq!(
+            entries,
+            vec![("Song A".to_string(), 1), ("Song B".to_string(), 1)]
+        );
+    }
+
+    #[test]
+    fn test_push_toc_entry_dedup_is_adjacent_only() {
+        // Upstream uses `%prev = ()` reset on section breaks and only stores
+        // the immediately preceding entry. Non-adjacent repeats MUST NOT be
+        // deduped.
+        let mut entries = vec![("Song A".to_string(), 1), ("Song B".to_string(), 2)];
+        push_toc_entry(&mut entries, "Song A".to_string(), 1);
+        assert_eq!(
+            entries,
+            vec![
+                ("Song A".to_string(), 1),
+                ("Song B".to_string(), 2),
+                ("Song A".to_string(), 1),
+            ],
+            "adjacent-only dedup must keep non-adjacent repeats"
+        );
+    }
+
+    #[test]
+    fn test_push_toc_entry_into_empty() {
+        let mut entries: Vec<(String, usize)> = Vec::new();
+        push_toc_entry(&mut entries, "Song A".to_string(), 1);
+        assert_eq!(entries, vec![("Song A".to_string(), 1)]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Mirror upstream R6.100.0's `(PDF) Dedup lines in tables of contents and outlines.` fix (commit [`55398859`](https://github.com/ChordPro/chordpro/commit/55398859)) for `chordsketch-render-pdf`.

The upstream Perl guard:
```perl
push( @{ $song->{body} }, { type => "tocline", title => $title, pageno => $pageno, ... } )
  unless %prev && $prev{title} eq $title && $prev{pageno} eq $pageno;
```
`%prev` retains only the immediately preceding entry — **adjacent-only**, not a global set. Non-adjacent repeats are intentionally NOT deduped.

This PR introduces `push_toc_entry(entries, title, page)` in `crates/render-pdf/src/lib.rs`, applying the same adjacent-only rule to `Vec<(String, usize)>`. The bare `toc_entries.push(...)` call in the body loop is replaced by the helper.

## Why

Sub-issue **#2294** of the R6.100.0 tracking umbrella **#2291**. The dedup is structurally a no-op in the current single-loop body that calls `body_doc.new_page()` between songs, but matching upstream behaviour stabilises the renderer against future code paths (multi-song-per-page or section-break ToC).

Outline parity is N/A: chordsketch does not generate PDF outlines.

## Test plan

- [x] Five new unit tests in `toc_tests`: adjacent-skip, different-page, different-title, **non-adjacent repeat is kept** (the defining property of adjacent-only), push-into-empty.
- [x] `cargo test --workspace` — all suites green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

### Sister-site audit (`.claude/rules/fix-propagation.md`)

The renderer-group sister sites (`render-text`, `render-html`) do not generate ToC output today, so no parallel change is needed. If a ToC is ever added to those renderers, the `push_toc_entry` helper should be lifted to a shared crate (`render_result.rs` or similar) per the same precedent as `validate_capo` / `validate_strict_key`.

## Deferred

None.

Closes #2294
Part of #2291