### PR TITLE
feat(chordpro): transposable {chord: [X]} / {define: [X]} (#2302)

### DIFF
--- a/crates/chordpro/src/ast.rs
+++ b/crates/chordpro/src/ast.rs
@@ -872,7 +872,16 @@ impl ChordDefinition {
         // path in `Song.pm:define_chord` (without the `do_warn` step,
         // which requires a warnings channel that is a separate follow-up).
         if name.len() >= 2 && name.starts_with('[') && name.ends_with(']') {
-            name = name[1..name.len() - 1].to_string();
+            // strip_prefix / strip_suffix operate on char boundaries, so
+            // chord names containing multi-byte characters (e.g. ♭) round-
+            // trip correctly. Both unwraps are infallible — guarded by the
+            // starts_with / ends_with check immediately above.
+            name = name
+                .strip_prefix('[')
+                .unwrap()
+                .strip_suffix(']')
+                .unwrap()
+                .to_string();
             return Self {
                 name,
                 keys: None,

--- a/crates/chordpro/src/ast.rs
+++ b/crates/chordpro/src/ast.rs
@@ -822,6 +822,19 @@ pub struct ChordDefinition {
     pub format: Option<String>,
     /// The raw definition value (for fretted definitions not yet parsed).
     pub raw: Option<String>,
+    /// True when the directive used the `[name]` bracket form introduced
+    /// by ChordPro upstream R6.100.0.
+    ///
+    /// Bracket form marks the chord name as transposable — the directive
+    /// is rewritten alongside lyrics chords when the song is transposed.
+    /// Per upstream `lib/ChordPro/Song.pm:define_chord`, bracket form
+    /// disallows other attributes (`frets`, `fingers`, `keys`, `copy`,
+    /// `copyall`, `display`, `format`); when attributes are present
+    /// upstream emits a `do_warn("Transposable chord ... does not allow
+    /// attributes")` and drops them. chordsketch silently drops the
+    /// attributes — surfacing the warning is a follow-up that requires a
+    /// parser-internal warnings channel.
+    pub transposable: bool,
 }
 
 impl ChordDefinition {
@@ -829,6 +842,13 @@ impl ChordDefinition {
     ///
     /// Recognizes `keys`, `copy`, `copyall`, and `display` tokens.
     /// Everything else is stored in `raw` for fretted chord definitions.
+    ///
+    /// The `[name]` bracket form (R6.100.0) is detected on the first
+    /// token: if the leading word is wrapped in `[ ]`, the brackets are
+    /// stripped, [`transposable`](Self::transposable) is set to `true`,
+    /// and any remaining attributes are dropped — matching upstream
+    /// `Song.pm:define_chord` which warns and drops attributes for the
+    /// bracket form.
     #[must_use]
     pub fn parse_value(value: &str) -> Self {
         let value = value.trim();
@@ -837,13 +857,33 @@ impl ChordDefinition {
         // next() is infallible here. If value is empty or whitespace-only after
         // trim(), name will be "" — the callers check def.display/format/raw
         // before using def.name, so an empty name is a harmless no-op.
-        let name = parts
+        let mut name = parts
             .next()
             .expect("splitn always yields at least one element")
             .to_string();
         // rest is None for single-word values (no whitespace); "" is the correct
         // default (no rest tokens to process).
         let rest = parts.next().unwrap_or("").trim();
+
+        // Detect the `[name]` bracket form (R6.100.0). The bracket form
+        // disallows further attributes, so we strip the brackets, set the
+        // transposable flag, and return immediately — matching the
+        // upstream `if ( $name =~ /^\[(.*)\]$/ ) { ... %kv = (); $name = $1; $fixed = 0; }`
+        // path in `Song.pm:define_chord` (without the `do_warn` step,
+        // which requires a warnings channel that is a separate follow-up).
+        if name.len() >= 2 && name.starts_with('[') && name.ends_with(']') {
+            name = name[1..name.len() - 1].to_string();
+            return Self {
+                name,
+                keys: None,
+                copy: None,
+                copyall: None,
+                display: None,
+                format: None,
+                raw: None,
+                transposable: true,
+            };
+        }
 
         let mut def = Self {
             name,
@@ -853,6 +893,7 @@ impl ChordDefinition {
             display: None,
             format: None,
             raw: None,
+            transposable: false,
         };
 
         if rest.is_empty() {
@@ -3531,6 +3572,81 @@ mod chord_definition_tests {
     fn has_src_returns_false_for_explicit_empty_string() {
         let attrs = ImageAttributes::new("");
         assert!(!attrs.has_src());
+    }
+
+    // -- transposable [name] bracket form (R6.100.0, #2302) ---------------
+
+    #[test]
+    fn parse_value_detects_bracket_form() {
+        let def = ChordDefinition::parse_value("[A]");
+        assert_eq!(def.name, "A");
+        assert!(def.transposable);
+        assert!(def.raw.is_none());
+    }
+
+    #[test]
+    fn parse_value_bracket_form_drops_attrs() {
+        // Upstream Song.pm warns and drops attributes for the bracket
+        // form; chordsketch silently drops them (warning emission is a
+        // separate follow-up) — verify the silently-dropped behavior.
+        let def = ChordDefinition::parse_value("[A] frets 0 2 2 1 0 0");
+        assert_eq!(def.name, "A");
+        assert!(def.transposable);
+        assert!(def.raw.is_none());
+        assert!(def.keys.is_none());
+        assert!(def.copy.is_none());
+        assert!(def.copyall.is_none());
+        assert!(def.display.is_none());
+        assert!(def.format.is_none());
+    }
+
+    #[test]
+    fn parse_value_bracket_form_drops_display_and_format() {
+        let def = ChordDefinition::parse_value("[Am] display=\"X\" format=\"%{root}%{quality}\"");
+        assert_eq!(def.name, "Am");
+        assert!(def.transposable);
+        assert!(def.display.is_none());
+        assert!(def.format.is_none());
+    }
+
+    #[test]
+    fn parse_value_no_brackets_is_not_transposable() {
+        let def = ChordDefinition::parse_value("A frets 0 2 2 1 0 0");
+        assert_eq!(def.name, "A");
+        assert!(!def.transposable);
+        assert!(def.raw.is_some());
+    }
+
+    #[test]
+    fn parse_value_extension_chord_in_brackets() {
+        // The bracket form passes the inner string through verbatim;
+        // extensions and slash chords must round-trip too.
+        let def = ChordDefinition::parse_value("[A#m7]");
+        assert_eq!(def.name, "A#m7");
+        assert!(def.transposable);
+    }
+
+    #[test]
+    fn parse_value_bracket_only_no_other_token() {
+        let def = ChordDefinition::parse_value("[]");
+        assert_eq!(def.name, "");
+        assert!(def.transposable);
+    }
+
+    #[test]
+    fn parse_value_unmatched_open_bracket_is_not_transposable() {
+        // "[A" without closing bracket is NOT bracket form; falls through
+        // to normal parsing and treats `[A` as a literal name.
+        let def = ChordDefinition::parse_value("[A");
+        assert_eq!(def.name, "[A");
+        assert!(!def.transposable);
+    }
+
+    #[test]
+    fn parse_value_unmatched_close_bracket_is_not_transposable() {
+        let def = ChordDefinition::parse_value("A]");
+        assert_eq!(def.name, "A]");
+        assert!(!def.transposable);
     }
 }
 

--- a/crates/chordpro/src/transpose.rs
+++ b/crates/chordpro/src/transpose.rs
@@ -7,7 +7,9 @@
 //! Chords whose notation could not be parsed structurally (i.e., `detail` is
 //! `None`) are left unchanged — only their raw `name` is preserved.
 
-use crate::ast::{Chord, Line, LyricsLine, LyricsSegment, Song};
+use crate::ast::{
+    Chord, ChordDefinition, Directive, DirectiveKind, Line, LyricsLine, LyricsSegment, Song,
+};
 use crate::chord::{Accidental, ChordDetail, Note};
 
 /// The chromatic scale using sharps for enharmonic equivalents.
@@ -157,6 +159,10 @@ pub fn transpose(song: &Song, semitones: i8) -> Song {
         .iter()
         .map(|line| match line {
             Line::Lyrics(lyrics_line) => Line::Lyrics(transpose_lyrics(lyrics_line, semitones)),
+            Line::Directive(directive) => Line::Directive(
+                transpose_transposable_define(directive, semitones)
+                    .unwrap_or_else(|| directive.clone()),
+            ),
             other => other.clone(),
         })
         .collect();
@@ -165,6 +171,41 @@ pub fn transpose(song: &Song, semitones: i8) -> Song {
         metadata: song.metadata.clone(),
         lines: new_lines,
     }
+}
+
+/// If `directive` is a `{define: [X]}` or `{chord: [X]}` directive whose
+/// chord name was written in the transposable bracket form (R6.100.0),
+/// return a clone of the directive with the chord name shifted by
+/// `semitones`. Returns `None` for any other directive (including
+/// non-bracket / "fixed" defines), so the caller can keep the original
+/// node untouched — matching upstream `Song.pm:define_chord`'s default
+/// `$fixed = 1` path.
+///
+/// The re-emitted value preserves the bracket form: a transposable
+/// `{define: [A]}` shifted by 2 becomes `{define: [B]}`. Bracket form
+/// disallows other attributes (see [`ChordDefinition::parse_value`]), so
+/// the rewrite is just `[<new_name>]`.
+fn transpose_transposable_define(directive: &Directive, semitones: i8) -> Option<Directive> {
+    if !matches!(
+        directive.kind,
+        DirectiveKind::Define | DirectiveKind::ChordDirective
+    ) {
+        return None;
+    }
+    let value = directive.value.as_deref()?;
+    let def = ChordDefinition::parse_value(value);
+    if !def.transposable {
+        return None;
+    }
+    let chord = Chord::new(&def.name);
+    let transposed = transpose_chord(&chord, semitones);
+    let new_value = format!("[{}]", transposed.name);
+    Some(Directive {
+        name: directive.name.clone(),
+        value: Some(new_value),
+        kind: directive.kind.clone(),
+        selector: directive.selector.clone(),
+    })
 }
 
 /// Combine a file-level transpose offset with a CLI transpose offset.
@@ -451,5 +492,63 @@ mod tests {
         let (result, saturated) = combine_transpose(100, 27);
         assert_eq!(result, 127);
         assert!(!saturated);
+    }
+
+    // -- transposable bracket-form defines (R6.100.0, #2302) -------------
+
+    fn directive_value(line: &Line) -> &str {
+        match line {
+            Line::Directive(d) => d.value.as_deref().expect("directive must have value"),
+            _ => panic!("expected Line::Directive"),
+        }
+    }
+
+    #[test]
+    fn transpose_rewrites_bracket_form_define() {
+        // {define: [A]} is transposable — +2 must rewrite to [B].
+        let song = crate::parse("{define: [A]}\n[A]Hello").unwrap();
+        let transposed = transpose(&song, 2);
+        assert_eq!(directive_value(&transposed.lines[0]), "[B]");
+    }
+
+    #[test]
+    fn transpose_rewrites_bracket_form_chord_directive() {
+        // {chord: [G]} (alias of {define}) follows the same rule.
+        let song = crate::parse("{chord: [G]}\n[G]Hi").unwrap();
+        let transposed = transpose(&song, 5);
+        assert_eq!(directive_value(&transposed.lines[0]), "[C]");
+    }
+
+    #[test]
+    fn transpose_leaves_fixed_define_alone() {
+        // Non-bracket form is "fixed" (upstream `$fixed = 1` default).
+        // The directive value MUST round-trip unchanged.
+        let song = crate::parse("{define: A frets 0 2 2 1 0 0}\n[A]Hello").unwrap();
+        let transposed = transpose(&song, 2);
+        // The directive name "A" stays put, attributes preserved.
+        let v = directive_value(&transposed.lines[0]);
+        assert!(v.starts_with("A "), "fixed define must keep name 'A': {v}");
+        assert!(v.contains("frets"), "fixed define must preserve attrs: {v}");
+    }
+
+    #[test]
+    fn transpose_zero_is_noop_on_bracket_form() {
+        let song = crate::parse("{define: [A]}\n[A]Hi").unwrap();
+        let transposed = transpose(&song, 0);
+        assert_eq!(directive_value(&transposed.lines[0]), "[A]");
+    }
+
+    #[test]
+    fn transpose_negative_on_bracket_form() {
+        let song = crate::parse("{define: [G]}\n[G]Hi").unwrap();
+        let transposed = transpose(&song, -7);
+        assert_eq!(directive_value(&transposed.lines[0]), "[C]");
+    }
+
+    #[test]
+    fn transpose_bracket_form_with_extension() {
+        let song = crate::parse("{define: [Am7]}\n[Am7]Hi").unwrap();
+        let transposed = transpose(&song, 3);
+        assert_eq!(directive_value(&transposed.lines[0]), "[Cm7]");
     }
 }

--- a/crates/chordpro/tests/fixtures/define-transposable/expected.txt
+++ b/crates/chordpro/tests/fixtures/define-transposable/expected.txt
@@ -1,0 +1,100 @@
+Song {
+    metadata: Metadata {
+        title: None,
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: None,
+        year: None,
+        key: None,
+        tempo: None,
+        time: None,
+        capo: None,
+        sort_title: None,
+        sort_artist: None,
+        arrangers: [],
+        copyright: None,
+        duration: None,
+        tags: [],
+        custom: [],
+    },
+    lines: [
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "[A]",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "chord",
+                value: Some(
+                    "[Am7]",
+                ),
+                kind: ChordDirective,
+                selector: None,
+            },
+        ),
+        Directive(
+            Directive {
+                name: "define",
+                value: Some(
+                    "B frets x 2 4 4 4 2",
+                ),
+                kind: Define,
+                selector: None,
+            },
+        ),
+        Lyrics(
+            LyricsLine {
+                segments: [
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "A",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Major,
+                                        extension: None,
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "Hello ",
+                        spans: [],
+                    },
+                    LyricsSegment {
+                        chord: Some(
+                            Chord {
+                                name: "Am7",
+                                detail: Some(
+                                    ChordDetail {
+                                        root: A,
+                                        root_accidental: None,
+                                        quality: Minor,
+                                        extension: Some(
+                                            "7",
+                                        ),
+                                        bass_note: None,
+                                    },
+                                ),
+                                display: None,
+                            },
+                        ),
+                        text: "world",
+                        spans: [],
+                    },
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/chordpro/tests/fixtures/define-transposable/input.cho
+++ b/crates/chordpro/tests/fixtures/define-transposable/input.cho
@@ -1,0 +1,4 @@
+{define: [A]}
+{chord: [Am7]}
+{define: B frets x 2 4 4 4 2}
+[A]Hello [Am7]world


### PR DESCRIPTION
## What

Implement ChordPro upstream R6.100.0's "Allow transposable chords in {chord}/{define}" feature ([commit `0542dbca`](https://github.com/ChordPro/chordpro/commit/0542dbca)). The bracket form `[X]` marks a chord-definition's name as transposable so it follows the song's transposition; non-bracket form (default `\$fixed = 1` upstream) leaves the directive unchanged across transpose.

* `crates/chordpro/src/ast.rs` — extend `ChordDefinition` with a `transposable: bool` field and detect the leading-token `[X]` pattern in `parse_value`. Bracket form strips the brackets, sets the flag, and silently drops any other attributes (per upstream `Song.pm:define_chord` which warns + drops).
* `crates/chordpro/src/transpose.rs` — add a private `transpose_transposable_define(directive, semitones) -> Option<Directive>` that returns a rewritten directive when the value parses to `transposable = true`. Wire it into `transpose()` for `Line::Directive` entries with `kind ∈ {Define, ChordDirective}`. Non-bracket / "fixed" defines round-trip unchanged.

## Why

Sub-issue **#2302** of the R6.100.0 tracking umbrella **#2291**. Upstream docs:

> The chord definition is not transposed or transcoded unless you write the chord name between chord brackets `[ ]`. In this case no other attributes may be specified.

## Test plan

- [x] `cargo test --workspace` — all 36 crates green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

Coverage:
- 7 parser tests: bracket detection, attribute drop on bracket form, no-bracket round-trip, extension chord in brackets (`[A#m7]`), empty `[]`, unmatched `[A` / `A]` open/close brackets stay literal (don't trigger bracket form).
- 6 transpose tests: rewrite on `Define`, rewrite on `ChordDirective` alias, fixed-define round-trip preserves `frets …` attrs, `+0` noop on bracket form, negative offset (`G - 7 → C`), extension preservation through transpose (`Am7 + 3 → Cm7`).

## Sister-site audit (`.claude/rules/fix-propagation.md`)

Parser + transpose change in the chordpro crate. Renderers read the post-transpose AST via `Song::fretted_defines()` / `keyboard_defines()`, both of which call `ChordDefinition::parse_value` on the (potentially-rewritten) directive value — they naturally pick up the new bracket-stripped name without renderer-side wiring. Bracket-form entries with no attributes have `raw = None`, so they are skipped by `fretted_defines()`, matching upstream's behaviour where bracket form without a shape falls through to default voicing.

## Deferred

- `do_warn("Transposable chord X does not allow attributes")` for bracket-form-with-attrs. `ChordDefinition::parse_value` has no warnings vec in scope; routing it is its own refactor.
- `dir_image` integration (`{image: chord=[X]}`). chordsketch does not yet emit `chord:` URIs in image directives, so upstream's `Song.pm:dir_image` arm has no equivalent landing site here.

Closes #2302
Part of #2291