### PR TITLE
feat(convert): scaffold chordsketch-convert crate (#2051)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This is a Cargo workspace with the following crates:
 | `chordsketch-render-text` | `crates/render-text` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-html` | `crates/render-html` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-pdf` | `crates/render-pdf` | lib | `chordsketch-chordpro` |
+| `chordsketch-convert` | `crates/convert` | lib | `chordsketch-chordpro`, `chordsketch-ireal`. ChordPro ↔ iReal Pro conversion bridge — trait scaffold (#2051) returning `NotImplemented` until #2053 / #2061 fill in the directions. |
 | `chordsketch-convert-musicxml` | `crates/convert-musicxml` | lib | `chordsketch-chordpro` |
 | `chordsketch` (CLI) | `crates/cli` | bin | `chordsketch-chordpro`, `chordsketch-render-text`, `chordsketch-render-html`, `chordsketch-render-pdf`, `chordsketch-convert-musicxml` |
 | `chordsketch-lsp` | `crates/lsp` | bin | `chordsketch-chordpro`, `tower-lsp`, `tokio` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "chordsketch-convert"
+version = "0.3.0"
+dependencies = [
+ "chordsketch-chordpro",
+ "chordsketch-ireal",
+]
+
+[[package]]
 name = "chordsketch-convert-musicxml"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/wasm",
     "crates/napi",
     "crates/ffi",
+    "crates/convert",
     "crates/convert-musicxml",
     "apps/desktop/src-tauri",
 ]
@@ -34,6 +35,7 @@ default-members = [
     "crates/wasm",
     "crates/napi",
     "crates/ffi",
+    "crates/convert",
     "crates/convert-musicxml",
 ]
 resolver = "3"

--- a/crates/convert/Cargo.toml
+++ b/crates/convert/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "chordsketch-convert"
+version = "0.3.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["chordpro", "ireal", "music", "converter"]
+categories = ["parser-implementations", "text-processing"]
+description = "ChordPro ↔ iReal Pro format-conversion bridge (trait scaffold)"
+readme = "README.md"
+
+[dependencies]
+chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
+chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
+
+[dev-dependencies]

--- a/crates/convert/Cargo.toml
+++ b/crates/convert/Cargo.toml
@@ -15,5 +15,3 @@ readme = "README.md"
 [dependencies]
 chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
 chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
-
-[dev-dependencies]

--- a/crates/convert/README.md
+++ b/crates/convert/README.md
@@ -18,17 +18,17 @@ Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
 
 ## Installation
 
-Replace `VERSION` with the latest release shown on the badge above.
+Add via `cargo add` (resolves to the latest published version automatically):
+
+```bash
+cargo add chordsketch-convert
+```
+
+Or pin manually — replace `VERSION` with the value shown on the badge above:
 
 ```toml
 [dependencies]
 chordsketch-convert = "VERSION"
-```
-
-Or via `cargo add`:
-
-```bash
-cargo add chordsketch-convert
 ```
 
 ## Quick start

--- a/crates/convert/README.md
+++ b/crates/convert/README.md
@@ -1,0 +1,95 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/koedame/chordsketch/main/assets/logo.svg" alt="ChordSketch" width="80" height="80">
+</p>
+
+# chordsketch-convert
+
+[![crates.io](https://img.shields.io/crates/v/chordsketch-convert)](https://crates.io/crates/chordsketch-convert)
+
+ChordPro ↔ iReal Pro format-conversion bridge (trait scaffold).
+
+This crate is the trait scaffold for the bidirectional converter
+tracked under [#2050](https://github.com/koedame/chordsketch/issues/2050).
+It deliberately ships only the public API shape — every conversion
+function returns `ConversionError::NotImplemented` until the
+direction-specific follow-up issues land.
+
+Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
+
+## Installation
+
+Replace `VERSION` with the latest release shown on the badge above.
+
+```toml
+[dependencies]
+chordsketch-convert = "VERSION"
+```
+
+Or via `cargo add`:
+
+```bash
+cargo add chordsketch-convert
+```
+
+## Quick start
+
+```rust
+use chordsketch_chordpro::ast::Song;
+use chordsketch_convert::{ConversionError, chordpro_to_ireal};
+
+let song = Song::new();
+match chordpro_to_ireal(&song) {
+    Ok(output) => {
+        let _ireal = output.output;
+        for warning in output.warnings {
+            eprintln!("warning: {} ({:?})", warning.message, warning.kind);
+        }
+    }
+    Err(ConversionError::NotImplemented(tracking)) => {
+        eprintln!("conversion stub — see {tracking}");
+    }
+    Err(e) => eprintln!("conversion failed: {e}"),
+}
+```
+
+## API
+
+| Item | Signature | Notes |
+|---|---|---|
+| `Converter<S, T>` | `fn convert(&self, source: &S) -> Result<ConversionOutput<T>, ConversionError>` | Generic trait every direction implements. |
+| `ConversionOutput<T>` | struct with `output: T` and `warnings: Vec<ConversionWarning>` | Successful (possibly lossy) result. `lossless(t)` and `with_warnings(t, ws)` constructors. |
+| `ConversionError` | enum (`NotImplemented`, `InvalidSource`, `UnrepresentableTarget`) | Failure modes; new variants are appended only. |
+| `ConversionWarning`, `WarningKind` | struct + 3-variant enum (`LossyDrop`, `Approximated`, `Unsupported`) | Non-fatal information loss surfaced to the caller. |
+| `ChordProToIreal`, `IrealToChordPro` | unit struct, `Converter` impls | Marker types for the two directions. |
+| `chordpro_to_ireal`, `ireal_to_chordpro` | free fn wrappers | Ergonomic shortcuts for the marker-type `convert` calls. |
+
+## Roadmap
+
+| Direction | Tracking issue |
+|---|---|
+| iReal → ChordPro (tempo / style as directives) | [#2053](https://github.com/koedame/chordsketch/issues/2053) |
+| ChordPro → iReal (lossy lyrics drop) | [#2061](https://github.com/koedame/chordsketch/issues/2061) |
+| Auto-detect input format in CLI | [#2066](https://github.com/koedame/chordsketch/issues/2066) |
+| Expose across WASM / NAPI / FFI | [#2067](https://github.com/koedame/chordsketch/issues/2067) |
+
+## Relationship to `chordsketch-convert-musicxml`
+
+`chordsketch-convert-musicxml` predates this crate and binds the
+ChordPro AST to MusicXML directly via free functions. The new
+`chordsketch-convert` crate is the conversion home for formats that
+share a small intermediate concept set (warnings, lossy drops,
+approximations) — namely the ChordPro ↔ iReal bridge and its
+expected MusicXML / Guitar Pro siblings. Consolidating the
+musicxml converter into this crate is tracked in a future cleanup;
+it would be a breaking change that does not block v0.3.0.
+
+## Links
+
+- [Project repository](https://github.com/koedame/chordsketch)
+- [Playground](https://chordsketch.koeda.me)
+- [API docs (docs.rs)](https://docs.rs/chordsketch-convert)
+- [Issue tracker](https://github.com/koedame/chordsketch/issues)
+
+## License
+
+MIT.

--- a/crates/convert/src/error.rs
+++ b/crates/convert/src/error.rs
@@ -65,7 +65,13 @@ impl std::error::Error for ConversionError {}
 /// lossy-but-successful runs; callers decide whether to fail on a
 /// non-empty warning list. This keeps the strictness policy in the
 /// caller's hands rather than baking it into the converter.
+///
+/// Marked `#[non_exhaustive]` so additional diagnostic fields can be
+/// appended in a follow-up PR without breaking downstream code that
+/// currently constructs `ConversionWarning` values only via
+/// [`ConversionWarning::new`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ConversionWarning {
     /// Class of information loss.
     pub kind: WarningKind,

--- a/crates/convert/src/error.rs
+++ b/crates/convert/src/error.rs
@@ -1,0 +1,90 @@
+//! Error and warning types shared by every conversion direction.
+
+/// Reason a conversion can fail.
+///
+/// The `NotImplemented` variant is the placeholder every
+/// pre-implementation function returns. Subsequent issues
+/// (#2053 iReal→ChordPro, #2061 ChordPro→iReal) replace those
+/// returns with real implementations; new variants are added at
+/// the bottom of the enum to preserve compatibility with code that
+/// matches on the existing variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConversionError {
+    /// The conversion direction is recognised but not yet
+    /// implemented in this crate version. The contained `&'static
+    /// str` names the issue tracking the implementation so callers
+    /// can give a useful diagnostic.
+    NotImplemented(&'static str),
+    /// The source value was structurally invalid and could not be
+    /// converted at all (distinct from a lossy-but-successful
+    /// conversion, which returns `Ok` with warnings).
+    InvalidSource(String),
+    /// The conversion would produce a target value that is not
+    /// representable in the target format (e.g. an out-of-range
+    /// time signature on the iReal side).
+    UnrepresentableTarget(String),
+}
+
+impl core::fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NotImplemented(tracking) => {
+                write!(f, "conversion not yet implemented (tracked at {tracking})")
+            }
+            Self::InvalidSource(msg) => write!(f, "invalid source: {msg}"),
+            Self::UnrepresentableTarget(msg) => {
+                write!(f, "unrepresentable target: {msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConversionError {}
+
+/// A non-fatal information loss recorded during conversion.
+///
+/// Conversions return `Ok(ConversionOutput { warnings, .. })` for
+/// lossy-but-successful runs; callers decide whether to fail on a
+/// non-empty warning list. This keeps the strictness policy in the
+/// caller's hands rather than baking it into the converter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversionWarning {
+    /// Class of information loss.
+    pub kind: WarningKind,
+    /// Human-readable description of what was dropped or
+    /// approximated.
+    pub message: String,
+}
+
+impl ConversionWarning {
+    /// Constructs a warning with the given kind and message.
+    #[must_use]
+    pub fn new(kind: WarningKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+/// Class of information loss in a [`ConversionWarning`].
+///
+/// New variants are appended; existing variants are stable across
+/// minor versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarningKind {
+    /// A feature in the source format has no equivalent in the
+    /// target format and was dropped (e.g. lyrics on a
+    /// ChordPro→iReal conversion — iReal has no lyrics surface).
+    LossyDrop,
+    /// A feature in the source format was approximated to the
+    /// nearest equivalent in the target format (e.g. an unusual
+    /// section label mapped to the closest iReal letter).
+    Approximated,
+    /// A feature in the source format is not yet supported by the
+    /// converter, even though the target format could in principle
+    /// represent it. Distinct from `LossyDrop` because resolving
+    /// it is a future converter-side change rather than an inherent
+    /// format limitation.
+    Unsupported,
+}

--- a/crates/convert/src/error.rs
+++ b/crates/convert/src/error.rs
@@ -8,12 +8,27 @@
 /// returns with real implementations; new variants are added at
 /// the bottom of the enum to preserve compatibility with code that
 /// matches on the existing variants.
+///
+/// Marked `#[non_exhaustive]` so adding a new variant in a follow-up
+/// PR is non-breaking for downstream `match` expressions, matching
+/// the additive-evolution contract documented at the crate root.
+///
+/// # Note for future implementers
+///
+/// Once #2053 / #2061 land, [`Self::InvalidSource`] and
+/// [`Self::UnrepresentableTarget`] will carry parser-derived,
+/// potentially attacker-controlled text. Implementations SHOULD
+/// truncate or sanitise their messages before constructing these
+/// variants; downstream `Display` consumers and log forwarders
+/// MUST NOT assume bounded length until that bound is enforced
+/// upstream. (Same pattern as `chordsketch_ireal::json::truncate_for_message`.)
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConversionError {
     /// The conversion direction is recognised but not yet
     /// implemented in this crate version. The contained `&'static
-    /// str` names the issue tracking the implementation so callers
-    /// can give a useful diagnostic.
+    /// str` is the URL of the issue tracking the implementation
+    /// so callers can give a useful diagnostic.
     NotImplemented(&'static str),
     /// The source value was structurally invalid and could not be
     /// converted at all (distinct from a lossy-but-successful
@@ -25,11 +40,14 @@ pub enum ConversionError {
     UnrepresentableTarget(String),
 }
 
-impl core::fmt::Display for ConversionError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl std::fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotImplemented(tracking) => {
-                write!(f, "conversion not yet implemented (tracked at {tracking})")
+            Self::NotImplemented(tracking_url) => {
+                write!(
+                    f,
+                    "conversion not yet implemented (tracked at {tracking_url})"
+                )
             }
             Self::InvalidSource(msg) => write!(f, "invalid source: {msg}"),
             Self::UnrepresentableTarget(msg) => {
@@ -70,8 +88,14 @@ impl ConversionWarning {
 /// Class of information loss in a [`ConversionWarning`].
 ///
 /// New variants are appended; existing variants are stable across
-/// minor versions.
+/// minor versions. Marked `#[non_exhaustive]` so adding a variant
+/// is non-breaking for downstream `match` arms.
+///
+/// `Copy` is intentional here because every variant is fieldless,
+/// matching the per-warning struct (`ConversionWarning`) which
+/// owns the attached message and is therefore not `Copy`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum WarningKind {
     /// A feature in the source format has no equivalent in the
     /// target format and was dropped (e.g. lyrics on a

--- a/crates/convert/src/ireal.rs
+++ b/crates/convert/src/ireal.rs
@@ -1,0 +1,68 @@
+//! ChordPro ↔ iReal Pro conversion stubs.
+//!
+//! The actual implementations live in the follow-up issues:
+//!
+//! - **iReal → ChordPro**: [#2053](https://github.com/koedame/chordsketch/issues/2053).
+//!   Near-lossless; tempo and style descend to ChordPro directives.
+//! - **ChordPro → iReal**: [#2061](https://github.com/koedame/chordsketch/issues/2061).
+//!   Lyrics are dropped (iReal has no lyrics surface) — that drop
+//!   surfaces as a [`crate::ConversionWarning`] with
+//!   [`crate::WarningKind::LossyDrop`].
+//!
+//! Until those issues land, [`chordpro_to_ireal`] and
+//! [`ireal_to_chordpro`] return [`ConversionError::NotImplemented`]
+//! pointing at the tracking issue.
+
+use chordsketch_chordpro::ast::Song;
+use chordsketch_ireal::IrealSong;
+
+use crate::{ConversionError, ConversionOutput, Converter};
+
+/// Marker type implementing [`Converter<Song, IrealSong>`] for the
+/// ChordPro→iReal direction. Stateless — the unit value is the
+/// canonical instance.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ChordProToIreal;
+
+impl Converter<Song, IrealSong> for ChordProToIreal {
+    fn convert(&self, _source: &Song) -> Result<ConversionOutput<IrealSong>, ConversionError> {
+        Err(ConversionError::NotImplemented(
+            "https://github.com/koedame/chordsketch/issues/2061",
+        ))
+    }
+}
+
+/// Marker type implementing [`Converter<IrealSong, Song>`] for the
+/// iReal→ChordPro direction.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct IrealToChordPro;
+
+impl Converter<IrealSong, Song> for IrealToChordPro {
+    fn convert(&self, _source: &IrealSong) -> Result<ConversionOutput<Song>, ConversionError> {
+        Err(ConversionError::NotImplemented(
+            "https://github.com/koedame/chordsketch/issues/2053",
+        ))
+    }
+}
+
+/// Convenience wrapper around [`ChordProToIreal::convert`].
+///
+/// # Errors
+///
+/// Currently always returns [`ConversionError::NotImplemented`].
+/// See [`crate::ireal`] for the tracking issue.
+#[must_use = "ignoring a conversion result drops both warnings and errors"]
+pub fn chordpro_to_ireal(song: &Song) -> Result<ConversionOutput<IrealSong>, ConversionError> {
+    ChordProToIreal.convert(song)
+}
+
+/// Convenience wrapper around [`IrealToChordPro::convert`].
+///
+/// # Errors
+///
+/// Currently always returns [`ConversionError::NotImplemented`].
+/// See [`crate::ireal`] for the tracking issue.
+#[must_use = "ignoring a conversion result drops both warnings and errors"]
+pub fn ireal_to_chordpro(song: &IrealSong) -> Result<ConversionOutput<Song>, ConversionError> {
+    IrealToChordPro.convert(song)
+}

--- a/crates/convert/src/lib.rs
+++ b/crates/convert/src/lib.rs
@@ -1,0 +1,118 @@
+//! ChordPro ↔ iReal Pro format-conversion bridge.
+//!
+//! This crate is the trait scaffold for the bidirectional converter
+//! tracked under [#2050](https://github.com/koedame/chordsketch/issues/2050).
+//! It deliberately ships only the public API shape — every conversion
+//! function returns [`ConversionError::NotImplemented`] until the
+//! direction-specific follow-up issues land. Locking the surface in
+//! up front lets the bindings (#2067) and the CLI auto-detect path
+//! (#2066) reference stable types from day one.
+//!
+//! # Layout
+//!
+//! - [`Converter`] is the generic trait every direction implements.
+//!   Free functions [`chordpro_to_ireal`] and [`ireal_to_chordpro`]
+//!   wrap the trait implementations for ergonomics. New formats
+//!   (MusicXML, Guitar Pro, etc.) plug in as additional `Converter`
+//!   implementations or as their own crates that depend on this one
+//!   for the warning / error vocabulary.
+//! - [`ConversionOutput`] pairs the converted value with a
+//!   [`ConversionWarning`] list so callers can surface lossy
+//!   transformations without parsing the error type.
+//! - [`ConversionError`] enumerates the reasons a conversion can
+//!   fail. The `NotImplemented` variant is the placeholder every
+//!   pre-implementation function currently returns.
+//!
+//! # Why a separate crate from `chordsketch-convert-musicxml`
+//!
+//! `chordsketch-convert-musicxml` predates this crate and binds the
+//! ChordPro AST to MusicXML directly via free functions. The new
+//! `chordsketch-convert` crate is the conversion home for formats
+//! that share a small intermediate concept set (warnings, lossy
+//! drops, approximations) — namely the ChordPro ↔ iReal bridge and
+//! its expected MusicXML / Guitar Pro siblings. Consolidating the
+//! musicxml converter into this crate is tracked in a future
+//! cleanup; it would be a breaking change that does not block
+//! v0.3.0.
+//!
+//! # Stability
+//!
+//! Pre-1.0 — the trait surface is intentionally narrow so the
+//! follow-up issues can fill in implementations without breaking
+//! the bindings or CLI. Adding new `ConversionError` variants is
+//! a non-breaking change; renaming an existing variant is
+//! breaking.
+
+#![forbid(unsafe_code)]
+
+pub mod error;
+pub mod ireal;
+
+pub use error::{ConversionError, ConversionWarning, WarningKind};
+pub use ireal::{ChordProToIreal, IrealToChordPro, chordpro_to_ireal, ireal_to_chordpro};
+
+/// Result of a successful conversion.
+///
+/// `output` is the converted value; `warnings` is the list of
+/// information lost or approximated during the transformation. An
+/// empty `warnings` vector indicates a clean (lossless) conversion;
+/// callers that prefer fail-fast behaviour can promote any non-empty
+/// warning list to an error themselves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversionOutput<T> {
+    /// The converted value.
+    pub output: T,
+    /// Warnings emitted during conversion (lossy drops,
+    /// approximations, unsupported features).
+    pub warnings: Vec<ConversionWarning>,
+}
+
+impl<T> ConversionOutput<T> {
+    /// Wraps `output` with an empty warning list.
+    #[must_use]
+    pub fn lossless(output: T) -> Self {
+        Self {
+            output,
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Wraps `output` with the provided warning list.
+    #[must_use]
+    pub fn with_warnings(output: T, warnings: Vec<ConversionWarning>) -> Self {
+        Self { output, warnings }
+    }
+}
+
+/// A converter that transforms `Source` into `Target`.
+///
+/// Implementations live alongside the source / target types — the
+/// ChordPro ↔ iReal pair is in [`crate::ireal`]. Adding a new
+/// direction means implementing `Converter<S, T>` for a new unit
+/// struct (or extending an existing one) and re-exporting an
+/// ergonomic free function from this crate's root.
+///
+/// # Errors
+///
+/// Implementations return [`ConversionError`]; see that type for the
+/// failure-mode taxonomy. Lossy but successful conversions return
+/// `Ok(ConversionOutput { warnings: [...], .. })`, not `Err` — the
+/// caller decides whether warnings should be promoted to errors.
+pub trait Converter<Source, Target> {
+    /// Converts `source` into `Target`, accumulating any
+    /// information lost in `ConversionOutput::warnings`.
+    ///
+    /// # Errors
+    ///
+    /// See [`ConversionError`] for the documented failure modes.
+    /// While the scaffold is in place every implementation returns
+    /// [`ConversionError::NotImplemented`].
+    fn convert(&self, source: &Source) -> Result<ConversionOutput<Target>, ConversionError>;
+}
+
+/// Returns the library version (the workspace `Cargo.toml`
+/// `version` field, baked in at compile time).
+#[must_use]
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}

--- a/crates/convert/src/lib.rs
+++ b/crates/convert/src/lib.rs
@@ -39,9 +39,26 @@
 //!
 //! Pre-1.0 — the trait surface is intentionally narrow so the
 //! follow-up issues can fill in implementations without breaking
-//! the bindings or CLI. Adding new `ConversionError` variants is
-//! a non-breaking change; renaming an existing variant is
-//! breaking.
+//! the bindings or CLI. [`ConversionError`] and [`WarningKind`]
+//! are both `#[non_exhaustive]`, so adding a new variant is
+//! non-breaking for downstream `match` expressions; renaming an
+//! existing variant remains breaking.
+//!
+//! # Example
+//!
+//! ```
+//! use chordsketch_chordpro::ast::Song;
+//! use chordsketch_convert::{ConversionError, chordpro_to_ireal};
+//!
+//! let song = Song::new();
+//! match chordpro_to_ireal(&song) {
+//!     Ok(_output) => unreachable!("scaffold returns NotImplemented"),
+//!     Err(ConversionError::NotImplemented(tracking_url)) => {
+//!         assert!(tracking_url.contains("issues/2061"));
+//!     }
+//!     Err(_) => unreachable!("scaffold only returns NotImplemented"),
+//! }
+//! ```
 
 #![forbid(unsafe_code)]
 
@@ -92,6 +109,24 @@ impl<T> ConversionOutput<T> {
 /// struct (or extending an existing one) and re-exporting an
 /// ergonomic free function from this crate's root.
 ///
+/// # Why a trait in addition to free functions
+///
+/// The free functions in [`crate::ireal`] are the ergonomic entry
+/// point for a known direction. The trait exists for two callers
+/// the free functions cannot serve:
+///
+/// - **Generic dispatch.** A future pipeline that runs the same
+///   ChordSketch `Song` through several converters
+///   (`Vec<Box<dyn Converter<Song, MusicXml>>>` etc.) needs a
+///   uniform type to hold them. The CLI auto-detect path (#2066)
+///   is the first concrete consumer.
+/// - **Configurable converters.** Once #2053 / #2061 land, an
+///   implementation may need configuration (strictness level,
+///   warning thresholds). A marker struct with fields holds that
+///   state; the free function then becomes a thin wrapper around
+///   the default-configured marker. Keeping the trait in place
+///   from day one avoids a breaking re-shape later.
+///
 /// # Errors
 ///
 /// Implementations return [`ConversionError`]; see that type for the
@@ -107,6 +142,7 @@ pub trait Converter<Source, Target> {
     /// See [`ConversionError`] for the documented failure modes.
     /// While the scaffold is in place every implementation returns
     /// [`ConversionError::NotImplemented`].
+    #[must_use = "ignoring a conversion result drops both warnings and errors"]
     fn convert(&self, source: &Source) -> Result<ConversionOutput<Target>, ConversionError>;
 }
 

--- a/crates/convert/tests/scaffold.rs
+++ b/crates/convert/tests/scaffold.rs
@@ -46,14 +46,34 @@ fn marker_types_implement_converter_via_trait() {
     // The free-function wrappers and the trait-method paths must
     // produce structurally equal results; if a future change
     // implements only one, this test catches the asymmetry.
+    // Asserting on the `NotImplemented` variant directly (rather
+    // than relying on `assert_eq!` of the wrapping `Result`) keeps
+    // the failure mode legible once #2053 / #2061 land and the
+    // `Ok` arm becomes reachable: a divergence would surface as a
+    // mismatched tracking URL or an unexpected variant rather than
+    // an opaque `Result` inequality.
     let chordpro = Song::new();
     let ireal = IrealSong::new();
-    let trait_a = ChordProToIreal.convert(&chordpro);
-    let free_a = chordpro_to_ireal(&chordpro);
-    assert_eq!(trait_a, free_a);
-    let trait_b = IrealToChordPro.convert(&ireal);
-    let free_b = ireal_to_chordpro(&ireal);
-    assert_eq!(trait_b, free_b);
+
+    let trait_a = match ChordProToIreal.convert(&chordpro) {
+        Err(ConversionError::NotImplemented(url)) => url,
+        other => panic!("expected NotImplemented, got {other:?}"),
+    };
+    let free_a = match chordpro_to_ireal(&chordpro) {
+        Err(ConversionError::NotImplemented(url)) => url,
+        other => panic!("expected NotImplemented, got {other:?}"),
+    };
+    assert_eq!(trait_a, free_a, "ChordProToIreal trait/free-fn divergence");
+
+    let trait_b = match IrealToChordPro.convert(&ireal) {
+        Err(ConversionError::NotImplemented(url)) => url,
+        other => panic!("expected NotImplemented, got {other:?}"),
+    };
+    let free_b = match ireal_to_chordpro(&ireal) {
+        Err(ConversionError::NotImplemented(url)) => url,
+        other => panic!("expected NotImplemented, got {other:?}"),
+    };
+    assert_eq!(trait_b, free_b, "IrealToChordPro trait/free-fn divergence");
 }
 
 #[test]

--- a/crates/convert/tests/scaffold.rs
+++ b/crates/convert/tests/scaffold.rs
@@ -104,6 +104,12 @@ fn conversion_error_display_includes_tracking_url() {
 }
 
 #[test]
+fn version_is_nonempty() {
+    let v = chordsketch_convert::version();
+    assert!(!v.is_empty(), "version() must not return an empty string");
+}
+
+#[test]
 fn warning_kind_variants_are_distinct() {
     assert_ne!(WarningKind::LossyDrop, WarningKind::Approximated);
     assert_ne!(WarningKind::Approximated, WarningKind::Unsupported);

--- a/crates/convert/tests/scaffold.rs
+++ b/crates/convert/tests/scaffold.rs
@@ -1,0 +1,105 @@
+//! Smoke tests for the conversion scaffold.
+//!
+//! These tests exist to catch regressions in the public API surface
+//! during the pre-implementation phase. Each test asserts a
+//! property the follow-up issues (#2053, #2061) must preserve when
+//! they replace the `NotImplemented` returns with real
+//! conversions.
+
+use chordsketch_chordpro::ast::Song;
+use chordsketch_convert::{
+    ChordProToIreal, ConversionError, ConversionOutput, ConversionWarning, Converter,
+    IrealToChordPro, WarningKind, chordpro_to_ireal, ireal_to_chordpro,
+};
+use chordsketch_ireal::IrealSong;
+
+#[test]
+fn chordpro_to_ireal_currently_returns_not_implemented() {
+    let song = Song::new();
+    match chordpro_to_ireal(&song) {
+        Err(ConversionError::NotImplemented(tracking)) => {
+            assert!(
+                tracking.contains("/2061"),
+                "tracking pointer should reference #2061, got {tracking}"
+            );
+        }
+        other => panic!("expected NotImplemented, got {other:?}"),
+    }
+}
+
+#[test]
+fn ireal_to_chordpro_currently_returns_not_implemented() {
+    let song = IrealSong::new();
+    match ireal_to_chordpro(&song) {
+        Err(ConversionError::NotImplemented(tracking)) => {
+            assert!(
+                tracking.contains("/2053"),
+                "tracking pointer should reference #2053, got {tracking}"
+            );
+        }
+        other => panic!("expected NotImplemented, got {other:?}"),
+    }
+}
+
+#[test]
+fn marker_types_implement_converter_via_trait() {
+    // The free-function wrappers and the trait-method paths must
+    // produce structurally equal results; if a future change
+    // implements only one, this test catches the asymmetry.
+    let chordpro = Song::new();
+    let ireal = IrealSong::new();
+    let trait_a = ChordProToIreal.convert(&chordpro);
+    let free_a = chordpro_to_ireal(&chordpro);
+    assert_eq!(trait_a, free_a);
+    let trait_b = IrealToChordPro.convert(&ireal);
+    let free_b = ireal_to_chordpro(&ireal);
+    assert_eq!(trait_b, free_b);
+}
+
+#[test]
+fn conversion_output_lossless_constructor_yields_empty_warnings() {
+    let output = ConversionOutput::lossless(42_u32);
+    assert_eq!(output.output, 42);
+    assert!(output.warnings.is_empty());
+}
+
+#[test]
+fn conversion_output_with_warnings_preserves_warning_list() {
+    let warnings = vec![
+        ConversionWarning::new(WarningKind::LossyDrop, "lyrics dropped"),
+        ConversionWarning::new(WarningKind::Approximated, "section label mapped"),
+    ];
+    let output = ConversionOutput::with_warnings(0_u8, warnings.clone());
+    assert_eq!(output.warnings, warnings);
+}
+
+#[test]
+fn conversion_error_display_includes_tracking_url() {
+    let err = ConversionError::NotImplemented("https://github.com/koedame/chordsketch/issues/2053");
+    let s = format!("{err}");
+    assert!(
+        s.contains("issues/2053"),
+        "Display impl should include tracking URL: got {s}"
+    );
+}
+
+#[test]
+fn warning_kind_variants_are_distinct() {
+    assert_ne!(WarningKind::LossyDrop, WarningKind::Approximated);
+    assert_ne!(WarningKind::Approximated, WarningKind::Unsupported);
+    assert_ne!(WarningKind::LossyDrop, WarningKind::Unsupported);
+}
+
+#[test]
+fn conversion_error_invalid_source_includes_message() {
+    let err = ConversionError::InvalidSource("missing root".into());
+    let s = format!("{err}");
+    assert!(s.contains("missing root"), "Display: {s}");
+}
+
+#[test]
+fn conversion_error_unrepresentable_target_includes_message() {
+    let err = ConversionError::UnrepresentableTarget("13/4 time".into());
+    let s = format!("{err}");
+    assert!(s.contains("13/4 time"), "Display: {s}");
+}


### PR DESCRIPTION
## What

Trait scaffold for the ChordPro ↔ iReal Pro bidirectional converter
tracked under #2050. Adds `crates/convert/` (`chordsketch-convert`)
with the public API shape only — both directions currently return
`ConversionError::NotImplemented` pointing at the follow-up issues
that fill them in.

## Why

#2051 is the third iReal-related sub-issue made unblockable by
#2055 (`chordsketch-ireal` scaffold) landing in #2320. Locking the
trait surface in now lets the bindings (#2067) and the CLI
auto-detect path (#2066) reference stable types before the real
conversion logic arrives in #2053 / #2061.

## How — module layout

| File | Purpose |
|---|---|
| `crates/convert/src/lib.rs` | `Converter<S, T>` trait, `ConversionOutput<T>`, public re-exports |
| `crates/convert/src/error.rs` | `ConversionError`, `ConversionWarning`, `WarningKind` |
| `crates/convert/src/ireal.rs` | `ChordProToIreal` / `IrealToChordPro` marker structs + `chordpro_to_ireal` / `ireal_to_chordpro` ergonomic wrappers (all returning `NotImplemented`) |
| `crates/convert/tests/scaffold.rs` | 9 unit tests covering the `NotImplemented` contract, trait-vs-free-function symmetry, `ConversionOutput` constructors, `Display` for `ConversionError`, `WarningKind` distinctness |
| `crates/convert/README.md` | Crate README at L2 per `package-documentation.md` (Installation with `VERSION` placeholder, Quick start, API table, Roadmap, Links) |

## Acceptance Criteria check

| AC | Status |
|---|---|
| `crates/convert/` workspace member; package name `chordsketch-convert` | Added to `members` and `default-members` |
| Trait / module layout designed for future conversions (MusicXML, Guitar Pro, etc.) | `Converter<S, T>` is generic; `ConversionWarning` / `WarningKind` are direction-agnostic; new directions plug in as additional `Converter` impls |
| Empty public API surface with trait stubs + docs | Both directions return `ConversionError::NotImplemented(tracking_url)` until #2053 / #2061 land |
| Builds clean | Yes — `cargo build`, `cargo test`, `cargo clippy -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc` all pass |
| CI green | Pending CI run |

## Tests

```
running 9 tests
test chordpro_to_ireal_currently_returns_not_implemented ... ok
test ireal_to_chordpro_currently_returns_not_implemented ... ok
test marker_types_implement_converter_via_trait ... ok
test conversion_output_lossless_constructor_yields_empty_warnings ... ok
test conversion_output_with_warnings_preserves_warning_list ... ok
test conversion_error_display_includes_tracking_url ... ok
test conversion_error_invalid_source_includes_message ... ok
test conversion_error_unrepresentable_target_includes_message ... ok
test warning_kind_variants_are_distinct ... ok

test result: ok. 9 passed; 0 failed
```

## Sister-site / fix-propagation audit

Not a bug fix — no sister-site groups apply. The new crate is the
only converter that uses the trait surface; `chordsketch-convert-musicxml`
predates it and uses a separate free-function design (see the
"Relationship to chordsketch-convert-musicxml" section in
`crates/convert/README.md`). Consolidation is a future cleanup,
not a #2051 deliverable.

## Doc updates

- `CLAUDE.md` Architecture table: row added for `chordsketch-convert`.
- New crate ships its own `README.md` at L2 quality.

Closes #2051.