### PR TITLE
feat(desktop): file I/O keyboard shortcuts (Cmd/Ctrl+O/S/Shift+S)

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -516,6 +516,15 @@ async function buildAppMenu(
     MenuItem.new({
       id: 'file-open',
       text: 'Open…',
+      // Tauri's accelerator parser maps `CmdOrCtrl` to ⌘ on macOS
+      // and `Ctrl` on Windows / Linux, matching the OS-conventional
+      // bindings called for in #2206. The menu accelerator wins over
+      // the WebView default (browser "Save Page As" for ⌘S, no
+      // default for ⌘O / ⌘⇧S) because Tauri intercepts the chord at
+      // the OS / window level before the WebView sees it, so the
+      // CodeMirror editor (#2072) and the playground `<textarea>`
+      // both remain unaffected.
+      accelerator: 'CmdOrCtrl+O',
       action: () => {
         void runOpen(handle, rebuildMenu);
       },
@@ -523,6 +532,7 @@ async function buildAppMenu(
     MenuItem.new({
       id: 'file-save',
       text: 'Save',
+      accelerator: 'CmdOrCtrl+S',
       action: () => {
         void runSave(handle, rebuildMenu);
       },
@@ -530,6 +540,7 @@ async function buildAppMenu(
     MenuItem.new({
       id: 'file-save-as',
       text: 'Save As…',
+      accelerator: 'CmdOrCtrl+Shift+S',
       action: () => {
         void runSaveAs(handle, rebuildMenu);
       },


### PR DESCRIPTION
## What

Add `accelerator` fields to the existing File menu items in
`apps/desktop/src/main.ts`:

| Menu item   | Accelerator           |
|-------------|-----------------------|
| Open…       | `CmdOrCtrl+O`         |
| Save        | `CmdOrCtrl+S`         |
| Save As…    | `CmdOrCtrl+Shift+S`   |

Tauri's accelerator parser maps `CmdOrCtrl` to ⌘ on macOS and `Ctrl`
on Windows / Linux, so the same options string covers all three
desktop targets without per-platform branching.

## Why

Closes #2206. The menu items, dirty-state guards, and underlying
open/save commands already exist (#2080); this change only pairs each
`MenuItem.new()` options block with the OS-conventional accelerator.

The chord is intercepted by the Tauri runtime at the OS / window
level, so it wins over any WebView default (browser "Save Page As"
for ⌘S, no default for ⌘O / ⌘⇧S) and does not collide with the
CodeMirror editor (#2072) or the playground `<textarea>` defaults —
satisfying the "no editor conflict" acceptance criterion.

The remaining shortcut tickets — #2190 (transpose Cmd/Ctrl+Up/Down)
and #2194 (pane focus toggle) — are intentionally out of scope: both
require a binding choice that crosses editor-default boundaries
(macOS textarea + CodeMirror both bind `Cmd+Up/Down` for cursor
navigation; pane-focus binding still under deliberation), so each
gets its own PR after the binding policy is settled.

## Test Results

No automated tests added: this is a single-property addition to
three menu options whose runtime correctness is enforced by the
Tauri menu API surface (`MenuItemOptions.accelerator: string`). The
desktop-smoke CI job (`tsc && vite build` inside `apps/desktop/`)
exercises the type contract.

Manual verification deferred to the maintainer's local Tauri build
(no `cargo test` coverage for menu accelerators today).

## Review Summary

- One file changed, 11 lines added.
- The accelerator strings use Tauri's `CmdOrCtrl` modifier, which is
  the standard cross-platform spelling for the file-I/O OS
  conventions.
- A code comment near `file-open` documents why the menu accelerator
  takes precedence over WebView / editor defaults so a future reader
  doesn't suspect a hidden conflict.