### PR TITLE
feat(render-ireal): 4-bars-per-line grid layout engine (#2060)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This is a Cargo workspace with the following crates:
 | `chordsketch-render-text` | `crates/render-text` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-html` | `crates/render-html` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-pdf` | `crates/render-pdf` | lib | `chordsketch-chordpro` |
-| `chordsketch-render-ireal` | `crates/render-ireal` | lib | `chordsketch-ireal`. iReal Pro chart SVG renderer — page frame + metadata header + empty 4-bar grid skeleton (#2058). Chord text / barlines / symbols / typography filled in by #2057 / #2059 / #2060 / #2062. |
+| `chordsketch-render-ireal` | `crates/render-ireal` | lib | `chordsketch-ireal`. iReal Pro chart SVG renderer — page frame + metadata header + 4-bars-per-line grid layout engine with centred chord text and section line breaks (#2058 scaffold + #2060 layout). Barlines / repeats / endings / music symbols / superscript chord typography filled in by #2057 / #2059 / #2062. |
 | `chordsketch-convert` | `crates/convert` | lib | `chordsketch-chordpro`, `chordsketch-ireal`. ChordPro ↔ iReal Pro conversion bridge — trait scaffold (#2051) returning `NotImplemented` until #2053 / #2061 fill in the directions. |
 | `chordsketch-convert-musicxml` | `crates/convert-musicxml` | lib | `chordsketch-chordpro` |
 | `chordsketch` (CLI) | `crates/cli` | bin | `chordsketch-chordpro`, `chordsketch-render-text`, `chordsketch-render-html`, `chordsketch-render-pdf`, `chordsketch-convert-musicxml` |

--- a/crates/render-ireal/README.md
+++ b/crates/render-ireal/README.md
@@ -6,15 +6,17 @@
 
 [![crates.io](https://img.shields.io/crates/v/chordsketch-render-ireal)](https://crates.io/crates/chordsketch-render-ireal)
 
-iReal Pro chart renderer — SVG skeleton.
+iReal Pro chart renderer — SVG with 4-bars-per-line grid layout.
 
-This crate is the SVG renderer scaffold for the iReal Pro feature
-set tracked under [#2050](https://github.com/koedame/chordsketch/issues/2050).
-It deliberately ships only the page frame, the metadata header
-(title / composer / style / key), and an empty 4-bar-per-line
-grid skeleton — chord text, barline shapes, repeat / ending
-brackets, music symbols, and chord-name typography each have their
-own follow-up issue.
+This crate renders an `IrealSong` AST as a fixed-size SVG document.
+The current scope (`#2058` scaffold + `#2060` layout engine) covers
+the page frame, the metadata header (title / composer / style /
+key), the 4-bars-per-line grid with section line breaks, and
+flat-layout chord text centred in each cell. Barlines, repeat /
+ending brackets, music symbols, and superscript chord-name
+typography land in follow-up issues (`#2057` / `#2059` / `#2062`).
+
+Tracked under [#2050](https://github.com/koedame/chordsketch/issues/2050).
 
 Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
 

--- a/crates/render-ireal/README.md
+++ b/crates/render-ireal/README.md
@@ -65,23 +65,24 @@ divided into:
 - **Header band** — title (top), composer (right, omitted if
   absent), style + key (left, beneath the title; falls back to
   iReal Pro's "Medium Swing" default when style is unset).
-- **Bar grid** — bars laid out 4-per-row in equal-width cells
-  below the header. Each cell is currently an empty `<rect>`;
-  chord text and inner glyphs are filled in by the follow-up
-  crates / issues.
+- **Bar grid** — bars laid out 4-per-row by `compute_layout`. Each
+  cell carries a centred chord-name `<text>` (flat layout — full
+  superscript typography lands in #2057). Trailing cells in a
+  section's last row are filled with empty placeholders so the
+  visible grid stays a clean rectangle; barlines / repeats /
+  endings / music symbols layer on top in #2059 / #2062.
 
 ## Roadmap
 
 | Feature | Tracking issue |
 |---|---|
-| 4-bars-per-line grid layout engine | [#2060](https://github.com/koedame/chordsketch/issues/2060) |
 | Repeat barlines, endings, section markers | [#2059](https://github.com/koedame/chordsketch/issues/2059) |
 | Chord-name typography with superscripts | [#2057](https://github.com/koedame/chordsketch/issues/2057) |
 | Music symbols via Bravura font (segno / coda / D.C. / D.S.) | [#2062](https://github.com/koedame/chordsketch/issues/2062) |
 | PNG rasterization via resvg | [#2064](https://github.com/koedame/chordsketch/issues/2064) |
 | PDF output layer | [#2063](https://github.com/koedame/chordsketch/issues/2063) |
 
-## Regenerating the golden fixture
+## Regenerating the golden fixtures
 
 When the renderer changes intentionally:
 
@@ -90,7 +91,9 @@ UPDATE_GOLDEN=1 cargo test -p chordsketch-render-ireal
 cargo test -p chordsketch-render-ireal   # re-run without the env var to confirm
 ```
 
-The expected SVG lives at `tests/fixtures/basic/expected.svg`.
+The expected SVGs live under `tests/fixtures/<name>/expected.svg`
+(currently `basic`, `twelve_bar_blues`, `aaba_32bar`,
+`sixteen_bar_loop`, `section_break_irregular`, `multi_chord_bar`).
 
 ## Links
 

--- a/crates/render-ireal/src/chord_format.rs
+++ b/crates/render-ireal/src/chord_format.rs
@@ -1,0 +1,164 @@
+//! Chord-name display formatting.
+//!
+//! Renders an AST `Chord` as a flat single-line string suitable for
+//! inline placement inside a bar cell. This is the "simple flat
+//! layout" called out in the AC for #2060; full superscript
+//! typography (raised extensions, alteration brackets) lands in
+//! #2057 and replaces this formatter at the call site.
+
+use chordsketch_ireal::{Accidental, Chord, ChordQuality, ChordRoot};
+
+/// Returns the display string for the given chord.
+///
+/// Format: `<root><accidental><quality>[/<bass>]`. Examples:
+/// `C`, `Cm7`, `B♭7`, `F♯m7♭5`, `C/G`. The quality string for
+/// [`ChordQuality::Custom`] is used verbatim.
+#[must_use]
+pub(crate) fn format_chord(chord: &Chord) -> String {
+    let mut out = String::new();
+    write_root(&mut out, chord.root);
+    out.push_str(quality_glyph(&chord.quality));
+    if let Some(bass) = chord.bass {
+        out.push('/');
+        write_root(&mut out, bass);
+    }
+    out
+}
+
+fn write_root(out: &mut String, root: ChordRoot) {
+    // The deserializer enforces `A..=G`, but downstream consumers can
+    // construct an AST with arbitrary `note` chars via direct field
+    // assignment. Fall back to `?` (matching the renderer's
+    // `format_key` fallback) so bogus input surfaces visibly rather
+    // than producing nonsense.
+    let glyph = if matches!(root.note, 'A'..='G') {
+        root.note
+    } else {
+        '?'
+    };
+    out.push(glyph);
+    out.push_str(match root.accidental {
+        Accidental::Natural => "",
+        Accidental::Flat => "\u{266D}",
+        Accidental::Sharp => "\u{266F}",
+    });
+}
+
+fn quality_glyph(q: &ChordQuality) -> &str {
+    match q {
+        ChordQuality::Major => "",
+        ChordQuality::Minor => "m",
+        ChordQuality::Diminished => "dim",
+        ChordQuality::Augmented => "aug",
+        ChordQuality::Major7 => "maj7",
+        ChordQuality::Minor7 => "m7",
+        ChordQuality::Dominant7 => "7",
+        ChordQuality::HalfDiminished => "m7\u{266D}5",
+        ChordQuality::Diminished7 => "dim7",
+        ChordQuality::Suspended2 => "sus2",
+        ChordQuality::Suspended4 => "sus4",
+        ChordQuality::Custom(s) => s.as_str(),
+    }
+}
+
+/// Joins multiple chords for placement inside a single bar cell with
+/// a single ASCII space between each rendered chord. Used by the
+/// flat-layout pass; the typography pass (#2057) replaces this with
+/// beat-aware horizontal placement.
+#[must_use]
+pub(crate) fn format_bar_chord_line(chords: &[chordsketch_ireal::BarChord]) -> String {
+    let mut out = String::new();
+    for (i, bc) in chords.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push_str(&format_chord(&bc.chord));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_bar_chord_line, format_chord};
+    use chordsketch_ireal::{Accidental, BarChord, BeatPosition, Chord, ChordQuality, ChordRoot};
+
+    #[test]
+    fn formats_major_triad() {
+        let chord = Chord::triad(ChordRoot::natural('C'), ChordQuality::Major);
+        assert_eq!(format_chord(&chord), "C");
+    }
+
+    #[test]
+    fn formats_minor_seventh() {
+        let chord = Chord::triad(ChordRoot::natural('A'), ChordQuality::Minor7);
+        assert_eq!(format_chord(&chord), "Am7");
+    }
+
+    #[test]
+    fn formats_flat_root() {
+        let chord = Chord::triad(
+            ChordRoot {
+                note: 'B',
+                accidental: Accidental::Flat,
+            },
+            ChordQuality::Dominant7,
+        );
+        assert_eq!(format_chord(&chord), "B\u{266D}7");
+    }
+
+    #[test]
+    fn formats_half_diminished_with_compound_glyph() {
+        let chord = Chord::triad(ChordRoot::natural('F'), ChordQuality::HalfDiminished);
+        assert_eq!(format_chord(&chord), "Fm7\u{266D}5");
+    }
+
+    #[test]
+    fn formats_slash_chord() {
+        let chord = Chord {
+            root: ChordRoot::natural('C'),
+            quality: ChordQuality::Major,
+            bass: Some(ChordRoot::natural('G')),
+        };
+        assert_eq!(format_chord(&chord), "C/G");
+    }
+
+    #[test]
+    fn formats_custom_quality_verbatim() {
+        let chord = Chord::triad(
+            ChordRoot::natural('C'),
+            ChordQuality::Custom("13\u{266F}11".into()),
+        );
+        assert_eq!(format_chord(&chord), "C13\u{266F}11");
+    }
+
+    #[test]
+    fn out_of_range_root_falls_back_to_question_mark() {
+        // Direct field assignment can produce a non-A..=G note; the
+        // renderer must emit a deterministic sentinel rather than
+        // smuggling raw input into the SVG.
+        let chord = Chord::triad(
+            ChordRoot {
+                note: 'X',
+                accidental: Accidental::Natural,
+            },
+            ChordQuality::Major,
+        );
+        assert_eq!(format_chord(&chord), "?");
+    }
+
+    #[test]
+    fn empty_bar_chord_line_is_empty() {
+        assert_eq!(format_bar_chord_line(&[]), "");
+    }
+
+    #[test]
+    fn multi_chord_bar_joins_with_space() {
+        let bc = |note, q| BarChord {
+            chord: Chord::triad(ChordRoot::natural(note), q),
+            position: BeatPosition::on_beat(1).unwrap(),
+        };
+        let line =
+            format_bar_chord_line(&[bc('C', ChordQuality::Major), bc('A', ChordQuality::Minor7)]);
+        assert_eq!(line, "C Am7");
+    }
+}

--- a/crates/render-ireal/src/chord_format.rs
+++ b/crates/render-ireal/src/chord_format.rs
@@ -185,6 +185,60 @@ mod tests {
         assert_eq!(line, expected);
     }
 
+    // ---- quality_glyph coverage ----
+
+    #[test]
+    fn formats_diminished() {
+        let chord = Chord::triad(ChordRoot::natural('B'), ChordQuality::Diminished);
+        assert_eq!(format_chord(&chord), "Bdim");
+    }
+
+    #[test]
+    fn formats_augmented() {
+        let chord = Chord::triad(ChordRoot::natural('C'), ChordQuality::Augmented);
+        assert_eq!(format_chord(&chord), "Caug");
+    }
+
+    #[test]
+    fn formats_major_seventh() {
+        let chord = Chord::triad(ChordRoot::natural('D'), ChordQuality::Major7);
+        assert_eq!(format_chord(&chord), "Dmaj7");
+    }
+
+    #[test]
+    fn formats_diminished_seventh() {
+        let chord = Chord::triad(ChordRoot::natural('G'), ChordQuality::Diminished7);
+        assert_eq!(format_chord(&chord), "Gdim7");
+    }
+
+    #[test]
+    fn formats_suspended_second() {
+        let chord = Chord::triad(ChordRoot::natural('A'), ChordQuality::Suspended2);
+        assert_eq!(format_chord(&chord), "Asus2");
+    }
+
+    #[test]
+    fn formats_suspended_fourth() {
+        let chord = Chord::triad(ChordRoot::natural('E'), ChordQuality::Suspended4);
+        assert_eq!(format_chord(&chord), "Esus4");
+    }
+
+    // ---- write_root accidental coverage ----
+
+    #[test]
+    fn formats_sharp_root() {
+        // Accidental::Sharp in write_root — the one untested arm
+        // after formats_flat_root covers Accidental::Flat.
+        let chord = Chord::triad(
+            ChordRoot {
+                note: 'F',
+                accidental: Accidental::Sharp,
+            },
+            ChordQuality::Minor7,
+        );
+        assert_eq!(format_chord(&chord), "F\u{266F}m7");
+    }
+
     #[test]
     fn empty_bar_chord_line_is_empty() {
         assert_eq!(format_bar_chord_line(&[]), "");

--- a/crates/render-ireal/src/chord_format.rs
+++ b/crates/render-ireal/src/chord_format.rs
@@ -8,11 +8,15 @@
 
 use chordsketch_ireal::{Accidental, Chord, ChordQuality, ChordRoot};
 
+use crate::page::MAX_CHORDS_PER_BAR;
+
 /// Returns the display string for the given chord.
 ///
 /// Format: `<root><accidental><quality>[/<bass>]`. Examples:
 /// `C`, `Cm7`, `B♭7`, `F♯m7♭5`, `C/G`. The quality string for
-/// [`ChordQuality::Custom`] is used verbatim.
+/// [`ChordQuality::Custom`] is included verbatim in the
+/// formatter's output; the SVG renderer applies XML escaping at
+/// the embedding site (`crate::svg::escape_xml`).
 #[must_use]
 pub(crate) fn format_chord(chord: &Chord) -> String {
     let mut out = String::new();
@@ -26,17 +30,7 @@ pub(crate) fn format_chord(chord: &Chord) -> String {
 }
 
 fn write_root(out: &mut String, root: ChordRoot) {
-    // The deserializer enforces `A..=G`, but downstream consumers can
-    // construct an AST with arbitrary `note` chars via direct field
-    // assignment. Fall back to `?` (matching the renderer's
-    // `format_key` fallback) so bogus input surfaces visibly rather
-    // than producing nonsense.
-    let glyph = if matches!(root.note, 'A'..='G') {
-        root.note
-    } else {
-        '?'
-    };
-    out.push(glyph);
+    out.push(crate::note_glyph_or_fallback(root.note));
     out.push_str(match root.accidental {
         Accidental::Natural => "",
         Accidental::Flat => "\u{266D}",
@@ -65,10 +59,17 @@ fn quality_glyph(q: &ChordQuality) -> &str {
 /// a single ASCII space between each rendered chord. Used by the
 /// flat-layout pass; the typography pass (#2057) replaces this with
 /// beat-aware horizontal placement.
+///
+/// Truncates the chord list to [`MAX_CHORDS_PER_BAR`] before joining
+/// so an adversarial AST cannot grow the rendered string without
+/// bound. Surplus chords are silently dropped — the cap is far
+/// above any practical iReal Pro chart layout, so a hit indicates
+/// malformed input rather than legitimate notation.
 #[must_use]
 pub(crate) fn format_bar_chord_line(chords: &[chordsketch_ireal::BarChord]) -> String {
     let mut out = String::new();
-    for (i, bc) in chords.iter().enumerate() {
+    let limit = chords.len().min(MAX_CHORDS_PER_BAR);
+    for (i, bc) in chords.iter().take(limit).enumerate() {
         if i > 0 {
             out.push(' ');
         }
@@ -144,6 +145,44 @@ mod tests {
             ChordQuality::Major,
         );
         assert_eq!(format_chord(&chord), "?");
+    }
+
+    #[test]
+    fn out_of_range_bass_falls_back_to_question_mark() {
+        // The `?`-fallback for `note` must apply symmetrically to
+        // the slash-chord bass; otherwise an attacker-supplied bass
+        // could smuggle through the formatter even when the root
+        // is sanitised.
+        let chord = Chord {
+            root: ChordRoot::natural('C'),
+            quality: ChordQuality::Major,
+            bass: Some(ChordRoot {
+                note: '<',
+                accidental: Accidental::Natural,
+            }),
+        };
+        assert_eq!(format_chord(&chord), "C/?");
+    }
+
+    #[test]
+    fn excess_chords_per_bar_are_truncated() {
+        use crate::page::MAX_CHORDS_PER_BAR;
+        // An adversarial AST with > MAX_CHORDS_PER_BAR chords
+        // must produce a bounded string. We do not assert exact
+        // output (the joined text grows with the cap) — only that
+        // the formatter returns rather than allocating without
+        // bound, and that the rendered length is consistent with
+        // exactly `MAX_CHORDS_PER_BAR` chords.
+        let bc = || BarChord {
+            chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Major),
+            position: BeatPosition::on_beat(1).unwrap(),
+        };
+        let chords = vec![bc(); MAX_CHORDS_PER_BAR + 100];
+        let line = format_bar_chord_line(&chords);
+        let expected = std::iter::repeat_n("C", MAX_CHORDS_PER_BAR)
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert_eq!(line, expected);
     }
 
     #[test]

--- a/crates/render-ireal/src/layout.rs
+++ b/crates/render-ireal/src/layout.rs
@@ -118,7 +118,11 @@ pub fn compute_layout(song: &IrealSong) -> Layout {
     let mut section_row_starts = Vec::with_capacity(song.sections.len());
     let mut row: usize = 0;
     let mut col: usize = 0;
-    let mut section_started_row = false;
+    // Highest row index that holds rendered content (bar OR
+    // trailing empty). Used to derive `total_rows` cleanly even
+    // when an empty trailing section bumps `row` past the last
+    // visible content.
+    let mut last_visible_row: Option<usize> = None;
     for (section_idx, section) in song.sections.iter().enumerate() {
         // Before opening a new section that does not start at the
         // row's left margin, emit empty trailers to fill the rest
@@ -133,11 +137,11 @@ pub fn compute_layout(song: &IrealSong) -> Layout {
                 base_cell_width,
                 last_cell_width,
             );
+            last_visible_row = Some(row);
             row += 1;
             col = 0;
         }
         section_row_starts.push(row);
-        section_started_row = false;
         if section.bars.is_empty() {
             // Empty section consumed no rows; the next non-empty
             // section will land on the same row this one would
@@ -153,7 +157,6 @@ pub fn compute_layout(song: &IrealSong) -> Layout {
                 row += 1;
                 col = 0;
             }
-            section_started_row = true;
             let cell_width = if col == BARS_PER_ROW - 1 {
                 last_cell_width
             } else {
@@ -169,6 +172,7 @@ pub fn compute_layout(song: &IrealSong) -> Layout {
                 section_index: section_idx,
                 bar_index_in_section: bar_idx,
             });
+            last_visible_row = Some(row);
             col += 1;
         }
         if bars.len() >= MAX_BARS {
@@ -185,13 +189,11 @@ pub fn compute_layout(song: &IrealSong) -> Layout {
             base_cell_width,
             last_cell_width,
         );
+        last_visible_row = Some(row);
     }
-    let total_rows = if bars.is_empty() {
-        0
-    } else if section_started_row && col == 0 {
-        row
-    } else {
-        row + 1
+    let total_rows = match last_visible_row {
+        Some(r) => r + 1,
+        None => 0,
     };
     Layout {
         bars,
@@ -380,6 +382,24 @@ mod tests {
         );
         let expected_rows = MAX_BARS.div_ceil(BARS_PER_ROW);
         assert_eq!(layout.total_rows, expected_rows);
+    }
+
+    #[test]
+    fn trailing_empty_section_row_start_can_exceed_total_rows() {
+        // When a song ends with empty section(s) following a non-
+        // empty one, `section_row_starts` records a row index for
+        // the empty section that is past `total_rows` — i.e. the
+        // row would have been used had the section had bars. The
+        // renderer's section-label path (#2059) reads
+        // `section_row_starts` and must tolerate this case rather
+        // than indexing an out-of-bounds row.
+        let layout = compute_layout(&song_with_bars(&[4, 0]));
+        assert_eq!(layout.total_rows, 1);
+        assert_eq!(layout.section_row_starts, vec![0, 1]);
+        assert!(
+            layout.section_row_starts[1] >= layout.total_rows,
+            "trailing empty section's row pointer should sit past total_rows"
+        );
     }
 
     #[test]

--- a/crates/render-ireal/src/layout.rs
+++ b/crates/render-ireal/src/layout.rs
@@ -1,0 +1,397 @@
+//! 4-bars-per-line grid layout engine.
+//!
+//! Translates an [`IrealSong`]'s bar list into deterministic page
+//! coordinates: each bar gets one [`BarCoord`] cell, sections start
+//! a new line (even when the previous row is partially filled),
+//! and bar widths absorb the integer-division remainder so the
+//! rightmost cell of each row aligns exactly with the right margin.
+//!
+//! The layout is bounded by [`crate::MAX_BARS`] — surplus bars are
+//! silently truncated, mirroring the renderer's saturating fold so
+//! adversarial input cannot allocate unbounded coordinates.
+//!
+//! # Stability
+//!
+//! Pre-1.0. Mid-chart time-signature changes (#2054 deferred AST
+//! scope), pickup-bar half-cell layout, and multi-bar repeat
+//! brackets are NOT modelled yet — every bar receives one
+//! full-width cell. The follow-up issues #2057 / #2059 / #2062
+//! refine the cell content; this engine owns only the cell
+//! coordinates.
+
+use chordsketch_ireal::IrealSong;
+
+use crate::page::{BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, PAGE_WIDTH};
+
+/// Page coordinates of a single bar cell.
+///
+/// Coordinates are integer-valued so the SVG output remains
+/// byte-stable for golden-snapshot tests. `width` is variable —
+/// the rightmost cell of each row absorbs the integer-division
+/// leftover so `x + width == PAGE_WIDTH - MARGIN_X` for that cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BarCoord {
+    /// X coordinate of the cell's left edge, in SVG user units.
+    pub x: i32,
+    /// Y coordinate of the cell's top edge.
+    pub y: i32,
+    /// Width of the cell.
+    pub width: i32,
+    /// Height of the cell (always [`BAR_ROW_HEIGHT`]).
+    pub height: i32,
+    /// 0-based index of the section this bar belongs to in
+    /// [`IrealSong::sections`]. Lets the renderer correlate cells
+    /// back to section labels (#2059) without a second walk.
+    pub section_index: usize,
+    /// 0-based bar index within the parent section.
+    pub bar_index_in_section: usize,
+}
+
+/// Coordinate of an empty cell that fills out the trailing
+/// positions in a section's last row.
+///
+/// iReal Pro renders a full 4-cell row even when the section runs
+/// short — the trailing cells are drawn empty so the page looks
+/// complete. The renderer iterates [`Layout::trailing_empties`]
+/// after [`Layout::bars`] and emits an unfilled `<rect>` for each.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmptyCell {
+    /// X coordinate of the cell's left edge.
+    pub x: i32,
+    /// Y coordinate of the cell's top edge.
+    pub y: i32,
+    /// Width of the cell.
+    pub width: i32,
+    /// Height of the cell.
+    pub height: i32,
+}
+
+/// Result of laying out a song.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Layout {
+    /// One [`BarCoord`] per laid-out bar, in source order. Length
+    /// is `min(total_bars, MAX_BARS)`.
+    pub bars: Vec<BarCoord>,
+    /// Empty trailing cells filling out the rest of each section's
+    /// final row (so the visible grid stays a clean rectangle even
+    /// when a section ends mid-row).
+    pub trailing_empties: Vec<EmptyCell>,
+    /// Total number of grid rows, including any partially-filled
+    /// trailing row. `0` when no bars are laid out.
+    pub total_rows: usize,
+    /// Row index at which each section begins. Length equals
+    /// `song.sections.len()`. Sections that are empty (zero bars)
+    /// still receive an entry pointing at the row they would have
+    /// occupied; this lets the renderer position section labels
+    /// even before chord text exists.
+    pub section_row_starts: Vec<usize>,
+}
+
+impl Layout {
+    /// Returns the cell width breakdown for one row: `(base_width,
+    /// last_cell_width)` where `last_cell_width = base_width +
+    /// leftover` so the rightmost cell aligns with
+    /// `PAGE_WIDTH - MARGIN_X`. Helper exposed for golden / test
+    /// inspection; runtime callers should read [`BarCoord::width`]
+    /// directly.
+    #[must_use]
+    pub fn cell_widths() -> (i32, i32) {
+        let inner_width = PAGE_WIDTH - 2 * MARGIN_X;
+        let base = inner_width / BARS_PER_ROW as i32;
+        let leftover = inner_width - base * BARS_PER_ROW as i32;
+        (base, base + leftover)
+    }
+}
+
+/// Lays out the bars in `song` according to the documented rules:
+///
+/// - Bars wrap every [`BARS_PER_ROW`] cells within a section.
+/// - Each new section starts on a new row, even if the previous
+///   row is only partially filled.
+/// - Bar count is clamped to [`MAX_BARS`]; surplus bars are not
+///   emitted (matches the renderer's allocation cap).
+#[must_use]
+pub fn compute_layout(song: &IrealSong) -> Layout {
+    let (base_cell_width, last_cell_width) = Layout::cell_widths();
+    let mut bars = Vec::new();
+    let mut trailing_empties = Vec::new();
+    let mut section_row_starts = Vec::with_capacity(song.sections.len());
+    let mut row: usize = 0;
+    let mut col: usize = 0;
+    let mut section_started_row = false;
+    for (section_idx, section) in song.sections.iter().enumerate() {
+        // Before opening a new section that does not start at the
+        // row's left margin, emit empty trailers to fill the rest
+        // of the current row so the visible grid stays a clean
+        // rectangle. The trailers carry the same width treatment
+        // as a real bar's last cell.
+        if col > 0 {
+            fill_trailing_empties(
+                &mut trailing_empties,
+                row,
+                col,
+                base_cell_width,
+                last_cell_width,
+            );
+            row += 1;
+            col = 0;
+        }
+        section_row_starts.push(row);
+        section_started_row = false;
+        if section.bars.is_empty() {
+            // Empty section consumed no rows; the next non-empty
+            // section will land on the same row this one would
+            // have occupied. The pointer in `section_row_starts`
+            // still records the intended row for label placement.
+            continue;
+        }
+        for (bar_idx, _bar) in section.bars.iter().enumerate() {
+            if bars.len() >= MAX_BARS {
+                break;
+            }
+            if col >= BARS_PER_ROW {
+                row += 1;
+                col = 0;
+            }
+            section_started_row = true;
+            let cell_width = if col == BARS_PER_ROW - 1 {
+                last_cell_width
+            } else {
+                base_cell_width
+            };
+            let x = MARGIN_X + (col as i32) * base_cell_width;
+            let y = row_y(row);
+            bars.push(BarCoord {
+                x,
+                y,
+                width: cell_width,
+                height: BAR_ROW_HEIGHT,
+                section_index: section_idx,
+                bar_index_in_section: bar_idx,
+            });
+            col += 1;
+        }
+        if bars.len() >= MAX_BARS {
+            break;
+        }
+    }
+    // Fill trailers for the very last partial row (no following
+    // section to trigger the wrap above).
+    if col > 0 {
+        fill_trailing_empties(
+            &mut trailing_empties,
+            row,
+            col,
+            base_cell_width,
+            last_cell_width,
+        );
+    }
+    let total_rows = if bars.is_empty() {
+        0
+    } else if section_started_row && col == 0 {
+        row
+    } else {
+        row + 1
+    };
+    Layout {
+        bars,
+        trailing_empties,
+        total_rows,
+        section_row_starts,
+    }
+}
+
+fn fill_trailing_empties(
+    out: &mut Vec<EmptyCell>,
+    row: usize,
+    start_col: usize,
+    base_cell_width: i32,
+    last_cell_width: i32,
+) {
+    let y = row_y(row);
+    for col in start_col..BARS_PER_ROW {
+        let cell_width = if col == BARS_PER_ROW - 1 {
+            last_cell_width
+        } else {
+            base_cell_width
+        };
+        let x = MARGIN_X + (col as i32) * base_cell_width;
+        out.push(EmptyCell {
+            x,
+            y,
+            width: cell_width,
+            height: BAR_ROW_HEIGHT,
+        });
+    }
+}
+
+fn row_y(row: usize) -> i32 {
+    // `MAX_BARS` keeps the row count bounded, so the cast and
+    // multiplication cannot overflow `i32`. Belt-and-braces with
+    // `try_from` in case `MAX_BARS` ever grows past that bound.
+    let row_offset = i32::try_from(row).unwrap_or(i32::MAX);
+    GRID_TOP + row_offset * BAR_ROW_HEIGHT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Layout, compute_layout};
+    use crate::page::{BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, PAGE_WIDTH};
+    use chordsketch_ireal::{Bar, IrealSong, Section, SectionLabel};
+
+    fn song_with_bars(per_section: &[usize]) -> IrealSong {
+        let mut song = IrealSong::new();
+        for (i, count) in per_section.iter().enumerate() {
+            song.sections.push(Section {
+                label: SectionLabel::Letter(['A', 'B', 'C', 'D'][i]),
+                bars: (0..*count).map(|_| Bar::new()).collect(),
+            });
+        }
+        song
+    }
+
+    #[test]
+    fn empty_song_has_zero_rows_and_no_bars() {
+        let layout = compute_layout(&IrealSong::new());
+        assert_eq!(layout.bars.len(), 0);
+        assert!(layout.trailing_empties.is_empty());
+        assert_eq!(layout.total_rows, 0);
+        assert!(layout.section_row_starts.is_empty());
+    }
+
+    #[test]
+    fn partial_row_emits_trailing_empties_to_complete_the_grid() {
+        // 3 bars in a single section → 1 row, 3 filled cells +
+        // 1 trailing empty so the visible grid is a complete
+        // 4-cell rectangle.
+        let layout = compute_layout(&song_with_bars(&[3]));
+        assert_eq!(layout.bars.len(), 3);
+        assert_eq!(layout.trailing_empties.len(), 1);
+        let trailer = &layout.trailing_empties[0];
+        // The trailing empty sits in column 3 (the rightmost) and
+        // absorbs the leftover pixels so the grid right edge
+        // hits PAGE_WIDTH - MARGIN_X.
+        assert_eq!(
+            trailer.x + trailer.width,
+            PAGE_WIDTH - MARGIN_X,
+            "trailing empty must align with the right margin"
+        );
+    }
+
+    #[test]
+    fn section_break_fills_trailing_empties_in_previous_row() {
+        // 3 bars in section A (row 0) + 2 bars in section B (row 1).
+        // Row 0 needs 1 trailing empty; row 1 needs 2.
+        let layout = compute_layout(&song_with_bars(&[3, 2]));
+        assert_eq!(layout.bars.len(), 5);
+        assert_eq!(layout.trailing_empties.len(), 3);
+        // Row 0 trailer at y = GRID_TOP.
+        assert_eq!(layout.trailing_empties[0].y, GRID_TOP);
+        // Row 1 trailers at y = GRID_TOP + BAR_ROW_HEIGHT.
+        assert_eq!(layout.trailing_empties[1].y, GRID_TOP + BAR_ROW_HEIGHT);
+        assert_eq!(layout.trailing_empties[2].y, GRID_TOP + BAR_ROW_HEIGHT);
+    }
+
+    #[test]
+    fn complete_rows_emit_no_trailing_empties() {
+        // 4 + 4 → both rows fully filled.
+        let layout = compute_layout(&song_with_bars(&[4, 4]));
+        assert!(layout.trailing_empties.is_empty());
+    }
+
+    #[test]
+    fn single_full_row_aligns_to_right_margin() {
+        let layout = compute_layout(&song_with_bars(&[4]));
+        assert_eq!(layout.total_rows, 1);
+        assert_eq!(layout.bars.len(), 4);
+        let last = layout.bars.last().unwrap();
+        assert_eq!(
+            last.x + last.width,
+            PAGE_WIDTH - MARGIN_X,
+            "rightmost cell must align with the right margin"
+        );
+    }
+
+    #[test]
+    fn nine_bars_round_up_to_three_rows() {
+        let layout = compute_layout(&song_with_bars(&[9]));
+        assert_eq!(layout.total_rows, 3);
+        assert_eq!(layout.bars.len(), 9);
+        assert_eq!(layout.bars[0].y, GRID_TOP);
+        assert_eq!(layout.bars[4].y, GRID_TOP + BAR_ROW_HEIGHT);
+        assert_eq!(layout.bars[8].y, GRID_TOP + 2 * BAR_ROW_HEIGHT);
+    }
+
+    #[test]
+    fn section_break_starts_new_row_even_with_partial_previous_row() {
+        // 3 bars in section A (row 0), then section B starts on row 1.
+        let layout = compute_layout(&song_with_bars(&[3, 4]));
+        assert_eq!(layout.total_rows, 2);
+        assert_eq!(layout.bars.len(), 7);
+        assert_eq!(layout.bars[0].y, GRID_TOP);
+        assert_eq!(layout.bars[2].y, GRID_TOP, "last bar of section A on row 0");
+        assert_eq!(
+            layout.bars[3].y,
+            GRID_TOP + BAR_ROW_HEIGHT,
+            "first bar of section B starts row 1"
+        );
+        assert_eq!(layout.section_row_starts, vec![0, 1]);
+    }
+
+    #[test]
+    fn aligned_section_break_does_not_skip_a_row() {
+        // 4 bars in section A fills row 0 exactly. Section B
+        // starts on row 1 — it must NOT skip to row 2.
+        let layout = compute_layout(&song_with_bars(&[4, 4]));
+        assert_eq!(layout.total_rows, 2);
+        assert_eq!(layout.bars[3].y, GRID_TOP);
+        assert_eq!(layout.bars[4].y, GRID_TOP + BAR_ROW_HEIGHT);
+        assert_eq!(layout.section_row_starts, vec![0, 1]);
+    }
+
+    #[test]
+    fn empty_section_is_recorded_but_consumes_no_row() {
+        // Sections: 4 bars / 0 bars / 4 bars. The middle section
+        // is empty, so the third section's bars sit immediately
+        // after the first.
+        let layout = compute_layout(&song_with_bars(&[4, 0, 4]));
+        assert_eq!(layout.total_rows, 2);
+        assert_eq!(layout.bars.len(), 8);
+        assert_eq!(layout.section_row_starts, vec![0, 1, 1]);
+        assert_eq!(layout.bars[4].y, GRID_TOP + BAR_ROW_HEIGHT);
+    }
+
+    #[test]
+    fn cell_widths_helper_matches_actual_layout() {
+        let (base, last) = Layout::cell_widths();
+        assert!(last >= base, "last cell absorbs the leftover");
+        let layout = compute_layout(&song_with_bars(&[4]));
+        assert_eq!(layout.bars[0].width, base);
+        assert_eq!(layout.bars[3].width, last);
+    }
+
+    #[test]
+    fn bar_count_clamps_to_max_bars() {
+        let layout = compute_layout(&song_with_bars(&[MAX_BARS + 100]));
+        assert_eq!(
+            layout.bars.len(),
+            MAX_BARS,
+            "surplus bars must be truncated"
+        );
+        let expected_rows = MAX_BARS.div_ceil(BARS_PER_ROW);
+        assert_eq!(layout.total_rows, expected_rows);
+    }
+
+    #[test]
+    fn each_bar_carries_its_section_index_and_position() {
+        let layout = compute_layout(&song_with_bars(&[2, 3]));
+        assert_eq!(layout.bars[0].section_index, 0);
+        assert_eq!(layout.bars[0].bar_index_in_section, 0);
+        assert_eq!(layout.bars[1].section_index, 0);
+        assert_eq!(layout.bars[1].bar_index_in_section, 1);
+        assert_eq!(layout.bars[2].section_index, 1);
+        assert_eq!(layout.bars[2].bar_index_in_section, 0);
+        assert_eq!(layout.bars[4].section_index, 1);
+        assert_eq!(layout.bars[4].bar_index_in_section, 2);
+    }
+}

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -1,13 +1,14 @@
-//! iReal Pro chart renderer — SVG skeleton.
+//! iReal Pro chart renderer — SVG with 4-bars-per-line grid.
 //!
-//! This crate is the SVG renderer scaffold for the iReal Pro
-//! feature set tracked under
+//! This crate renders an [`chordsketch_ireal::IrealSong`] AST as a
+//! fixed-size SVG document. The current scope (#2058 scaffold +
+//! #2060 layout engine) ships the page frame, the metadata header
+//! (title / composer / style / key), the 4-bars-per-line grid with
+//! section line breaks, and flat-layout chord-name text centred in
+//! each cell. Barlines, repeat / ending brackets, music symbols,
+//! and superscript chord-name typography land in follow-up issues
+//! (#2057 / #2059 / #2062). Tracked under
 //! [#2050](https://github.com/koedame/chordsketch/issues/2050).
-//! It deliberately ships only the page frame, the metadata header
-//! (title / composer / style / key), and an empty 4-bar-per-line
-//! grid skeleton — chord text, barline shapes, repeat / ending
-//! brackets, music symbols, and chord-name typography each have
-//! their own follow-up issue.
 //!
 //! # Layout overview
 //!
@@ -17,10 +18,13 @@
 //!
 //! - **Header band** — title (top), composer (right), style + key
 //!   (left, beneath the title).
-//! - **Bar grid** — bars laid out 4-per-row in equal-width cells
-//!   below the header. Each cell is currently an empty `<rect>`;
-//!   chord text and inner glyphs are filled in by the follow-up
-//!   crates / issues.
+//! - **Bar grid** — bars laid out 4-per-row by the
+//!   [`layout::compute_layout`] engine. Each cell carries a
+//!   centred chord-name `<text>` (flat layout — superscript
+//!   typography lands in #2057). Trailing cells in a section's
+//!   last row are filled with empty placeholders so the visible
+//!   grid stays a clean rectangle; barlines / repeats / endings
+//!   / music symbols layer on top in #2059 / #2062.
 //!
 //! # Dependency policy
 //!
@@ -33,11 +37,11 @@
 //! # Stability
 //!
 //! Pre-1.0. The SVG output structure is expected to grow new
-//! elements (chord text, barlines, music symbols) as #2057 / #2059
-//! / #2060 / #2062 land. Existing elements stay stable so that
-//! crate consumers (the playground preview, the PDF rasteriser
-//! #2063, the PNG rasteriser #2064) can rely on a small set of
-//! stable selectors / IDs.
+//! elements (barlines, music symbols, superscript chord
+//! typography) as #2057 / #2059 / #2062 land. Existing elements
+//! stay stable so that crate consumers (the playground preview,
+//! the PDF rasteriser #2063, the PNG rasteriser #2064) can rely
+//! on a small set of stable selectors / IDs.
 //!
 //! # Example
 //!
@@ -167,18 +171,7 @@ fn format_style_and_key(song: &IrealSong) -> String {
 
 fn format_key(song: &IrealSong) -> String {
     let root = song.key_signature.root;
-    // The AST documents `root.note` as `'A'..='G'` uppercase ASCII
-    // but the field is `pub` and not validated at construction. A
-    // malformed AST that flows in via direct field assignment must
-    // still produce a deterministic, non-malicious string — fall
-    // back to `'?'` so a corrupted root is visually distinct from
-    // any valid one and `escape_xml` cannot be tricked by a
-    // structural character.
-    let note_glyph = if matches!(root.note, 'A'..='G') {
-        root.note
-    } else {
-        '?'
-    };
+    let note_glyph = note_glyph_or_fallback(root.note);
     let acc = match root.accidental {
         Accidental::Natural => "",
         Accidental::Flat => "\u{266D}",
@@ -189,6 +182,24 @@ fn format_key(song: &IrealSong) -> String {
         KeyMode::Minor => "minor",
     };
     format!("{note_glyph}{acc} {mode}")
+}
+
+/// Returns `note` if it is in the documented `'A'..='G'` uppercase
+/// ASCII range, otherwise `'?'`. Single source of truth for the
+/// out-of-range fallback shared between [`format_key`] and the
+/// [`crate::chord_format::format_chord`] root / bass writers, so a
+/// future tightening of the rule (per
+/// `.claude/rules/sanitizer-security.md` "security asymmetry")
+/// only needs to change one site.
+///
+/// The AST documents `root.note` as `'A'..='G'` uppercase ASCII
+/// but the field is `pub` and not validated at construction. A
+/// malformed AST that flows in via direct field assignment still
+/// produces a deterministic, non-malicious string — `'?'` is
+/// visually distinct from any valid one and is unaffected by
+/// [`crate::svg::escape_xml`].
+pub(crate) fn note_glyph_or_fallback(note: char) -> char {
+    if matches!(note, 'A'..='G') { note } else { '?' }
 }
 
 fn write_grid(out: &mut String, song: &IrealSong, layout: &Layout) {
@@ -220,6 +231,13 @@ font-size=\"14\" text-anchor=\"middle\" class=\"chord\">{line}</text>\n"
             ));
         }
     }
+    // Paint trailing empties AFTER all bars. With `fill="none"`
+    // SVG rectangles, paint order is invisible today — but #2059
+    // is expected to add bar-level barlines / repeat brackets
+    // and may rely on cell painting being interleaved by row.
+    // Document the contract so #2059 either preserves the
+    // bars-then-empties order or migrates to a row-interleaved
+    // emit pattern explicitly.
     for empty in &layout.trailing_empties {
         out.push_str(&format!(
             "    <rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" \
@@ -250,6 +268,12 @@ fn render_bar_chord_text(chords: &[BarChord]) -> Option<String> {
         return None;
     }
     let raw = chord_format::format_bar_chord_line(chords);
+    // Defense-in-depth: today `format_bar_chord_line` only returns
+    // empty when `chords` is empty (already filtered above), but if
+    // a future formatter returns empty for some new edge case —
+    // e.g. all chords truncated by `MAX_CHORDS_PER_BAR` to zero —
+    // skip emitting an empty `<text>` element rather than
+    // producing malformed-but-valid SVG.
     if raw.is_empty() {
         return None;
     }

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -53,11 +53,14 @@
 
 #![forbid(unsafe_code)]
 
+mod chord_format;
+pub mod layout;
 pub mod page;
 mod svg;
 
-use chordsketch_ireal::{Accidental, IrealSong, KeyMode};
+use chordsketch_ireal::{Accidental, BarChord, IrealSong, KeyMode};
 
+pub use layout::{BarCoord, EmptyCell, Layout, compute_layout};
 pub use page::{
     BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, HEADER_BAND_HEIGHT, MARGIN_X, MARGIN_Y, MAX_BARS,
     PAGE_HEIGHT, PAGE_WIDTH,
@@ -91,16 +94,7 @@ pub struct RenderOptions {}
 /// the y-coordinate arithmetic.
 #[must_use = "rendering produces a string the caller is expected to consume"]
 pub fn render_svg(song: &IrealSong, _options: &RenderOptions) -> String {
-    let raw_bar_count: usize = song
-        .sections
-        .iter()
-        .map(|s| s.bars.len())
-        // Use saturating addition so a malformed AST with 2^64-ish
-        // total bars (only reachable via a bug or attacker control)
-        // does not wrap to a smaller usize and bypass the cap below.
-        .fold(0usize, |acc, n| acc.saturating_add(n));
-    let bar_count = raw_bar_count.min(MAX_BARS);
-    let row_count = bar_count.div_ceil(BARS_PER_ROW);
+    let layout = compute_layout(song);
     let mut out = String::new();
     out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     out.push_str(&format!(
@@ -109,7 +103,7 @@ height=\"{PAGE_HEIGHT}\" viewBox=\"0 0 {PAGE_WIDTH} {PAGE_HEIGHT}\">\n"
     ));
     write_page_frame(&mut out);
     write_header(&mut out, song);
-    write_grid(&mut out, row_count);
+    write_grid(&mut out, song, &layout);
     out.push_str("</svg>\n");
     out
 }
@@ -197,47 +191,69 @@ fn format_key(song: &IrealSong) -> String {
     format!("{note_glyph}{acc} {mode}")
 }
 
-fn write_grid(out: &mut String, row_count: usize) {
-    if row_count == 0 {
+fn write_grid(out: &mut String, song: &IrealSong, layout: &Layout) {
+    if layout.bars.is_empty() && layout.trailing_empties.is_empty() {
         return;
     }
-    let grid_left = MARGIN_X;
-    let grid_right = PAGE_WIDTH - MARGIN_X;
-    // Integer division truncates the cell width, so the residual
-    // pixels are absorbed into the rightmost cell's width. Without
-    // this, the rightmost cell ends ≤ 3px short of `grid_right`
-    // and chord text / repeat brackets in #2057 / #2059 / #2060
-    // overflow the visible cell. The invariant the test
-    // `grid_aligns_to_right_margin` enforces:
-    //
-    //   sum of cell widths == grid_right - grid_left
-    //
-    // independent of the chosen `BARS_PER_ROW` and margin values.
-    let inner_width = grid_right - grid_left;
-    let base_cell_width = inner_width / BARS_PER_ROW as i32;
-    let leftover = inner_width - base_cell_width * (BARS_PER_ROW as i32);
     out.push_str("  <g class=\"bar-grid\">\n");
-    for row in 0..row_count {
-        // `row * BAR_ROW_HEIGHT` is bounded by the `MAX_BARS`
-        // compile-time assertion in `page.rs`, so the cast and
-        // multiplication cannot overflow `i32`.
-        let row_offset = i32::try_from(row).unwrap_or(i32::MAX);
-        let row_y = GRID_TOP + row_offset * BAR_ROW_HEIGHT;
-        let mut cell_x = grid_left;
-        for col in 0..BARS_PER_ROW {
-            let cell_width = if col == BARS_PER_ROW - 1 {
-                base_cell_width + leftover
-            } else {
-                base_cell_width
-            };
+    for cell in &layout.bars {
+        out.push_str(&format!(
+            "    <rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" \
+fill=\"none\" stroke=\"black\" stroke-width=\"1\"/>\n",
+            x = cell.x,
+            y = cell.y,
+            w = cell.width,
+            h = cell.height,
+        ));
+        let chords = chords_for_bar(song, cell);
+        if let Some(line) = render_bar_chord_text(chords) {
+            // Centre the chord text inside the cell. The 0.62
+            // y-fraction is the visual baseline iReal Pro itself
+            // uses — it lifts the text into the upper half of the
+            // cell so the future barline overlay (#2059) lives
+            // beneath it without collision.
+            let text_x = cell.x + cell.width / 2;
+            let text_y = cell.y + (cell.height * 62) / 100;
             out.push_str(&format!(
-                "    <rect x=\"{cell_x}\" y=\"{row_y}\" width=\"{cell_width}\" \
-height=\"{BAR_ROW_HEIGHT}\" fill=\"none\" stroke=\"black\" stroke-width=\"1\"/>\n"
+                "    <text x=\"{text_x}\" y=\"{text_y}\" font-family=\"sans-serif\" \
+font-size=\"14\" text-anchor=\"middle\" class=\"chord\">{line}</text>\n"
             ));
-            cell_x += cell_width;
         }
     }
+    for empty in &layout.trailing_empties {
+        out.push_str(&format!(
+            "    <rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" \
+fill=\"none\" stroke=\"black\" stroke-width=\"1\" class=\"empty\"/>\n",
+            x = empty.x,
+            y = empty.y,
+            w = empty.width,
+            h = empty.height,
+        ));
+    }
     out.push_str("  </g>\n");
+}
+
+fn chords_for_bar<'a>(song: &'a IrealSong, cell: &BarCoord) -> &'a [BarChord] {
+    // The layout engine guarantees `section_index` and
+    // `bar_index_in_section` are valid for the song that produced
+    // it, but defensive `get` lookups keep the renderer crash-free
+    // if a caller hand-rolls a `Layout` for a different song.
+    song.sections
+        .get(cell.section_index)
+        .and_then(|s| s.bars.get(cell.bar_index_in_section))
+        .map(|b| b.chords.as_slice())
+        .unwrap_or(&[])
+}
+
+fn render_bar_chord_text(chords: &[BarChord]) -> Option<String> {
+    if chords.is_empty() {
+        return None;
+    }
+    let raw = chord_format::format_bar_chord_line(chords);
+    if raw.is_empty() {
+        return None;
+    }
+    Some(svg::escape_xml(&raw))
 }
 
 /// Returns the library version (the workspace `Cargo.toml`

--- a/crates/render-ireal/src/page.rs
+++ b/crates/render-ireal/src/page.rs
@@ -43,9 +43,23 @@ pub const BAR_ROW_HEIGHT: i32 = 50;
 /// `4096` bars is well past any real chart length (a typical jazz
 /// standard is 16–64 bars). When this cap is hit, surplus bars are
 /// silently truncated; documenting the limit in the public-API
-/// rustdoc lets future callers (#2057, #2059, #2060) detect when
-/// they need to surface a warning instead.
+/// rustdoc lets future callers (#2057, #2059) detect when they
+/// need to surface a warning instead.
 pub const MAX_BARS: usize = 4096;
+
+/// Maximum number of chords the renderer lays out inside a single
+/// bar before truncating.
+///
+/// `BarChord` is `pub` and the AST allows direct field assignment,
+/// so a malformed in-process `Vec<BarChord>` could in principle
+/// hold `usize::MAX/2` entries. The flat-layout chord-name
+/// formatter joins them with a space into a single `<text>`
+/// element; without this cap, an adversarial AST could OOM the
+/// renderer on one bar. `64` is far above the iReal Pro grid's
+/// practical limit (an 8/8 bar with sub-beat changes tops out at
+/// ~16 chord placements). When the cap is hit, surplus chords are
+/// silently truncated.
+pub const MAX_CHORDS_PER_BAR: usize = 64;
 
 // Compile-time invariants. Asserting `MAX_BARS` and `BARS_PER_ROW`
 // at build time keeps the y-coordinate arithmetic in `lib.rs`

--- a/crates/render-ireal/src/page.rs
+++ b/crates/render-ireal/src/page.rs
@@ -67,6 +67,7 @@ pub const MAX_CHORDS_PER_BAR: usize = 64;
 // `row_y` is well within `i32` range.
 const _: () = assert!(BARS_PER_ROW > 0);
 const _: () = assert!(MAX_BARS > 0);
+const _: () = assert!(MAX_CHORDS_PER_BAR > 0);
 const _: () = {
     let max_rows = MAX_BARS.div_ceil(BARS_PER_ROW);
     // Conservatively check that `row_y = GRID_TOP + row * BAR_ROW_HEIGHT`

--- a/crates/render-ireal/tests/fixtures/aaba_32bar/expected.svg
+++ b/crates/render-ireal/tests/fixtures/aaba_32bar/expected.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">AABA Standard</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Swing • B major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Bmaj7</text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Em7</text>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">A7</text>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dmaj7</text>
+    <rect x="40" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Bmaj7</text>
+    <rect x="168" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Fm7</text>
+    <rect x="296" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">B7</text>
+    <rect x="424" y="170" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Emaj7</text>
+    <rect x="40" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Bmaj7</text>
+    <rect x="168" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Em7</text>
+    <rect x="296" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">A7</text>
+    <rect x="424" y="220" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dmaj7</text>
+    <rect x="40" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Bmaj7</text>
+    <rect x="168" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Fm7</text>
+    <rect x="296" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">B7</text>
+    <rect x="424" y="270" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Emaj7</text>
+    <rect x="40" y="320" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="351" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Am7</text>
+    <rect x="168" y="320" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="351" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">D7</text>
+    <rect x="296" y="320" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="351" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Gmaj7</text>
+    <rect x="424" y="320" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="351" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cm7</text>
+    <rect x="40" y="370" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="401" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">F7</text>
+    <rect x="168" y="370" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="401" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Bmaj7</text>
+    <rect x="296" y="370" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="401" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cm7</text>
+    <rect x="424" y="370" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="401" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">F7</text>
+    <rect x="40" y="420" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="451" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Bmaj7</text>
+    <rect x="168" y="420" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="451" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Em7</text>
+    <rect x="296" y="420" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="451" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">A7</text>
+    <rect x="424" y="420" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="451" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dmaj7</text>
+    <rect x="40" y="470" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="501" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Bmaj7</text>
+    <rect x="168" y="470" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="501" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Fm7</text>
+    <rect x="296" y="470" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="501" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">B7</text>
+    <rect x="424" y="470" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="501" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Emaj7</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/basic/expected.svg
+++ b/crates/render-ireal/tests/fixtures/basic/expected.svg
@@ -6,8 +6,9 @@
   <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Swing • E minor</text>
   <g class="bar-grid">
     <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
-    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
-    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
-    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cm7</text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
   </g>
 </svg>

--- a/crates/render-ireal/tests/fixtures/multi_chord_bar/expected.svg
+++ b/crates/render-ireal/tests/fixtures/multi_chord_bar/expected.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Split-Bar Demo</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Swing • C major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cmaj7</text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Am7 Dm7</text>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cmaj7</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/section_break_irregular/expected.svg
+++ b/crates/render-ireal/tests/fixtures/section_break_irregular/expected.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Irregular Form</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Free Time • C major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cmaj7</text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Am7</text>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="40" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="168" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cmaj7</text>
+    <rect x="296" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Am7</text>
+    <rect x="424" y="170" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="40" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="40" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cmaj7</text>
+    <rect x="168" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Fmaj7</text>
+    <rect x="296" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Cmaj7</text>
+    <rect x="424" y="270" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="168" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="296" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="424" y="220" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/sixteen_bar_loop/expected.svg
+++ b/crates/render-ireal/tests/fixtures/sixteen_bar_loop/expected.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Sixteen-Bar Vamp</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Bossa Nova • C major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="40" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="168" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="296" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="424" y="170" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="40" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="168" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="296" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="424" y="220" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="40" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="168" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="296" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">Dm7</text>
+    <rect x="424" y="270" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="301" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/twelve_bar_blues/expected.svg
+++ b/crates/render-ireal/tests/fixtures/twelve_bar_blues/expected.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">12-Bar Blues in C</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Blues • C major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">C7</text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">F7</text>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">C7</text>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="151" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">C7</text>
+    <rect x="40" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">F7</text>
+    <rect x="168" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">F7</text>
+    <rect x="296" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">C7</text>
+    <rect x="424" y="170" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="201" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">C7</text>
+    <rect x="40" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+    <rect x="168" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">F7</text>
+    <rect x="296" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">C7</text>
+    <rect x="424" y="220" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="251" font-family="sans-serif" font-size="14" text-anchor="middle" class="chord">G7</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/progressions.rs
+++ b/crates/render-ireal/tests/progressions.rs
@@ -1,0 +1,278 @@
+//! Golden-snapshot tests for the 4-bars-per-line grid layout
+//! engine across five canonical progression shapes (#2060 AC).
+//!
+//! Each helper builds an `IrealSong` deterministically; the
+//! corresponding `tests/fixtures/<name>/expected.svg` snapshot is
+//! checked byte-for-byte. Regenerate any snapshot with
+//!
+//! ```bash
+//! UPDATE_GOLDEN=1 cargo test -p chordsketch-render-ireal --test progressions
+//! ```
+//!
+//! and re-run without the env var to confirm parity.
+
+use chordsketch_ireal::{
+    Bar, BarChord, BeatPosition, Chord, ChordQuality, ChordRoot, IrealSong, KeyMode, KeySignature,
+    Section, SectionLabel,
+};
+use chordsketch_render_ireal::{RenderOptions, render_svg};
+
+fn bar_with_chord(note: char, quality: ChordQuality) -> Bar {
+    let chord = Chord::triad(ChordRoot::natural(note), quality);
+    Bar {
+        chords: vec![BarChord {
+            chord,
+            position: BeatPosition::on_beat(1).unwrap(),
+        }],
+        ..Bar::new()
+    }
+}
+
+fn bar_with_two_chords(c1: (char, ChordQuality), c2: (char, ChordQuality)) -> Bar {
+    Bar {
+        chords: vec![
+            BarChord {
+                chord: Chord::triad(ChordRoot::natural(c1.0), c1.1),
+                position: BeatPosition::on_beat(1).unwrap(),
+            },
+            BarChord {
+                chord: Chord::triad(ChordRoot::natural(c2.0), c2.1),
+                position: BeatPosition::on_beat(3).unwrap(),
+            },
+        ],
+        ..Bar::new()
+    }
+}
+
+fn check_golden(name: &str, song: &IrealSong) {
+    let path = format!(
+        "{}/tests/fixtures/{}/expected.svg",
+        env!("CARGO_MANIFEST_DIR"),
+        name,
+    );
+    let actual = render_svg(song, &RenderOptions::default());
+    if std::env::var_os("UPDATE_GOLDEN").is_some() {
+        std::fs::write(&path, &actual).unwrap_or_else(|e| panic!("write {path}: {e}"));
+    }
+    let expected = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {path}: {e} — set UPDATE_GOLDEN=1 to regenerate"));
+    assert_eq!(
+        actual, expected,
+        "render output drifted for {name}; rerun with UPDATE_GOLDEN=1 to regenerate"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: 12-bar blues
+//
+// One section, 12 bars in C major. Classic I-IV-V chord set; tests that
+// 12 ÷ 4 = 3 rows align cleanly without trailing empties.
+// ---------------------------------------------------------------------------
+
+fn twelve_bar_blues() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "12-Bar Blues in C".into();
+    song.style = Some("Medium Blues".into());
+    song.key_signature = KeySignature {
+        root: ChordRoot::natural('C'),
+        mode: KeyMode::Major,
+    };
+    let bars = vec![
+        bar_with_chord('C', ChordQuality::Dominant7), // I
+        bar_with_chord('F', ChordQuality::Dominant7), // IV
+        bar_with_chord('C', ChordQuality::Dominant7), // I
+        bar_with_chord('C', ChordQuality::Dominant7), // I
+        bar_with_chord('F', ChordQuality::Dominant7), // IV
+        bar_with_chord('F', ChordQuality::Dominant7), // IV
+        bar_with_chord('C', ChordQuality::Dominant7), // I
+        bar_with_chord('C', ChordQuality::Dominant7), // I
+        bar_with_chord('G', ChordQuality::Dominant7), // V
+        bar_with_chord('F', ChordQuality::Dominant7), // IV
+        bar_with_chord('C', ChordQuality::Dominant7), // I
+        bar_with_chord('G', ChordQuality::Dominant7), // V (turnaround)
+    ];
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars,
+    });
+    song
+}
+
+#[test]
+fn render_twelve_bar_blues() {
+    check_golden("twelve_bar_blues", &twelve_bar_blues());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: AABA 32-bar form
+//
+// Four sections × 8 bars. Tests that section breaks align row starts
+// and that no trailing empties are emitted between sections that end
+// at a 4-bar boundary.
+// ---------------------------------------------------------------------------
+
+fn aaba_32_bar() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "AABA Standard".into();
+    song.style = Some("Medium Swing".into());
+    song.key_signature = KeySignature {
+        root: ChordRoot::natural('B'),
+        mode: KeyMode::Major,
+    };
+    let a_section = || -> Vec<Bar> {
+        vec![
+            bar_with_chord('B', ChordQuality::Major7),
+            bar_with_chord('E', ChordQuality::Minor7),
+            bar_with_chord('A', ChordQuality::Dominant7),
+            bar_with_chord('D', ChordQuality::Major7),
+            bar_with_chord('B', ChordQuality::Major7),
+            bar_with_chord('F', ChordQuality::Minor7),
+            bar_with_chord('B', ChordQuality::Dominant7),
+            bar_with_chord('E', ChordQuality::Major7),
+        ]
+    };
+    let b_section = vec![
+        bar_with_chord('A', ChordQuality::Minor7),
+        bar_with_chord('D', ChordQuality::Dominant7),
+        bar_with_chord('G', ChordQuality::Major7),
+        bar_with_chord('C', ChordQuality::Minor7),
+        bar_with_chord('F', ChordQuality::Dominant7),
+        bar_with_chord('B', ChordQuality::Major7),
+        bar_with_chord('C', ChordQuality::Minor7),
+        bar_with_chord('F', ChordQuality::Dominant7),
+    ];
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars: a_section(),
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars: a_section(),
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Letter('B'),
+        bars: b_section,
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars: a_section(),
+    });
+    song
+}
+
+#[test]
+fn render_aaba_32_bar() {
+    check_golden("aaba_32bar", &aaba_32_bar());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: 16-bar loop
+//
+// Single section, 16 bars; 4 clean rows, no section break.
+// ---------------------------------------------------------------------------
+
+fn sixteen_bar_loop() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "Sixteen-Bar Vamp".into();
+    song.style = Some("Bossa Nova".into());
+    let bars = (0..16)
+        .map(|i| {
+            // Alternate Dm7 / G7 each bar.
+            if i % 2 == 0 {
+                bar_with_chord('D', ChordQuality::Minor7)
+            } else {
+                bar_with_chord('G', ChordQuality::Dominant7)
+            }
+        })
+        .collect();
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars,
+    });
+    song
+}
+
+#[test]
+fn render_sixteen_bar_loop() {
+    check_golden("sixteen_bar_loop", &sixteen_bar_loop());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: irregular section-break layout
+//
+// Sections of 3, 5, 4 bars. Forces trailing-empty cells in the first
+// row (3 bars) and second row (5 bars wraps to 4+1, leaving 3
+// trailers). Validates the section-break wrap rule.
+// ---------------------------------------------------------------------------
+
+fn section_break_irregular() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "Irregular Form".into();
+    song.style = Some("Free Time".into());
+    let intro = vec![
+        bar_with_chord('C', ChordQuality::Major7),
+        bar_with_chord('A', ChordQuality::Minor7),
+        bar_with_chord('D', ChordQuality::Minor7),
+    ];
+    let verse = vec![
+        bar_with_chord('G', ChordQuality::Dominant7),
+        bar_with_chord('C', ChordQuality::Major7),
+        bar_with_chord('A', ChordQuality::Minor7),
+        bar_with_chord('D', ChordQuality::Minor7),
+        bar_with_chord('G', ChordQuality::Dominant7),
+    ];
+    let coda = vec![
+        bar_with_chord('C', ChordQuality::Major7),
+        bar_with_chord('F', ChordQuality::Major7),
+        bar_with_chord('C', ChordQuality::Major7),
+        bar_with_chord('G', ChordQuality::Dominant7),
+    ];
+    song.sections.push(Section {
+        label: SectionLabel::Intro,
+        bars: intro,
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Verse,
+        bars: verse,
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Outro,
+        bars: coda,
+    });
+    song
+}
+
+#[test]
+fn render_section_break_irregular() {
+    check_golden("section_break_irregular", &section_break_irregular());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: multi-chord bar
+//
+// Single section, 4 bars; bar 2 holds two chords (a "split bar" in
+// iReal Pro parlance). Validates that the simple-flat-layout joins
+// chords with a space and centres the combined string in the cell.
+// ---------------------------------------------------------------------------
+
+fn multi_chord_bar() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "Split-Bar Demo".into();
+    song.style = Some("Medium Swing".into());
+    let bars = vec![
+        bar_with_chord('C', ChordQuality::Major7),
+        bar_with_two_chords(('A', ChordQuality::Minor7), ('D', ChordQuality::Minor7)),
+        bar_with_chord('G', ChordQuality::Dominant7),
+        bar_with_chord('C', ChordQuality::Major7),
+    ];
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars,
+    });
+    song
+}
+
+#[test]
+fn render_multi_chord_bar() {
+    check_golden("multi_chord_bar", &multi_chord_bar());
+}


### PR DESCRIPTION
## What

Adds the deterministic 4-bars-per-line grid layout engine that
chord-name typography (#2057), barlines / repeats / endings
(#2059), and music symbols (#2062) all hang off. Also wires
flat-layout chord-name text into the renderer so the SVG output
is no longer a metadata-only skeleton.

## Why

#2060 is the first iReal Pro renderer issue the #2058 scaffold
unblocks. Locking the bar / section / cell coordinate vocabulary
in now lets the three follow-up renderer PRs reference stable
shapes (`BarCoord`, `EmptyCell`, `Layout`).

## How

| File | Change |
|---|---|
| `crates/render-ireal/src/layout.rs` (new) | `compute_layout(song) -> Layout` with `bars: Vec<BarCoord>`, `trailing_empties: Vec<EmptyCell>`, `total_rows`, `section_row_starts` |
| `crates/render-ireal/src/chord_format.rs` (new) | Flat chord-name formatter (`Cm7`, `B♭7`, `F♯m7♭5`, `C/G`, `C13♯11`); enforces ASCII `A..=G` root via `note_glyph_or_fallback`; truncates per-bar chord count to `MAX_CHORDS_PER_BAR` |
| `crates/render-ireal/src/lib.rs` | `render_svg` walks the Layout: cells get `<rect>` + centred `<text class="chord">`; trailers get `<rect class="empty">`. `note_glyph_or_fallback` is the single-source-of-truth fallback shared with `format_key` |
| `crates/render-ireal/src/page.rs` | Adds `MAX_CHORDS_PER_BAR = 64` |
| `crates/render-ireal/tests/golden.rs` | Existing basic fixture re-baselined to include chord text + 3 trailing empties |
| `crates/render-ireal/tests/progressions.rs` (new) | 5 byte-stable golden snapshots for canonical progression shapes |
| `crates/render-ireal/tests/fixtures/{aaba_32bar,multi_chord_bar,section_break_irregular,sixteen_bar_loop,twelve_bar_blues}/expected.svg` (new) | Fixture data |
| `CLAUDE.md`, `crates/render-ireal/README.md` | Scope updated to reflect post-#2060 state |

## Acceptance Criteria check

| AC | Status |
|---|---|
| Layout engine computes bar coordinates given page dimensions and bar count | Done — `compute_layout` produces `BarCoord { x, y, width, height, section_index, bar_index_in_section }` per bar |
| Chord name text placed centred in each bar (simple flat layout) | Done — `<text>` at `(x + width/2, y + 0.62*height)` with `text-anchor="middle"` |
| Correct handling of section line breaks (new section → new line) | Done — explicit "current row's trailing cells become empty trailers; next section starts at row + 1" rule, with regression tests for partial-row breaks AND aligned breaks |
| Correct handling of multi-chord bars | Done — `format_bar_chord_line` joins multiple chords with spaces; full beat-aware split-bar typography deferred to #2057 (recorded in `chord_format.rs` doc) |
| Correct handling of pickup bars | **Deferred — see below** |
| Golden SVG fixtures for 5 progression shapes (12-bar blues, AABA, etc.) | Done — `twelve_bar_blues`, `aaba_32bar`, `sixteen_bar_loop`, `section_break_irregular`, `multi_chord_bar` |
| Unit tests for layout math | Done — 12 in `layout.rs`, 11 in `chord_format.rs` |
| CI green | Pending CI run |

## Deferred

- **Pickup-bar layout (half-cell width).** The `Bar` AST in
  `chordsketch-ireal` carries no field for partial-beat pickup
  bars; modelling them requires a structural addition to the AST
  that is upstream of #2060. Tracked under #2050; will be
  reopened when the AST gains the representation. This PR's
  layout engine treats every bar as a full-width cell.

## Tests

```
running 12 tests          (layout.rs)
test result: ok. 12 passed; 0 failed

running 11 tests          (chord_format.rs)
test result: ok. 11 passed; 0 failed

running 12 tests          (tests/golden.rs)
test result: ok. 12 passed; 0 failed

running 5 tests           (tests/progressions.rs)
test render_twelve_bar_blues ... ok
test render_aaba_32_bar ... ok
test render_sixteen_bar_loop ... ok
test render_section_break_irregular ... ok
test render_multi_chord_bar ... ok
test result: ok. 5 passed; 0 failed

running 1 test            (doctest)
test result: ok. 1 passed; 0 failed
```

## Sister-site / fix-propagation audit

Not a bug fix — no sister-site groups apply. The `note_glyph_or_fallback`
helper consolidates the previously-duplicated `'A'..='G'` fallback
between `format_key` and `chord_format::write_root` so a future
tightening (per `.claude/rules/sanitizer-security.md`'s "security
asymmetry" clause) needs to change one site rather than two. The
`escape_xml` helper in `svg.rs` continues to mirror
`chordsketch-chordpro::escape::escape_xml`; the duplication contract
is already documented at the top of `svg.rs`.

## Resource limits

- Bar count clamped to `MAX_BARS = 4096` before any allocation
  (preserved from #2058 / #2324).
- Per-bar chord count clamped to `MAX_CHORDS_PER_BAR = 64` so an
  AST with `usize::MAX/2` chords in one bar cannot OOM the
  renderer on a single `<text>` element.
- Compile-time `const_assert!` in `page.rs` continues to guarantee
  `MAX_BARS × BAR_ROW_HEIGHT` stays within `i32` range.

## Doc updates

- `CLAUDE.md` Architecture row scope updated.
- `crates/render-ireal/README.md` rewritten end-to-end —
  `## Layout`, `## Roadmap`, `## Regenerating the golden fixtures`
  all reflect the post-#2060 reality.
- New module-level rustdoc on `layout.rs` and `chord_format.rs`
  spells out which follow-up issue replaces each piece.

Closes #2060.