### PR TITLE
chore(gitignore): ignore .playwright-mcp/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,13 @@ apps/desktop/src-tauri/gen/
 # Tools
 .serena/
 
+# Playwright MCP server scratch dir
+# Created at the repo root when the Playwright MCP server captures
+# page snapshots (`page-*.yml`) or console logs (`console-*.log`)
+# during a Claude Code session. Session-scoped debugging output, not
+# source. See #2305.
+.playwright-mcp/
+
 # Python (used by scripts/ and CI helpers, not a runtime dep)
 __pycache__/
 *.pyc


### PR DESCRIPTION
## What

Add `.playwright-mcp/` to `.gitignore`.

## Why

The Playwright MCP server, when invoked during a Claude Code session, writes session-scoped debugging artifacts to `.playwright-mcp/` at the repo root:

- `console-*.log` — captured browser console messages
- `page-*.yml` — accessibility-tree page snapshots

These are not source. They are equivalent in nature to other tool scratch directories already ignored (`.serena/`, `.uniffi-tmp/`).

## Test results

Verified locally that creating `.playwright-mcp/test-marker.log` after the change leaves the working tree clean per `git status`.

## Review summary

Trivial gitignore-only change — no code paths affected. No sister-site audit required (no security or rendering surface touched).

Closes #2305