### PR TITLE
feat(desktop): transpose keyboard shortcuts (Cmd/Ctrl+Alt+ArrowUp/Down) (#2190)

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -473,6 +473,10 @@ async function buildAppMenu(
     editMenuSep,
     focusEditorItem,
     focusPreviewItem,
+    viewMenuSep,
+    transposeUpItem,
+    transposeDownItem,
+    transposeResetItem,
     minimizeItem,
     maximizeItem,
     homepageItem,
@@ -596,6 +600,54 @@ async function buildAppMenu(
         handle.focusPreview();
       },
     }),
+    PredefinedMenuItem.new({ item: 'Separator' }),
+    MenuItem.new({
+      id: 'view-transpose-up',
+      text: 'Transpose Up',
+      // The issue (#2190) proposed `CmdOrCtrl+Up/Down`, but the same
+      // AC also forbids colliding with editor-local navigation. On
+      // macOS, CodeMirror's `standardKeymap` binds `Cmd-ArrowUp` /
+      // `Cmd-ArrowDown` to `cursorDocStart` / `cursorDocEnd`, and
+      // `<textarea>` uses the same chord for "move to start/end of
+      // text" — there is no Home / End key on most Mac keyboards, so
+      // shadowing those shortcuts at the OS-level menu would strand
+      // users who want to jump to the document boundaries. The
+      // `Alt` modifier (== ⌥ on macOS) takes the chord out of every
+      // CodeMirror default map and out of the `<textarea>` defaults
+      // on every platform, while staying close enough to the
+      // proposed `Cmd+Up/Down` to remain discoverable. Logic Pro's
+      // Option+Up/Down "transpose by semitone" convention is the
+      // closest established precedent. See the `file-open`
+      // accelerator comment in this same `Promise.all` for the
+      // general rationale on why the OS-level chord wins over the
+      // WebView.
+      accelerator: 'CmdOrCtrl+Alt+ArrowUp',
+      action: () => {
+        handle.stepTranspose(1);
+      },
+    }),
+    MenuItem.new({
+      id: 'view-transpose-down',
+      text: 'Transpose Down',
+      accelerator: 'CmdOrCtrl+Alt+ArrowDown',
+      action: () => {
+        handle.stepTranspose(-1);
+      },
+    }),
+    MenuItem.new({
+      id: 'view-transpose-reset',
+      text: 'Reset Transpose',
+      // No accelerator: ⌘0 is the natural "reset" chord by web
+      // convention but conflicts with browser zoom-reset, and there
+      // is no second free chord that is obviously a "transpose
+      // reset". Leaving the menu item without an accelerator keeps
+      // the action discoverable while deferring the binding choice
+      // — same pattern as `Export PDF…` / `Export HTML…`, which
+      // ship without accelerators in this menu.
+      action: () => {
+        handle.resetTranspose();
+      },
+    }),
     PredefinedMenuItem.new({ item: 'Minimize' }),
     // macOS convention calls this "Zoom"; Tauri's predefined item
     // is `Maximize` and the platform layer renames the surface
@@ -662,13 +714,24 @@ async function buildAppMenu(
       selectAllItem,
     ],
   });
-  // View menu hosts the focus-toggle shortcuts (#2194). macOS HIG
-  // surfaces View between Edit and Window for navigation-related
-  // commands, and the same item list renders identically on
-  // Windows / Linux without further platform branching.
+  // View menu hosts the focus-toggle shortcuts (#2194) and the
+  // transpose shortcuts (#2190). macOS HIG surfaces View between
+  // Edit and Window for navigation-related commands, and the same
+  // item list renders identically on Windows / Linux without
+  // further platform branching. The transpose group is separated
+  // from the focus-toggle group so a screen-reader user can tell
+  // the two are conceptually distinct, even though they share the
+  // submenu.
   const viewMenu = await Submenu.new({
     text: 'View',
-    items: [focusEditorItem, focusPreviewItem],
+    items: [
+      focusEditorItem,
+      focusPreviewItem,
+      viewMenuSep,
+      transposeUpItem,
+      transposeDownItem,
+      transposeResetItem,
+    ],
   });
   const windowMenu = await Submenu.new({
     text: 'Window',

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -172,6 +172,24 @@ export interface ChordSketchUiHandle {
    * Backs the desktop app's `View → Focus Preview` shortcut (#2194).
    */
   focusPreview(): void;
+  /**
+   * Adjust the transpose offset by `delta` semitones, clamped to the
+   * same `[-11, 11]` window the trio buttons and the `<input>` itself
+   * enforce. Triggers the same debounced rerender path as a click on
+   * the existing `+` / `−` buttons so the preview stays in sync.
+   * Backs the desktop app's `View → Transpose Up / Down` shortcuts
+   * (#2190); hosts that bind the same action elsewhere (a custom
+   * floating control, a hardware MIDI pedal) reuse this method
+   * instead of synthesising click events on the trio buttons.
+   */
+  stepTranspose(delta: number): void;
+  /**
+   * Reset the transpose offset to `0`, matching what `Reset` on the
+   * existing trio does. Surfaced so the desktop app can offer a
+   * `View → Reset Transpose` menu item without poking at the
+   * internal `<button>` (#2190).
+   */
+  resetTranspose(): void;
 }
 
 const RENDER_DEBOUNCE_MS = 300;
@@ -987,6 +1005,20 @@ export async function mountChordSketchUi(
           'focusPreview: no preview surface visible — showPane() invariant broken?',
         );
       }
+    },
+    stepTranspose(delta: number): void {
+      // `setTranspose` clamps to `[TRANSPOSE_MIN, TRANSPOSE_MAX]`
+      // and schedules a render, so a `delta` larger than the
+      // remaining headroom degrades to "snap to the boundary"
+      // rather than overshooting. Reading via `getTranspose()`
+      // (not `transposeInput.valueAsNumber`) keeps us using the
+      // same clamp-and-fallback path as the click handlers, which
+      // is the safer choice if a host calls this between an in-
+      // progress edit and the next debounce tick.
+      setTranspose(getTranspose() + delta);
+    },
+    resetTranspose(): void {
+      setTranspose(TRANSPOSE_RESET);
     },
   };
 }

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -175,12 +175,22 @@ export interface ChordSketchUiHandle {
   /**
    * Adjust the transpose offset by `delta` semitones, clamped to the
    * same `[-11, 11]` window the trio buttons and the `<input>` itself
-   * enforce. Triggers the same debounced rerender path as a click on
-   * the existing `+` / `−` buttons so the preview stays in sync.
-   * Backs the desktop app's `View → Transpose Up / Down` shortcuts
-   * (#2190); hosts that bind the same action elsewhere (a custom
-   * floating control, a hardware MIDI pedal) reuse this method
-   * instead of synthesising click events on the trio buttons.
+   * enforce. `delta` must be a finite integer; non-finite (`NaN` /
+   * `Infinity`) or zero values are treated as no-ops, and fractional
+   * values are truncated toward zero. Triggers the same debounced
+   * rerender path as a click on the existing `+` / `−` buttons so
+   * the preview stays in sync. Backs the desktop app's `View →
+   * Transpose Up / Down` shortcuts (#2190); hosts that bind the same
+   * action elsewhere (a custom floating control, a hardware MIDI
+   * pedal) reuse this method instead of synthesising click events on
+   * the trio buttons.
+   *
+   * The signed-delta shape is intentionally distinct from
+   * `@chordsketch/react`'s `useTranspose` hook (`increment(step?)` /
+   * `decrement(step?)` / `reset()`) because the React hook keeps its
+   * state in user-supplied React state, while this handle drives the
+   * built-in DOM trio. Hosts that already use one shape are not
+   * expected to switch to the other.
    */
   stepTranspose(delta: number): void;
   /**
@@ -1007,15 +1017,32 @@ export async function mountChordSketchUi(
       }
     },
     stepTranspose(delta: number): void {
+      // Validate at the public-API boundary per
+      // `.claude/rules/defensive-inputs.md`. Non-finite `delta`
+      // (`NaN`/`±Infinity`) propagates through `getTranspose() +
+      // delta` and `Math.max/min` as `NaN`, which `setTranspose`
+      // would write into `transposeInput.value` as the literal
+      // string `"NaN"` — `getTranspose()` self-heals on the next
+      // read via `Number.isNaN`, but the `<input>` briefly displays
+      // bogus state and a render is scheduled with stale-feeling
+      // numbers. `Math.trunc` rounds fractional `delta` toward zero
+      // so a host passing `0.5` or `-1.7` produces a deterministic
+      // integer step instead of letting `transposeInput.value =
+      // "0.5"` drift away from `parseInt`'s truncation in
+      // `getTranspose()`. A truncated-to-zero `delta` falls into
+      // the early-return so we don't schedule a no-op render.
+      if (!Number.isFinite(delta)) return;
+      const step = Math.trunc(delta);
+      if (step === 0) return;
       // `setTranspose` clamps to `[TRANSPOSE_MIN, TRANSPOSE_MAX]`
-      // and schedules a render, so a `delta` larger than the
+      // and schedules a render, so a `step` larger than the
       // remaining headroom degrades to "snap to the boundary"
       // rather than overshooting. Reading via `getTranspose()`
       // (not `transposeInput.valueAsNumber`) keeps us using the
       // same clamp-and-fallback path as the click handlers, which
       // is the safer choice if a host calls this between an in-
       // progress edit and the next debounce tick.
-      setTranspose(getTranspose() + delta);
+      setTranspose(getTranspose() + step);
     },
     resetTranspose(): void {
       setTranspose(TRANSPOSE_RESET);


### PR DESCRIPTION
## What

Adds three menu entries to the desktop app's `View` submenu:

- `View → Transpose Up`    → `CmdOrCtrl+Alt+ArrowUp`
- `View → Transpose Down`  → `CmdOrCtrl+Alt+ArrowDown`
- `View → Reset Transpose` (no accelerator)

The two step accelerators bump the transpose offset by ±1 semitone,
clamped to `[-11, 11]`. The reset entry returns it to `0`. All three
route through new `stepTranspose(delta)` / `resetTranspose()` methods
on `ChordSketchUiHandle`, which reuse the existing clamp-and-rerender
path that backs the `+` / `−` / `Reset` trio buttons.

## Why

Closes #2190. The AC asked for a transpose keyboard shortcut on the
desktop app and explicitly forbade colliding with editor navigation.

## Accelerator choice — deliberate deviation from the AC's literal binding

The issue title proposes `Cmd+ArrowUp` / `Cmd+ArrowDown` (macOS) and
`Ctrl+ArrowUp` / `Ctrl+ArrowDown` (Windows / Linux), but the same
issue body's AC item 3 reads:

> No conflict with editor navigation shortcuts already used by the
> `<textarea>` (today) or the future CodeMirror editor (#2072).

Those two AC items contradict each other on macOS:

- CodeMirror's `standardKeymap` binds `Cmd-ArrowUp` and
  `Cmd-ArrowDown` to `cursorDocStart` / `cursorDocEnd` on macOS.
  Source:
  https://github.com/codemirror/view/blob/main/src/keymap.ts
  (`standardKeymap` array entries ``{ mac: "Cmd-ArrowUp", run:
  cursorDocStart, ... }`` and ``{ mac: "Cmd-ArrowDown", run:
  cursorDocEnd, ... }``); `defaultKeymap` re-exports
  `standardKeymap` via
  https://github.com/codemirror/commands/blob/main/src/commands.ts
  so the desktop editor in `apps/desktop/src/codemirror-editor.ts`
  (which calls `keymap.of([...defaultKeymap, ...historyKeymap])`)
  inherits these bindings unchanged.
- macOS `<textarea>` uses the same chord for "move cursor to start /
  end of text" — see Apple's *Mac Keyboard Shortcuts* (HT201236)
  under "Document shortcuts": "Command-Up Arrow" → "Move the
  insertion point to the beginning of the document". On Mac
  keyboards without a Home/End key (the entire MacBook line and
  most desktop wireless keyboards), this is the only chord that
  jumps to the document boundary.

The Tauri menu accelerator runs at the OS / window level and beats
the WebView, so registering `Cmd+Up/Down` would strand users who want
to jump to document boundaries inside the editor — exactly the
scenario AC item 3 forbids. This matches the rationale in #2194's
focus-toggle PR (#2314), which also chose chord variants
(`Cmd+Shift+E/P`) that CodeMirror leaves unbound rather than the
"obvious" letter chords that would have shadowed editor commands.

The chosen `Cmd+Alt+ArrowUp/Down` (and `Ctrl+Alt+ArrowUp/Down` on
Windows / Linux):

- is unbound in CodeMirror's `standardKeymap` and `defaultKeymap` on
  every platform (the only `Alt+ArrowUp/Down` entries in the
  upstream `defaultKeymap` are bare-`Alt` for `moveLineUp` /
  `moveLineDown` — the `Mod+Alt` chord is not in either array),
- is unbound in `<textarea>` defaults on every platform,
- stays close enough to the proposed `Cmd+Up/Down` to remain
  discoverable from a user who reads the menu,
- aligns with Logic Pro's `Option+Up/Down` "transpose selection by
  semitone" convention (Apple's *Logic Pro User Guide* —
  "Transpose selected events by semitone"), which is the closest
  established music-app precedent for this action.

The trade-off versus the issue title's literal binding is an extra
modifier press; the trade-off versus shadowing the editor is losing
the only Mac chord for jumping to doc start/end. On GNOME / Linux,
`Ctrl+Alt+Arrow` is the compositor-level "switch workspace" binding
when static workspaces are enabled; the compositor wins over a
window-level Tauri accelerator there, so the menu shortcut degrades
to a no-op (the compositor preserves its own binding) rather than
hijacking it. Users on that configuration can still use the trio
buttons or the `View → Transpose …` menu entries.

`Reset Transpose` ships without an accelerator. `Cmd+0` is the
natural "reset" chord by web convention but conflicts with browser
zoom-reset, and there is no second free chord that is obviously a
"transpose reset". The action stays discoverable through the menu
itself — same approach as `Export PDF…` / `Export HTML…`. The menu
item stays enabled even when the offset is already `0`; invoking it
in that state is a deterministic no-op (the existing
`setTranspose(TRANSPOSE_RESET)` path is idempotent).

## Implementation

- `packages/ui-web/src/index.ts`: extends `ChordSketchUiHandle` with
  `stepTranspose(delta: number)` and `resetTranspose()`. `delta` is
  validated at the public-API boundary per
  `.claude/rules/defensive-inputs.md`: non-finite values
  (`NaN` / `±Infinity`) and a truncated-to-zero fractional delta
  short-circuit before the clamp / render path runs, and fractional
  deltas are truncated toward zero with `Math.trunc` so a host
  passing `0.5` produces a deterministic integer step instead of
  drifting between `transposeInput.value = "0.5"` and `parseInt`'s
  later truncation. Both methods reuse the internal `setTranspose`
  so the existing clamp + debounced render are exercised — no
  parallel rerender path.
- `apps/desktop/src/main.ts`: adds three `MenuItem.new` entries in
  the `View` submenu's `Promise.all`, plus a `Separator` to mark the
  transpose group as visually distinct from the focus-toggle group.
  The submenu items list is updated to include the new entries.

## Playground scope

The browser playground hosts the same `mountChordSketchUi` handle
but does not build a native menu, so the Tauri accelerator path does
not apply. Per #2194's precedent, the playground deliberately opts
out of registering page-level shortcuts to avoid colliding with
browser-default chords. The new handle methods are still exposed for
hosts that want to wire their own bindings (a custom floating
control, a hardware MIDI pedal, etc.).

This matches the AC's "explicit opt-out documented" branch for the
playground.

## Test results

- `tsc --noEmit` against `packages/ui-web/`: clean (both before and
  after the review-fix commit).
- `tsc --noEmit` against `apps/desktop/`: only the same two
  pre-existing module-resolution errors that depend on the
  `prebuild` step (tree-sitter wasm copy) and a built
  `@chordsketch/wasm` package — unchanged from `main`. The
  `desktop-smoke` job in `ci.yml` exercises the full build chain on
  every PR, so end-to-end verification is delegated there (same as
  #2314 and #2307).
- I did not run the desktop dev loop (no GUI / Tauri runtime
  available in the worktree), so the actual menu chord routing must
  be confirmed at human review time. The code changes are
  mechanical: each new `MenuItem.new({ accelerator, action: () =>
  handle.stepTranspose(...) })` mirrors the file-I/O and
  focus-toggle accelerator patterns landed in #2307 / #2314.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`: this is a desktop-only
feature addition rather than a bug fix, so the sister-site groups
(renderers / bindings / external tools / sanitizers) do not apply.
The feature surface is the desktop's native menu and the ui-web
handle; both updated together in this PR.

The closest API-shape sibling is `@chordsketch/react`'s
`useTranspose` hook (`increment(step?)` / `decrement(step?)` /
`reset()`). The signed-delta shape chosen here is deliberately
distinct: the React hook keeps its state in user-supplied React
state, while this handle drives the built-in DOM trio. Hosts that
already use one shape are not expected to switch to the other; the
JSDoc on `stepTranspose` flags the cross-reference for future
maintainers reading both APIs side by side.

## Closes

Closes #2190

🤖 Generated with [Claude Code](https://claude.com/claude-code)