### PR TITLE
feat(desktop): focus-toggle keyboard shortcuts (Cmd/Ctrl+Shift+E/P)

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -579,9 +579,10 @@ async function buildAppMenu(
       // avoid colliding with the editor-local navigation shortcuts
       // the AC for #2194 explicitly forbids — `<textarea>` and the
       // CodeMirror editor (#2072) leave both chords unbound, so the
-      // OS-level menu intercept (see the File-menu shortcut comment
-      // above) does not steal a key the user expects to see in the
-      // editor.
+      // OS-level menu intercept does not steal a key the user
+      // expects to see in the editor. See the `file-open`
+      // accelerator comment in this same `Promise.all` for the full
+      // rationale on why the OS-level chord wins over the WebView.
       accelerator: 'CmdOrCtrl+Shift+E',
       action: () => {
         handle.focusEditor();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -471,6 +471,8 @@ async function buildAppMenu(
     pasteItem,
     selectAllItem,
     editMenuSep,
+    focusEditorItem,
+    focusPreviewItem,
     minimizeItem,
     maximizeItem,
     homepageItem,
@@ -570,6 +572,29 @@ async function buildAppMenu(
     PredefinedMenuItem.new({ item: 'Paste' }),
     PredefinedMenuItem.new({ item: 'SelectAll' }),
     PredefinedMenuItem.new({ item: 'Separator' }),
+    MenuItem.new({
+      id: 'view-focus-editor',
+      text: 'Focus Editor',
+      // `CmdOrCtrl+Shift+E` and `CmdOrCtrl+Shift+P` were chosen to
+      // avoid colliding with the editor-local navigation shortcuts
+      // the AC for #2194 explicitly forbids — `<textarea>` and the
+      // CodeMirror editor (#2072) leave both chords unbound, so the
+      // OS-level menu intercept (see the File-menu shortcut comment
+      // above) does not steal a key the user expects to see in the
+      // editor.
+      accelerator: 'CmdOrCtrl+Shift+E',
+      action: () => {
+        handle.focusEditor();
+      },
+    }),
+    MenuItem.new({
+      id: 'view-focus-preview',
+      text: 'Focus Preview',
+      accelerator: 'CmdOrCtrl+Shift+P',
+      action: () => {
+        handle.focusPreview();
+      },
+    }),
     PredefinedMenuItem.new({ item: 'Minimize' }),
     // macOS convention calls this "Zoom"; Tauri's predefined item
     // is `Maximize` and the platform layer renames the surface
@@ -636,6 +661,14 @@ async function buildAppMenu(
       selectAllItem,
     ],
   });
+  // View menu hosts the focus-toggle shortcuts (#2194). macOS HIG
+  // surfaces View between Edit and Window for navigation-related
+  // commands, and the same item list renders identically on
+  // Windows / Linux without further platform branching.
+  const viewMenu = await Submenu.new({
+    text: 'View',
+    items: [focusEditorItem, focusPreviewItem],
+  });
   const windowMenu = await Submenu.new({
     text: 'Window',
     items: [minimizeItem, maximizeItem],
@@ -646,7 +679,7 @@ async function buildAppMenu(
   });
 
   return Menu.new({
-    items: [appMenu, fileMenu, editMenu, windowMenu, helpMenu],
+    items: [appMenu, fileMenu, editMenu, viewMenu, windowMenu, helpMenu],
   });
 }
 

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -971,13 +971,21 @@ export async function mountChordSketchUi(
       // Pick whichever output surface is currently visible — the
       // user's mental model of "preview" follows the format select,
       // so the focus shortcut should land on the surface they're
-      // actually looking at.
+      // actually looking at. `showPane()` always reveals exactly
+      // one of the three; the terminal `else` exists only as a
+      // forward-safety guard so a future arm added to `showPane`
+      // without a matching arm here fails loudly during dev rather
+      // than silently no-op'ing the shortcut.
       if (!preview.classList.contains('hidden')) {
         preview.focus();
       } else if (!textOutput.classList.contains('hidden')) {
         textOutput.focus();
       } else if (!pdfPane.classList.contains('hidden')) {
         pdfPane.focus();
+      } else {
+        console.warn(
+          'focusPreview: no preview surface visible — showPane() invariant broken?',
+        );
       }
     },
   };

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -156,6 +156,22 @@ export interface ChordSketchUiHandle {
    * the same time it calls this.
    */
   setChordPro(value: string): void;
+  /**
+   * Move keyboard focus into the editor pane. Routes through the
+   * injected {@link EditorAdapter#focus} when present (the desktop
+   * CodeMirror factory and the default `<textarea>` factory both
+   * supply one); a no-op if the active editor adapter does not
+   * expose `focus`. Backs the desktop app's `View → Focus Editor`
+   * shortcut (#2194).
+   */
+  focusEditor(): void;
+  /**
+   * Move keyboard focus to the preview pane — specifically the
+   * currently visible output surface (HTML iframe / text `<pre>` /
+   * PDF download pane), so the focus follows the format select.
+   * Backs the desktop app's `View → Focus Preview` shortcut (#2194).
+   */
+  focusPreview(): void;
 }
 
 const RENDER_DEBOUNCE_MS = 300;
@@ -445,10 +461,18 @@ function buildDom(root: HTMLElement, title: string): UiNodes {
   const textOutput = document.createElement('pre');
   textOutput.id = 'text-output';
   textOutput.className = 'hidden';
+  // `<pre>` is not focusable by default. `tabIndex = -1` lets
+  // {@link ChordSketchUiHandle.focusPreview} land focus here when
+  // the text format is selected without inserting the element into
+  // the natural Tab order. (#2194)
+  textOutput.tabIndex = -1;
 
   const pdfPane = document.createElement('div');
   pdfPane.id = 'pdf-pane';
   pdfPane.className = 'hidden';
+  // Same rationale as `textOutput.tabIndex` above — programmatic
+  // focus via `focusPreview()` only, no Tab-order insertion. (#2194)
+  pdfPane.tabIndex = -1;
   const pdfHint = document.createElement('p');
   pdfHint.textContent = 'Click the button to generate and download a PDF.';
   const downloadPdfBtn = document.createElement('button');
@@ -939,6 +963,22 @@ export async function mountChordSketchUi(
       // loads are discrete events — users expect the preview to
       // reflect the loaded file without a 300 ms debounce delay.
       render();
+    },
+    focusEditor(): void {
+      editor.focus?.();
+    },
+    focusPreview(): void {
+      // Pick whichever output surface is currently visible — the
+      // user's mental model of "preview" follows the format select,
+      // so the focus shortcut should land on the surface they're
+      // actually looking at.
+      if (!preview.classList.contains('hidden')) {
+        preview.focus();
+      } else if (!textOutput.classList.contains('hidden')) {
+        textOutput.focus();
+      } else if (!pdfPane.classList.contains('hidden')) {
+        pdfPane.focus();
+      }
     },
   };
 }

--- a/packages/ui-web/src/style.css
+++ b/packages/ui-web/src/style.css
@@ -237,6 +237,19 @@ main {
   background: #fff;
 }
 
+/*
+ * Focus rings on the three preview surfaces so the `View → Focus
+ * Preview` shortcut (#2194) gives keyboard users a visible landing.
+ * `outline-offset: -2px` keeps the ring inside the pane edge,
+ * matching the splitter's inward focus style above.
+ */
+#preview:focus-visible,
+#text-output:focus-visible,
+#pdf-pane:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 #text-output {
   flex: 1;
   padding: 1rem;


### PR DESCRIPTION
## What

Adds a `View` submenu to the desktop app with two accelerators that move keyboard focus between the editor and the currently visible preview surface:

- `View → Focus Editor`   → `CmdOrCtrl+Shift+E`
- `View → Focus Preview`  → `CmdOrCtrl+Shift+P`

## Why

Closes #2194. The split-pane editor + preview layout (#2071) and the file-I/O accelerators (#2206 / #2307) ship without a way to move focus between the two panes from the keyboard. With this PR, a keyboard-only user can land focus on either pane without touching the mouse, and a screen-reader user gets a deterministic landing on whichever output surface matches the active format.

## Implementation

- `ChordSketchUiHandle` (`packages/ui-web/src/index.ts`) gains `focusEditor()` / `focusPreview()`.
  - `focusEditor()` routes through the injected `EditorAdapter#focus` that both the default `<textarea>` factory and the desktop CodeMirror factory (#2072) already implement.
  - `focusPreview()` focuses whichever output element is currently shown — iframe for HTML, `<pre>` for text, the PDF download pane for PDF. Picking by visibility (rather than always targeting the iframe) keeps the shortcut useful in the text and PDF formats.
- `<pre>` and the PDF pane are not focusable by default; both get `tabIndex = -1` so programmatic focus lands them without inserting them into the natural Tab order.
- `:focus-visible` outlines on all three preview surfaces give keyboard users a visible landing.
- Desktop `apps/desktop/src/main.ts` adds a `View` submenu between Edit and Window, with the two `MenuItem`s wired to the new handle methods. The accelerator keys are picked specifically because `<textarea>` and CodeMirror's `defaultKeymap` leave both unbound — the AC's "no conflict with editor navigation" requirement is satisfied.

## Playground scope

The playground hosts the same `mountChordSketchUi` but does not build a native menu, so the OS-level Tauri accelerator path does not apply there. The new handle methods are still exposed for hosts that want to wire their own bindings; the playground deliberately opts out of registering global page-level shortcuts to avoid colliding with browser-default chords (`Cmd+Shift+P` opens the print dialog in some browsers, etc.). This matches the AC's "explicit opt-out documented" branch.

## Test results

- `tsc --noEmit` against `packages/ui-web/` (the only package whose `.ts` source I touched, and one I can run in isolation): clean.
- `apps/desktop/` `tsc` requires the `prebuild` (tree-sitter wasm copy) and a built `@chordsketch/wasm`; the `desktop-smoke` job in `ci.yml` exercises the full build chain on every PR, so verification is delegated there.
- I did not run the desktop dev loop (no GUI / Tauri runtime available in the worktree), so the actual menu chord routing must be confirmed at human review time. The code changes are mechanical: a new `MenuItem.new({ accelerator, action: () => handle.focusEditor() })` mirrors the file-I/O shortcut pattern landed in #2307.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`: this is a desktop-only feature addition rather than a bug fix, so the sister-site groups (renderers / bindings / external tool invocations / sanitizers) do not apply. The feature surface is the desktop's native menu and the ui-web handle; both updated together in this PR. No equivalent menu construction exists in the playground (it does not build a Tauri menu).

## Closes

Closes #2194

🤖 Generated with [Claude Code](https://claude.com/claude-code)