### PR TITLE
feat(ireal): scaffold chordsketch-ireal crate + AST types (#2055)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,8 +42,7 @@ jobs:
     permissions:
       contents: read
       # Required for codecov-action's `use_oidc: true`: GitHub refuses to
-      # mint the OIDC token without this, and `fail_ci_if_error: false`
-      # would otherwise swallow the failure silently.
+      # mint the OIDC token without this.
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -73,5 +72,5 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: lcov.info
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ This is a Cargo workspace with the following crates:
 | Crate | Path | Kind | Dependencies |
 |---|---|---|---|
 | `chordsketch-chordpro` | `crates/chordpro` | lib | *none* (zero external deps) |
+| `chordsketch-ireal` | `crates/ireal` | lib | *none* (zero external deps). iReal Pro AST + zero-dep JSON debug serializer / parser (#2055); foundation for the iReal Pro feature set tracked under #2050. |
 | `chordsketch-render-text` | `crates/render-text` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-html` | `crates/render-html` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-pdf` | `crates/render-pdf` | lib | `chordsketch-chordpro` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "chordsketch-ireal"
+version = "0.3.0"
+
+[[package]]
 name = "chordsketch-lsp"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/chordpro",
+    "crates/ireal",
     "crates/render-text",
     "crates/render-html",
     "crates/render-pdf",
@@ -24,6 +25,7 @@ members = [
 # stop covering the new crate.
 default-members = [
     "crates/chordpro",
+    "crates/ireal",
     "crates/render-text",
     "crates/render-html",
     "crates/render-pdf",

--- a/crates/ireal/ARCHITECTURE.md
+++ b/crates/ireal/ARCHITECTURE.md
@@ -158,10 +158,56 @@ Format properties relied on by golden tests:
 
 The deserializer is round-trip-only: it accepts exactly the subset
 of JSON the serializer emits (no booleans, no floats, no trailing
-commas, no duplicate keys, no surrogate-pair `\u` escapes) and
-rejects anything else. Widening one half of the pair without the
-other is a structural defect — see the `json_round_trip_*` tests
-in `tests/ast.rs`.
+commas, no leading-zero or `-0` integers, no duplicate keys, no
+surrogate-pair `\u` escapes) and rejects anything else. Widening
+one half of the pair without the other is a structural defect —
+see the `json_round_trip_*` tests in `tests/ast.rs`.
+
+The deserializer additionally enforces value-range invariants the
+type system does not encode:
+
+- `IrealSong.transpose` clamped to `[-11, 11]` (matches the
+  `chordsketch-chordpro` clamp).
+- `IrealSong.tempo` rejected when `Some(0)`; "no tempo recorded"
+  is `None`.
+- `ChordRoot.note` restricted to ASCII `A..=G` uppercase.
+- `Ending::new(0)` and `BeatPosition::on_beat(0)` rejected via the
+  `NonZeroU8` field types.
+- `TimeSignature::new` enforces `numerator: 1..=12` and
+  `denominator ∈ {2, 4, 8}`.
+
+Out-of-range values produced by the serializer (i.e. supplied via
+direct `pub` field mutation, bypassing the validating constructors)
+will round-trip-fail in the deserializer — that is the load-bearing
+property of the round-trip-only contract.
+
+### Resource limits
+
+`parse_json` enforces:
+
+| Constant | Default |
+|---|---|
+| `MAX_INPUT_BYTES` | 4 MiB |
+| `MAX_DEPTH` | 128 |
+| `MAX_ARRAY_LEN` | 65 536 |
+| `MAX_OBJECT_FIELDS` | 65 536 |
+| `MAX_STRING_CHARS` | 1 048 576 |
+
+These bounds are documented `pub const`s and changing any of them
+is a review-required change. The duplicate-key check uses
+`BTreeSet<String>` to keep the per-object cost `O(n log n)`.
+
+### Diagnostic position semantics
+
+`JsonError::position` is the byte index in the source string where
+the parser detected the problem. For errors raised by the
+post-parse AST extractors (missing field, wrong variant tag, value
+out of documented range), the position is `0` because the parsed
+[`crate::json::JsonValue`] tree does not preserve source spans;
+the `message` is the only diagnostic for those cases. This is a
+deliberate trade-off — adding spans to the value tree would
+complicate every implementation of `FromJson` for marginal benefit
+in a debug-only format.
 
 If any property above changes, the tests
 `json_serialization_is_byte_stable`,

--- a/crates/ireal/ARCHITECTURE.md
+++ b/crates/ireal/ARCHITECTURE.md
@@ -1,0 +1,189 @@
+# `chordsketch-ireal` — AST design notes
+
+This document records the design decisions that shape the AST in
+`src/ast.rs` so the follow-up crates (#2052 / #2053 / #2054 /
+#2058 / #2061 / #2066 / #2067) inherit a stable foundation. Every
+choice listed here is a load-bearing assumption for at least one
+of those tickets.
+
+## Reference data model
+
+The iReal Pro chart format has no published spec. The closest
+public artefact is the [`daumling/ireal-renderer`][1] JS project,
+which the AC for #2055 explicitly nominates as the reference. We
+ported the **data model** (what fields a chart carries, how chords
+sit inside bars, how repeats and endings nest) and intentionally
+did **not** port the JS rendering code — rendering lives in
+`chordsketch-render-ireal` (#2058) and binds to the data model
+through this crate's public API.
+
+[1]: https://github.com/daumling/ireal-renderer
+
+## Field-level rationale
+
+### `IrealSong`
+
+- `title: String` (not `Option`). iReal Pro tolerates an empty
+  title, and the conversion crate (#2053) gains nothing from
+  carrying a `None`-vs-`Some("")` distinction. Empty string is
+  the canonical "no title".
+- `composer / style: Option<String>`. These are user-supplied and
+  often missing on community-shared charts; `Option` reflects the
+  source data better than an empty-string convention.
+- `key_signature: KeySignature` (not `Option`). iReal Pro always
+  has an implicit key (`C major` is the format default), and a
+  default keeps every consumer monomorphic.
+- `time_signature: TimeSignature` (not `Option`). Same reasoning;
+  `4/4` is iReal's default.
+- `tempo: Option<u16>`. Many charts leave tempo to the player;
+  `Option` is honest.
+- `transpose: i8`. Range `[-11, 11]` matches the existing
+  `chordsketch-chordpro` clamp.
+- `sections: Vec<Section>`. The chart is a flat list; nesting
+  (e.g. forms inside forms) is not part of the iReal model.
+
+### `Section`
+
+- `label: SectionLabel`. The named-variant set (`Verse`, `Chorus`,
+  `Intro`, `Outro`, `Bridge`) covers the strings the conversion
+  crate (#2053) needs to map deterministically to ChordPro
+  `{start_of_chorus}` / `{start_of_verse}` / etc. Letter form
+  (`A`/`B`/`C`/`D`) is the jazz convention. `Custom(String)` is
+  the escape hatch for anything else.
+
+### `Bar`
+
+- `start / end: BarLine` (no implicit defaults at the type level).
+  Mid-section bars use `Single` on both sides; section boundaries
+  use `Double`; repeat blocks use `OpenRepeat` / `CloseRepeat`;
+  the chart's last bar uses `Final`.
+- `chords: Vec<BarChord>`. An empty vector is the iReal "repeat
+  the previous bar" idiom (the rendering crate paints a `W` glyph).
+  Storing it as empty rather than introducing a `RepeatPrior`
+  variant on `Bar` keeps the structure denormalised but keeps the
+  bar-list ordering trivially indexable, which matters for the
+  4-bar-per-line layout engine in #2060.
+- `ending: Option<Ending>`. `Ending` wraps `NonZeroU8` so the
+  `Some(Ending(0))` shape is unrepresentable.
+- `symbol: Option<MusicalSymbol>`. Single-symbol-per-bar matches
+  iReal Pro convention. If a future format extension allows
+  multiples, this becomes `Vec<MusicalSymbol>` and call sites that
+  match on `Option` need to update — flagged here so the migration
+  is not surprising.
+
+### `BarChord` and `BeatPosition`
+
+- `BeatPosition { beat: NonZeroU8, subdivision: u8 }`. Discrete
+  integers (not `f32`) so equality is byte-stable for golden
+  tests. `subdivision` is in units of `2 ^ subdivision`-of-a-beat:
+  `0` = on the beat, `1` = half-beat after, `2` = quarter-beat
+  after, etc. This is enough resolution for the iReal grid (which
+  shows up to 8th notes off-beat) without floating-point grief.
+
+### `Chord` and `ChordQuality`
+
+- `Chord { root, quality, bass }`. Slash chords are decomposed,
+  not encoded as a special quality. `bass.is_none()` is "no slash".
+- `ChordQuality::Custom(String)`. The named variants cover the
+  qualities `chordsketch-render-ireal` (#2057) renders as a
+  distinct glyph; everything beyond (extensions, alterations, poly
+  chords) is a Custom string with the post-root token preserved
+  verbatim. This avoids enum-bloat and keeps the rendering crate
+  in charge of glyph mapping.
+
+### `ChordRoot`
+
+- `note: char` (uppercase ASCII letter). Storing as `char`
+  instead of an enum keeps round-tripping with the URL serializer
+  (#2052) trivial without paying the cost of a 7-variant enum
+  whose `match` arms duplicate `c.is_ascii_uppercase()` checks.
+  The character set is documented here and asserted at parse time
+  (#2054 owns that check).
+
+### `TimeSignature`
+
+- `numerator: u8` clamped to `1 ..= 12` and `denominator` clamped
+  to `{2, 4, 8}` at construction. The numerator cap matches iReal
+  Pro's UI; the denominator allow-list excludes `1/x` and `x/16`
+  because the iReal grid cannot render them. Construction errors
+  return `None` rather than panicking — public APIs validate at
+  the boundary per `.claude/rules/defensive-inputs.md`.
+
+## Deferred AST scope
+
+Items the iReal app supports but the AST does **not** model yet,
+along with where they should land when implemented:
+
+- **Mid-chart time changes.** A chart can switch from `4/4` to
+  `3/4` mid-form. Modelling this requires either per-section
+  `TimeSignature` overrides or per-bar overrides; the design call
+  is deferred to #2054 where the parser will surface the format's
+  actual encoding (`T34` markers).
+- **Mid-chart key changes.** Same shape problem as time changes.
+  Defer to #2054.
+- **Slash-chord with non-letter bass.** A chord like
+  `C/D♯` parses as `Chord { root: C, quality: Major, bass: Some(D♯) }`
+  today; future work for the parser may need to accept root-less
+  bass forms or pedal-tone extensions. Adding new `ChordQuality`
+  variants is non-breaking and is the planned migration path.
+- **Coda-2 / Segno-2.** iReal Pro distinguishes a second segno
+  and a second coda for double-jump pieces. `MusicalSymbol`
+  currently lists only one of each; if #2059 surfaces a need for
+  the second forms, add `SegnoSecondary` / `CodaSecondary` variants
+  rather than abusing the existing names.
+- **Full repeat-bar-counts.** iReal supports "repeat the last 2
+  bars" (a single `r` glyph spanning two bars). The current AST
+  represents only single-bar repeats (an empty `Bar { chords: [] }`).
+  #2059 owns the multi-bar form when it lands.
+- **Lyrics.** iReal Pro has no native lyrics surface; the
+  ChordPro→iReal converter (#2061) drops them. Modelling lyrics
+  in this AST would be premature.
+
+## JSON debug format
+
+`src/json.rs` emits a stable, compact JSON view of an `IrealSong`
+for golden-snapshot tests, and parses it back via the `FromJson`
+trait. It is **not** a public wire format — the canonical iReal
+serialisation is the `irealb://` URL, owned by #2052.
+
+Format properties relied on by golden tests:
+
+- Compact (no indentation, no whitespace inside objects).
+- Field order matches the struct field order in `ast.rs`.
+- Enums are tagged with a `"kind"` discriminator key when carrying
+  payload data (`SectionLabel`, `ChordQuality`); plain enums (e.g.
+  `Accidental`, `BarLine`) are bare strings.
+- Strings use only the JSON-mandatory escapes plus `\u{XXXX}` for
+  C0 controls. Non-ASCII passes through as UTF-8.
+
+The deserializer is round-trip-only: it accepts exactly the subset
+of JSON the serializer emits (no booleans, no floats, no trailing
+commas, no duplicate keys, no surrogate-pair `\u` escapes) and
+rejects anything else. Widening one half of the pair without the
+other is a structural defect — see the `json_round_trip_*` tests
+in `tests/ast.rs`.
+
+If any property above changes, the tests
+`json_serialization_is_byte_stable`,
+`json_round_trips_through_deserializer`, and
+`json_round_trip_handles_every_enum_variant` in `tests/ast.rs`,
+plus this section, must be updated together.
+
+## Dependency policy
+
+Zero external dependencies. Every iReal-related follow-up crate
+(#2052 / #2054 / #2058 / etc.) builds on this AST, so adding a
+runtime dependency here would force the policy onto every
+dependent. `chordsketch-chordpro` follows the same rule for the
+same reason.
+
+## Open questions for the parser (#2054)
+
+- Should the parser produce `IrealSong` directly, or an interim
+  per-bar token stream that this crate doesn't model? The current
+  scaffold assumes the former; if the latter turns out to be
+  structurally needed, it lives in `chordsketch-ireal::parser` as
+  a separate module rather than disturbing the public AST shape.
+- How are multi-song iReal collections (`irealbook://`) surfaced
+  to callers? Most likely as `Vec<IrealSong>` from a top-level
+  `parse_collection` function. Confirmed when #2054 lands.

--- a/crates/ireal/Cargo.toml
+++ b/crates/ireal/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "chordsketch-ireal"
+version = "0.3.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "iReal Pro AST types and a zero-dep JSON debug serializer / parser"
+readme = "README.md"
+
+[dependencies]
+
+[dev-dependencies]

--- a/crates/ireal/README.md
+++ b/crates/ireal/README.md
@@ -4,6 +4,8 @@
 
 # chordsketch-ireal
 
+[![crates.io](https://img.shields.io/crates/v/chordsketch-ireal)](https://crates.io/crates/chordsketch-ireal)
+
 iReal Pro AST types and a zero-dependency JSON debug serializer / parser.
 
 This crate is the foundational scaffold for the iReal Pro feature
@@ -14,42 +16,76 @@ before the follow-up crates layer features on top.
 
 Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
 
-## Status
+## Installation
 
-Pre-1.0 scaffold. The AST is intentionally minimal: every named
-type and variant is grounded in `#2055`'s acceptance criteria. Field
-additions and new enum variants are expected to be non-breaking; if
-a follow-up crate needs a structural change, the change happens in
-this crate first and is reflected in `ARCHITECTURE.md`.
+Replace `VERSION` with the latest release shown on the badge above.
 
-## Usage
+```toml
+[dependencies]
+chordsketch-ireal = "VERSION"
+```
+
+Or via `cargo add`:
+
+```bash
+cargo add chordsketch-ireal
+```
+
+## Quick start
 
 ```rust
 use chordsketch_ireal::{
-    Chord, ChordQuality, ChordRoot, IrealSong, ToJson,
+    Chord, ChordQuality, ChordRoot, FromJson, IrealSong, Section,
+    SectionLabel, ToJson,
 };
 
 let mut song = IrealSong::new();
 song.title = "Autumn Leaves".to_string();
-// ... build sections / bars / chords ...
+song.sections.push(Section::new(SectionLabel::Letter('A')));
 
 // JSON debug output for golden-snapshot tests.
 let json = song.to_json_string();
 assert!(json.contains("\"title\":\"Autumn Leaves\""));
+
+// Round-trip back through the deserializer.
+let parsed = IrealSong::from_json_str(&json).expect("round-trip succeeds");
+assert_eq!(parsed, song);
 ```
 
-## Features
+## API
 
-- AST types for an iReal Pro chart: `IrealSong`, `Section`, `Bar`,
-  `Chord`, `TimeSignature`, `KeySignature`, repeat / ending markers,
-  `MusicalSymbol`.
-- Zero external dependencies (consistent with `chordsketch-chordpro`).
-- Structural equality (`PartialEq` / `Eq`) on every node.
-- Hand-rolled JSON debug serializer (`ToJson` trait) with byte-stable
-  output ordering — useful for golden snapshots in follow-up crates.
-- Round-trip JSON deserializer (`FromJson` trait) sized to exactly the
-  format `ToJson` emits; rejects drift outside that subset rather than
-  silently coercing.
+| Item | Signature | Notes |
+|---|---|---|
+| `IrealSong` | struct with `title`, `composer`, `style`, `key_signature`, `time_signature`, `tempo`, `transpose`, `sections` | Root AST node. `IrealSong::new()` builds an empty `C major` 4/4 chart. |
+| `Section`, `SectionLabel` | struct + 7-variant enum (`Letter(c)`, `Verse`, `Chorus`, `Intro`, `Outro`, `Bridge`, `Custom(s)`) | Labelled block of bars. |
+| `Bar`, `BarLine`, `Ending` | struct + 5-variant enum + `NonZeroU8` newtype | One measure with opening / closing barline, chords, ending number, optional `MusicalSymbol`. |
+| `BarChord`, `BeatPosition` | structs | Chord placed at a beat position inside a bar. |
+| `Chord`, `ChordRoot`, `ChordQuality`, `Accidental` | structs + enums | Root, quality (12 named + `Custom`), optional bass note, accidental. |
+| `KeySignature`, `KeyMode`, `TimeSignature` | structs + enum | Key (C major default) and time signature (4/4 default). |
+| `MusicalSymbol` | enum (`Segno`, `Coda`, `DaCapo`, `DalSegno`, `Fine`) | Bar-attached navigation symbols. |
+| `ToJson` | `fn to_json(&self, &mut String)` and `fn to_json_string(&self) -> String` | Hand-rolled, byte-stable, compact JSON. |
+| `FromJson` | `fn from_json_str(&str) -> Result<Self, JsonError>` and `fn from_json_value(&JsonValue) -> Result<Self, JsonError>` | Round-trip-only deserializer; accepts only the subset `ToJson` emits. |
+| `parse_json` | `fn parse_json(&str) -> Result<JsonValue, JsonError>` | Free function for the underlying JSON value tree. |
+
+Validating constructors: `TimeSignature::new`, `Ending::new`,
+`BeatPosition::on_beat` all return `Option`. Direct field
+mutation bypasses these checks — see the module-level "Public-field
+mutation contract" comment in `ast.rs`.
+
+## Configuration / limits
+
+The deserializer enforces hard caps to keep adversarial input
+bounded:
+
+| Constant | Default | Purpose |
+|---|---|---|
+| `MAX_INPUT_BYTES` | 4 MiB | Total input length |
+| `MAX_DEPTH` | 128 | Container nesting (objects + arrays) |
+| `MAX_ARRAY_LEN` | 65 536 | Single-array element count |
+| `MAX_OBJECT_FIELDS` | 65 536 | Single-object field count |
+| `MAX_STRING_CHARS` | 1 048 576 | Decoded length of any single JSON string |
+
+All constants are `pub` in `chordsketch_ireal::json`.
 
 ## Roadmap
 
@@ -62,6 +98,13 @@ assert!(json.contains("\"title\":\"Autumn Leaves\""));
 | SVG / PNG / PDF renderer | [#2058](https://github.com/koedame/chordsketch/issues/2058) and follow-ups |
 | CLI auto-detect | [#2066](https://github.com/koedame/chordsketch/issues/2066) |
 | WASM / NAPI / FFI bindings | [#2067](https://github.com/koedame/chordsketch/issues/2067) |
+
+## Links
+
+- [Project repository](https://github.com/koedame/chordsketch)
+- [Playground](https://chordsketch.koeda.me)
+- [API docs (docs.rs)](https://docs.rs/chordsketch-ireal)
+- [Issue tracker](https://github.com/koedame/chordsketch/issues)
 
 ## License
 

--- a/crates/ireal/README.md
+++ b/crates/ireal/README.md
@@ -1,0 +1,68 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/koedame/chordsketch/main/assets/logo.svg" alt="ChordSketch" width="80" height="80">
+</p>
+
+# chordsketch-ireal
+
+iReal Pro AST types and a zero-dependency JSON debug serializer / parser.
+
+This crate is the foundational scaffold for the iReal Pro feature
+set tracked under [#2050](https://github.com/koedame/chordsketch/issues/2050).
+It deliberately ships only the AST shape — no `irealb://` URL parser,
+no URL serializer, no renderer — so the cross-cutting AST stabilises
+before the follow-up crates layer features on top.
+
+Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
+
+## Status
+
+Pre-1.0 scaffold. The AST is intentionally minimal: every named
+type and variant is grounded in `#2055`'s acceptance criteria. Field
+additions and new enum variants are expected to be non-breaking; if
+a follow-up crate needs a structural change, the change happens in
+this crate first and is reflected in `ARCHITECTURE.md`.
+
+## Usage
+
+```rust
+use chordsketch_ireal::{
+    Chord, ChordQuality, ChordRoot, IrealSong, ToJson,
+};
+
+let mut song = IrealSong::new();
+song.title = "Autumn Leaves".to_string();
+// ... build sections / bars / chords ...
+
+// JSON debug output for golden-snapshot tests.
+let json = song.to_json_string();
+assert!(json.contains("\"title\":\"Autumn Leaves\""));
+```
+
+## Features
+
+- AST types for an iReal Pro chart: `IrealSong`, `Section`, `Bar`,
+  `Chord`, `TimeSignature`, `KeySignature`, repeat / ending markers,
+  `MusicalSymbol`.
+- Zero external dependencies (consistent with `chordsketch-chordpro`).
+- Structural equality (`PartialEq` / `Eq`) on every node.
+- Hand-rolled JSON debug serializer (`ToJson` trait) with byte-stable
+  output ordering — useful for golden snapshots in follow-up crates.
+- Round-trip JSON deserializer (`FromJson` trait) sized to exactly the
+  format `ToJson` emits; rejects drift outside that subset rather than
+  silently coercing.
+
+## Roadmap
+
+| Feature | Tracking issue |
+|---|---|
+| `irealb://` URL parser | [#2054](https://github.com/koedame/chordsketch/issues/2054) |
+| AST → `irealb://` URL serializer | [#2052](https://github.com/koedame/chordsketch/issues/2052) |
+| iReal → ChordPro conversion | [#2053](https://github.com/koedame/chordsketch/issues/2053) |
+| ChordPro → iReal conversion (lossy) | [#2061](https://github.com/koedame/chordsketch/issues/2061) |
+| SVG / PNG / PDF renderer | [#2058](https://github.com/koedame/chordsketch/issues/2058) and follow-ups |
+| CLI auto-detect | [#2066](https://github.com/koedame/chordsketch/issues/2066) |
+| WASM / NAPI / FFI bindings | [#2067](https://github.com/koedame/chordsketch/issues/2067) |
+
+## License
+
+MIT.

--- a/crates/ireal/src/ast.rs
+++ b/crates/ireal/src/ast.rs
@@ -1,0 +1,488 @@
+//! AST types for an iReal Pro chart.
+//!
+//! Every node is a plain owned struct/enum with `Clone`, `Debug`, and
+//! `PartialEq` (and `Eq` where the contained types allow). The types
+//! are deliberately decoupled from any specific wire format —
+//! parsing the `irealb://` URL into this AST happens in #2054,
+//! serializing back happens in #2052, and either direction can
+//! evolve without disturbing call sites once this scaffold is in
+//! place.
+//!
+//! See `ARCHITECTURE.md` for the field-level design rationale.
+
+use std::num::NonZeroU8;
+
+// ---------------------------------------------------------------------------
+// Song (root node)
+// ---------------------------------------------------------------------------
+
+/// The root node — a single iReal Pro chart.
+///
+/// A chart has document-level metadata (title, composer, style, key,
+/// time, tempo, transposition) plus an ordered list of [`Section`]s.
+/// Multi-song iReal collections (`irealbook://...===Title2===...`)
+/// are represented at a higher layer as a `Vec<IrealSong>`; this
+/// struct models exactly one chart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IrealSong {
+    /// Title of the tune. Empty string if the chart did not declare
+    /// one, mirroring the iReal Pro app's tolerance for unnamed
+    /// charts. Use [`IrealSong::new`] to start from an empty default.
+    pub title: String,
+    /// Composer attribution (`Author` field in the iReal format).
+    /// Optional because old user-submitted charts often omit it.
+    pub composer: Option<String>,
+    /// iReal Pro style tag — e.g. "Medium Swing", "Bossa Nova",
+    /// "Ballad". Optional; the iReal app falls back to "Medium Swing"
+    /// when missing, but the AST does not impose that default.
+    pub style: Option<String>,
+    /// Concert-pitch key the chart is written in.
+    pub key_signature: KeySignature,
+    /// Time signature in force at the start of the chart. Time
+    /// changes inside the chart are not yet modelled — see
+    /// `ARCHITECTURE.md` §"Deferred AST scope" for the rationale.
+    pub time_signature: TimeSignature,
+    /// Beats-per-minute tempo. Optional because many shared charts
+    /// leave tempo to the player.
+    pub tempo: Option<u16>,
+    /// Display-time transposition in semitones, in the range
+    /// `[-11, 11]`. Stored as the chart-level transpose offset; the
+    /// iReal app applies this on top of `key_signature` when rendering.
+    pub transpose: i8,
+    /// Ordered list of sections (intro / A / B / outro / etc.).
+    pub sections: Vec<Section>,
+}
+
+impl IrealSong {
+    /// Creates an empty chart with a `C major` key, `4/4` time, and
+    /// no metadata, sections, tempo, or transpose. Mirrors
+    /// `Song::new` in `chordsketch-chordpro` so call sites can pick
+    /// the same idiom.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            title: String::new(),
+            composer: None,
+            style: None,
+            key_signature: KeySignature::default(),
+            time_signature: TimeSignature::default(),
+            tempo: None,
+            transpose: 0,
+            sections: Vec::new(),
+        }
+    }
+}
+
+impl Default for IrealSong {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+/// A labelled block of bars (e.g. "A", "B", "Verse").
+///
+/// iReal charts use letter labels for jazz-form sections (A / B / C /
+/// D); fakebook-style or non-jazz charts may use named labels like
+/// "Verse" / "Chorus" / "Intro" / "Outro". Both are representable
+/// via [`SectionLabel`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Section {
+    /// The section's label. See [`SectionLabel`] for the supported
+    /// shapes.
+    pub label: SectionLabel,
+    /// Ordered list of bars in this section.
+    pub bars: Vec<Bar>,
+}
+
+impl Section {
+    /// Creates a new section with the given label and an empty bar list.
+    #[must_use]
+    pub fn new(label: SectionLabel) -> Self {
+        Self {
+            label,
+            bars: Vec::new(),
+        }
+    }
+}
+
+/// A section label.
+///
+/// Most iReal charts use a single uppercase letter for jazz form
+/// labels (`Letter('A')`); `Custom` is the escape hatch for the long
+/// tail of non-letter labels the iReal app accepts (named verses,
+/// non-Latin script, free-form annotations). The named variants
+/// (`Verse`, `Chorus`, etc.) exist so common cases parse to the same
+/// shape across the conversion crate (#2053 / #2061) without each
+/// site re-comparing strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SectionLabel {
+    /// A single uppercase letter — the canonical jazz-form label.
+    Letter(char),
+    /// `Verse`.
+    Verse,
+    /// `Chorus`.
+    Chorus,
+    /// `Intro`.
+    Intro,
+    /// `Outro`.
+    Outro,
+    /// `Bridge`.
+    Bridge,
+    /// Any other label. The contained string is preserved verbatim
+    /// and is the canonical round-trip carrier for labels that do
+    /// not fit one of the named variants.
+    Custom(String),
+}
+
+// ---------------------------------------------------------------------------
+// Bar
+// ---------------------------------------------------------------------------
+
+/// One measure inside a [`Section`].
+///
+/// A bar has an opening and closing barline, an ordered list of
+/// chords (each anchored at a beat position), an optional ending
+/// number, and an optional musical symbol attached to the bar (e.g.
+/// the segno or coda mark).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Bar {
+    /// Opening barline. Defaults to [`BarLine::Single`] for
+    /// mid-section bars.
+    pub start: BarLine,
+    /// Closing barline.
+    pub end: BarLine,
+    /// Chords in this bar, anchored to beat positions. An empty
+    /// vector represents a bar that repeats the prior bar's chords
+    /// — see [`BarChord`] for anchoring semantics.
+    pub chords: Vec<BarChord>,
+    /// `Some(NonZeroU8)` if this bar starts an N-th ending bracket.
+    /// `None` if the bar is not part of an ending. The non-zero
+    /// guarantee means a `1`/`2`/`3` ending always reads as a
+    /// non-zero number; `Ending::is_first` style helpers live on
+    /// [`Ending`] so call sites do not re-derive them.
+    pub ending: Option<Ending>,
+    /// Optional musical-symbol attachment (segno / coda / D.C. /
+    /// D.S. / Fine). At most one symbol per bar is the iReal Pro
+    /// convention; if a future format extension allows multiple
+    /// symbols per bar, this becomes `Vec<MusicalSymbol>` and call
+    /// sites that match on `Option` will need to update — flagged
+    /// in `ARCHITECTURE.md`.
+    pub symbol: Option<MusicalSymbol>,
+}
+
+impl Bar {
+    /// Creates a new bar with single barlines on both sides and no
+    /// chords / ending / symbol. The most common starting point.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            start: BarLine::Single,
+            end: BarLine::Single,
+            chords: Vec::new(),
+            ending: None,
+            symbol: None,
+        }
+    }
+}
+
+impl Default for Bar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Barline shape at a bar boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BarLine {
+    /// Single barline `|`.
+    Single,
+    /// Double barline `||` — used between sections.
+    Double,
+    /// Final barline `|||` — only at the end of a chart.
+    Final,
+    /// Open-repeat `|:` — start of a repeat block.
+    OpenRepeat,
+    /// Close-repeat `:|` — end of a repeat block.
+    CloseRepeat,
+}
+
+/// Ending bracket number (1, 2, 3 …). Stored as [`NonZeroU8`] so the
+/// `Option<Ending>` discriminant cannot drift into "ending zero" via
+/// `Default`. Call sites read the number with [`Ending::number`];
+/// equality is structural.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ending(NonZeroU8);
+
+impl Ending {
+    /// Creates an ending with the given number. Returns `None` if
+    /// `n == 0` since "ending zero" is not a meaningful concept in
+    /// the iReal format.
+    #[must_use]
+    pub const fn new(n: u8) -> Option<Self> {
+        match NonZeroU8::new(n) {
+            Some(nz) => Some(Self(nz)),
+            None => None,
+        }
+    }
+
+    /// Returns the ending number as a plain `u8`.
+    #[must_use]
+    pub const fn number(self) -> u8 {
+        self.0.get()
+    }
+}
+
+/// A chord placed at a beat inside a bar.
+///
+/// iReal's bar grid divides the bar into beat slots (one per
+/// numerator beat); a chord can sit on any beat. [`BeatPosition`]
+/// carries the slot index plus an optional sub-beat fraction for
+/// charts that mark "and-of-2" or similar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BarChord {
+    /// The chord at this position.
+    pub chord: Chord,
+    /// Where in the bar the chord lands.
+    pub position: BeatPosition,
+}
+
+/// Position inside a bar, expressed as `beat` (1-indexed, 1 ..= the
+/// time-signature numerator) and an optional `subdivision` integer
+/// in the unit `2 ^ subdivision` of a beat. `subdivision == 0`
+/// (default) means "on the beat"; `subdivision == 1` means "the
+/// half-beat after"; etc. The discrete-integer layout keeps
+/// equality byte-stable for golden tests, which a `f32` would not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BeatPosition {
+    /// 1-indexed beat number inside the bar.
+    pub beat: NonZeroU8,
+    /// Sub-beat offset; `0` means "on the beat".
+    pub subdivision: u8,
+}
+
+impl BeatPosition {
+    /// Creates a position on beat `beat` (1-indexed) with no
+    /// subdivision. Returns `None` if `beat == 0`.
+    #[must_use]
+    pub const fn on_beat(beat: u8) -> Option<Self> {
+        match NonZeroU8::new(beat) {
+            Some(nz) => Some(Self {
+                beat: nz,
+                subdivision: 0,
+            }),
+            None => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Chord
+// ---------------------------------------------------------------------------
+
+/// A chord: root, quality, and optional bass note (slash chord).
+///
+/// Slash chords are represented with the bass distinct from the
+/// root — `C/G` is `Chord { root: C, quality: Major, bass: Some(G) }`.
+/// `bass.is_none()` means "no slash". Equality is by all three
+/// fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Chord {
+    /// Root note of the chord.
+    pub root: ChordRoot,
+    /// Chord quality.
+    pub quality: ChordQuality,
+    /// Slash-chord bass note. `None` if the chord has no slash.
+    pub bass: Option<ChordRoot>,
+}
+
+impl Chord {
+    /// Creates a triad with no slash. The most common starting
+    /// point for AST construction in tests.
+    #[must_use]
+    pub fn triad(root: ChordRoot, quality: ChordQuality) -> Self {
+        Self {
+            root,
+            quality,
+            bass: None,
+        }
+    }
+}
+
+/// A root or bass note: pitch class + accidental.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChordRoot {
+    /// The diatonic letter (`A` … `G`). Stored as the uppercase
+    /// ASCII letter so the value is a structural enum-like key
+    /// without the round-trip cost of a real `enum`.
+    pub note: char,
+    /// Accidental on the root.
+    pub accidental: Accidental,
+}
+
+impl ChordRoot {
+    /// Creates a root with a natural accidental.
+    #[must_use]
+    pub const fn natural(note: char) -> Self {
+        Self {
+            note,
+            accidental: Accidental::Natural,
+        }
+    }
+}
+
+/// Accidental on a note: natural, flat, sharp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Accidental {
+    /// Natural — the unaltered diatonic letter.
+    Natural,
+    /// Flat (♭).
+    Flat,
+    /// Sharp (♯).
+    Sharp,
+}
+
+/// Chord quality (triad + extension).
+///
+/// The named variants cover the qualities iReal Pro renders as a
+/// distinct symbol; everything else (slash, suspended, altered,
+/// polychord, etc.) falls into [`ChordQuality::Custom`]. The
+/// `Custom` variant is intentional: keeping the named set narrow
+/// avoids the AST having to track every notation variant the iReal
+/// format permits, and lets the rendering crate (#2057) decide on
+/// glyph mapping without an enum-bloat refactor here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChordQuality {
+    /// Major triad (e.g. `C`).
+    Major,
+    /// Minor triad (e.g. `Cm`).
+    Minor,
+    /// Diminished triad (e.g. `Cdim` / `Co`).
+    Diminished,
+    /// Augmented triad (e.g. `Caug` / `C+`).
+    Augmented,
+    /// Major 7th (e.g. `Cmaj7` / `CM7` / `CΔ`).
+    Major7,
+    /// Minor 7th (e.g. `Cm7`).
+    Minor7,
+    /// Dominant 7th (e.g. `C7`).
+    Dominant7,
+    /// Half-diminished 7th (e.g. `Cm7♭5` / `Cø`).
+    HalfDiminished,
+    /// Fully diminished 7th (e.g. `Cdim7` / `C°7`).
+    Diminished7,
+    /// Suspended 2nd (e.g. `Csus2`).
+    Suspended2,
+    /// Suspended 4th (e.g. `Csus4`).
+    Suspended4,
+    /// Anything else, preserved verbatim from the source.
+    /// Examples: `C7♯9`, `C13♭9♯11`, `C/G/E` polychord. The string
+    /// is the post-root quality token (i.e. without the root letter
+    /// or accidental), so `C7♯9` stores `"7♯9"` here.
+    Custom(String),
+}
+
+// ---------------------------------------------------------------------------
+// Signatures
+// ---------------------------------------------------------------------------
+
+/// Time signature `numerator / denominator`.
+///
+/// `numerator` is in `1 ..= 12` for representable iReal time
+/// signatures (the iReal app accepts up to 12/x), and `denominator`
+/// is one of 2, 4, or 8. This range is enforced at construction by
+/// [`TimeSignature::new`]; the public fields are still settable so
+/// callers building ASTs in tests can intentionally exercise edge
+/// cases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeSignature {
+    /// Beats per bar.
+    pub numerator: u8,
+    /// Beat unit (typically 2, 4, or 8).
+    pub denominator: u8,
+}
+
+impl TimeSignature {
+    /// Creates a time signature, returning `None` if `numerator` is
+    /// outside `1 ..= 12` or `denominator` is not one of 2, 4, 8.
+    /// The numerator cap matches iReal Pro's own UI; the denominator
+    /// allow-list excludes `1/x` (uncommon) and `x/16` (not
+    /// representable in the iReal grid).
+    #[must_use]
+    pub const fn new(numerator: u8, denominator: u8) -> Option<Self> {
+        if numerator == 0 || numerator > 12 {
+            return None;
+        }
+        match denominator {
+            2 | 4 | 8 => Some(Self {
+                numerator,
+                denominator,
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl Default for TimeSignature {
+    fn default() -> Self {
+        // 4/4 is iReal Pro's implicit default when a chart omits a
+        // time signature. `unwrap()` is safe because (4, 4) is
+        // always inside the allowed range.
+        Self::new(4, 4).expect("4/4 is a valid TimeSignature")
+    }
+}
+
+/// Key signature: tonic + mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeySignature {
+    /// Tonic of the key.
+    pub root: ChordRoot,
+    /// Major / minor.
+    pub mode: KeyMode,
+}
+
+impl Default for KeySignature {
+    fn default() -> Self {
+        // C major matches iReal Pro's implicit default.
+        Self {
+            root: ChordRoot::natural('C'),
+            mode: KeyMode::Major,
+        }
+    }
+}
+
+/// Key mode: major / minor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyMode {
+    /// Major mode.
+    Major,
+    /// Minor mode.
+    Minor,
+}
+
+// ---------------------------------------------------------------------------
+// Musical symbols
+// ---------------------------------------------------------------------------
+
+/// A repeat / navigation symbol attached to a bar.
+///
+/// iReal Pro renders these as Bravura-font glyphs (#2062). The
+/// AST keeps them as plain enum variants so the rendering crate
+/// owns the glyph mapping and the conversion crate (#2053) can
+/// decide which ChordPro directive each symbol maps to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MusicalSymbol {
+    /// Segno mark (𝄋).
+    Segno,
+    /// Coda mark (𝄌).
+    Coda,
+    /// "Da Capo" jump-to-start instruction.
+    DaCapo,
+    /// "Dal Segno" jump-to-segno instruction.
+    DalSegno,
+    /// "Fine" — terminal marker for a `D.C. al fine` / `D.S. al fine`.
+    Fine,
+}

--- a/crates/ireal/src/ast.rs
+++ b/crates/ireal/src/ast.rs
@@ -9,6 +9,23 @@
 //! place.
 //!
 //! See `ARCHITECTURE.md` for the field-level design rationale.
+//!
+//! # Public-field mutation contract
+//!
+//! Every struct in this module exposes its fields as `pub`, deliberately,
+//! so test fixtures and builders can mutate the AST inline. The
+//! validating constructors ([`TimeSignature::new`], [`Ending::new`],
+//! [`BeatPosition::on_beat`]) and the [`crate::json::FromJson`]
+//! deserializer enforce the documented value ranges; **direct
+//! field mutation bypasses those checks**. Downstream consumers
+//! (renderer in #2057, URL writer in #2052) are expected to treat
+//! ASTs constructed by anything other than a documented constructor /
+//! parser as untrusted and re-validate at their own boundary, per the
+//! "validate at the public boundary" rule in `defensive-inputs.md`.
+//! In particular: [`TimeSignature::numerator`] / [`TimeSignature::denominator`],
+//! [`IrealSong::transpose`], [`BeatPosition::subdivision`], and
+//! [`ChordRoot::note`] all carry doc-comment ranges that the type system
+//! does not enforce.
 
 use std::num::NonZeroU8;
 
@@ -254,7 +271,10 @@ pub struct BarChord {
 /// time-signature numerator) and an optional `subdivision` integer
 /// in the unit `2 ^ subdivision` of a beat. `subdivision == 0`
 /// (default) means "on the beat"; `subdivision == 1` means "the
-/// half-beat after"; etc. The discrete-integer layout keeps
+/// half-beat after"; etc. Practical values are 0..=3 (down to
+/// 32nd-note resolution); larger values are not produced by any
+/// known iReal Pro source format and are reserved for future grid-
+/// resolution increases. The discrete-integer layout keeps
 /// equality byte-stable for golden tests, which a `f32` would not.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BeatPosition {
@@ -317,7 +337,9 @@ impl Chord {
 pub struct ChordRoot {
     /// The diatonic letter (`A` … `G`). Stored as the uppercase
     /// ASCII letter so the value is a structural enum-like key
-    /// without the round-trip cost of a real `enum`.
+    /// without the round-trip cost of a real `enum`. The
+    /// [`crate::json::FromJson`] deserializer enforces the
+    /// `A..=G` range; direct field assignment does not.
     pub note: char,
     /// Accidental on the root.
     pub accidental: Accidental,

--- a/crates/ireal/src/ast.rs
+++ b/crates/ireal/src/ast.rs
@@ -325,6 +325,11 @@ pub struct ChordRoot {
 
 impl ChordRoot {
     /// Creates a root with a natural accidental.
+    ///
+    /// `note` is expected to be an uppercase ASCII letter in `'A'..='G'`.
+    /// No validation is performed here — enforcing valid note letters is
+    /// the responsibility of the iReal URL parser (#2054), which is the
+    /// public-API entry point.
     #[must_use]
     pub const fn natural(note: char) -> Self {
         Self {

--- a/crates/ireal/src/json.rs
+++ b/crates/ireal/src/json.rs
@@ -752,14 +752,22 @@ impl<'a> Parser<'a> {
                     })?;
                     self.pos += 1;
                     match escape {
-                        b'"' => out.push('"'),
-                        b'\\' => out.push('\\'),
-                        b'/' => out.push('/'),
-                        b'n' => out.push('\n'),
-                        b'r' => out.push('\r'),
-                        b't' => out.push('\t'),
-                        b'b' => out.push('\u{08}'),
-                        b'f' => out.push('\u{0c}'),
+                        b'"' | b'\\' | b'/' | b'n' | b'r' | b't' | b'b' | b'f' => {
+                            let ch = match escape {
+                                b'"' => '"',
+                                b'\\' => '\\',
+                                b'/' => '/',
+                                b'n' => '\n',
+                                b'r' => '\r',
+                                b't' => '\t',
+                                b'b' => '\u{08}',
+                                b'f' => '\u{0c}',
+                                // SAFETY: all arms covered by the outer match guard
+                                _ => unreachable!(),
+                            };
+                            out.push(ch);
+                            chars_decoded += 1;
+                        }
                         b'u' => {
                             let hex_start = self.pos;
                             let hex =

--- a/crates/ireal/src/json.rs
+++ b/crates/ireal/src/json.rs
@@ -1,0 +1,1062 @@
+//! Zero-dependency JSON debug serializer.
+//!
+//! Emits a stable, human-readable JSON view of an [`IrealSong`] for
+//! testing and golden-snapshot diffing. Not a public wire format —
+//! the canonical iReal serialisation is the `irealb://` URL, owned
+//! by #2052.
+//!
+//! # Why hand-rolled
+//!
+//! `chordsketch-chordpro` is zero-dependency on principle (see the
+//! crate's `Cargo.toml`); this crate inherits that policy because the
+//! AST types are the cross-cutting layer that every iReal-related
+//! follow-up crate (#2052 / #2054 / #2058 / etc.) builds on. Adding
+//! `serde` here would force the policy onto every dependent. The
+//! debug-format escape rules are limited to what the AST actually
+//! produces (printable strings + numbers + finite enum variants), so
+//! the hand-rolled writer stays small without sacrificing
+//! correctness.
+//!
+//! # Format
+//!
+//! Output is compact (no indentation) but deterministic — the field
+//! order matches the struct field order in `ast.rs`, which is the
+//! property golden-snapshot tests rely on. JSON strings are escaped
+//! per RFC 8259 §7 (only the mandatory escapes plus `\u{XXXX}` for
+//! C0 control chars).
+
+use crate::ast::{
+    Accidental, Bar, BarChord, BarLine, BeatPosition, Chord, ChordQuality, ChordRoot, Ending,
+    IrealSong, KeyMode, KeySignature, MusicalSymbol, Section, SectionLabel, TimeSignature,
+};
+
+/// Anything that knows how to write itself as JSON into a `String`
+/// buffer. Implementors append; the caller decides what the buffer
+/// is for (a `String::new()` for one-off serialisation, a shared
+/// buffer for a multi-song collection).
+pub trait ToJson {
+    /// Append this value's JSON form to `out`. The format is
+    /// documented at the module level.
+    fn to_json(&self, out: &mut String);
+
+    /// Convenience: allocate a fresh `String` and serialise into it.
+    /// Equivalent to `let mut s = String::new(); self.to_json(&mut s); s`.
+    #[must_use]
+    fn to_json_string(&self) -> String {
+        let mut out = String::new();
+        self.to_json(&mut out);
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+fn write_str(out: &mut String, s: &str) {
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\x08' => out.push_str("\\b"),
+            '\x0c' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                // Mandatory `\u{XXXX}` escape for the remaining C0
+                // controls (NUL, …, US except the named escapes
+                // above). Higher Unicode passes through verbatim
+                // because the JSON output is UTF-8 and JSON allows
+                // any Unicode scalar inside a string literal.
+                use core::fmt::Write;
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+fn write_opt_str(out: &mut String, s: &Option<String>) {
+    match s {
+        Some(v) => write_str(out, v),
+        None => out.push_str("null"),
+    }
+}
+
+fn write_u8(out: &mut String, v: u8) {
+    use core::fmt::Write;
+    let _ = write!(out, "{v}");
+}
+
+fn write_i8(out: &mut String, v: i8) {
+    use core::fmt::Write;
+    let _ = write!(out, "{v}");
+}
+
+fn write_u16(out: &mut String, v: u16) {
+    use core::fmt::Write;
+    let _ = write!(out, "{v}");
+}
+
+fn write_opt_u16(out: &mut String, v: &Option<u16>) {
+    match v {
+        Some(n) => write_u16(out, *n),
+        None => out.push_str("null"),
+    }
+}
+
+fn write_array<T: ToJson>(out: &mut String, items: &[T]) {
+    out.push('[');
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        item.to_json(out);
+    }
+    out.push(']');
+}
+
+// ---------------------------------------------------------------------------
+// AST impls
+// ---------------------------------------------------------------------------
+
+impl ToJson for IrealSong {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"title\":");
+        write_str(out, &self.title);
+        out.push_str(",\"composer\":");
+        write_opt_str(out, &self.composer);
+        out.push_str(",\"style\":");
+        write_opt_str(out, &self.style);
+        out.push_str(",\"key_signature\":");
+        self.key_signature.to_json(out);
+        out.push_str(",\"time_signature\":");
+        self.time_signature.to_json(out);
+        out.push_str(",\"tempo\":");
+        write_opt_u16(out, &self.tempo);
+        out.push_str(",\"transpose\":");
+        write_i8(out, self.transpose);
+        out.push_str(",\"sections\":");
+        write_array(out, &self.sections);
+        out.push('}');
+    }
+}
+
+impl ToJson for Section {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"label\":");
+        self.label.to_json(out);
+        out.push_str(",\"bars\":");
+        write_array(out, &self.bars);
+        out.push('}');
+    }
+}
+
+impl ToJson for SectionLabel {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        match self {
+            Self::Letter(c) => {
+                out.push_str("\"kind\":\"letter\",\"value\":");
+                let s = c.to_string();
+                write_str(out, &s);
+            }
+            Self::Verse => out.push_str("\"kind\":\"verse\""),
+            Self::Chorus => out.push_str("\"kind\":\"chorus\""),
+            Self::Intro => out.push_str("\"kind\":\"intro\""),
+            Self::Outro => out.push_str("\"kind\":\"outro\""),
+            Self::Bridge => out.push_str("\"kind\":\"bridge\""),
+            Self::Custom(s) => {
+                out.push_str("\"kind\":\"custom\",\"value\":");
+                write_str(out, s);
+            }
+        }
+        out.push('}');
+    }
+}
+
+impl ToJson for Bar {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"start\":");
+        self.start.to_json(out);
+        out.push_str(",\"end\":");
+        self.end.to_json(out);
+        out.push_str(",\"chords\":");
+        write_array(out, &self.chords);
+        out.push_str(",\"ending\":");
+        match &self.ending {
+            Some(e) => write_u8(out, e.number()),
+            None => out.push_str("null"),
+        }
+        out.push_str(",\"symbol\":");
+        match &self.symbol {
+            Some(s) => s.to_json(out),
+            None => out.push_str("null"),
+        }
+        out.push('}');
+    }
+}
+
+impl ToJson for BarLine {
+    fn to_json(&self, out: &mut String) {
+        let s = match self {
+            Self::Single => "single",
+            Self::Double => "double",
+            Self::Final => "final",
+            Self::OpenRepeat => "open_repeat",
+            Self::CloseRepeat => "close_repeat",
+        };
+        write_str(out, s);
+    }
+}
+
+impl ToJson for Ending {
+    fn to_json(&self, out: &mut String) {
+        write_u8(out, self.number());
+    }
+}
+
+impl ToJson for BarChord {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"chord\":");
+        self.chord.to_json(out);
+        out.push_str(",\"position\":");
+        self.position.to_json(out);
+        out.push('}');
+    }
+}
+
+impl ToJson for BeatPosition {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"beat\":");
+        write_u8(out, self.beat.get());
+        out.push_str(",\"subdivision\":");
+        write_u8(out, self.subdivision);
+        out.push('}');
+    }
+}
+
+impl ToJson for Chord {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"root\":");
+        self.root.to_json(out);
+        out.push_str(",\"quality\":");
+        self.quality.to_json(out);
+        out.push_str(",\"bass\":");
+        match &self.bass {
+            Some(b) => b.to_json(out),
+            None => out.push_str("null"),
+        }
+        out.push('}');
+    }
+}
+
+impl ToJson for ChordRoot {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"note\":");
+        let s = self.note.to_string();
+        write_str(out, &s);
+        out.push_str(",\"accidental\":");
+        self.accidental.to_json(out);
+        out.push('}');
+    }
+}
+
+impl ToJson for Accidental {
+    fn to_json(&self, out: &mut String) {
+        let s = match self {
+            Self::Natural => "natural",
+            Self::Flat => "flat",
+            Self::Sharp => "sharp",
+        };
+        write_str(out, s);
+    }
+}
+
+impl ToJson for ChordQuality {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        match self {
+            Self::Major => out.push_str("\"kind\":\"major\""),
+            Self::Minor => out.push_str("\"kind\":\"minor\""),
+            Self::Diminished => out.push_str("\"kind\":\"diminished\""),
+            Self::Augmented => out.push_str("\"kind\":\"augmented\""),
+            Self::Major7 => out.push_str("\"kind\":\"major7\""),
+            Self::Minor7 => out.push_str("\"kind\":\"minor7\""),
+            Self::Dominant7 => out.push_str("\"kind\":\"dominant7\""),
+            Self::HalfDiminished => out.push_str("\"kind\":\"half_diminished\""),
+            Self::Diminished7 => out.push_str("\"kind\":\"diminished7\""),
+            Self::Suspended2 => out.push_str("\"kind\":\"suspended2\""),
+            Self::Suspended4 => out.push_str("\"kind\":\"suspended4\""),
+            Self::Custom(s) => {
+                out.push_str("\"kind\":\"custom\",\"value\":");
+                write_str(out, s);
+            }
+        }
+        out.push('}');
+    }
+}
+
+impl ToJson for KeySignature {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"root\":");
+        self.root.to_json(out);
+        out.push_str(",\"mode\":");
+        self.mode.to_json(out);
+        out.push('}');
+    }
+}
+
+impl ToJson for KeyMode {
+    fn to_json(&self, out: &mut String) {
+        let s = match self {
+            Self::Major => "major",
+            Self::Minor => "minor",
+        };
+        write_str(out, s);
+    }
+}
+
+impl ToJson for TimeSignature {
+    fn to_json(&self, out: &mut String) {
+        out.push('{');
+        out.push_str("\"numerator\":");
+        write_u8(out, self.numerator);
+        out.push_str(",\"denominator\":");
+        write_u8(out, self.denominator);
+        out.push('}');
+    }
+}
+
+impl ToJson for MusicalSymbol {
+    fn to_json(&self, out: &mut String) {
+        let s = match self {
+            Self::Segno => "segno",
+            Self::Coda => "coda",
+            Self::DaCapo => "da_capo",
+            Self::DalSegno => "dal_segno",
+            Self::Fine => "fine",
+        };
+        write_str(out, s);
+    }
+}
+
+// ===========================================================================
+// Deserialization
+// ===========================================================================
+//
+// A minimal JSON parser sized to exactly the shape `ToJson` emits — strings,
+// non-negative integers, signed integers (only for `transpose`), `null`,
+// arrays, and string-keyed objects. The deserializer is **not** a generic
+// JSON library; it round-trips the testing-only debug format documented at
+// the top of this module and rejects anything outside that grammar with
+// `JsonError`. Parser scope and AST scope evolve together; widening one
+// without the other is a structural defect.
+
+/// An error produced by [`parse_json`] or one of the [`FromJson`] impls.
+///
+/// `position` is the zero-based byte index in the input string at which the
+/// parser noticed the problem (or `0` for "field missing" errors that
+/// originate after parsing). `message` is a short, English description.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonError {
+    /// Byte index in the source where the error was detected.
+    pub position: usize,
+    /// Short human-readable description.
+    pub message: String,
+}
+
+impl JsonError {
+    fn new(position: usize, msg: impl Into<String>) -> Self {
+        Self {
+            position,
+            message: msg.into(),
+        }
+    }
+}
+
+impl core::fmt::Display for JsonError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} (at byte {})", self.message, self.position)
+    }
+}
+
+impl std::error::Error for JsonError {}
+
+/// A parsed JSON value. The variants correspond exactly to what the
+/// [`ToJson`] impls in this module emit; `Bool` and floating-point numbers
+/// are absent on purpose because the AST never serialises them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonValue {
+    /// JSON `null`.
+    Null,
+    /// A signed integer. The serialiser only emits `i8`, `u8`, and `u16`,
+    /// so `i64` covers every value losslessly.
+    Integer(i64),
+    /// A JSON string with all escapes already decoded.
+    String(String),
+    /// A JSON array.
+    Array(Vec<JsonValue>),
+    /// A JSON object with insertion-order field list. Duplicate keys are
+    /// rejected at parse time so AST extractors do not have to choose
+    /// between "first wins" and "last wins" semantics.
+    Object(Vec<(String, JsonValue)>),
+}
+
+impl JsonValue {
+    fn get(&self, key: &str) -> Result<&JsonValue, JsonError> {
+        match self {
+            Self::Object(fields) => fields
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v)
+                .ok_or_else(|| JsonError::new(0, format!("missing field {key:?}"))),
+            _ => Err(JsonError::new(0, format!("expected object for {key:?}"))),
+        }
+    }
+
+    fn as_str(&self) -> Result<&str, JsonError> {
+        match self {
+            Self::String(s) => Ok(s.as_str()),
+            _ => Err(JsonError::new(0, "expected string".to_string())),
+        }
+    }
+
+    fn as_array(&self) -> Result<&[JsonValue], JsonError> {
+        match self {
+            Self::Array(v) => Ok(v.as_slice()),
+            _ => Err(JsonError::new(0, "expected array".to_string())),
+        }
+    }
+
+    fn as_int(&self) -> Result<i64, JsonError> {
+        match self {
+            Self::Integer(n) => Ok(*n),
+            _ => Err(JsonError::new(0, "expected integer".to_string())),
+        }
+    }
+
+    fn as_opt_str(&self) -> Result<Option<&str>, JsonError> {
+        match self {
+            Self::Null => Ok(None),
+            Self::String(s) => Ok(Some(s.as_str())),
+            _ => Err(JsonError::new(0, "expected string or null".to_string())),
+        }
+    }
+
+    fn as_opt_int(&self) -> Result<Option<i64>, JsonError> {
+        match self {
+            Self::Null => Ok(None),
+            Self::Integer(n) => Ok(Some(*n)),
+            _ => Err(JsonError::new(0, "expected integer or null".to_string())),
+        }
+    }
+}
+
+/// Parses a JSON string into a [`JsonValue`].
+///
+/// The parser accepts only the subset of JSON that the [`ToJson`] impls in
+/// this module emit. In particular, floating-point numbers, booleans,
+/// trailing commas, and unquoted keys are rejected — see the module-level
+/// documentation for the format definition.
+///
+/// # Errors
+///
+/// Returns `Err(JsonError)` if the input violates the supported subset
+/// (unexpected tokens, unterminated strings, duplicate object keys, integer
+/// overflow, leftover bytes after the top-level value, etc.).
+pub fn parse_json(input: &str) -> Result<JsonValue, JsonError> {
+    let mut parser = Parser::new(input);
+    let value = parser.parse_value()?;
+    parser.skip_ws();
+    if parser.pos < parser.bytes.len() {
+        return Err(JsonError::new(
+            parser.pos,
+            "unexpected trailing content after top-level value".to_string(),
+        ));
+    }
+    Ok(value)
+}
+
+struct Parser<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            bytes: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn skip_ws(&mut self) {
+        while let Some(&b) = self.bytes.get(self.pos) {
+            if matches!(b, b' ' | b'\t' | b'\r' | b'\n') {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn expect_byte(&mut self, expected: u8) -> Result<(), JsonError> {
+        match self.peek() {
+            Some(b) if b == expected => {
+                self.pos += 1;
+                Ok(())
+            }
+            Some(b) => Err(JsonError::new(
+                self.pos,
+                format!("expected {:?}, got {:?}", expected as char, b as char),
+            )),
+            None => Err(JsonError::new(
+                self.pos,
+                format!("expected {:?}, got end of input", expected as char),
+            )),
+        }
+    }
+
+    fn parse_value(&mut self) -> Result<JsonValue, JsonError> {
+        self.skip_ws();
+        match self.peek() {
+            Some(b'{') => self.parse_object(),
+            Some(b'[') => self.parse_array(),
+            Some(b'"') => self.parse_string().map(JsonValue::String),
+            Some(b'n') => self.parse_null(),
+            Some(b'-' | b'0'..=b'9') => self.parse_integer(),
+            Some(b) => Err(JsonError::new(
+                self.pos,
+                format!("unexpected byte {:?} at value start", b as char),
+            )),
+            None => Err(JsonError::new(
+                self.pos,
+                "unexpected end of input at value start".to_string(),
+            )),
+        }
+    }
+
+    fn parse_null(&mut self) -> Result<JsonValue, JsonError> {
+        let start = self.pos;
+        if self.bytes.get(start..start + 4) == Some(b"null") {
+            self.pos += 4;
+            Ok(JsonValue::Null)
+        } else {
+            Err(JsonError::new(start, "expected `null`".to_string()))
+        }
+    }
+
+    fn parse_integer(&mut self) -> Result<JsonValue, JsonError> {
+        let start = self.pos;
+        if self.peek() == Some(b'-') {
+            self.pos += 1;
+        }
+        let digit_start = self.pos;
+        while let Some(b) = self.peek() {
+            if b.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos == digit_start {
+            return Err(JsonError::new(start, "expected digit".to_string()));
+        }
+        if matches!(self.peek(), Some(b'.' | b'e' | b'E')) {
+            return Err(JsonError::new(
+                self.pos,
+                "non-integer numbers are not supported".to_string(),
+            ));
+        }
+        // Safe: digit_start..pos is all ASCII bytes the loop accepted, and
+        // the optional leading `-` is also ASCII.
+        let text = core::str::from_utf8(&self.bytes[start..self.pos])
+            .expect("integer slice is ASCII by construction");
+        text.parse::<i64>()
+            .map(JsonValue::Integer)
+            .map_err(|e| JsonError::new(start, format!("integer parse: {e}")))
+    }
+
+    fn parse_string(&mut self) -> Result<String, JsonError> {
+        self.expect_byte(b'"')?;
+        let mut out = String::new();
+        loop {
+            match self.peek() {
+                Some(b'"') => {
+                    self.pos += 1;
+                    return Ok(out);
+                }
+                Some(b'\\') => {
+                    self.pos += 1;
+                    let escape = self.peek().ok_or_else(|| {
+                        JsonError::new(self.pos, "unterminated escape".to_string())
+                    })?;
+                    self.pos += 1;
+                    match escape {
+                        b'"' => out.push('"'),
+                        b'\\' => out.push('\\'),
+                        b'/' => out.push('/'),
+                        b'n' => out.push('\n'),
+                        b'r' => out.push('\r'),
+                        b't' => out.push('\t'),
+                        b'b' => out.push('\u{08}'),
+                        b'f' => out.push('\u{0c}'),
+                        b'u' => {
+                            let hex_start = self.pos;
+                            let hex =
+                                self.bytes.get(hex_start..hex_start + 4).ok_or_else(|| {
+                                    JsonError::new(hex_start, "incomplete \\u escape".to_string())
+                                })?;
+                            let hex_str = core::str::from_utf8(hex).map_err(|_| {
+                                JsonError::new(hex_start, "non-ASCII in \\u escape".to_string())
+                            })?;
+                            let code = u32::from_str_radix(hex_str, 16).map_err(|_| {
+                                JsonError::new(hex_start, "invalid \\u hex digits".to_string())
+                            })?;
+                            // The serializer only emits `\uXXXX` for C0
+                            // controls (U+0000..U+001F), which are all
+                            // single-unit BMP scalars. UTF-16 surrogate
+                            // pairs are out of scope and rejected here.
+                            let ch = char::from_u32(code).ok_or_else(|| {
+                                JsonError::new(
+                                    hex_start,
+                                    "\\u escape is not a valid scalar".to_string(),
+                                )
+                            })?;
+                            out.push(ch);
+                            self.pos += 4;
+                        }
+                        other => {
+                            return Err(JsonError::new(
+                                self.pos - 1,
+                                format!("unknown escape \\{}", other as char),
+                            ));
+                        }
+                    }
+                }
+                Some(b) if b < 0x20 => {
+                    return Err(JsonError::new(
+                        self.pos,
+                        format!("unescaped control byte 0x{b:02x} in string"),
+                    ));
+                }
+                Some(_) => {
+                    // Decode one UTF-8 scalar at `self.pos` so multi-byte
+                    // characters are not split. Falling back to byte-level
+                    // copying would corrupt non-ASCII content.
+                    let rest = &self.bytes[self.pos..];
+                    let s = core::str::from_utf8(rest).map_err(|_| {
+                        JsonError::new(self.pos, "invalid UTF-8 in string".to_string())
+                    })?;
+                    let ch = s.chars().next().expect("string is non-empty");
+                    out.push(ch);
+                    self.pos += ch.len_utf8();
+                }
+                None => {
+                    return Err(JsonError::new(self.pos, "unterminated string".to_string()));
+                }
+            }
+        }
+    }
+
+    fn parse_array(&mut self) -> Result<JsonValue, JsonError> {
+        self.expect_byte(b'[')?;
+        self.skip_ws();
+        let mut items = Vec::new();
+        if self.peek() == Some(b']') {
+            self.pos += 1;
+            return Ok(JsonValue::Array(items));
+        }
+        loop {
+            let value = self.parse_value()?;
+            items.push(value);
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => {
+                    self.pos += 1;
+                    self.skip_ws();
+                }
+                Some(b']') => {
+                    self.pos += 1;
+                    return Ok(JsonValue::Array(items));
+                }
+                Some(b) => {
+                    return Err(JsonError::new(
+                        self.pos,
+                        format!("expected `,` or `]`, got {:?}", b as char),
+                    ));
+                }
+                None => {
+                    return Err(JsonError::new(self.pos, "unterminated array".to_string()));
+                }
+            }
+        }
+    }
+
+    fn parse_object(&mut self) -> Result<JsonValue, JsonError> {
+        self.expect_byte(b'{')?;
+        self.skip_ws();
+        let mut fields: Vec<(String, JsonValue)> = Vec::new();
+        if self.peek() == Some(b'}') {
+            self.pos += 1;
+            return Ok(JsonValue::Object(fields));
+        }
+        loop {
+            self.skip_ws();
+            let key_pos = self.pos;
+            let key = self.parse_string()?;
+            if fields.iter().any(|(k, _)| k == &key) {
+                return Err(JsonError::new(
+                    key_pos,
+                    format!("duplicate object key {key:?}"),
+                ));
+            }
+            self.skip_ws();
+            self.expect_byte(b':')?;
+            let value = self.parse_value()?;
+            fields.push((key, value));
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => {
+                    self.pos += 1;
+                }
+                Some(b'}') => {
+                    self.pos += 1;
+                    return Ok(JsonValue::Object(fields));
+                }
+                Some(b) => {
+                    return Err(JsonError::new(
+                        self.pos,
+                        format!("expected `,` or `}}`, got {:?}", b as char),
+                    ));
+                }
+                None => {
+                    return Err(JsonError::new(self.pos, "unterminated object".to_string()));
+                }
+            }
+        }
+    }
+}
+
+/// AST nodes that can be reconstructed from the JSON debug format produced
+/// by [`ToJson`].
+///
+/// The trait is round-trip-only: `T::from_json(v.to_json_string())` returns
+/// a value structurally equal to `v`. It is **not** a tolerant parser for
+/// hand-written JSON; field order is the only ordering accepted by
+/// [`parse_json`], but every required field is read by name, so reordering
+/// only matters for the byte-stable property of the serialiser, not for
+/// `from_json` itself.
+pub trait FromJson: Sized {
+    /// Reads a JSON string produced by [`ToJson::to_json_string`] and
+    /// returns the corresponding AST node.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when the input is malformed JSON (per [`parse_json`]),
+    /// when a required field is missing, or when a field carries a value
+    /// outside the expected shape (e.g. a `numerator` of `0` for
+    /// [`TimeSignature`]).
+    fn from_json_str(input: &str) -> Result<Self, JsonError> {
+        let value = parse_json(input)?;
+        Self::from_json_value(&value)
+    }
+
+    /// Same as [`FromJson::from_json_str`] but starts from an already-parsed
+    /// [`JsonValue`]. Useful when an extractor walks a parent object and
+    /// needs to reconstruct one nested AST node at a time.
+    ///
+    /// # Errors
+    ///
+    /// See [`FromJson::from_json_str`].
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError>;
+}
+
+fn extract_char(value: &JsonValue) -> Result<char, JsonError> {
+    let s = value.as_str()?;
+    let mut iter = s.chars();
+    let ch = iter
+        .next()
+        .ok_or_else(|| JsonError::new(0, "expected single-character string".to_string()))?;
+    if iter.next().is_some() {
+        return Err(JsonError::new(
+            0,
+            "expected single-character string".to_string(),
+        ));
+    }
+    Ok(ch)
+}
+
+fn extract_u8(value: &JsonValue) -> Result<u8, JsonError> {
+    let n = value.as_int()?;
+    u8::try_from(n).map_err(|_| JsonError::new(0, format!("integer {n} out of u8 range")))
+}
+
+fn extract_opt_u16(value: &JsonValue) -> Result<Option<u16>, JsonError> {
+    match value.as_opt_int()? {
+        None => Ok(None),
+        Some(n) => u16::try_from(n)
+            .map(Some)
+            .map_err(|_| JsonError::new(0, format!("integer {n} out of u16 range"))),
+    }
+}
+
+fn extract_i8(value: &JsonValue) -> Result<i8, JsonError> {
+    let n = value.as_int()?;
+    i8::try_from(n).map_err(|_| JsonError::new(0, format!("integer {n} out of i8 range")))
+}
+
+impl FromJson for IrealSong {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let title = value.get("title")?.as_str()?.to_string();
+        let composer = value.get("composer")?.as_opt_str()?.map(str::to_string);
+        let style = value.get("style")?.as_opt_str()?.map(str::to_string);
+        let key_signature = KeySignature::from_json_value(value.get("key_signature")?)?;
+        let time_signature = TimeSignature::from_json_value(value.get("time_signature")?)?;
+        let tempo = extract_opt_u16(value.get("tempo")?)?;
+        let transpose = extract_i8(value.get("transpose")?)?;
+        let sections = value
+            .get("sections")?
+            .as_array()?
+            .iter()
+            .map(Section::from_json_value)
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            title,
+            composer,
+            style,
+            key_signature,
+            time_signature,
+            tempo,
+            transpose,
+            sections,
+        })
+    }
+}
+
+impl FromJson for Section {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let label = SectionLabel::from_json_value(value.get("label")?)?;
+        let bars = value
+            .get("bars")?
+            .as_array()?
+            .iter()
+            .map(Bar::from_json_value)
+            .collect::<Result<_, _>>()?;
+        Ok(Self { label, bars })
+    }
+}
+
+impl FromJson for SectionLabel {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let kind = value.get("kind")?.as_str()?;
+        match kind {
+            "letter" => {
+                let ch = extract_char(value.get("value")?)?;
+                Ok(Self::Letter(ch))
+            }
+            "verse" => Ok(Self::Verse),
+            "chorus" => Ok(Self::Chorus),
+            "intro" => Ok(Self::Intro),
+            "outro" => Ok(Self::Outro),
+            "bridge" => Ok(Self::Bridge),
+            "custom" => {
+                let s = value.get("value")?.as_str()?.to_string();
+                Ok(Self::Custom(s))
+            }
+            other => Err(JsonError::new(
+                0,
+                format!("unknown section label kind {other:?}"),
+            )),
+        }
+    }
+}
+
+impl FromJson for Bar {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let start = BarLine::from_json_value(value.get("start")?)?;
+        let end = BarLine::from_json_value(value.get("end")?)?;
+        let chords = value
+            .get("chords")?
+            .as_array()?
+            .iter()
+            .map(BarChord::from_json_value)
+            .collect::<Result<_, _>>()?;
+        let ending = match value.get("ending")? {
+            JsonValue::Null => None,
+            other => {
+                let n = extract_u8(other)?;
+                Some(Ending::new(n).ok_or_else(|| {
+                    JsonError::new(0, "ending number must be non-zero".to_string())
+                })?)
+            }
+        };
+        let symbol = match value.get("symbol")? {
+            JsonValue::Null => None,
+            other => Some(MusicalSymbol::from_json_value(other)?),
+        };
+        Ok(Self {
+            start,
+            end,
+            chords,
+            ending,
+            symbol,
+        })
+    }
+}
+
+impl FromJson for BarLine {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        match value.as_str()? {
+            "single" => Ok(Self::Single),
+            "double" => Ok(Self::Double),
+            "final" => Ok(Self::Final),
+            "open_repeat" => Ok(Self::OpenRepeat),
+            "close_repeat" => Ok(Self::CloseRepeat),
+            other => Err(JsonError::new(0, format!("unknown bar line {other:?}"))),
+        }
+    }
+}
+
+impl FromJson for BarChord {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let chord = Chord::from_json_value(value.get("chord")?)?;
+        let position = BeatPosition::from_json_value(value.get("position")?)?;
+        Ok(Self { chord, position })
+    }
+}
+
+impl FromJson for BeatPosition {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let beat = extract_u8(value.get("beat")?)?;
+        let beat = core::num::NonZeroU8::new(beat)
+            .ok_or_else(|| JsonError::new(0, "beat must be non-zero".to_string()))?;
+        let subdivision = extract_u8(value.get("subdivision")?)?;
+        Ok(Self { beat, subdivision })
+    }
+}
+
+impl FromJson for Chord {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let root = ChordRoot::from_json_value(value.get("root")?)?;
+        let quality = ChordQuality::from_json_value(value.get("quality")?)?;
+        let bass = match value.get("bass")? {
+            JsonValue::Null => None,
+            other => Some(ChordRoot::from_json_value(other)?),
+        };
+        Ok(Self {
+            root,
+            quality,
+            bass,
+        })
+    }
+}
+
+impl FromJson for ChordRoot {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let note = extract_char(value.get("note")?)?;
+        let accidental = Accidental::from_json_value(value.get("accidental")?)?;
+        Ok(Self { note, accidental })
+    }
+}
+
+impl FromJson for Accidental {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        match value.as_str()? {
+            "natural" => Ok(Self::Natural),
+            "flat" => Ok(Self::Flat),
+            "sharp" => Ok(Self::Sharp),
+            other => Err(JsonError::new(0, format!("unknown accidental {other:?}"))),
+        }
+    }
+}
+
+impl FromJson for ChordQuality {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let kind = value.get("kind")?.as_str()?;
+        match kind {
+            "major" => Ok(Self::Major),
+            "minor" => Ok(Self::Minor),
+            "diminished" => Ok(Self::Diminished),
+            "augmented" => Ok(Self::Augmented),
+            "major7" => Ok(Self::Major7),
+            "minor7" => Ok(Self::Minor7),
+            "dominant7" => Ok(Self::Dominant7),
+            "half_diminished" => Ok(Self::HalfDiminished),
+            "diminished7" => Ok(Self::Diminished7),
+            "suspended2" => Ok(Self::Suspended2),
+            "suspended4" => Ok(Self::Suspended4),
+            "custom" => {
+                let s = value.get("value")?.as_str()?.to_string();
+                Ok(Self::Custom(s))
+            }
+            other => Err(JsonError::new(
+                0,
+                format!("unknown chord quality kind {other:?}"),
+            )),
+        }
+    }
+}
+
+impl FromJson for KeySignature {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let root = ChordRoot::from_json_value(value.get("root")?)?;
+        let mode = KeyMode::from_json_value(value.get("mode")?)?;
+        Ok(Self { root, mode })
+    }
+}
+
+impl FromJson for KeyMode {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        match value.as_str()? {
+            "major" => Ok(Self::Major),
+            "minor" => Ok(Self::Minor),
+            other => Err(JsonError::new(0, format!("unknown key mode {other:?}"))),
+        }
+    }
+}
+
+impl FromJson for TimeSignature {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        let numerator = extract_u8(value.get("numerator")?)?;
+        let denominator = extract_u8(value.get("denominator")?)?;
+        Self::new(numerator, denominator).ok_or_else(|| {
+            JsonError::new(
+                0,
+                format!("invalid time signature {numerator}/{denominator}"),
+            )
+        })
+    }
+}
+
+impl FromJson for MusicalSymbol {
+    fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
+        match value.as_str()? {
+            "segno" => Ok(Self::Segno),
+            "coda" => Ok(Self::Coda),
+            "da_capo" => Ok(Self::DaCapo),
+            "dal_segno" => Ok(Self::DalSegno),
+            "fine" => Ok(Self::Fine),
+            other => Err(JsonError::new(
+                0,
+                format!("unknown musical symbol {other:?}"),
+            )),
+        }
+    }
+}

--- a/crates/ireal/src/json.rs
+++ b/crates/ireal/src/json.rs
@@ -363,6 +363,81 @@ impl ToJson for MusicalSymbol {
 // the top of this module and rejects anything outside that grammar with
 // `JsonError`. Parser scope and AST scope evolve together; widening one
 // without the other is a structural defect.
+//
+// # Resource limits
+//
+// The parser is intended for trusted debug-snapshot input but is hardened
+// for adversarial use anyway, because the AST surface is reachable from
+// every iReal-related follow-up crate and the bindings in #2067. Hard
+// limits below are documented constants — tweaking any of them is a
+// review-required change because raising the bound on adversarial input
+// linearly raises the worst-case memory cost.
+
+/// Hard cap on the input byte length accepted by [`parse_json`]. Larger
+/// inputs are rejected up-front so a single very-long string cannot
+/// dominate the heap.
+pub const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Maximum nesting depth (objects + arrays). Protects against
+/// stack-overflow crashes from inputs like `[[[[[[…`.
+pub const MAX_DEPTH: u16 = 128;
+
+/// Maximum number of elements in any single array.
+pub const MAX_ARRAY_LEN: usize = 65_536;
+
+/// Maximum number of fields in any single object.
+pub const MAX_OBJECT_FIELDS: usize = 65_536;
+
+/// Maximum decoded length of any single JSON string in characters
+/// (after escape decoding). Keeps individual string-allocation cost
+/// bounded so a 4 MB input cannot decode into a much larger heap value.
+pub const MAX_STRING_CHARS: usize = 1 << 20;
+
+fn utf8_lead_width(b: u8) -> Option<usize> {
+    // Maps a UTF-8 leading byte to its scalar width in bytes. Returns
+    // `None` for continuation bytes (0x80..=0xBF) and invalid lead bytes
+    // (0xF8..). The single-byte ASCII case is handled by the caller.
+    if b < 0x80 {
+        Some(1)
+    } else if b < 0xC0 {
+        None
+    } else if b < 0xE0 {
+        Some(2)
+    } else if b < 0xF0 {
+        Some(3)
+    } else if b < 0xF8 {
+        Some(4)
+    } else {
+        None
+    }
+}
+
+fn truncate_for_message(s: &str) -> String {
+    // Cap user-controlled bytes that flow into `JsonError::message` so the
+    // error-string size stays bounded even if upstream relaxes
+    // `MAX_STRING_CHARS`. 64 chars is enough to identify a key/value
+    // without dominating a log line.
+    const LIMIT: usize = 64;
+    let mut out = String::new();
+    out.push('"');
+    for (i, ch) in s.chars().enumerate() {
+        if i >= LIMIT {
+            out.push('…');
+            break;
+        }
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if (c as u32) < 0x20 => {
+                use core::fmt::Write;
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
 
 /// An error produced by [`parse_json`] or one of the [`FromJson`] impls.
 ///
@@ -421,8 +496,13 @@ impl JsonValue {
                 .iter()
                 .find(|(k, _)| k == key)
                 .map(|(_, v)| v)
-                .ok_or_else(|| JsonError::new(0, format!("missing field {key:?}"))),
-            _ => Err(JsonError::new(0, format!("expected object for {key:?}"))),
+                .ok_or_else(|| {
+                    JsonError::new(0, format!("missing field {}", truncate_for_message(key)))
+                }),
+            _ => Err(JsonError::new(
+                0,
+                format!("expected object for {}", truncate_for_message(key)),
+            )),
         }
     }
 
@@ -468,15 +548,33 @@ impl JsonValue {
 ///
 /// The parser accepts only the subset of JSON that the [`ToJson`] impls in
 /// this module emit. In particular, floating-point numbers, booleans,
-/// trailing commas, and unquoted keys are rejected — see the module-level
-/// documentation for the format definition.
+/// trailing commas, leading-zero integers, and unquoted keys are rejected —
+/// see the module-level documentation for the format definition.
+///
+/// # Resource limits
+///
+/// The parser enforces [`MAX_INPUT_BYTES`], [`MAX_DEPTH`], [`MAX_ARRAY_LEN`],
+/// [`MAX_OBJECT_FIELDS`], and [`MAX_STRING_CHARS`]; inputs that exceed any
+/// of these bounds are rejected with a descriptive [`JsonError`] rather
+/// than allocating without bound. The constants are documented above.
 ///
 /// # Errors
 ///
 /// Returns `Err(JsonError)` if the input violates the supported subset
 /// (unexpected tokens, unterminated strings, duplicate object keys, integer
-/// overflow, leftover bytes after the top-level value, etc.).
+/// overflow, leftover bytes after the top-level value, etc.) or any of the
+/// resource limits documented above.
+#[must_use = "ignoring a parse result drops every error this function exists to surface"]
 pub fn parse_json(input: &str) -> Result<JsonValue, JsonError> {
+    if input.len() > MAX_INPUT_BYTES {
+        return Err(JsonError::new(
+            0,
+            format!(
+                "input length {} exceeds MAX_INPUT_BYTES ({MAX_INPUT_BYTES})",
+                input.len()
+            ),
+        ));
+    }
     let mut parser = Parser::new(input);
     let value = parser.parse_value()?;
     parser.skip_ws();
@@ -492,6 +590,9 @@ pub fn parse_json(input: &str) -> Result<JsonValue, JsonError> {
 struct Parser<'a> {
     bytes: &'a [u8],
     pos: usize,
+    /// Current nesting depth of arrays + objects. Increment on entry,
+    /// decrement on exit, reject above [`MAX_DEPTH`].
+    depth: u16,
 }
 
 impl<'a> Parser<'a> {
@@ -499,7 +600,25 @@ impl<'a> Parser<'a> {
         Self {
             bytes: input.as_bytes(),
             pos: 0,
+            depth: 0,
         }
+    }
+
+    fn enter_container(&mut self) -> Result<(), JsonError> {
+        if self.depth >= MAX_DEPTH {
+            return Err(JsonError::new(
+                self.pos,
+                format!("nesting depth exceeds MAX_DEPTH ({MAX_DEPTH})"),
+            ));
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    fn leave_container(&mut self) {
+        // Decrement is bounds-safe because every `leave_container` is paired
+        // with a successful `enter_container` earlier in the call stack.
+        self.depth = self.depth.saturating_sub(1);
     }
 
     fn skip_ws(&mut self) {
@@ -564,7 +683,8 @@ impl<'a> Parser<'a> {
 
     fn parse_integer(&mut self) -> Result<JsonValue, JsonError> {
         let start = self.pos;
-        if self.peek() == Some(b'-') {
+        let negative = self.peek() == Some(b'-');
+        if negative {
             self.pos += 1;
         }
         let digit_start = self.pos;
@@ -577,6 +697,22 @@ impl<'a> Parser<'a> {
         }
         if self.pos == digit_start {
             return Err(JsonError::new(start, "expected digit".to_string()));
+        }
+        // RFC 8259 §6 forbids leading zeros (and `-0` is not produced by
+        // the serializer). Rejecting them here keeps the deserializer
+        // round-trip-only and prevents drift between hand-written
+        // snapshots and the serializer's output.
+        if self.bytes[digit_start] == b'0' && self.pos - digit_start > 1 {
+            return Err(JsonError::new(
+                digit_start,
+                "leading zeros are not permitted".to_string(),
+            ));
+        }
+        if negative && self.bytes[digit_start] == b'0' && self.pos - digit_start == 1 {
+            return Err(JsonError::new(
+                start,
+                "negative zero is not permitted".to_string(),
+            ));
         }
         if matches!(self.peek(), Some(b'.' | b'e' | b'E')) {
             return Err(JsonError::new(
@@ -596,7 +732,14 @@ impl<'a> Parser<'a> {
     fn parse_string(&mut self) -> Result<String, JsonError> {
         self.expect_byte(b'"')?;
         let mut out = String::new();
+        let mut chars_decoded: usize = 0;
         loop {
+            if chars_decoded > MAX_STRING_CHARS {
+                return Err(JsonError::new(
+                    self.pos,
+                    format!("decoded string exceeds MAX_STRING_CHARS ({MAX_STRING_CHARS})"),
+                ));
+            }
             match self.peek() {
                 Some(b'"') => {
                     self.pos += 1;
@@ -632,7 +775,16 @@ impl<'a> Parser<'a> {
                             // The serializer only emits `\uXXXX` for C0
                             // controls (U+0000..U+001F), which are all
                             // single-unit BMP scalars. UTF-16 surrogate
-                            // pairs are out of scope and rejected here.
+                            // pairs (`U+D800..=U+DFFF`) and any out-of-
+                            // range code unit are rejected here so a
+                            // hand-written snapshot cannot synthesise an
+                            // input the serializer would never emit.
+                            if (0xD800..=0xDFFF).contains(&code) {
+                                return Err(JsonError::new(
+                                    hex_start,
+                                    "surrogate-pair \\u escapes are not supported".to_string(),
+                                ));
+                            }
                             let ch = char::from_u32(code).ok_or_else(|| {
                                 JsonError::new(
                                     hex_start,
@@ -641,6 +793,7 @@ impl<'a> Parser<'a> {
                             })?;
                             out.push(ch);
                             self.pos += 4;
+                            chars_decoded += 1;
                         }
                         other => {
                             return Err(JsonError::new(
@@ -656,17 +809,34 @@ impl<'a> Parser<'a> {
                         format!("unescaped control byte 0x{b:02x} in string"),
                     ));
                 }
-                Some(_) => {
-                    // Decode one UTF-8 scalar at `self.pos` so multi-byte
-                    // characters are not split. Falling back to byte-level
-                    // copying would corrupt non-ASCII content.
-                    let rest = &self.bytes[self.pos..];
-                    let s = core::str::from_utf8(rest).map_err(|_| {
+                Some(b) if b < 0x80 => {
+                    // ASCII non-control byte: copy directly.
+                    out.push(b as char);
+                    self.pos += 1;
+                    chars_decoded += 1;
+                }
+                Some(b) => {
+                    // Multi-byte UTF-8 scalar. The leading byte determines
+                    // the width (2/3/4); the input is a `&str`, so the
+                    // remaining bytes are guaranteed to form a valid
+                    // continuation, but we validate the bounded slice to
+                    // avoid an unsafe `from_utf8_unchecked` and to keep
+                    // the work O(1) per char (the previous implementation
+                    // re-validated the entire remainder, which was O(N²)
+                    // on long non-ASCII strings).
+                    let width = utf8_lead_width(b).ok_or_else(|| {
+                        JsonError::new(self.pos, "invalid UTF-8 lead byte in string".to_string())
+                    })?;
+                    let chunk = self.bytes.get(self.pos..self.pos + width).ok_or_else(|| {
+                        JsonError::new(self.pos, "truncated UTF-8 sequence".to_string())
+                    })?;
+                    let s = core::str::from_utf8(chunk).map_err(|_| {
                         JsonError::new(self.pos, "invalid UTF-8 in string".to_string())
                     })?;
                     let ch = s.chars().next().expect("string is non-empty");
                     out.push(ch);
-                    self.pos += ch.len_utf8();
+                    self.pos += width;
+                    chars_decoded += 1;
                 }
                 None => {
                     return Err(JsonError::new(self.pos, "unterminated string".to_string()));
@@ -677,13 +847,21 @@ impl<'a> Parser<'a> {
 
     fn parse_array(&mut self) -> Result<JsonValue, JsonError> {
         self.expect_byte(b'[')?;
+        self.enter_container()?;
         self.skip_ws();
         let mut items = Vec::new();
         if self.peek() == Some(b']') {
             self.pos += 1;
+            self.leave_container();
             return Ok(JsonValue::Array(items));
         }
         loop {
+            if items.len() >= MAX_ARRAY_LEN {
+                return Err(JsonError::new(
+                    self.pos,
+                    format!("array length exceeds MAX_ARRAY_LEN ({MAX_ARRAY_LEN})"),
+                ));
+            }
             let value = self.parse_value()?;
             items.push(value);
             self.skip_ws();
@@ -694,6 +872,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(b']') => {
                     self.pos += 1;
+                    self.leave_container();
                     return Ok(JsonValue::Array(items));
                 }
                 Some(b) => {
@@ -710,26 +889,39 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_object(&mut self) -> Result<JsonValue, JsonError> {
+        use std::collections::BTreeSet;
         self.expect_byte(b'{')?;
+        self.enter_container()?;
         self.skip_ws();
         let mut fields: Vec<(String, JsonValue)> = Vec::new();
+        let mut seen: BTreeSet<String> = BTreeSet::new();
         if self.peek() == Some(b'}') {
             self.pos += 1;
+            self.leave_container();
             return Ok(JsonValue::Object(fields));
         }
         loop {
+            if fields.len() >= MAX_OBJECT_FIELDS {
+                return Err(JsonError::new(
+                    self.pos,
+                    format!("object has more than MAX_OBJECT_FIELDS ({MAX_OBJECT_FIELDS}) fields"),
+                ));
+            }
             self.skip_ws();
             let key_pos = self.pos;
             let key = self.parse_string()?;
-            if fields.iter().any(|(k, _)| k == &key) {
+            // O(log n) duplicate-key check; the previous linear scan was
+            // quadratic on adversarial wide objects.
+            if seen.contains(&key) {
                 return Err(JsonError::new(
                     key_pos,
-                    format!("duplicate object key {key:?}"),
+                    format!("duplicate object key {}", truncate_for_message(&key)),
                 ));
             }
             self.skip_ws();
             self.expect_byte(b':')?;
             let value = self.parse_value()?;
+            seen.insert(key.clone());
             fields.push((key, value));
             self.skip_ws();
             match self.peek() {
@@ -738,6 +930,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(b'}') => {
                     self.pos += 1;
+                    self.leave_container();
                     return Ok(JsonValue::Object(fields));
                 }
                 Some(b) => {
@@ -773,6 +966,7 @@ pub trait FromJson: Sized {
     /// when a required field is missing, or when a field carries a value
     /// outside the expected shape (e.g. a `numerator` of `0` for
     /// [`TimeSignature`]).
+    #[must_use = "ignoring a parse result drops every error this method exists to surface"]
     fn from_json_str(input: &str) -> Result<Self, JsonError> {
         let value = parse_json(input)?;
         Self::from_json_value(&value)
@@ -785,6 +979,7 @@ pub trait FromJson: Sized {
     /// # Errors
     ///
     /// See [`FromJson::from_json_str`].
+    #[must_use = "ignoring a parse result drops every error this method exists to surface"]
     fn from_json_value(value: &JsonValue) -> Result<Self, JsonError>;
 }
 
@@ -822,6 +1017,22 @@ fn extract_i8(value: &JsonValue) -> Result<i8, JsonError> {
     i8::try_from(n).map_err(|_| JsonError::new(0, format!("integer {n} out of i8 range")))
 }
 
+fn extract_root_note(value: &JsonValue) -> Result<char, JsonError> {
+    // `ChordRoot::note` is documented (and asserted by the parser in
+    // #2054) as an uppercase ASCII letter `A`..=`G`. Enforce it here so
+    // a hand-written snapshot cannot inject nonsense roots that round-
+    // trip silently and then surface as crashes in #2057 (renderer) or
+    // #2052 (URL serializer).
+    let ch = extract_char(value)?;
+    if !matches!(ch, 'A'..='G') {
+        return Err(JsonError::new(
+            0,
+            format!("chord root note must be one of A..=G, got {ch:?}"),
+        ));
+    }
+    Ok(ch)
+}
+
 impl FromJson for IrealSong {
     fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
         let title = value.get("title")?.as_str()?.to_string();
@@ -830,7 +1041,21 @@ impl FromJson for IrealSong {
         let key_signature = KeySignature::from_json_value(value.get("key_signature")?)?;
         let time_signature = TimeSignature::from_json_value(value.get("time_signature")?)?;
         let tempo = extract_opt_u16(value.get("tempo")?)?;
+        if matches!(tempo, Some(0)) {
+            return Err(JsonError::new(0, "tempo must be non-zero".to_string()));
+        }
         let transpose = extract_i8(value.get("transpose")?)?;
+        if !(-11..=11).contains(&transpose) {
+            // Mirrors the `chordsketch-chordpro` clamp and the doc-comment
+            // contract on `IrealSong::transpose`. Rejecting here keeps the
+            // round-trip-only deserializer symmetric with the serializer
+            // (which never emits a value outside this range when called on
+            // a well-constructed AST).
+            return Err(JsonError::new(
+                0,
+                format!("transpose {transpose} out of range [-11, 11]"),
+            ));
+        }
         let sections = value
             .get("sections")?
             .as_array()?
@@ -882,7 +1107,7 @@ impl FromJson for SectionLabel {
             }
             other => Err(JsonError::new(
                 0,
-                format!("unknown section label kind {other:?}"),
+                format!("unknown section label kind {}", truncate_for_message(other)),
             )),
         }
     }
@@ -929,7 +1154,10 @@ impl FromJson for BarLine {
             "final" => Ok(Self::Final),
             "open_repeat" => Ok(Self::OpenRepeat),
             "close_repeat" => Ok(Self::CloseRepeat),
-            other => Err(JsonError::new(0, format!("unknown bar line {other:?}"))),
+            other => Err(JsonError::new(
+                0,
+                format!("unknown bar line {}", truncate_for_message(other)),
+            )),
         }
     }
 }
@@ -970,7 +1198,7 @@ impl FromJson for Chord {
 
 impl FromJson for ChordRoot {
     fn from_json_value(value: &JsonValue) -> Result<Self, JsonError> {
-        let note = extract_char(value.get("note")?)?;
+        let note = extract_root_note(value.get("note")?)?;
         let accidental = Accidental::from_json_value(value.get("accidental")?)?;
         Ok(Self { note, accidental })
     }
@@ -982,7 +1210,10 @@ impl FromJson for Accidental {
             "natural" => Ok(Self::Natural),
             "flat" => Ok(Self::Flat),
             "sharp" => Ok(Self::Sharp),
-            other => Err(JsonError::new(0, format!("unknown accidental {other:?}"))),
+            other => Err(JsonError::new(
+                0,
+                format!("unknown accidental {}", truncate_for_message(other)),
+            )),
         }
     }
 }
@@ -1008,7 +1239,7 @@ impl FromJson for ChordQuality {
             }
             other => Err(JsonError::new(
                 0,
-                format!("unknown chord quality kind {other:?}"),
+                format!("unknown chord quality kind {}", truncate_for_message(other)),
             )),
         }
     }
@@ -1027,7 +1258,10 @@ impl FromJson for KeyMode {
         match value.as_str()? {
             "major" => Ok(Self::Major),
             "minor" => Ok(Self::Minor),
-            other => Err(JsonError::new(0, format!("unknown key mode {other:?}"))),
+            other => Err(JsonError::new(
+                0,
+                format!("unknown key mode {}", truncate_for_message(other)),
+            )),
         }
     }
 }
@@ -1055,7 +1289,7 @@ impl FromJson for MusicalSymbol {
             "fine" => Ok(Self::Fine),
             other => Err(JsonError::new(
                 0,
-                format!("unknown musical symbol {other:?}"),
+                format!("unknown musical symbol {}", truncate_for_message(other)),
             )),
         }
     }

--- a/crates/ireal/src/lib.rs
+++ b/crates/ireal/src/lib.rs
@@ -1,0 +1,42 @@
+//! iReal Pro AST types and a zero-dependency JSON debug serializer / parser.
+//!
+//! This crate is the foundational scaffold for `irealb://` URL parsing
+//! (#2054), URL serialization (#2052), conversion to/from ChordPro
+//! (#2053 / #2061), and the iReal-style graphical renderer (#2058 et seq).
+//! It deliberately ships only the data model — no parser, no URL writer,
+//! no renderer — so the cross-cutting AST shape can stabilise before the
+//! follow-up crates layer features on top.
+//!
+//! See `ARCHITECTURE.md` (in this crate's directory) for the design
+//! decisions behind the AST shape, the field/variant choices made up
+//! front to keep the follow-up crates non-breaking, and the open
+//! questions deferred to the parser crate (#2054).
+//!
+//! # Dependency policy
+//!
+//! Like `chordsketch-chordpro`, this crate has **zero external
+//! dependencies**. Mirrors the policy that anchors the core AST in the
+//! standard library so downstream crates inherit a minimal compile
+//! surface and a stable transitive-dep tree.
+
+#![forbid(unsafe_code)]
+
+pub mod ast;
+pub mod json;
+
+// Re-export the AST types so call sites can write
+// `chordsketch_ireal::IrealSong` instead of
+// `chordsketch_ireal::ast::IrealSong`. Mirrors the re-export style
+// `chordsketch-chordpro` uses for its frequently-typed names.
+pub use ast::{
+    Accidental, Bar, BarChord, BarLine, BeatPosition, Chord, ChordQuality, ChordRoot, Ending,
+    IrealSong, KeyMode, KeySignature, MusicalSymbol, Section, SectionLabel, TimeSignature,
+};
+pub use json::{FromJson, JsonError, JsonValue, ToJson, parse_json};
+
+/// Returns the library version (the workspace `Cargo.toml` `version`
+/// field, baked in at compile time).
+#[must_use]
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}

--- a/crates/ireal/tests/ast.rs
+++ b/crates/ireal/tests/ast.rs
@@ -300,6 +300,123 @@ fn musical_symbol_variants_are_distinct() {
     assert_eq!(MusicalSymbol::Fine, MusicalSymbol::Fine);
 }
 
+#[test]
+fn json_rejects_recursion_depth_overflow() {
+    // Stack-overflow protection: deeply nested input is rejected with a
+    // structured error rather than crashing the process. The cap is
+    // documented as `MAX_DEPTH` (currently 128) — pick a depth above
+    // that so the test fails when the cap is removed.
+    let depth = chordsketch_ireal::json::MAX_DEPTH as usize + 16;
+    let nested = "[".repeat(depth) + &"]".repeat(depth);
+    let err = chordsketch_ireal::parse_json(&nested).expect_err("must reject deep nesting");
+    assert!(err.message.contains("MAX_DEPTH"), "unexpected error: {err}");
+}
+
+#[test]
+fn json_rejects_oversized_input() {
+    // Inputs above `MAX_INPUT_BYTES` are rejected up-front, before any
+    // parser allocation runs.
+    let oversized = String::from("[") + &"0,".repeat(chordsketch_ireal::json::MAX_INPUT_BYTES);
+    assert!(chordsketch_ireal::parse_json(&oversized).is_err());
+}
+
+#[test]
+fn json_rejects_leading_zeros_and_negative_zero() {
+    // RFC 8259 §6 forbids leading zeros. The serializer never emits
+    // them, so accepting them would let hand-written snapshots round-
+    // trip through paths the serializer cannot produce.
+    assert!(chordsketch_ireal::parse_json("01").is_err());
+    assert!(chordsketch_ireal::parse_json("-01").is_err());
+    assert!(chordsketch_ireal::parse_json("-0").is_err());
+    assert!(chordsketch_ireal::parse_json("0").is_ok());
+    assert!(chordsketch_ireal::parse_json("10").is_ok());
+}
+
+#[test]
+fn json_rejects_surrogate_pair_escapes() {
+    // The serializer never emits surrogate pairs (only C0-control
+    // escapes). Rejecting them makes the round-trip-only contract
+    // explicit.
+    assert!(chordsketch_ireal::parse_json("\"\\uD800\"").is_err());
+    assert!(chordsketch_ireal::parse_json("\"\\uDFFF\"").is_err());
+}
+
+#[test]
+fn json_rejects_oversized_array() {
+    let n = chordsketch_ireal::json::MAX_ARRAY_LEN + 1;
+    let mut s = String::from("[");
+    for i in 0..n {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push('0');
+    }
+    s.push(']');
+    if s.len() <= chordsketch_ireal::json::MAX_INPUT_BYTES {
+        assert!(chordsketch_ireal::parse_json(&s).is_err());
+    } else {
+        // Still rejected — by the input-bytes cap before reaching the
+        // array-length cap. Both rejections satisfy this test's intent.
+        assert!(chordsketch_ireal::parse_json(&s).is_err());
+    }
+}
+
+#[test]
+fn json_round_trip_rejects_out_of_range_transpose() {
+    // Documented contract on `IrealSong.transpose` is `[-11, 11]`. The
+    // deserializer enforces the contract so a hand-written snapshot
+    // outside the range cannot land an invalid AST.
+    let json = "{\
+\"title\":\"\",\
+\"composer\":null,\
+\"style\":null,\
+\"key_signature\":{\"root\":{\"note\":\"C\",\"accidental\":\"natural\"},\"mode\":\"major\"},\
+\"time_signature\":{\"numerator\":4,\"denominator\":4},\
+\"tempo\":null,\
+\"transpose\":12,\
+\"sections\":[]\
+}";
+    let err = IrealSong::from_json_str(json).expect_err("must reject transpose=12");
+    assert!(err.message.contains("transpose"), "unexpected: {err}");
+}
+
+#[test]
+fn json_round_trip_rejects_invalid_chord_root_note() {
+    // `ChordRoot.note` is documented A..=G uppercase ASCII. A lowercase
+    // letter or non-letter is a structural lie that must not survive a
+    // round-trip.
+    let json = "{\
+\"title\":\"\",\
+\"composer\":null,\
+\"style\":null,\
+\"key_signature\":{\"root\":{\"note\":\"x\",\"accidental\":\"natural\"},\"mode\":\"major\"},\
+\"time_signature\":{\"numerator\":4,\"denominator\":4},\
+\"tempo\":null,\
+\"transpose\":0,\
+\"sections\":[]\
+}";
+    let err = IrealSong::from_json_str(json).expect_err("must reject note='x'");
+    assert!(err.message.contains("A..=G"), "unexpected: {err}");
+}
+
+#[test]
+fn json_round_trip_rejects_zero_tempo() {
+    // 0 BPM is meaningless; the serializer emits `null` for "no tempo
+    // recorded" and never `0`.
+    let json = "{\
+\"title\":\"\",\
+\"composer\":null,\
+\"style\":null,\
+\"key_signature\":{\"root\":{\"note\":\"C\",\"accidental\":\"natural\"},\"mode\":\"major\"},\
+\"time_signature\":{\"numerator\":4,\"denominator\":4},\
+\"tempo\":0,\
+\"transpose\":0,\
+\"sections\":[]\
+}";
+    let err = IrealSong::from_json_str(json).expect_err("must reject tempo=0");
+    assert!(err.message.contains("tempo"), "unexpected: {err}");
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/crates/ireal/tests/ast.rs
+++ b/crates/ireal/tests/ast.rs
@@ -1,0 +1,337 @@
+//! Unit tests for AST constructors and equality.
+//!
+//! Per #2055 AC, the scaffold ships with coverage that exercises the
+//! `new()` / `default()` / `triad()` / `natural()` / `on_beat()` /
+//! `Ending::new()` / `TimeSignature::new()` constructors, asserts
+//! that two AST trees built from equal inputs compare `Eq`, and that
+//! the JSON debug output is byte-stable for a known input.
+
+use chordsketch_ireal::{
+    Accidental, Bar, BarChord, BarLine, BeatPosition, Chord, ChordQuality, ChordRoot, Ending,
+    FromJson, IrealSong, KeyMode, KeySignature, MusicalSymbol, Section, SectionLabel,
+    TimeSignature, ToJson,
+};
+
+#[test]
+fn empty_song_defaults() {
+    let song = IrealSong::new();
+    assert_eq!(song.title, "");
+    assert!(song.composer.is_none());
+    assert!(song.style.is_none());
+    assert_eq!(song.key_signature, KeySignature::default());
+    assert_eq!(song.time_signature, TimeSignature::default());
+    assert!(song.tempo.is_none());
+    assert_eq!(song.transpose, 0);
+    assert!(song.sections.is_empty());
+}
+
+#[test]
+fn default_key_is_c_major() {
+    let key = KeySignature::default();
+    assert_eq!(key.root, ChordRoot::natural('C'));
+    assert_eq!(key.mode, KeyMode::Major);
+}
+
+#[test]
+fn default_time_is_four_four() {
+    let ts = TimeSignature::default();
+    assert_eq!(ts.numerator, 4);
+    assert_eq!(ts.denominator, 4);
+}
+
+#[test]
+fn time_signature_rejects_invalid_inputs() {
+    assert!(TimeSignature::new(0, 4).is_none());
+    assert!(TimeSignature::new(13, 4).is_none());
+    assert!(TimeSignature::new(4, 1).is_none());
+    assert!(TimeSignature::new(4, 16).is_none());
+    assert!(TimeSignature::new(4, 0).is_none());
+    assert_eq!(TimeSignature::new(3, 4).unwrap().numerator, 3);
+    assert_eq!(TimeSignature::new(6, 8).unwrap().denominator, 8);
+    assert_eq!(TimeSignature::new(2, 2).unwrap().numerator, 2);
+}
+
+#[test]
+fn ending_rejects_zero() {
+    assert!(Ending::new(0).is_none());
+    assert_eq!(Ending::new(1).unwrap().number(), 1);
+    assert_eq!(Ending::new(2).unwrap().number(), 2);
+    assert_eq!(Ending::new(255).unwrap().number(), 255);
+}
+
+#[test]
+fn beat_position_rejects_zero() {
+    assert!(BeatPosition::on_beat(0).is_none());
+    let p = BeatPosition::on_beat(2).unwrap();
+    assert_eq!(p.beat.get(), 2);
+    assert_eq!(p.subdivision, 0);
+}
+
+#[test]
+fn chord_triad_has_no_bass() {
+    let chord = Chord::triad(ChordRoot::natural('G'), ChordQuality::Major);
+    assert_eq!(chord.root.note, 'G');
+    assert_eq!(chord.root.accidental, Accidental::Natural);
+    assert!(chord.bass.is_none());
+    assert_eq!(chord.quality, ChordQuality::Major);
+}
+
+#[test]
+fn bar_default_has_single_barlines() {
+    let bar = Bar::new();
+    assert_eq!(bar.start, BarLine::Single);
+    assert_eq!(bar.end, BarLine::Single);
+    assert!(bar.chords.is_empty());
+    assert!(bar.ending.is_none());
+    assert!(bar.symbol.is_none());
+}
+
+#[test]
+fn equality_is_structural() {
+    // Two ASTs built from the same data compare equal. This is the
+    // load-bearing property for golden tests in the follow-up
+    // crates (#2052 / #2054 / #2058).
+    let a = make_sample();
+    let b = make_sample();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn equality_distinguishes_chord_changes() {
+    // Same input except the bass note differs — must compare unequal.
+    let mut a = make_sample();
+    let mut b = make_sample();
+    if let Some(section) = b.sections.get_mut(0) {
+        if let Some(bar) = section.bars.get_mut(0) {
+            if let Some(bc) = bar.chords.get_mut(0) {
+                bc.chord.bass = Some(ChordRoot::natural('G'));
+            }
+        }
+    }
+    assert_eq!(
+        a.sections[0].bars[0].chords[0].chord.bass, None,
+        "fixture invariant: original sample has no bass"
+    );
+    assert_ne!(a, b);
+    a.sections[0].bars[0].chords[0].chord.bass = Some(ChordRoot::natural('G'));
+    assert_eq!(a, b);
+}
+
+#[test]
+fn section_label_variants_are_distinct() {
+    assert_ne!(SectionLabel::Letter('A'), SectionLabel::Verse);
+    assert_ne!(SectionLabel::Verse, SectionLabel::Chorus);
+    assert_ne!(
+        SectionLabel::Custom("Pre-chorus".into()),
+        SectionLabel::Custom("Bridge 2".into())
+    );
+    assert_eq!(SectionLabel::Letter('B'), SectionLabel::Letter('B'));
+}
+
+#[test]
+fn json_serialization_is_byte_stable() {
+    // Byte-stable JSON debug output is what golden-snapshot tests
+    // in the follow-up crates rely on. If this assertion changes,
+    // the field-order documentation in `ARCHITECTURE.md` and the
+    // module-level `json.rs` doc comment both need a refresh.
+    let song = make_sample();
+    let json = song.to_json_string();
+    let expected = "{\
+        \"title\":\"Autumn Leaves\",\
+        \"composer\":\"Joseph Kosma\",\
+        \"style\":\"Medium Swing\",\
+        \"key_signature\":{\"root\":{\"note\":\"E\",\"accidental\":\"natural\"},\"mode\":\"minor\"},\
+        \"time_signature\":{\"numerator\":4,\"denominator\":4},\
+        \"tempo\":120,\
+        \"transpose\":0,\
+        \"sections\":[\
+            {\
+                \"label\":{\"kind\":\"letter\",\"value\":\"A\"},\
+                \"bars\":[\
+                    {\
+                        \"start\":\"open_repeat\",\
+                        \"end\":\"close_repeat\",\
+                        \"chords\":[\
+                            {\"chord\":{\"root\":{\"note\":\"C\",\"accidental\":\"natural\"},\"quality\":{\"kind\":\"minor7\"},\"bass\":null},\"position\":{\"beat\":1,\"subdivision\":0}}\
+                        ],\
+                        \"ending\":1,\
+                        \"symbol\":\"segno\"\
+                    }\
+                ]\
+            }\
+        ]\
+    }";
+    assert_eq!(json, expected);
+}
+
+#[test]
+fn json_round_trips_through_deserializer() {
+    // The serializer + deserializer are AC-required to round-trip an
+    // arbitrary AST. Asserting `parsed == original` catches every
+    // class of mismatch in one assertion: missing fields, wrong
+    // variants, incorrect numeric handling, lost optional `None`s.
+    let song = make_sample();
+    let json = song.to_json_string();
+    let parsed = IrealSong::from_json_str(&json).expect("round-trip parse must succeed");
+    assert_eq!(song, parsed);
+}
+
+#[test]
+fn json_round_trip_handles_every_enum_variant() {
+    // Walk every named enum variant once — variants that only fail to
+    // round-trip in isolation (e.g. a missing `from_json` arm) would
+    // otherwise hide behind whichever variant `make_sample` happens
+    // to use.
+    let mut song = IrealSong::new();
+    song.title = "Variants".into();
+    song.composer = None;
+    song.key_signature = KeySignature {
+        root: ChordRoot {
+            note: 'F',
+            accidental: Accidental::Sharp,
+        },
+        mode: KeyMode::Minor,
+    };
+    song.time_signature = TimeSignature::new(6, 8).unwrap();
+    song.tempo = Some(90);
+    song.transpose = -3;
+    let qualities = [
+        ChordQuality::Major,
+        ChordQuality::Minor,
+        ChordQuality::Diminished,
+        ChordQuality::Augmented,
+        ChordQuality::Major7,
+        ChordQuality::Minor7,
+        ChordQuality::Dominant7,
+        ChordQuality::HalfDiminished,
+        ChordQuality::Diminished7,
+        ChordQuality::Suspended2,
+        ChordQuality::Suspended4,
+        ChordQuality::Custom("7\u{266F}9".into()),
+    ];
+    let labels = [
+        SectionLabel::Letter('A'),
+        SectionLabel::Verse,
+        SectionLabel::Chorus,
+        SectionLabel::Intro,
+        SectionLabel::Outro,
+        SectionLabel::Bridge,
+        SectionLabel::Custom("Pre-chorus".into()),
+    ];
+    let symbols = [
+        MusicalSymbol::Segno,
+        MusicalSymbol::Coda,
+        MusicalSymbol::DaCapo,
+        MusicalSymbol::DalSegno,
+        MusicalSymbol::Fine,
+    ];
+    let barlines = [
+        BarLine::Single,
+        BarLine::Double,
+        BarLine::Final,
+        BarLine::OpenRepeat,
+        BarLine::CloseRepeat,
+    ];
+    for (i, quality) in qualities.iter().enumerate() {
+        let label = labels[i % labels.len()].clone();
+        let symbol = symbols[i % symbols.len()];
+        let start = barlines[i % barlines.len()];
+        let end = barlines[(i + 1) % barlines.len()];
+        let bar = Bar {
+            start,
+            end,
+            chords: vec![BarChord {
+                chord: Chord {
+                    root: ChordRoot::natural('A'),
+                    quality: quality.clone(),
+                    bass: Some(ChordRoot {
+                        note: 'D',
+                        accidental: Accidental::Flat,
+                    }),
+                },
+                position: BeatPosition::on_beat(u8::try_from(i % 4 + 1).unwrap()).unwrap(),
+            }],
+            ending: Ending::new(u8::try_from(i % 3 + 1).unwrap()),
+            symbol: Some(symbol),
+        };
+        song.sections.push(Section {
+            label,
+            bars: vec![bar],
+        });
+    }
+    let json = song.to_json_string();
+    let parsed = IrealSong::from_json_str(&json).expect("variant round-trip must succeed");
+    assert_eq!(song, parsed);
+}
+
+#[test]
+fn json_rejects_malformed_input() {
+    // The parser is intentionally strict — these are the failure
+    // shapes a hand-written debug snapshot is most likely to drift
+    // into. The deserializer is round-trip-only and rejecting drift
+    // is the load-bearing property.
+    assert!(IrealSong::from_json_str("").is_err());
+    assert!(IrealSong::from_json_str("{").is_err());
+    assert!(IrealSong::from_json_str("{}").is_err()); // missing fields
+    assert!(IrealSong::from_json_str("null").is_err()); // wrong shape
+    let bad_trailing_comma = "{\"title\":\"x\",}";
+    assert!(IrealSong::from_json_str(bad_trailing_comma).is_err());
+}
+
+#[test]
+fn json_escapes_special_characters() {
+    let mut song = IrealSong::new();
+    song.title = String::from("a\"b\\c\nd\te\x01f");
+    let json = song.to_json_string();
+    // Title field encodes the four standard escapes plus a ``
+    // for the C0 control. The rest of the song is left at defaults.
+    assert!(
+        json.contains("\"title\":\"a\\\"b\\\\c\\nd\\te\\u0001f\""),
+        "unexpected title encoding: {json}"
+    );
+    let parsed = IrealSong::from_json_str(&json).expect("escape round-trip must succeed");
+    assert_eq!(parsed.title, song.title);
+}
+
+#[test]
+fn musical_symbol_variants_are_distinct() {
+    assert_ne!(MusicalSymbol::Segno, MusicalSymbol::Coda);
+    assert_ne!(MusicalSymbol::DaCapo, MusicalSymbol::DalSegno);
+    assert_eq!(MusicalSymbol::Fine, MusicalSymbol::Fine);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_sample() -> IrealSong {
+    let chord = Chord::triad(ChordRoot::natural('C'), ChordQuality::Minor7);
+    let bar_chord = BarChord {
+        chord,
+        position: BeatPosition::on_beat(1).unwrap(),
+    };
+    let bar = Bar {
+        start: BarLine::OpenRepeat,
+        end: BarLine::CloseRepeat,
+        chords: vec![bar_chord],
+        ending: Ending::new(1),
+        symbol: Some(MusicalSymbol::Segno),
+    };
+    let section = Section {
+        label: SectionLabel::Letter('A'),
+        bars: vec![bar],
+    };
+    IrealSong {
+        title: String::from("Autumn Leaves"),
+        composer: Some(String::from("Joseph Kosma")),
+        style: Some(String::from("Medium Swing")),
+        key_signature: KeySignature {
+            root: ChordRoot::natural('E'),
+            mode: KeyMode::Minor,
+        },
+        time_signature: TimeSignature::default(),
+        tempo: Some(120),
+        transpose: 0,
+        sections: vec![section],
+    }
+}

--- a/crates/ireal/tests/ast.rs
+++ b/crates/ireal/tests/ast.rs
@@ -352,13 +352,9 @@ fn json_rejects_oversized_array() {
         s.push('0');
     }
     s.push(']');
-    if s.len() <= chordsketch_ireal::json::MAX_INPUT_BYTES {
-        assert!(chordsketch_ireal::parse_json(&s).is_err());
-    } else {
-        // Still rejected — by the input-bytes cap before reaching the
-        // array-length cap. Both rejections satisfy this test's intent.
-        assert!(chordsketch_ireal::parse_json(&s).is_err());
-    }
+    // Rejected by MAX_ARRAY_LEN (the string fits within MAX_INPUT_BYTES at
+    // current constants — both caps are independent rejection paths anyway).
+    assert!(chordsketch_ireal::parse_json(&s).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## What

Foundational AST scaffold for the iReal Pro feature set (#2050).
Adds `crates/ireal/` (`chordsketch-ireal`) with the iReal AST
types and a paired zero-dependency JSON debug serializer / parser.

The crate ships **only** the data model — no `irealb://` URL
parser, no URL serializer, no renderer — so the cross-cutting AST
shape can stabilise before #2052 (URL serialize), #2054 (URL
parse), #2058 (SVG renderer), #2061 (ChordPro→iReal), etc. layer
features on top.

## Why

`#2055` is the first iReal sub-issue that became unblocked once
`#2056` (rename `crates/core` → `crates/chordpro`) merged in v0.3.0.
Every other iReal sub-issue (`#2052`, `#2054`, `#2058`, `#2051`,
…) has this scaffold as its prerequisite, so landing it now
unblocks the rest of the tracker.

## How — module layout

| File | Purpose |
|---|---|
| `crates/ireal/src/ast.rs` | `IrealSong`, `Section`, `Bar`, `BarChord`, `BeatPosition`, `Chord`, `ChordRoot`, `Accidental`, `ChordQuality`, `BarLine`, `Ending`, `KeySignature`, `KeyMode`, `TimeSignature`, `SectionLabel`, `MusicalSymbol` |
| `crates/ireal/src/json.rs` | `ToJson` trait + hand-rolled writer; `FromJson` trait + `parse_json` recursive-descent reader. Round-trip-only deserializer — accepts only the subset the serializer emits |
| `crates/ireal/src/lib.rs` | Public re-exports + `version()` |
| `crates/ireal/tests/ast.rs` | 17 unit tests (constructors, equality, byte-stable serialisation, full round-trip, every-variant round-trip, escape handling, malformed-input rejection) |
| `crates/ireal/ARCHITECTURE.md` | Field-level rationale, deferred AST scope, open questions for `#2054` |
| `crates/ireal/README.md` | Crate README per `package-documentation.md` |

## Acceptance Criteria check

| AC | Status |
|---|---|
| `crates/ireal/` workspace member; package name `chordsketch-ireal` | Done — added to `members` and `default-members` |
| AST types: `IrealSong`, `Section`, `Bar`, `Chord`, `TimeSignature`, `KeySignature`, repeat / ending markers, musical symbols (segno / coda / D.C. / D.S.) | Done |
| Zero external dependencies | Done (`[dependencies]` block is empty; `[forbid(unsafe_code)]`) |
| Basic serialization / deserialization to a JSON debug format (testing only) | Done — `ToJson` and `FromJson` traits round-trip the AST |
| Unit tests for AST constructors and equality | Done — `tests/ast.rs` (17 tests) |
| CI green | `cargo test`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` all pass locally |

## Tests

```
running 17 tests
test bar_default_has_single_barlines ... ok
test beat_position_rejects_zero ... ok
test chord_triad_has_no_bass ... ok
test default_key_is_c_major ... ok
test default_time_is_four_four ... ok
test empty_song_defaults ... ok
test ending_rejects_zero ... ok
test equality_distinguishes_chord_changes ... ok
test equality_is_structural ... ok
test json_escapes_special_characters ... ok
test json_rejects_malformed_input ... ok
test json_round_trip_handles_every_enum_variant ... ok
test json_round_trips_through_deserializer ... ok
test json_serialization_is_byte_stable ... ok
test musical_symbol_variants_are_distinct ... ok
test section_label_variants_are_distinct ... ok
test time_signature_rejects_invalid_inputs ... ok

test result: ok. 17 passed; 0 failed
```

## Sister-site / fix-propagation audit

Not a bug fix — no sister-site groups apply. The new crate sits
alongside `chordsketch-chordpro` (zero-dep parent of the renderer
group); no shared validation logic was touched.

## Doc updates

- `CLAUDE.md` Architecture table: new row for `chordsketch-ireal`.
- `crates/ireal/ARCHITECTURE.md`: design decisions, deferred
  scope, parser open questions.

Closes #2055.