### PR TITLE
ci(coverage): surface Codecov upload failures (fail_ci_if_error: true)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,8 +42,7 @@ jobs:
     permissions:
       contents: read
       # Required for codecov-action's `use_oidc: true`: GitHub refuses to
-      # mint the OIDC token without this, and `fail_ci_if_error: false`
-      # would otherwise swallow the failure silently.
+      # mint the OIDC token without this.
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -73,5 +72,5 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: lcov.info
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true


### PR DESCRIPTION
## What

Set `fail_ci_if_error: true` on the `codecov/codecov-action` step in `.github/workflows/coverage.yml`, and trim the now-stale half of the comment on `id-token: write`.

## Why

The dashboard at `app.codecov.io/gh/koedame/chordsketch` was showing the unactivated-project setup wizard despite `coverage.yml` succeeding on every push to `main`. Inspection of run `25088449532` (2026-04-29 02:49Z) showed the upload step retrying three times against HTTP 500 from `ingest.codecov.io` and aborting:

```
info -- Found 1 coverage files to report
warning -- Response status code was 500. --- {"retry": 0..2}
Exception: Request failed after too many retries.
URL: https://ingest.codecov.io/upload/github/koedame::::chordsketch/upload-coverage
==> Failed to run upload-coverage
```

`fail_ci_if_error: false` swallowed the non-zero exit, so the workflow reported success and no signal reached the maintainer. The repo has since been activated on Codecov (workspace coverage now ~92%), but the same masking problem will reoccur on any future ingest outage, OIDC change, or codecov-action regression.

This PR makes the upload step's status faithful to whether the upload actually succeeded.

## Why not also wire this into branch protection

`#1846 §Strategy` sequences this work intentionally:

> add to branch protection required checks only after two consecutive green main builds at the gate value

`fail_ci_if_error: true` is the precondition for "consecutive green main builds" being a meaningful signal — without it, a string of green runs only proves the action did not raise an unmaskable error. Bundling both changes into one PR collapses the gate.

## Test plan

- [ ] CI runs on this PR and the Coverage workflow itself shows up green (the project is now activated on Codecov; OIDC upload is expected to succeed).
- [ ] After merge, the next push-to-main run of `coverage.yml` is green, confirming `fail_ci_if_error: true` does not break the working path.
- [ ] After two consecutive green main runs, follow up with a separate PR adding the Codecov status to branch protection's required checks per `#1846 §Strategy`.

Closes #2318