### PR TITLE
ci: restrict rust-cache save-if to main to fix 10GB cache cap thrash

### DIFF
--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -63,6 +63,32 @@ specific target, to avoid cache thrashing across targets:
     shared-key: kotlin-x86_64-unknown-linux-gnu
 ```
 
+Every `Swatinem/rust-cache` invocation MUST also pin `save-if` so only
+main pushes write to the cache:
+
+```yaml
+- uses: Swatinem/rust-cache@...
+  with:
+    shared-key: kotlin-x86_64-unknown-linux-gnu
+    save-if: ${{ github.ref == 'refs/heads/main' }}
+```
+
+The repository's GitHub Actions cache pool is capped at 10 GB with LRU
+eviction. Without this guard, the `Swatinem/rust-cache` default (`save-if:
+true`) saves a fresh entry on every PR ref and every
+`refs/heads/gh-readonly-queue/*` merge-queue ref. Those entries are bit-
+for-bit duplicates of `main`'s cache when the PR did not change
+`Cargo.lock`, but they cost the full per-cell size (typical: 200–500 MB)
+and are scoped to refs that no other run can read from. The pool fills
+within ~24 hours and LRU starts evicting the `main` caches that PR runs
+restore from — producing the `No cache found.` reports that motivated
+#2308.
+
+PR and `merge_group:` runs continue to **restore** cached entries via the
+`shared-key` prefix; they simply do not write back. Cargo.lock-changing
+PRs (mostly Dependabot) trade away one warm cache they would not have
+hit cleanly anyway in exchange for keeping `main`'s cache resident.
+
 ### Tool-version single source of truth
 
 Tool versions that multiple workflows pin SHOULD live in exactly one

--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -42,7 +42,8 @@ YAML noise.
 
 **Required (workflows that run at least weekly):**
 `ci.yml`, `wasm.yml`, `python.yml`, `ruby.yml`, `kotlin.yml`, `swift.yml`,
-`napi.yml`, `ffi.yml`, `deploy-playground.yml`, `readme-smoke.yml`
+`napi.yml`, `ffi.yml`, `deploy-playground.yml`, `readme-smoke.yml`,
+`coverage.yml`, `vscode-extension.yml`
 
 **Intentionally omitted (infrequent — cache expires before next run):**
 - `release.yml` — ~every 10 days on version tags

--- a/.github/actions/desktop-build-steps/action.yml
+++ b/.github/actions/desktop-build-steps/action.yml
@@ -100,6 +100,11 @@ runs:
         # dir from the root `Cargo.toml`, so the default
         # `workspaces: . -> target` is correct — no override.
         shared-key: ${{ inputs.cache-key-prefix }}-${{ inputs.target }}
+        # Only main pushes save the cache; PR and merge-queue runs
+        # restore via prefix matching against main's entry. See
+        # `.claude/rules/ci-parallelization.md` §2 for the rationale
+        # (10 GB Actions cache budget vs. duplicate PR caches).
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install Tauri system dependencies (Linux)
       # `runner.os` is a stable context value ('Linux' / 'macOS' /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Clippy lints
         # `chordsketch-desktop` is excluded because its Tauri/WRY deps
@@ -72,6 +74,8 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build docs (warnings as errors)
         # See the clippy job for the `chordsketch-desktop` exclusion rationale.
@@ -152,6 +156,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
         # See the clippy job for the `chordsketch-desktop` exclusion rationale.
@@ -196,6 +202,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: desktop-smoke-x86_64-unknown-linux-gnu
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install wasm-pack
         uses: ./.github/actions/install-wasm-pack

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: coverage
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -35,6 +35,8 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install wasm-pack
         uses: ./.github/actions/install-wasm-pack

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ffi
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         run: cargo build -p chordsketch-ffi
@@ -76,6 +77,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ffi
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build FFI crate
         run: cargo build -p chordsketch-ffi

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: kotlin-x86_64-unknown-linux-gnu
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         run: cargo build -p chordsketch-ffi --release --target x86_64-unknown-linux-gnu
@@ -120,6 +121,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: kotlin-${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         # `cross` is used for the aarch64-linux target (matrix.cross == true);
@@ -153,6 +155,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: kotlin-generate
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build FFI crate
         run: cargo build -p chordsketch-ffi

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -95,6 +95,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: napi-${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -211,6 +212,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: napi-lint
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Clippy
         run: cargo clippy -p chordsketch-napi -- -D warnings

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -151,6 +151,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: python-x86_64-pc-windows-msvc
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -540,6 +540,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: readme-smoke-library
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and run README Library Usage snippet
         run: |
@@ -616,6 +617,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: readme-smoke-usage
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install CLI from workspace
         env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ruby-x86_64-unknown-linux-gnu
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         run: cargo build -p chordsketch-ffi --release --target x86_64-unknown-linux-gnu
@@ -118,6 +119,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ruby-${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         env:
@@ -146,6 +148,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ruby-generate
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build FFI crate
         run: cargo build -p chordsketch-ffi

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -89,6 +89,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: swift-${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build library for ${{ matrix.target }}
         run: cargo build -p chordsketch-ffi --release --target ${{ matrix.target }}
@@ -138,6 +139,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: swift-assemble
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Download static libraries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -78,6 +78,7 @@ jobs:
           # Distinct shared-key per workflow + target so vscode-extension's
           # wasm-pack build does not thrash the cache shared by `wasm.yml`.
           shared-key: vscode-extension-wasm-pack
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build @chordsketch/wasm from source (web + node builds)
         run: node packages/npm/scripts/build.mjs
@@ -224,6 +225,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: vscode-extension-wasm-pack
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build @chordsketch/wasm from source (web + node builds)
         run: node packages/npm/scripts/build.mjs

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -31,6 +31,8 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install wasm-pack
         uses: ./.github/actions/install-wasm-pack


### PR DESCRIPTION
## What

Add `save-if: ${{ github.ref == 'refs/heads/main' }}` to all 25 `Swatinem/rust-cache` invocations across 13 workflow files and the `desktop-build-steps` composite action. Update `.claude/rules/ci-parallelization.md` §2 to document the requirement.

## Why

Measured 2026-04-28 against `koedame/chordsketch`:

- Active cache size: **9.84 GB / 10 GB** (`gh api repos/.../actions/cache/usage`).
- 38 active entries, 12 of which sit on `refs/pull/*/merge` or `refs/heads/gh-readonly-queue/*` refs.
- Sample collision: `v0-rust-desktop-build-aarch64-apple-darwin-...-090192e6` exists on both `refs/heads/main` and `refs/pull/2307/merge` — identical 456 MB blobs because the PR did not change `Cargo.lock`.
- `desktop-build.yml` macos-aarch64 cell: 3 of last 5 runs hit cache, 2 missed despite no toolchain churn — consistent with LRU eviction under the 10 GB pressure. Run 25047560373 took 466 s on a `No cache found.`; warm runs finish in ~180 s.

The default `save-if: true` saves a duplicate cache on every PR ref and merge-queue ref. Those entries cannot be read by other PRs (Actions cache scope is per-branch), so they are pure write amplification against the 10 GB budget.

## How

`save-if: ${{ github.ref == 'refs/heads/main' }}` makes the save side a no-op on PR / `merge_group:` runs. Restoration via `shared-key` prefix matching is unaffected — PR runs continue to hit main's cache the same way they do today.

## Test plan

- [x] All 25 `Swatinem/rust-cache` invocations have `save-if` (`grep -c save-if:` matches `grep -c Swatinem/rust-cache@`).
- [x] All workflow files parse as valid YAML.
- [ ] CI green on this PR.
- [ ] Verify after merge: at least one PR run on a follow-up PR shows `Cache hit for: v0-rust-...` against a key written by this PR's main run, confirming PR → main prefix matching still works.
- [ ] Verify ~24 hours after merge: `gh api repos/koedame/chordsketch/actions/cache/usage` reports active size below 8 GB (LRU should reclaim the orphaned PR / merge-queue entries).

## Out of scope

- Cache cleanup workflow on PR close — separate follow-up if `save-if` alone proves insufficient.
- Per-entry size reduction (`cache-targets: false` etc.) — premature until duplicates are gone.
- Desktop Build matrix restructuring — measure post-fix before deciding.

Closes #2308