### PR TITLE
feat(render-html): add settings.wraplines (#2296)

### DIFF
--- a/crates/chordpro/src/config.rs
+++ b/crates/chordpro/src/config.rs
@@ -820,7 +820,15 @@ const DEFAULT_CONFIG: &str = r#"{
         // warnings for spec violations that are otherwise silent. Default is
         // false, matching ChordPro R6.100.0 (which flipped its own default
         // from true to false in the same release).
-        strict: false
+        strict: false,
+        // HTML line wrapping. When true (default), the `.line` flex container
+        // uses `flex-wrap: wrap` so chord/lyric runs that exceed the viewport
+        // width reflow onto subsequent rows. When false, `flex-wrap: nowrap`
+        // is emitted instead, preserving the source line structure even when
+        // it overflows. Default true matches ChordPro R6.100.0. Only the HTML
+        // renderer reads this setting; render-text and render-pdf have their
+        // own width-handling logic and ignore wraplines.
+        wraplines: true
     },
 
     // PDF rendering

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -76,6 +76,12 @@ namespace chordsketch {
     /// supplying its own document envelope (#2279).
     string render_html_css();
 
+    /// Variant of `render_html_css` that honours `settings.wraplines`
+    /// from the supplied config (R6.100.0). When `wraplines` is false,
+    /// the `.line` rule emits `flex-wrap: nowrap`.
+    [Throws=ChordSketchError]
+    string render_html_css_with_config_json(string? config_json);
+
     /// Validate ChordPro input and return any parse errors as structured
     /// records. Returns an empty list if the input is valid.
     ///

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -337,6 +337,7 @@ pub fn render_html_css() -> String {
 ///
 /// Returns [`ChordSketchError::InvalidConfig`] when `config_json` cannot
 /// be parsed.
+#[must_use = "callers must handle render errors"]
 pub fn render_html_css_with_config_json(
     config_json: Option<String>,
 ) -> Result<String, ChordSketchError> {

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -341,7 +341,9 @@ pub fn render_html_css_with_config_json(
     config_json: Option<String>,
 ) -> Result<String, ChordSketchError> {
     let config = resolve_config(config_json)?;
-    Ok(chordsketch_render_html::render_html_css_with_config(&config))
+    Ok(chordsketch_render_html::render_html_css_with_config(
+        &config,
+    ))
 }
 
 /// A single validation issue reported by [`validate`].

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -325,7 +325,7 @@ pub fn parse_and_render_html_body_with_warnings(
 /// supplying its own document envelope.
 #[must_use]
 pub fn render_html_css() -> String {
-    chordsketch_render_html::render_html_css().to_string()
+    chordsketch_render_html::render_html_css()
 }
 
 /// A single validation issue reported by [`validate`].

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -328,6 +328,22 @@ pub fn render_html_css() -> String {
     chordsketch_render_html::render_html_css()
 }
 
+/// Variant of [`render_html_css`] that honours `settings.wraplines` from
+/// the supplied config (R6.100.0). When `wraplines` is false, the `.line`
+/// rule emits `flex-wrap: nowrap` so chord/lyric runs preserve the source
+/// line structure instead of reflowing onto subsequent rows.
+///
+/// # Errors
+///
+/// Returns [`ChordSketchError::InvalidConfig`] when `config_json` cannot
+/// be parsed.
+pub fn render_html_css_with_config_json(
+    config_json: Option<String>,
+) -> Result<String, ChordSketchError> {
+    let config = resolve_config(config_json)?;
+    Ok(chordsketch_render_html::render_html_css_with_config(&config))
+}
+
 /// A single validation issue reported by [`validate`].
 ///
 /// Mirrors the NAPI binding's `ValidationError` (#1990) and the UDL

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -495,7 +495,9 @@ pub fn render_html_css() -> String {
 #[napi]
 pub fn render_html_css_with_options(options: RenderOptions) -> napi::Result<String> {
     let config = resolve_config(options.config)?;
-    Ok(chordsketch_render_html::render_html_css_with_config(&config))
+    Ok(chordsketch_render_html::render_html_css_with_config(
+        &config,
+    ))
 }
 
 /// A single validation issue reported by [`validate`]. Mirrors the

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -483,7 +483,7 @@ pub fn render_html_body_with_warnings_and_options(
 #[must_use]
 #[napi]
 pub fn render_html_css() -> String {
-    chordsketch_render_html::render_html_css().to_string()
+    chordsketch_render_html::render_html_css()
 }
 
 /// A single validation issue reported by [`validate`]. Mirrors the

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -492,6 +492,7 @@ pub fn render_html_css() -> String {
 /// line structure instead of reflowing onto subsequent rows.
 ///
 /// See [`render_html_with_options`] for the `options` format.
+#[must_use = "callers must handle render errors"]
 #[napi]
 pub fn render_html_css_with_options(options: RenderOptions) -> napi::Result<String> {
     let config = resolve_config(options.config)?;

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -486,6 +486,18 @@ pub fn render_html_css() -> String {
     chordsketch_render_html::render_html_css()
 }
 
+/// Variant of [`render_html_css`] that honours `settings.wraplines` from
+/// the supplied options (R6.100.0). When `wraplines` is false, the `.line`
+/// rule emits `flex-wrap: nowrap` so chord/lyric runs preserve the source
+/// line structure instead of reflowing onto subsequent rows.
+///
+/// See [`render_html_with_options`] for the `options` format.
+#[napi]
+pub fn render_html_css_with_options(options: RenderOptions) -> napi::Result<String> {
+    let config = resolve_config(options.config)?;
+    Ok(chordsketch_render_html::render_html_css_with_config(&config))
+}
+
 /// A single validation issue reported by [`validate`]. Mirrors the
 /// `ValidationError` interface in `crates/napi/index.d.ts`; the `#[napi(object)]`
 /// attribute marshals this into a plain JS `{line, column, message}` record.

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -197,7 +197,7 @@ pub fn render_song_with_warnings(
         escape(title)
     );
     html.push_str("<style>\n");
-    html.push_str(CSS);
+    html.push_str(&css_for_wraplines(read_wraplines(config)));
     html.push_str("</style>\n</head>\n<body>\n");
     render_song_body_into(song, cli_transpose, config, &mut html, &mut warnings);
     html.push_str("</body>\n</html>\n");
@@ -705,7 +705,7 @@ pub fn render_songs_with_warnings(
         escape(title)
     );
     html.push_str("<style>\n");
-    html.push_str(CSS);
+    html.push_str(&css_for_wraplines(read_wraplines(config)));
     html.push_str("</style>\n</head>\n<body>\n");
 
     for (i, song) in songs.iter().enumerate() {
@@ -834,6 +834,11 @@ pub fn render_songs_body_with_warnings(
 /// The canonical chord-over-lyrics CSS that the full-document renderers
 /// embed inside `<style>`.
 ///
+/// Returns the default-configuration variant (`flex-wrap: wrap` on the
+/// `.line` rule, matching `settings.wraplines: true`). To obtain the CSS
+/// for a non-default `settings.wraplines`, call
+/// [`render_html_css_with_config`] instead.
+///
 /// Pair this with [`render_song_body`] / [`render_songs_body`] when the
 /// consumer is supplying its own document envelope: inline the returned
 /// string inside a `<style>` block, ship it as a separate file referenced
@@ -841,8 +846,36 @@ pub fn render_songs_body_with_warnings(
 /// stylesheet. The contract is byte-stable; consumers can hash the result
 /// for cache-busting filenames.
 #[must_use]
-pub fn render_html_css() -> &'static str {
-    CSS
+pub fn render_html_css() -> String {
+    css_for_wraplines(true)
+}
+
+/// Variant of [`render_html_css`] that honours `settings.wraplines` from
+/// the supplied config (R6.100.0). When `wraplines` is false, the `.line`
+/// rule emits `flex-wrap: nowrap` so chord/lyric runs that exceed the
+/// viewport width preserve the source line structure instead of reflowing.
+#[must_use]
+pub fn render_html_css_with_config(config: &Config) -> String {
+    css_for_wraplines(read_wraplines(config))
+}
+
+/// Read `settings.wraplines` from the config, defaulting to `true` when
+/// missing or non-boolean.
+fn read_wraplines(config: &Config) -> bool {
+    config.get_path("settings.wraplines").as_bool() != Some(false)
+}
+
+/// Build the embedded CSS string with the supplied wraplines value
+/// substituted into the `.line` rule.
+///
+/// The substitution targets a unique sentinel rather than the literal
+/// `flex-wrap: wrap` so that `.chord-diagrams-grid` (which intentionally
+/// keeps its own `flex-wrap: wrap`) is not affected.
+fn css_for_wraplines(wraplines: bool) -> String {
+    CSS_TEMPLATE.replace(
+        "__LINE_FLEX_WRAP__",
+        if wraplines { "wrap" } else { "nowrap" },
+    )
 }
 
 /// Parse a ChordPro source string and render it to HTML.
@@ -876,12 +909,17 @@ pub fn render(input: &str) -> String {
 // CSS
 // ---------------------------------------------------------------------------
 
-/// Embedded CSS for chord-over-lyrics layout.
-const CSS: &str = "\
+/// Embedded CSS template for chord-over-lyrics layout.
+///
+/// The `.line` rule contains a sentinel `__LINE_FLEX_WRAP__` substituted
+/// at render time by [`css_for_wraplines`] based on `settings.wraplines`.
+/// The substitution targets the sentinel rather than the literal value so
+/// `.chord-diagrams-grid`'s own `flex-wrap: wrap` is unaffected.
+const CSS_TEMPLATE: &str = "\
 body { font-family: serif; max-width: 800px; margin: 2em auto; padding: 0 1em; }
 h1 { margin-bottom: 0.2em; }
 h2 { margin-top: 0; font-weight: normal; color: #555; }
-.line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
+.line { display: flex; flex-wrap: __LINE_FLEX_WRAP__; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-weight: bold; color: #b00; font-size: 0.9em; min-height: 1.2em; }
 .lyrics { white-space: pre; }
@@ -2211,12 +2249,80 @@ mod tests {
         assert!(css.contains(".chord-block"));
         assert!(css.contains(".chord "));
         assert!(css.contains(".lyrics"));
+        // Default config has settings.wraplines=true, so the canonical
+        // block must reference the wrap variant of the .line rule.
+        assert!(css.contains(".line { display: flex; flex-wrap: wrap;"));
         // The full-document renderer embeds *exactly* this string
         // inside its `<style>` block — assert the lockstep so a
         // future divergence is caught immediately.
         let song = chordsketch_chordpro::parse("{title: t}").unwrap();
         let full = render_song(&song);
-        assert!(full.contains(css));
+        assert!(full.contains(&css));
+    }
+
+    // -- settings.wraplines (R6.100.0, #2296) ------------------------------
+
+    #[test]
+    fn test_wraplines_default_is_wrap() {
+        // No setting → default true → wrap.
+        let css = render_html_css_with_config(&Config::defaults());
+        assert!(
+            css.contains(".line { display: flex; flex-wrap: wrap;"),
+            "default settings.wraplines must emit flex-wrap: wrap; got: {css}"
+        );
+        // The grid keeps its own wrap regardless.
+        assert!(
+            css.contains(".chord-diagrams-grid { display: flex; flex-wrap: wrap;"),
+            ".chord-diagrams-grid wrap must never be substituted"
+        );
+        // Sentinel must not survive.
+        assert!(
+            !css.contains("__LINE_FLEX_WRAP__"),
+            "the sentinel must always be replaced; got: {css}"
+        );
+    }
+
+    #[test]
+    fn test_wraplines_false_emits_nowrap() {
+        let cfg = Config::defaults()
+            .with_define("settings.wraplines=false")
+            .unwrap();
+        let css = render_html_css_with_config(&cfg);
+        assert!(
+            css.contains(".line { display: flex; flex-wrap: nowrap;"),
+            "settings.wraplines=false must emit flex-wrap: nowrap; got: {css}"
+        );
+        // .chord-diagrams-grid must keep its own wrap.
+        assert!(
+            css.contains(".chord-diagrams-grid { display: flex; flex-wrap: wrap;"),
+            ".chord-diagrams-grid wrap must NOT change with settings.wraplines"
+        );
+    }
+
+    #[test]
+    fn test_wraplines_full_document_embeds_configured_value() {
+        // The full-document renderer must embed the same CSS that
+        // render_html_css_with_config returns for the same config.
+        let cfg = Config::defaults()
+            .with_define("settings.wraplines=false")
+            .unwrap();
+        let song = chordsketch_chordpro::parse("{title: t}").unwrap();
+        let full = render_song_with_warnings(&song, 0, &cfg).output;
+        assert!(
+            full.contains(".line { display: flex; flex-wrap: nowrap;"),
+            "full document must embed nowrap when settings.wraplines=false"
+        );
+    }
+
+    #[test]
+    fn test_wraplines_true_explicit_matches_default() {
+        let cfg = Config::defaults()
+            .with_define("settings.wraplines=true")
+            .unwrap();
+        assert_eq!(
+            render_html_css_with_config(&cfg),
+            render_html_css_with_config(&Config::defaults())
+        );
     }
 
     #[test]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -373,7 +373,9 @@ pub fn render_html_css() -> String {
 pub fn render_html_css_with_options(options: JsValue) -> Result<String, JsValue> {
     let opts = deserialize_options(options)?;
     let config = resolve_config(&opts)?;
-    Ok(chordsketch_render_html::render_html_css_with_config(&config))
+    Ok(chordsketch_render_html::render_html_css_with_config(
+        &config,
+    ))
 }
 
 /// Structured render result returned by the `*_with_warnings` family.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -355,7 +355,7 @@ pub fn render_html_body_with_options(input: &str, options: JsValue) -> Result<St
 #[must_use]
 #[wasm_bindgen]
 pub fn render_html_css() -> String {
-    chordsketch_render_html::render_html_css().to_string()
+    chordsketch_render_html::render_html_css()
 }
 
 /// Structured render result returned by the `*_with_warnings` family.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -369,6 +369,7 @@ pub fn render_html_css() -> String {
 ///
 /// Returns a `JsValue` error string if the `config` option value is not a
 /// known preset and cannot be parsed as RRJSON.
+#[must_use = "callers must handle render errors"]
 #[wasm_bindgen]
 pub fn render_html_css_with_options(options: JsValue) -> Result<String, JsValue> {
     let opts = deserialize_options(options)?;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -358,6 +358,24 @@ pub fn render_html_css() -> String {
     chordsketch_render_html::render_html_css()
 }
 
+/// Variant of [`render_html_css`] that honours `settings.wraplines` from
+/// the supplied options (R6.100.0). When `wraplines` is false, the `.line`
+/// rule emits `flex-wrap: nowrap` so chord/lyric runs preserve the source
+/// line structure instead of reflowing onto subsequent rows.
+///
+/// See [`render_html_with_options`] for the `options` format.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string if the `config` option value is not a
+/// known preset and cannot be parsed as RRJSON.
+#[wasm_bindgen]
+pub fn render_html_css_with_options(options: JsValue) -> Result<String, JsValue> {
+    let opts = deserialize_options(options)?;
+    let config = resolve_config(&opts)?;
+    Ok(chordsketch_render_html::render_html_css_with_config(&config))
+}
+
 /// Structured render result returned by the `*_with_warnings` family.
 ///
 /// Serialized to a plain JS object `{ output, warnings }` where


### PR DESCRIPTION
## What

Add the `settings.wraplines` config setting introduced by ChordPro upstream R6.100.0 and gate the `.line` rule's `flex-wrap` on it. Default `true` matches upstream and preserves existing visual output.

* `crates/chordpro/src/config.rs` — add `wraplines: true` under `settings` in `DEFAULT_CONFIG`.
* `crates/render-html/src/lib.rs` — replace the static `CSS` with `CSS_TEMPLATE` containing a `__LINE_FLEX_WRAP__` sentinel. `css_for_wraplines(bool)` substitutes the sentinel; full-document renderers feed it `read_wraplines(config)`. New public `render_html_css_with_config(&Config)` exposes the variant for body-only consumers; existing `render_html_css()` returns the default-wrap variant (now `String` rather than `&'static str`). The substitution targets the sentinel, not the literal `flex-wrap: wrap`, so `.chord-diagrams-grid`'s own `flex-wrap: wrap` is unaffected.
* `crates/{wasm,ffi,napi}/src/lib.rs` — drop the now-redundant `.to_string()` on the upstream `render_html_css()` call. Binding-side return types are unchanged.

## Why

Sub-issue **#2296** of the R6.100.0 tracking umbrella **#2291**. Upstream changelog:
> * Added a new configuration setting `settings.wraplines` to control line wrapping. Enabled by default.

When `wraplines: false`, long chord/lyric runs preserve the source line structure (`flex-wrap: nowrap`) instead of reflowing onto subsequent rows — useful for embedding ChordPro output in fixed-width hosts where reflow obscures the original layout.

## Sister-site audit (`.claude/rules/fix-propagation.md`)

The renderer-group sister sites (`render-text`, `render-pdf`) have no analogous CSS layer; their width handling lives in their own column / wrap logic and ignores `wraplines` by design. The PR description, the in-source comment in `DEFAULT_CONFIG`, and the issue body all record this.

## Test plan

- [x] `cargo test --workspace` — all suites green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

Coverage: default (`flex-wrap: wrap`), explicit `false` (`nowrap`), explicit `true` matches default, full-document lockstep with the configured value, and the sentinel never leaks into output.

## Deferred

None.

Closes #2296
Part of #2291