### PR TITLE
feat(render-ireal): repeat barlines + endings + section labels (#2059)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This is a Cargo workspace with the following crates:
 | `chordsketch-render-text` | `crates/render-text` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-html` | `crates/render-html` | lib | `chordsketch-chordpro` |
 | `chordsketch-render-pdf` | `crates/render-pdf` | lib | `chordsketch-chordpro` |
-| `chordsketch-render-ireal` | `crates/render-ireal` | lib | `chordsketch-ireal`. iReal Pro chart SVG renderer — page frame + metadata header + 4-bars-per-line grid layout engine with section line breaks + superscript chord-name typography (#2058 scaffold + #2060 layout + #2057 typography). Barlines / repeats / endings / music symbols filled in by #2059 / #2062. |
+| `chordsketch-render-ireal` | `crates/render-ireal` | lib | `chordsketch-ireal`. iReal Pro chart SVG renderer — page frame + metadata header + 4-bars-per-line grid layout engine with section line breaks + superscript chord-name typography + repeat / final / double barlines + N-th-ending brackets + section-letter labels (#2058 scaffold + #2060 layout + #2057 typography + #2059 barlines/markers). Music symbols (segno / coda / D.C. / D.S.) filled in by #2062. |
 | `chordsketch-convert` | `crates/convert` | lib | `chordsketch-chordpro`, `chordsketch-ireal`. ChordPro ↔ iReal Pro conversion bridge — trait scaffold (#2051) returning `NotImplemented` until #2053 / #2061 fill in the directions. |
 | `chordsketch-convert-musicxml` | `crates/convert-musicxml` | lib | `chordsketch-chordpro` |
 | `chordsketch` (CLI) | `crates/cli` | bin | `chordsketch-chordpro`, `chordsketch-render-text`, `chordsketch-render-html`, `chordsketch-render-pdf`, `chordsketch-convert-musicxml` |

--- a/crates/render-ireal/README.md
+++ b/crates/render-ireal/README.md
@@ -6,16 +6,19 @@
 
 [![crates.io](https://img.shields.io/crates/v/chordsketch-render-ireal)](https://crates.io/crates/chordsketch-render-ireal)
 
-iReal Pro chart renderer — SVG with chord-name typography.
+iReal Pro chart renderer — SVG with chord-name typography,
+repeat barlines, ending brackets, and section labels.
 
 This crate renders an `IrealSong` AST as a fixed-size SVG document.
 The current scope covers the page frame, the metadata header
 (title / composer / style / key), the 4-bars-per-line grid with
-section line breaks, and superscript chord-name typography (root
-+ accidental at base size, quality / extensions raised as
-superscript at a smaller size, slash + bass back at base size).
-Barlines, repeat / ending brackets, and music symbols land in
-follow-up issues (`#2059` / `#2062`).
+section line breaks, superscript chord-name typography (root +
+accidental at base size, quality / extensions raised as
+superscript at a smaller size, slash + bass back at base size),
+repeat / final / double barline glyphs, N-th-ending brackets
+with `1.` / `2.` labels, and section-letter labels above each
+section start. Music symbols (segno / coda / D.C. / D.S.) land
+in follow-up issue `#2062`.
 
 Tracked under [#2050](https://github.com/koedame/chordsketch/issues/2050).
 
@@ -82,7 +85,6 @@ divided into:
 
 | Feature | Tracking issue |
 |---|---|
-| Repeat barlines, endings, section markers | [#2059](https://github.com/koedame/chordsketch/issues/2059) |
 | Music symbols via Bravura font (segno / coda / D.C. / D.S.) | [#2062](https://github.com/koedame/chordsketch/issues/2062) |
 | PNG rasterization via resvg | [#2064](https://github.com/koedame/chordsketch/issues/2064) |
 | PDF output layer | [#2063](https://github.com/koedame/chordsketch/issues/2063) |

--- a/crates/render-ireal/src/barlines.rs
+++ b/crates/render-ireal/src/barlines.rs
@@ -99,7 +99,13 @@ fn dot(cx: i32, cy: i32, class: &str) -> String {
 fn double_line(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> String {
     // The cell-rect stroke already draws one line at `edge_x`. Add
     // a second line offset toward the cell interior so the pair
-    // forms a visible "||".
+    // forms a visible "||". Adjacent cells whose shared boundary
+    // is `Double` will produce two overlay strokes (one from each
+    // side) — both sit on the cell-interior side of `edge_x`, so
+    // visually three strokes can appear at the boundary. This is
+    // the documented limitation; sister-site coordination across
+    // adjacent bars is deferred until #2062 / #2063 force a
+    // single-pass barline emitter.
     let inner_x = match side {
         BarlineSide::Left => edge_x + BARLINE_GAP,
         BarlineSide::Right => edge_x - BARLINE_GAP,
@@ -108,19 +114,27 @@ fn double_line(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> Str
 }
 
 fn final_line(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> String {
-    // Thick line offset toward the cell interior, paired with the
-    // existing thin cell-rect stroke at `edge_x`.
-    let thick_x = match side {
+    // The Final glyph reads "thin → thick" toward the chart's
+    // outer edge — the convention shows the loud line at the bar
+    // boundary and a thinner line just inside it. We emit both:
+    // the thick line ON the boundary (`edge_x`) overrides the
+    // cell-rect's thin stroke there; the thin overlay sits on
+    // the cell-interior side at `± BARLINE_GAP` so a final bar
+    // surrounded by Single neighbours reads as a clear pair.
+    let mut out = String::new();
+    let inner_x = match side {
         BarlineSide::Left => edge_x + BARLINE_GAP,
         BarlineSide::Right => edge_x - BARLINE_GAP,
     };
-    vertical_line(
-        thick_x,
+    out.push_str(&vertical_line(
+        edge_x,
         y_top,
         y_bottom,
         2 * THICK_HALF_WIDTH + 1,
         "barline-final",
-    )
+    ));
+    out.push_str(&vertical_line(inner_x, y_top, y_bottom, 1, "barline-final"));
+    out
 }
 
 fn open_repeat(
@@ -253,11 +267,18 @@ mod tests {
     }
 
     #[test]
-    fn final_barline_emits_thick_line_with_stroke_width_3() {
+    fn final_barline_emits_thick_plus_thin_line_pair() {
+        // Standard music notation reads "thin → thick" toward the
+        // chart's outer edge for a Final barline. The renderer
+        // emits the thick line on the cell boundary and the thin
+        // line on the cell-interior side.
         let svg = render_right_barline(&coord(), BarLine::Final);
-        assert_eq!(svg.matches("<line").count(), 1);
+        assert_eq!(svg.matches("<line").count(), 2);
         assert!(svg.contains("stroke-width=\"3\""));
-        assert!(svg.contains("class=\"barline-final\""));
+        assert!(svg.contains("stroke-width=\"1\""));
+        // Both lines carry the `barline-final` class so styling
+        // can target the pair as one logical glyph.
+        assert_eq!(svg.matches("class=\"barline-final\"").count(), 2);
     }
 
     #[test]
@@ -309,14 +330,16 @@ mod tests {
     }
 
     #[test]
-    fn final_barline_on_left_side_offsets_thick_line_into_cell() {
-        // The Final glyph on the LEFT side of a cell sits to the
-        // right of the cell-rect stroke. This case is unusual
-        // (Final is typically a `bar.end`) but the AST allows it.
+    fn final_barline_on_left_side_emits_thick_plus_thin() {
+        // The Final glyph on the LEFT side of a cell pairs the
+        // thick line on the boundary (cell.x = 40) with the thin
+        // line on the cell-interior side (40 + BARLINE_GAP = 43).
+        // Final is usually a `bar.end`, but the AST allows it on
+        // either side.
         let svg = render_left_barline(&coord(), BarLine::Final);
-        // The thick line's x should be cell.x + BARLINE_GAP = 43.
-        assert!(svg.contains(" x1=\"43\""), "expected x1=43: {svg}");
-        assert!(svg.contains("stroke-width=\"3\""));
+        assert!(svg.contains(" x1=\"40\""), "expected boundary x1=40: {svg}");
+        assert!(svg.contains(" x1=\"43\""), "expected interior x1=43: {svg}");
+        assert_eq!(svg.matches("stroke-width=\"3\"").count(), 1);
     }
 
     #[test]

--- a/crates/render-ireal/src/barlines.rs
+++ b/crates/render-ireal/src/barlines.rs
@@ -77,8 +77,8 @@ fn render_barline(cell: &BarCoord, kind: BarLine, side: BarlineSide) -> String {
         BarLine::Single => String::new(),
         BarLine::Double => double_line(edge_x, side, y_top, y_bottom),
         BarLine::Final => final_line(edge_x, side, y_top, y_bottom),
-        BarLine::OpenRepeat => open_repeat(edge_x, side, y_top, y_bottom, cell.y, cell.height),
-        BarLine::CloseRepeat => close_repeat(edge_x, side, y_top, y_bottom, cell.y, cell.height),
+        BarLine::OpenRepeat => open_repeat(edge_x, side, y_top, y_bottom),
+        BarLine::CloseRepeat => close_repeat(edge_x, side, y_top, y_bottom),
     }
 }
 
@@ -137,14 +137,7 @@ fn final_line(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> Stri
     out
 }
 
-fn open_repeat(
-    edge_x: i32,
-    side: BarlineSide,
-    y_top: i32,
-    y_bottom: i32,
-    cell_y: i32,
-    cell_h: i32,
-) -> String {
+fn open_repeat(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> String {
     // `OpenRepeat` opens a repeat block, so the loud edge faces
     // out (toward the previous bar / row start). Layout from
     // outside to inside:
@@ -158,12 +151,10 @@ fn open_repeat(
         BarlineSide::Left => edge_x + 2 * BARLINE_GAP + REPEAT_DOT_R + 1,
         BarlineSide::Right => edge_x - 2 * BARLINE_GAP - REPEAT_DOT_R - 1,
     };
-    let thick_y_top = y_top;
-    let thick_y_bottom = y_bottom;
     out.push_str(&vertical_line(
         edge_x,
-        thick_y_top,
-        thick_y_bottom,
+        y_top,
+        y_bottom,
         2 * THICK_HALF_WIDTH + 1,
         "barline-repeat-thick",
     ));
@@ -174,7 +165,7 @@ fn open_repeat(
         1,
         "barline-repeat-thin",
     ));
-    let cell_centre = cell_y + cell_h / 2;
+    let cell_centre = (y_top + y_bottom) / 2;
     out.push_str(&dot(
         dots_x,
         cell_centre - REPEAT_DOT_OFFSET,
@@ -188,14 +179,7 @@ fn open_repeat(
     out
 }
 
-fn close_repeat(
-    edge_x: i32,
-    side: BarlineSide,
-    y_top: i32,
-    y_bottom: i32,
-    cell_y: i32,
-    cell_h: i32,
-) -> String {
+fn close_repeat(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> String {
     // Mirror of `open_repeat`: the loud edge faces the bar's exit
     // boundary, so the dots sit on the cell-interior side and the
     // thick line sits on the outside.
@@ -208,14 +192,15 @@ fn close_repeat(
         BarlineSide::Left => edge_x + 2 * BARLINE_GAP + REPEAT_DOT_R + 1,
         BarlineSide::Right => edge_x - 2 * BARLINE_GAP - REPEAT_DOT_R - 1,
     };
+    let cell_centre = (y_top + y_bottom) / 2;
     out.push_str(&dot(
         dots_x,
-        cell_y + cell_h / 2 - REPEAT_DOT_OFFSET,
+        cell_centre - REPEAT_DOT_OFFSET,
         "barline-repeat-dot",
     ));
     out.push_str(&dot(
         dots_x,
-        cell_y + cell_h / 2 + REPEAT_DOT_OFFSET,
+        cell_centre + REPEAT_DOT_OFFSET,
         "barline-repeat-dot",
     ));
     out.push_str(&vertical_line(

--- a/crates/render-ireal/src/barlines.rs
+++ b/crates/render-ireal/src/barlines.rs
@@ -1,0 +1,355 @@
+//! Barline glyph rendering.
+//!
+//! Replaces the default cell-rectangle stroke at a bar boundary
+//! with the iReal Pro convention for the bar's [`BarLine`] kind.
+//! Glyph shapes:
+//!
+//! - [`BarLine::Single`] — handled by the cell rectangle stroke;
+//!   no overlay emitted.
+//! - [`BarLine::Double`] — two thin vertical lines drawn slightly
+//!   inside the cell-edge stroke.
+//! - [`BarLine::Final`] — one thin + one thick vertical line. The
+//!   thick line is drawn over the cell stroke to make the
+//!   final-barline emphasis visible.
+//! - [`BarLine::OpenRepeat`] — thick line + thin line + two dots
+//!   on the cell-interior side.
+//! - [`BarLine::CloseRepeat`] — two dots + thin line + thick line
+//!   (mirror image of `OpenRepeat`).
+//!
+//! All glyphs sit between the row's top and bottom y-coordinates
+//! ([`BarCoord::y`] and `BarCoord::y + BarCoord::height`) so they
+//! visually replace the cell-rectangle stroke at that x position.
+
+use crate::layout::BarCoord;
+use chordsketch_ireal::BarLine;
+
+/// Pixel offset between the inner and outer line of a Double /
+/// Final / repeat-barline pair. 3px keeps the two strokes
+/// visually distinct without overlapping at the default 1px
+/// stroke width.
+const BARLINE_GAP: i32 = 3;
+
+/// Half-width of the thick stroke used for the loud line of a
+/// Final / repeat barline. The actual rendered width is
+/// `2 * THICK_HALF_WIDTH`.
+const THICK_HALF_WIDTH: i32 = 1;
+
+/// Vertical-offset of a repeat dot from the cell's vertical
+/// centre. 8px keeps the dots clear of the chord-text baseline
+/// (which sits at `cell.y + 0.62 * cell.height`).
+const REPEAT_DOT_OFFSET: i32 = 8;
+
+/// Radius of a repeat dot.
+const REPEAT_DOT_R: i32 = 2;
+
+/// Renders the barline glyph for the bar at `cell.x` (left edge)
+/// when the bar's [`BarLine`] is `kind` and the boundary is the
+/// LEFT side of the cell.
+///
+/// Returns an empty string for [`BarLine::Single`] — the cell
+/// rectangle's stroke already draws the simple line.
+#[must_use]
+pub(crate) fn render_left_barline(cell: &BarCoord, kind: BarLine) -> String {
+    render_barline(cell, kind, BarlineSide::Left)
+}
+
+/// Same as [`render_left_barline`] but for the RIGHT side of the
+/// cell (`cell.x + cell.width`).
+#[must_use]
+pub(crate) fn render_right_barline(cell: &BarCoord, kind: BarLine) -> String {
+    render_barline(cell, kind, BarlineSide::Right)
+}
+
+#[derive(Copy, Clone)]
+enum BarlineSide {
+    Left,
+    Right,
+}
+
+fn render_barline(cell: &BarCoord, kind: BarLine, side: BarlineSide) -> String {
+    let edge_x = match side {
+        BarlineSide::Left => cell.x,
+        BarlineSide::Right => cell.x + cell.width,
+    };
+    let y_top = cell.y;
+    let y_bottom = cell.y + cell.height;
+    match kind {
+        BarLine::Single => String::new(),
+        BarLine::Double => double_line(edge_x, side, y_top, y_bottom),
+        BarLine::Final => final_line(edge_x, side, y_top, y_bottom),
+        BarLine::OpenRepeat => open_repeat(edge_x, side, y_top, y_bottom, cell.y, cell.height),
+        BarLine::CloseRepeat => close_repeat(edge_x, side, y_top, y_bottom, cell.y, cell.height),
+    }
+}
+
+fn vertical_line(x: i32, y1: i32, y2: i32, stroke_width: i32, class: &str) -> String {
+    format!(
+        "    <line x1=\"{x}\" y1=\"{y1}\" x2=\"{x}\" y2=\"{y2}\" \
+stroke=\"black\" stroke-width=\"{stroke_width}\" class=\"{class}\"/>\n"
+    )
+}
+
+fn dot(cx: i32, cy: i32, class: &str) -> String {
+    format!(
+        "    <circle cx=\"{cx}\" cy=\"{cy}\" r=\"{r}\" fill=\"black\" class=\"{class}\"/>\n",
+        r = REPEAT_DOT_R,
+    )
+}
+
+fn double_line(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> String {
+    // The cell-rect stroke already draws one line at `edge_x`. Add
+    // a second line offset toward the cell interior so the pair
+    // forms a visible "||".
+    let inner_x = match side {
+        BarlineSide::Left => edge_x + BARLINE_GAP,
+        BarlineSide::Right => edge_x - BARLINE_GAP,
+    };
+    vertical_line(inner_x, y_top, y_bottom, 1, "barline-double")
+}
+
+fn final_line(edge_x: i32, side: BarlineSide, y_top: i32, y_bottom: i32) -> String {
+    // Thick line offset toward the cell interior, paired with the
+    // existing thin cell-rect stroke at `edge_x`.
+    let thick_x = match side {
+        BarlineSide::Left => edge_x + BARLINE_GAP,
+        BarlineSide::Right => edge_x - BARLINE_GAP,
+    };
+    vertical_line(
+        thick_x,
+        y_top,
+        y_bottom,
+        2 * THICK_HALF_WIDTH + 1,
+        "barline-final",
+    )
+}
+
+fn open_repeat(
+    edge_x: i32,
+    side: BarlineSide,
+    y_top: i32,
+    y_bottom: i32,
+    cell_y: i32,
+    cell_h: i32,
+) -> String {
+    // `OpenRepeat` opens a repeat block, so the loud edge faces
+    // out (toward the previous bar / row start). Layout from
+    // outside to inside:
+    //   thick — gap — thin — gap — dots
+    let mut out = String::new();
+    let inner_x = match side {
+        BarlineSide::Left => edge_x + BARLINE_GAP,
+        BarlineSide::Right => edge_x - BARLINE_GAP,
+    };
+    let dots_x = match side {
+        BarlineSide::Left => edge_x + 2 * BARLINE_GAP + REPEAT_DOT_R + 1,
+        BarlineSide::Right => edge_x - 2 * BARLINE_GAP - REPEAT_DOT_R - 1,
+    };
+    let thick_y_top = y_top;
+    let thick_y_bottom = y_bottom;
+    out.push_str(&vertical_line(
+        edge_x,
+        thick_y_top,
+        thick_y_bottom,
+        2 * THICK_HALF_WIDTH + 1,
+        "barline-repeat-thick",
+    ));
+    out.push_str(&vertical_line(
+        inner_x,
+        y_top,
+        y_bottom,
+        1,
+        "barline-repeat-thin",
+    ));
+    let cell_centre = cell_y + cell_h / 2;
+    out.push_str(&dot(
+        dots_x,
+        cell_centre - REPEAT_DOT_OFFSET,
+        "barline-repeat-dot",
+    ));
+    out.push_str(&dot(
+        dots_x,
+        cell_centre + REPEAT_DOT_OFFSET,
+        "barline-repeat-dot",
+    ));
+    out
+}
+
+fn close_repeat(
+    edge_x: i32,
+    side: BarlineSide,
+    y_top: i32,
+    y_bottom: i32,
+    cell_y: i32,
+    cell_h: i32,
+) -> String {
+    // Mirror of `open_repeat`: the loud edge faces the bar's exit
+    // boundary, so the dots sit on the cell-interior side and the
+    // thick line sits on the outside.
+    let mut out = String::new();
+    let inner_x = match side {
+        BarlineSide::Left => edge_x + BARLINE_GAP,
+        BarlineSide::Right => edge_x - BARLINE_GAP,
+    };
+    let dots_x = match side {
+        BarlineSide::Left => edge_x + 2 * BARLINE_GAP + REPEAT_DOT_R + 1,
+        BarlineSide::Right => edge_x - 2 * BARLINE_GAP - REPEAT_DOT_R - 1,
+    };
+    out.push_str(&dot(
+        dots_x,
+        cell_y + cell_h / 2 - REPEAT_DOT_OFFSET,
+        "barline-repeat-dot",
+    ));
+    out.push_str(&dot(
+        dots_x,
+        cell_y + cell_h / 2 + REPEAT_DOT_OFFSET,
+        "barline-repeat-dot",
+    ));
+    out.push_str(&vertical_line(
+        inner_x,
+        y_top,
+        y_bottom,
+        1,
+        "barline-repeat-thin",
+    ));
+    out.push_str(&vertical_line(
+        edge_x,
+        y_top,
+        y_bottom,
+        2 * THICK_HALF_WIDTH + 1,
+        "barline-repeat-thick",
+    ));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_left_barline, render_right_barline};
+    use crate::layout::BarCoord;
+    use crate::page::BAR_ROW_HEIGHT;
+    use chordsketch_ireal::BarLine;
+
+    fn coord() -> BarCoord {
+        BarCoord {
+            x: 40,
+            y: 120,
+            width: 128,
+            height: BAR_ROW_HEIGHT,
+            section_index: 0,
+            bar_index_in_section: 0,
+        }
+    }
+
+    #[test]
+    fn single_barline_emits_no_overlay() {
+        assert!(render_left_barline(&coord(), BarLine::Single).is_empty());
+        assert!(render_right_barline(&coord(), BarLine::Single).is_empty());
+    }
+
+    #[test]
+    fn double_barline_emits_one_inner_line() {
+        let svg = render_right_barline(&coord(), BarLine::Double);
+        assert_eq!(svg.matches("<line").count(), 1);
+        assert!(svg.contains("class=\"barline-double\""));
+    }
+
+    #[test]
+    fn final_barline_emits_thick_line_with_stroke_width_3() {
+        let svg = render_right_barline(&coord(), BarLine::Final);
+        assert_eq!(svg.matches("<line").count(), 1);
+        assert!(svg.contains("stroke-width=\"3\""));
+        assert!(svg.contains("class=\"barline-final\""));
+    }
+
+    #[test]
+    fn open_repeat_emits_thick_thin_and_two_dots() {
+        let svg = render_left_barline(&coord(), BarLine::OpenRepeat);
+        assert_eq!(svg.matches("<line").count(), 2);
+        assert_eq!(svg.matches("<circle").count(), 2);
+        assert!(svg.contains("class=\"barline-repeat-thick\""));
+        assert!(svg.contains("class=\"barline-repeat-thin\""));
+        assert!(svg.contains("class=\"barline-repeat-dot\""));
+    }
+
+    #[test]
+    fn close_repeat_emits_two_dots_thin_and_thick() {
+        let svg = render_right_barline(&coord(), BarLine::CloseRepeat);
+        assert_eq!(svg.matches("<line").count(), 2);
+        assert_eq!(svg.matches("<circle").count(), 2);
+        assert!(svg.contains("class=\"barline-repeat-thick\""));
+    }
+
+    #[test]
+    fn open_repeat_dots_offset_to_cell_interior_on_left_side() {
+        // Open-repeat dots should appear inside the cell, not on
+        // the bar boundary. For the left side of a cell at x=40,
+        // the dots should sit at x > 40.
+        let svg = render_left_barline(&coord(), BarLine::OpenRepeat);
+        // Find the first cx attribute on a `<circle>`.
+        let cx_pos = svg.find("cx=\"").unwrap() + "cx=\"".len();
+        let cx_end = svg[cx_pos..].find('"').unwrap();
+        let cx: i32 = svg[cx_pos..cx_pos + cx_end].parse().unwrap();
+        assert!(
+            cx > 40,
+            "left-side repeat dot must sit inside the cell, got cx={cx}"
+        );
+    }
+
+    #[test]
+    fn close_repeat_dots_offset_to_cell_interior_on_right_side() {
+        // Close-repeat dots on the right side should sit inside
+        // the cell — i.e. cx < cell.x + cell.width.
+        let svg = render_right_barline(&coord(), BarLine::CloseRepeat);
+        let cx_pos = svg.find("cx=\"").unwrap() + "cx=\"".len();
+        let cx_end = svg[cx_pos..].find('"').unwrap();
+        let cx: i32 = svg[cx_pos..cx_pos + cx_end].parse().unwrap();
+        assert!(
+            cx < 40 + 128,
+            "right-side repeat dot must sit inside the cell, got cx={cx}"
+        );
+    }
+
+    #[test]
+    fn final_barline_on_left_side_offsets_thick_line_into_cell() {
+        // The Final glyph on the LEFT side of a cell sits to the
+        // right of the cell-rect stroke. This case is unusual
+        // (Final is typically a `bar.end`) but the AST allows it.
+        let svg = render_left_barline(&coord(), BarLine::Final);
+        // The thick line's x should be cell.x + BARLINE_GAP = 43.
+        assert!(svg.contains(" x1=\"43\""), "expected x1=43: {svg}");
+        assert!(svg.contains("stroke-width=\"3\""));
+    }
+
+    #[test]
+    fn double_barline_on_left_side_offsets_inner_line_into_cell() {
+        let svg = render_left_barline(&coord(), BarLine::Double);
+        assert!(svg.contains(" x1=\"43\""), "expected x1=43: {svg}");
+        assert!(svg.contains("class=\"barline-double\""));
+    }
+
+    #[test]
+    fn open_repeat_on_right_side_mirrors_the_glyph() {
+        // OpenRepeat as a `bar.end` sits on the right edge with
+        // dots offset toward the cell interior (left of the
+        // boundary). This case is unusual but the AST allows it.
+        let svg = render_right_barline(&coord(), BarLine::OpenRepeat);
+        let cx_pos = svg.find("cx=\"").unwrap() + "cx=\"".len();
+        let cx_end = svg[cx_pos..].find('"').unwrap();
+        let cx: i32 = svg[cx_pos..cx_pos + cx_end].parse().unwrap();
+        assert!(
+            cx < 40 + 128,
+            "right-side open-repeat dot must sit inside the cell, got cx={cx}"
+        );
+    }
+
+    #[test]
+    fn close_repeat_on_left_side_mirrors_the_glyph() {
+        let svg = render_left_barline(&coord(), BarLine::CloseRepeat);
+        let cx_pos = svg.find("cx=\"").unwrap() + "cx=\"".len();
+        let cx_end = svg[cx_pos..].find('"').unwrap();
+        let cx: i32 = svg[cx_pos..cx_pos + cx_end].parse().unwrap();
+        assert!(
+            cx > 40,
+            "left-side close-repeat dot must sit inside the cell, got cx={cx}"
+        );
+    }
+}

--- a/crates/render-ireal/src/layout.rs
+++ b/crates/render-ireal/src/layout.rs
@@ -175,8 +175,13 @@ pub fn compute_layout(song: &IrealSong) -> Layout {
             last_visible_row = Some(row);
             col += 1;
         }
+        // Continue (rather than break) so every section pushes a
+        // `section_row_starts` entry even when its bars were
+        // entirely truncated by `MAX_BARS`. The marker layer
+        // (#2059) reads this slice in lockstep with `song.sections`
+        // and would otherwise index out of bounds.
         if bars.len() >= MAX_BARS {
-            break;
+            continue;
         }
     }
     // Fill trailers for the very last partial row (no following

--- a/crates/render-ireal/src/layout.rs
+++ b/crates/render-ireal/src/layout.rs
@@ -21,7 +21,9 @@
 
 use chordsketch_ireal::IrealSong;
 
-use crate::page::{BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, PAGE_WIDTH};
+use crate::page::{
+    BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, MAX_SECTIONS, PAGE_WIDTH,
+};
 
 /// Page coordinates of a single bar cell.
 ///
@@ -123,7 +125,11 @@ pub fn compute_layout(song: &IrealSong) -> Layout {
     // when an empty trailing section bumps `row` past the last
     // visible content.
     let mut last_visible_row: Option<usize> = None;
-    for (section_idx, section) in song.sections.iter().enumerate() {
+    // Clamp the section iterator to `MAX_SECTIONS` so an
+    // adversarially-large `Vec<Section>` cannot dominate
+    // `section_row_starts` allocation. The cap mirrors the
+    // `MAX_BARS` / `MAX_CHORDS_PER_BAR` truncation posture.
+    for (section_idx, section) in song.sections.iter().take(MAX_SECTIONS).enumerate() {
         // Before opening a new section that does not start at the
         // row's left margin, emit empty trailers to fill the rest
         // of the current row so the visible grid stays a clean
@@ -243,7 +249,9 @@ fn row_y(row: usize) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::{Layout, compute_layout};
-    use crate::page::{BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, PAGE_WIDTH};
+    use crate::page::{
+        BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, MAX_SECTIONS, PAGE_WIDTH,
+    };
     use chordsketch_ireal::{Bar, IrealSong, Section, SectionLabel};
 
     fn song_with_bars(per_section: &[usize]) -> IrealSong {
@@ -387,6 +395,49 @@ mod tests {
         );
         let expected_rows = MAX_BARS.div_ceil(BARS_PER_ROW);
         assert_eq!(layout.total_rows, expected_rows);
+    }
+
+    #[test]
+    fn truncated_sections_still_record_section_row_starts() {
+        // Direct regression for the `break → continue` invariant
+        // in `compute_layout`: when section 0 fills the entire
+        // `MAX_BARS` budget, every subsequent section must still
+        // push a `section_row_starts` entry so marker layers
+        // (#2059) can index in lockstep with `song.sections`.
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: (0..MAX_BARS).map(|_| Bar::new()).collect(),
+        });
+        song.sections.push(Section {
+            label: SectionLabel::Letter('B'),
+            bars: vec![Bar::new(), Bar::new()],
+        });
+        let layout = compute_layout(&song);
+        assert_eq!(
+            layout.section_row_starts.len(),
+            2,
+            "section_row_starts must align 1:1 with song.sections"
+        );
+        assert_eq!(layout.bars.len(), MAX_BARS, "MAX_BARS clamp preserved");
+    }
+
+    #[test]
+    fn excess_section_count_clamps_to_max_sections() {
+        use crate::page::MAX_SECTIONS;
+        let mut song = IrealSong::new();
+        for _ in 0..(MAX_SECTIONS + 100) {
+            song.sections.push(Section {
+                label: SectionLabel::Letter('A'),
+                bars: Vec::new(),
+            });
+        }
+        let layout = compute_layout(&song);
+        assert!(
+            layout.section_row_starts.len() <= MAX_SECTIONS,
+            "compute_layout must clamp to MAX_SECTIONS, got {}",
+            layout.section_row_starts.len()
+        );
     }
 
     #[test]

--- a/crates/render-ireal/src/layout.rs
+++ b/crates/render-ireal/src/layout.rs
@@ -249,9 +249,7 @@ fn row_y(row: usize) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::{Layout, compute_layout};
-    use crate::page::{
-        BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, MAX_SECTIONS, PAGE_WIDTH,
-    };
+    use crate::page::{BAR_ROW_HEIGHT, BARS_PER_ROW, GRID_TOP, MARGIN_X, MAX_BARS, PAGE_WIDTH};
     use chordsketch_ireal::{Bar, IrealSong, Section, SectionLabel};
 
     fn song_with_bars(per_section: &[usize]) -> IrealSong {

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -1,14 +1,16 @@
-//! iReal Pro chart renderer — SVG with chord-name typography.
+//! iReal Pro chart renderer — SVG with chord-name typography,
+//! repeat barlines, ending brackets, and section labels.
 //!
 //! This crate renders an [`chordsketch_ireal::IrealSong`] AST as a
 //! fixed-size SVG document. The current scope covers the page
 //! frame, the metadata header (title / composer / style / key),
-//! the 4-bars-per-line grid with section line breaks, and
-//! superscript chord-name typography (root + accidental at base
-//! size, quality / extensions raised as superscript, slash + bass
-//! back at base size). Barlines, repeat / ending brackets, and
-//! music symbols land in follow-up issues
-//! (#2059 / #2062). Tracked under
+//! the 4-bars-per-line grid with section line breaks, superscript
+//! chord-name typography (root + accidental at base size, quality
+//! / extensions raised as superscript, slash + bass back at base
+//! size), repeat / final / double barline glyphs, N-th-ending
+//! brackets with `1.` / `2.` labels, and section-letter labels
+//! above each section start. Music symbols (segno / coda / D.C.
+//! / D.S.) land in follow-up issue #2062. Tracked under
 //! [#2050](https://github.com/koedame/chordsketch/issues/2050).
 //!
 //! # Layout overview
@@ -24,10 +26,14 @@
 //!   centred chord-name `<text>` with mixed `<tspan>` runs:
 //!   root + accidental at base size, quality / extensions
 //!   raised as superscript at a smaller size, slash + bass at
-//!   base size on the original baseline. Trailing cells in a
+//!   base size on the original baseline. Bar boundaries display
+//!   the appropriate barline glyph (`Single` via the cell-rect
+//!   stroke; `Double`, `Final`, `OpenRepeat`, `CloseRepeat`
+//!   overlay the cell stroke). N-th-ending brackets and section-
+//!   letter labels sit above the row. Trailing cells in a
 //!   section's last row are filled with empty placeholders so the
-//!   visible grid stays a clean rectangle; barlines / repeats /
-//!   endings / music symbols layer on top in #2059 / #2062.
+//!   visible grid stays a clean rectangle; music symbols layer on
+//!   top in #2062.
 //!
 //! # Dependency policy
 //!
@@ -40,14 +46,17 @@
 //! # Stability
 //!
 //! Pre-1.0. The SVG output structure is expected to grow new
-//! elements (barlines, music symbols) as #2059 / #2062 land.
-//! Existing elements stay stable so that crate consumers (the
-//! playground preview, the PDF rasteriser #2063, the PNG
-//! rasteriser #2064) can rely on a small set of stable selectors
-//! / IDs (`class="title"`, `class="composer"`, `class="meta"`,
-//! `class="bar-grid"`, `class="chord"`, `class="chord-root"`,
-//! `class="chord-ext"`, `class="chord-slash"`, `class="chord-bass"`,
-//! `class="empty"`).
+//! elements (music symbols) as #2062 lands. Existing elements
+//! stay stable so that crate consumers (the playground preview,
+//! the PDF rasteriser #2063, the PNG rasteriser #2064) can rely
+//! on a small set of stable selectors / IDs (`class="title"`,
+//! `class="composer"`, `class="meta"`, `class="bar-grid"`,
+//! `class="chord"`, `class="chord-root"`, `class="chord-ext"`,
+//! `class="chord-slash"`, `class="chord-bass"`, `class="empty"`,
+//! `class="section-label"`, `class="ending-bracket"`,
+//! `class="ending-label"`, `class="barline-double"`,
+//! `class="barline-final"`, `class="barline-repeat-thick"`,
+//! `class="barline-repeat-thin"`, `class="barline-repeat-dot"`).
 //!
 //! # Example
 //!
@@ -278,7 +287,8 @@ fn chords_for_bar<'a>(song: &'a IrealSong, cell: &BarCoord) -> &'a [BarChord] {
 /// Multi-chord bars (split bars) are rendered as a single
 /// space-separated `<text>` whose children alternate per chord.
 /// Beat-aware horizontal placement (one chord per beat slot)
-/// requires bar-cell subdivision and is deferred to #2059.
+/// requires bar-cell subdivision and is deferred to a follow-up
+/// of the iReal Pro tracker (#2050).
 fn write_bar_chord_text(out: &mut String, cell: &BarCoord, chords: &[BarChord]) {
     if chords.is_empty() {
         return;

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -63,8 +63,10 @@
 
 #![forbid(unsafe_code)]
 
+mod barlines;
 pub mod chord_typography;
 pub mod layout;
+mod markers;
 pub mod page;
 mod svg;
 
@@ -226,14 +228,19 @@ fill=\"none\" stroke=\"black\" stroke-width=\"1\"/>\n",
         ));
         let chords = chords_for_bar(song, cell);
         write_bar_chord_text(out, cell, chords);
+        // Overlay non-Single barline glyphs for the bar's start
+        // (left edge) and end (right edge). The cell rectangle's
+        // stroke already provides the simple line for `Single`,
+        // so `barlines::*` returns an empty string there.
+        if let Some(bar) = song
+            .sections
+            .get(cell.section_index)
+            .and_then(|s| s.bars.get(cell.bar_index_in_section))
+        {
+            out.push_str(&barlines::render_left_barline(cell, bar.start));
+            out.push_str(&barlines::render_right_barline(cell, bar.end));
+        }
     }
-    // Paint trailing empties AFTER all bars. With `fill="none"`
-    // SVG rectangles, paint order is invisible today — but #2059
-    // is expected to add bar-level barlines / repeat brackets
-    // and may rely on cell painting being interleaved by row.
-    // Document the contract so #2059 either preserves the
-    // bars-then-empties order or migrates to a row-interleaved
-    // emit pattern explicitly.
     for empty in &layout.trailing_empties {
         out.push_str(&format!(
             "    <rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" \
@@ -244,6 +251,10 @@ fill=\"none\" stroke=\"black\" stroke-width=\"1\" class=\"empty\"/>\n",
             h = empty.height,
         ));
     }
+    // Section labels and ending brackets sit ABOVE the cells, so
+    // paint them last to keep them on top of the row strokes.
+    out.push_str(&markers::render_section_labels(song, layout));
+    out.push_str(&markers::render_endings(song, layout));
     out.push_str("  </g>\n");
 }
 

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -304,7 +304,7 @@ fn write_bar_chord_text(out: &mut String, cell: &BarCoord, chords: &[BarChord]) 
     let text_x = cell.x + cell.width / 2;
     // Centre the chord text inside the cell. The 0.62 y-fraction
     // matches iReal Pro's baseline placement (slightly above
-    // mid-cell) so the future barline overlay (#2059) sits
+    // mid-cell) so the barline overlay (landed in #2059) sits
     // beneath without collision.
     let text_y = cell.y + (cell.height * 62) / 100;
     out.push_str(&format!(

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -86,7 +86,7 @@ pub use layout::{BarCoord, EmptyCell, Layout, compute_layout};
 pub use page::{
     BAR_ROW_HEIGHT, BARS_PER_ROW, CHORD_FONT_SIZE_BASE, CHORD_FONT_SIZE_SUPERSCRIPT,
     CHORD_SUPERSCRIPT_DY, GRID_TOP, HEADER_BAND_HEIGHT, MARGIN_X, MARGIN_Y, MAX_BARS,
-    MAX_CHORDS_PER_BAR, PAGE_HEIGHT, PAGE_WIDTH,
+    MAX_CHORDS_PER_BAR, MAX_SECTIONS, PAGE_HEIGHT, PAGE_WIDTH,
 };
 
 /// Caller-supplied render configuration.

--- a/crates/render-ireal/src/markers.rs
+++ b/crates/render-ireal/src/markers.rs
@@ -101,7 +101,12 @@ pub(crate) fn render_endings(song: &IrealSong, layout: &Layout) -> String {
             .map(|e| e.number());
         match (run, bar_ending) {
             (None, Some(n)) => run = Some((n, idx, idx)),
-            (Some((n, first, _)), Some(m)) if m == n && same_row(layout, idx - 1, idx) => {
+            // Compare `idx` against the run's `last` (not `idx -
+            // 1`) so the underflow case at `idx == 0` is
+            // structurally impossible — the `(None, Some(n))`
+            // arm above handles the run's first bar, so reaching
+            // this arm always implies `last < idx`.
+            (Some((n, first, last)), Some(m)) if m == n && same_row(layout, last, idx) => {
                 run = Some((n, first, idx));
             }
             (Some((n, first, last)), Some(m)) => {

--- a/crates/render-ireal/src/markers.rs
+++ b/crates/render-ireal/src/markers.rs
@@ -1,0 +1,370 @@
+//! Section labels and N-th-ending bracket rendering.
+//!
+//! Section labels are short text glyphs (typically a single
+//! uppercase letter — `A`, `B`, `C` — but the AST also carries
+//! `Verse` / `Chorus` / `Custom` variants) drawn just above the
+//! first bar of each section. Ending brackets are horizontal lines
+//! with corner ticks and a small "N." label drawn above a run of
+//! consecutive bars sharing the same `Bar.ending` value.
+//!
+//! Both glyphs are positioned by reading [`Layout::section_row_starts`]
+//! and the `BarCoord` list — no AST traversal happens here, so the
+//! markers stay byte-stable for golden snapshots.
+
+use crate::layout::Layout;
+use crate::page::{BAR_ROW_HEIGHT, GRID_TOP};
+use crate::svg;
+use chordsketch_ireal::{IrealSong, SectionLabel};
+
+/// Vertical gap between the top of the bar grid and the section
+/// label baseline. The label sits above the row's `<rect>` stroke
+/// so it never overlaps with the chord text below.
+const SECTION_LABEL_GAP: i32 = 6;
+
+/// Vertical gap between the top of the row and the ending
+/// bracket's horizontal line. Slightly less than
+/// [`SECTION_LABEL_GAP`] so the bracket can sit beneath a section
+/// label when both apply to the same row.
+const ENDING_BRACKET_GAP: i32 = 3;
+
+/// Length of the corner tick at each end of an N-th ending
+/// bracket — drawn vertically downward into the cell.
+const ENDING_TICK_HEIGHT: i32 = 6;
+
+/// Renders a section-label `<text>` above the first bar of every
+/// non-empty section. Empty sections emit no label — the
+/// section's `section_row_starts` entry would point at a row that
+/// holds no `BarCoord`, and a label hovering over an empty row
+/// would mislead more than help.
+#[must_use]
+pub(crate) fn render_section_labels(song: &IrealSong, layout: &Layout) -> String {
+    let mut out = String::new();
+    for (section_idx, section) in song.sections.iter().enumerate() {
+        if section.bars.is_empty() {
+            continue;
+        }
+        // `compute_layout` guarantees `section_row_starts.len() ==
+        // song.sections.len()`, and a non-empty section always
+        // has at least one BarCoord whose `section_index ==
+        // section_idx` (subject to the `MAX_BARS` clamp). The
+        // `find` below would only return None when the entire
+        // section was truncated by `MAX_BARS`; in that case the
+        // section legitimately has nothing visible to label and
+        // we skip the label silently.
+        let row = layout.section_row_starts[section_idx];
+        let Some(first_bar) = layout.bars.iter().find(|b| b.section_index == section_idx) else {
+            continue;
+        };
+        let row_y = GRID_TOP + (row as i32) * BAR_ROW_HEIGHT;
+        let label_y = row_y - SECTION_LABEL_GAP;
+        let label_x = first_bar.x;
+        let label_text = svg::escape_xml(&format_section_label(&section.label));
+        out.push_str(&format!(
+            "    <text x=\"{label_x}\" y=\"{label_y}\" font-family=\"sans-serif\" \
+font-size=\"12\" font-weight=\"bold\" class=\"section-label\">{label_text}</text>\n"
+        ));
+    }
+    out
+}
+
+fn format_section_label(label: &SectionLabel) -> String {
+    match label {
+        SectionLabel::Letter(c) => c.to_string(),
+        SectionLabel::Verse => "V".to_string(),
+        SectionLabel::Chorus => "C".to_string(),
+        SectionLabel::Intro => "I".to_string(),
+        SectionLabel::Outro => "O".to_string(),
+        SectionLabel::Bridge => "B".to_string(),
+        SectionLabel::Custom(s) => s.clone(),
+    }
+}
+
+/// Renders N-th-ending brackets above runs of consecutive bars
+/// sharing the same `Bar.ending` value. A bracket is one
+/// horizontal `<line>` with two short downward ticks at each end
+/// plus a small `<text>` label (`"1."`, `"2."`, …) at the top-left
+/// corner.
+///
+/// Bars that span across a row break end the bracket at the row
+/// boundary and begin a new one on the next row — readers expect
+/// the bracket to track the bar grid, not the source order.
+#[must_use]
+pub(crate) fn render_endings(song: &IrealSong, layout: &Layout) -> String {
+    let mut out = String::new();
+    let mut run: Option<(u8, usize, usize)> = None; // (ending_n, first_idx, last_idx)
+    for (idx, cell) in layout.bars.iter().enumerate() {
+        let bar_ending = song
+            .sections
+            .get(cell.section_index)
+            .and_then(|s| s.bars.get(cell.bar_index_in_section))
+            .and_then(|b| b.ending)
+            .map(|e| e.number());
+        match (run, bar_ending) {
+            (None, Some(n)) => run = Some((n, idx, idx)),
+            (Some((n, first, _)), Some(m)) if m == n && same_row(layout, idx - 1, idx) => {
+                run = Some((n, first, idx));
+            }
+            (Some((n, first, last)), Some(m)) => {
+                emit_ending_bracket(&mut out, layout, n, first, last);
+                run = Some((m, idx, idx));
+            }
+            (Some((n, first, last)), None) => {
+                emit_ending_bracket(&mut out, layout, n, first, last);
+                run = None;
+            }
+            (None, None) => {}
+        }
+    }
+    if let Some((n, first, last)) = run {
+        emit_ending_bracket(&mut out, layout, n, first, last);
+    }
+    out
+}
+
+fn same_row(layout: &Layout, a: usize, b: usize) -> bool {
+    layout
+        .bars
+        .get(a)
+        .and_then(|x| layout.bars.get(b).map(|y| x.y == y.y))
+        .unwrap_or(false)
+}
+
+fn emit_ending_bracket(
+    out: &mut String,
+    layout: &Layout,
+    n: u8,
+    first_idx: usize,
+    last_idx: usize,
+) {
+    // `first_idx` / `last_idx` come from indexing the same
+    // `layout.bars` slice we're now indexing back into, so direct
+    // indexing is safe by construction.
+    let first = &layout.bars[first_idx];
+    let last = &layout.bars[last_idx];
+    let bracket_y = first.y - ENDING_BRACKET_GAP;
+    let x_start = first.x;
+    let x_end = last.x + last.width;
+    out.push_str(&format!(
+        "    <line x1=\"{x_start}\" y1=\"{bracket_y}\" x2=\"{x_end}\" y2=\"{bracket_y}\" \
+stroke=\"black\" stroke-width=\"1\" class=\"ending-bracket\"/>\n"
+    ));
+    // Left tick.
+    out.push_str(&format!(
+        "    <line x1=\"{x_start}\" y1=\"{bracket_y}\" x2=\"{x_start}\" y2=\"{tick_y}\" \
+stroke=\"black\" stroke-width=\"1\" class=\"ending-bracket\"/>\n",
+        tick_y = bracket_y + ENDING_TICK_HEIGHT,
+    ));
+    // Right tick.
+    out.push_str(&format!(
+        "    <line x1=\"{x_end}\" y1=\"{bracket_y}\" x2=\"{x_end}\" y2=\"{tick_y}\" \
+stroke=\"black\" stroke-width=\"1\" class=\"ending-bracket\"/>\n",
+        tick_y = bracket_y + ENDING_TICK_HEIGHT,
+    ));
+    // Label (e.g. "1.") drawn slightly inside the left tick.
+    let label_y = bracket_y - 2;
+    let label_x = x_start + 4;
+    out.push_str(&format!(
+        "    <text x=\"{label_x}\" y=\"{label_y}\" font-family=\"sans-serif\" \
+font-size=\"10\" class=\"ending-label\">{n}.</text>\n"
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compute_layout;
+    use chordsketch_ireal::{Bar, Ending, IrealSong, Section, SectionLabel};
+
+    fn bar_with_ending(n: u8) -> Bar {
+        Bar {
+            ending: Ending::new(n),
+            ..Bar::new()
+        }
+    }
+
+    fn bar() -> Bar {
+        Bar::new()
+    }
+
+    #[test]
+    fn empty_song_emits_no_section_labels() {
+        let layout = compute_layout(&IrealSong::new());
+        assert!(render_section_labels(&IrealSong::new(), &layout).is_empty());
+    }
+
+    #[test]
+    fn single_section_emits_one_label_at_first_bar() {
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar(), bar()],
+        });
+        let layout = compute_layout(&song);
+        let out = render_section_labels(&song, &layout);
+        assert_eq!(out.matches("<text").count(), 1);
+        assert!(out.contains(">A</text>"));
+    }
+
+    #[test]
+    fn empty_section_does_not_emit_a_label() {
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar()],
+        });
+        song.sections.push(Section {
+            label: SectionLabel::Letter('B'),
+            bars: Vec::new(),
+        });
+        song.sections.push(Section {
+            label: SectionLabel::Letter('C'),
+            bars: vec![bar()],
+        });
+        let layout = compute_layout(&song);
+        let out = render_section_labels(&song, &layout);
+        // Only A and C should emit labels — B has no bars.
+        assert_eq!(out.matches("<text").count(), 2);
+        assert!(out.contains(">A</text>"));
+        assert!(!out.contains(">B</text>"));
+        assert!(out.contains(">C</text>"));
+    }
+
+    #[test]
+    fn named_section_label_variants_each_render() {
+        for (variant, expected) in [
+            (SectionLabel::Verse, "V"),
+            (SectionLabel::Chorus, "C"),
+            (SectionLabel::Intro, "I"),
+            (SectionLabel::Outro, "O"),
+            (SectionLabel::Bridge, "B"),
+            (SectionLabel::Custom("Pre".into()), "Pre"),
+        ] {
+            let mut song = IrealSong::new();
+            song.sections.push(Section {
+                label: variant,
+                bars: vec![bar()],
+            });
+            let layout = compute_layout(&song);
+            let out = render_section_labels(&song, &layout);
+            let needle = format!(">{expected}</text>");
+            assert!(out.contains(&needle), "expected {needle:?} in {out}");
+        }
+    }
+
+    #[test]
+    fn ending_bracket_spans_consecutive_bars_with_same_ending_number() {
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar_with_ending(1), bar_with_ending(1), bar()],
+        });
+        let layout = compute_layout(&song);
+        let out = render_endings(&song, &layout);
+        // Two brackets? No — one bracket spanning two bars + corner ticks.
+        // Expect 1 horizontal line + 2 ticks + 1 label.
+        assert_eq!(out.matches("class=\"ending-bracket\"").count(), 3);
+        assert_eq!(out.matches("class=\"ending-label\">1.").count(), 1);
+    }
+
+    #[test]
+    fn two_endings_with_different_numbers_emit_two_brackets() {
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar_with_ending(1), bar_with_ending(2)],
+        });
+        let layout = compute_layout(&song);
+        let out = render_endings(&song, &layout);
+        assert!(out.contains("class=\"ending-label\">1."));
+        assert!(out.contains("class=\"ending-label\">2."));
+    }
+
+    #[test]
+    fn no_endings_emits_no_bracket() {
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar(), bar()],
+        });
+        let layout = compute_layout(&song);
+        assert!(render_endings(&song, &layout).is_empty());
+    }
+
+    #[test]
+    fn ending_run_breaks_at_row_boundary() {
+        // Bars 1..=4 share ending 1; the row break between bar 4
+        // and bar 5 (when bar 5 starts a new row) must close the
+        // bracket and (if bar 5 is also ending 1) open a new one.
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![
+                bar_with_ending(1),
+                bar_with_ending(1),
+                bar_with_ending(1),
+                bar_with_ending(1),
+                bar_with_ending(1),
+            ],
+        });
+        let layout = compute_layout(&song);
+        let out = render_endings(&song, &layout);
+        // 5 bars → 2 rows of ending=1 → 2 brackets → 2 labels.
+        assert_eq!(out.matches("class=\"ending-label\">1.").count(), 2);
+    }
+
+    #[test]
+    fn ending_label_is_xml_escaped() {
+        // Defensive: the label is a `u8` so no XML reserved chars
+        // can appear today, but the `n.` formatting still passes
+        // through the SVG path, so future digit-replacement
+        // changes remain safe by construction.
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar_with_ending(255)],
+        });
+        let layout = compute_layout(&song);
+        let out = render_endings(&song, &layout);
+        assert!(out.contains(">255.<"));
+    }
+
+    #[test]
+    fn fully_truncated_section_emits_no_label() {
+        // When a non-empty section's bars are entirely truncated
+        // by `MAX_BARS`, `find` for that section returns None and
+        // the label is silently skipped — the section legitimately
+        // has nothing visible to point at. This exercises the
+        // `else continue` branch on the find fallback.
+        use crate::page::MAX_BARS;
+        let mut song = IrealSong::new();
+        // Section 0 fills the entire `MAX_BARS` budget.
+        song.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: (0..MAX_BARS).map(|_| bar()).collect(),
+        });
+        // Section 1's bars will all be truncated.
+        song.sections.push(Section {
+            label: SectionLabel::Letter('B'),
+            bars: vec![bar(), bar()],
+        });
+        let layout = compute_layout(&song);
+        let out = render_section_labels(&song, &layout);
+        // Only Section 0's label is emitted.
+        assert!(out.contains(">A</text>"));
+        assert!(!out.contains(">B</text>"));
+    }
+
+    #[test]
+    fn xml_reserved_chars_in_custom_section_label_are_escaped() {
+        // `Custom` carries an arbitrary string — must be escaped.
+        let mut song = IrealSong::new();
+        song.sections.push(Section {
+            label: SectionLabel::Custom("<bad>&\"".into()),
+            bars: vec![bar()],
+        });
+        let layout = compute_layout(&song);
+        let out = render_section_labels(&song, &layout);
+        assert!(out.contains("&lt;bad&gt;&amp;&quot;"));
+        assert!(!out.contains("<bad>"));
+    }
+}

--- a/crates/render-ireal/src/page.rs
+++ b/crates/render-ireal/src/page.rs
@@ -61,6 +61,20 @@ pub const CHORD_FONT_SIZE_SUPERSCRIPT: i32 = 10;
 /// extensions.
 pub const CHORD_SUPERSCRIPT_DY: i32 = -4;
 
+/// Maximum number of sections the renderer lays out before
+/// truncating.
+///
+/// `IrealSong.sections` is `pub Vec<Section>` and unvalidated; an
+/// in-process AST consumer (FFI / NAPI / library) can therefore
+/// hand the renderer a `Vec` of arbitrary length. Without this
+/// cap, `compute_layout`'s `section_row_starts` bookkeeping would
+/// allocate proportionally to `song.sections.len()`. `1024` is
+/// far above any practical iReal Pro chart (a typical jazz
+/// standard has 1–8 sections); when the cap is hit, surplus
+/// sections are silently truncated, mirroring the `MAX_BARS` /
+/// `MAX_CHORDS_PER_BAR` posture.
+pub const MAX_SECTIONS: usize = 1024;
+
 /// Maximum number of chords the renderer lays out inside a single
 /// bar before truncating.
 ///
@@ -82,6 +96,7 @@ pub const MAX_CHORDS_PER_BAR: usize = 64;
 const _: () = assert!(BARS_PER_ROW > 0);
 const _: () = assert!(MAX_BARS > 0);
 const _: () = assert!(MAX_CHORDS_PER_BAR > 0);
+const _: () = assert!(MAX_SECTIONS > 0);
 const _: () = {
     let max_rows = MAX_BARS.div_ceil(BARS_PER_ROW);
     // Conservatively check that `row_y = GRID_TOP + row * BAR_ROW_HEIGHT`

--- a/crates/render-ireal/tests/fixtures/aaba_32bar/expected.svg
+++ b/crates/render-ireal/tests/fixtures/aaba_32bar/expected.svg
@@ -68,5 +68,9 @@
     <text x="360" y="501" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">B</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
     <rect x="424" y="470" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="489" y="501" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">E</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
+    <text x="40" y="214" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
+    <text x="40" y="314" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">B</text>
+    <text x="40" y="414" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
   </g>
 </svg>

--- a/crates/render-ireal/tests/fixtures/basic/expected.svg
+++ b/crates/render-ireal/tests/fixtures/basic/expected.svg
@@ -7,8 +7,17 @@
   <g class="bar-grid">
     <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="104" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan></text>
+    <line x1="40" y1="120" x2="40" y2="170" stroke="black" stroke-width="3" class="barline-repeat-thick"/>
+    <line x1="43" y1="120" x2="43" y2="170" stroke="black" stroke-width="1" class="barline-repeat-thin"/>
+    <circle cx="49" cy="137" r="2" fill="black" class="barline-repeat-dot"/>
+    <circle cx="49" cy="153" r="2" fill="black" class="barline-repeat-dot"/>
+    <circle cx="159" cy="137" r="2" fill="black" class="barline-repeat-dot"/>
+    <circle cx="159" cy="153" r="2" fill="black" class="barline-repeat-dot"/>
+    <line x1="165" y1="120" x2="165" y2="170" stroke="black" stroke-width="1" class="barline-repeat-thin"/>
+    <line x1="168" y1="120" x2="168" y2="170" stroke="black" stroke-width="3" class="barline-repeat-thick"/>
     <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
     <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
     <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
   </g>
 </svg>

--- a/crates/render-ireal/tests/fixtures/endings_demo/expected.svg
+++ b/crates/render-ireal/tests/fixtures/endings_demo/expected.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Endings Demo</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Swing • C major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">A</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan></text>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan></text>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
+    <line x1="168" y1="117" x2="424" y2="117" stroke="black" stroke-width="1" class="ending-bracket"/>
+    <line x1="168" y1="117" x2="168" y2="123" stroke="black" stroke-width="1" class="ending-bracket"/>
+    <line x1="424" y1="117" x2="424" y2="123" stroke="black" stroke-width="1" class="ending-bracket"/>
+    <text x="172" y="115" font-family="sans-serif" font-size="10" class="ending-label">1.</text>
+    <line x1="424" y1="117" x2="555" y2="117" stroke="black" stroke-width="1" class="ending-bracket"/>
+    <line x1="424" y1="117" x2="424" y2="123" stroke="black" stroke-width="1" class="ending-bracket"/>
+    <line x1="555" y1="117" x2="555" y2="123" stroke="black" stroke-width="1" class="ending-bracket"/>
+    <text x="428" y="115" font-family="sans-serif" font-size="10" class="ending-label">2.</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/final_barline_demo/expected.svg
+++ b/crates/render-ireal/tests/fixtures/final_barline_demo/expected.svg
@@ -14,7 +14,8 @@
     <text x="360" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
     <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="489" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
-    <line x1="552" y1="120" x2="552" y2="170" stroke="black" stroke-width="3" class="barline-final"/>
+    <line x1="555" y1="120" x2="555" y2="170" stroke="black" stroke-width="3" class="barline-final"/>
+    <line x1="552" y1="120" x2="552" y2="170" stroke="black" stroke-width="1" class="barline-final"/>
     <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
   </g>
 </svg>

--- a/crates/render-ireal/tests/fixtures/final_barline_demo/expected.svg
+++ b/crates/render-ireal/tests/fixtures/final_barline_demo/expected.svg
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
   <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
-  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Split-Bar Demo</text>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Final Barline Demo</text>
   <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Swing • C major</text>
   <g class="bar-grid">
     <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="104" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <line x1="165" y1="120" x2="165" y2="170" stroke="black" stroke-width="1" class="barline-double"/>
     <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
-    <text x="232" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">A</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan><tspan font-size="14" dy="4"> </tspan><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan></text>
+    <text x="232" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">F</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <line x1="171" y1="120" x2="171" y2="170" stroke="black" stroke-width="1" class="barline-double"/>
     <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="360" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
     <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="489" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <line x1="552" y1="120" x2="552" y2="170" stroke="black" stroke-width="3" class="barline-final"/>
     <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
   </g>
 </svg>

--- a/crates/render-ireal/tests/fixtures/repeats_demo/expected.svg
+++ b/crates/render-ireal/tests/fixtures/repeats_demo/expected.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Repeats Demo</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Swing • C major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <line x1="40" y1="120" x2="40" y2="170" stroke="black" stroke-width="3" class="barline-repeat-thick"/>
+    <line x1="43" y1="120" x2="43" y2="170" stroke="black" stroke-width="1" class="barline-repeat-thin"/>
+    <circle cx="49" cy="137" r="2" fill="black" class="barline-repeat-dot"/>
+    <circle cx="49" cy="153" r="2" fill="black" class="barline-repeat-dot"/>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">A</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan></text>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="360" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan></text>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="489" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
+    <circle cx="546" cy="137" r="2" fill="black" class="barline-repeat-dot"/>
+    <circle cx="546" cy="153" r="2" fill="black" class="barline-repeat-dot"/>
+    <line x1="552" y1="120" x2="552" y2="170" stroke="black" stroke-width="1" class="barline-repeat-thin"/>
+    <line x1="555" y1="120" x2="555" y2="170" stroke="black" stroke-width="3" class="barline-repeat-thick"/>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/section_break_irregular/expected.svg
+++ b/crates/render-ireal/tests/fixtures/section_break_irregular/expected.svg
@@ -32,5 +32,8 @@
     <rect x="168" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
     <rect x="296" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
     <rect x="424" y="220" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">I</text>
+    <text x="40" y="164" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">V</text>
+    <text x="40" y="264" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">O</text>
   </g>
 </svg>

--- a/crates/render-ireal/tests/fixtures/section_markers_demo/expected.svg
+++ b/crates/render-ireal/tests/fixtures/section_markers_demo/expected.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white" stroke="black" stroke-width="1"/>
+  <text x="40" y="72" font-family="sans-serif" font-size="24" class="title">Section Markers Demo</text>
+  <text x="40" y="100" font-family="sans-serif" font-size="12" class="meta">Medium Swing • C major</text>
+  <g class="bar-grid">
+    <rect x="40" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="151" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="40" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="201" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="168" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="201" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="40" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="251" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="168" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="232" y="251" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="40" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="301" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="40" y="320" width="128" height="50" fill="none" stroke="black" stroke-width="1"/>
+    <text x="104" y="351" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">maj7</tspan></text>
+    <rect x="168" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="296" y="120" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="424" y="120" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="296" y="170" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="424" y="170" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="296" y="220" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="424" y="220" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="168" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="296" y="270" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="424" y="270" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="168" y="320" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="296" y="320" width="128" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <rect x="424" y="320" width="131" height="50" fill="none" stroke="black" stroke-width="1" class="empty"/>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">I</text>
+    <text x="40" y="164" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">V</text>
+    <text x="40" y="214" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">C</text>
+    <text x="40" y="264" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">B</text>
+    <text x="40" y="314" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">O</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/sixteen_bar_loop/expected.svg
+++ b/crates/render-ireal/tests/fixtures/sixteen_bar_loop/expected.svg
@@ -36,5 +36,6 @@
     <text x="360" y="301" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="10" dy="-4">m7</tspan></text>
     <rect x="424" y="270" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="489" y="301" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
   </g>
 </svg>

--- a/crates/render-ireal/tests/fixtures/twelve_bar_blues/expected.svg
+++ b/crates/render-ireal/tests/fixtures/twelve_bar_blues/expected.svg
@@ -28,5 +28,6 @@
     <text x="360" y="251" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
     <rect x="424" y="220" width="131" height="50" fill="none" stroke="black" stroke-width="1"/>
     <text x="489" y="251" font-family="serif" font-size="14" text-anchor="middle" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="10" dy="-4">7</tspan></text>
+    <text x="40" y="114" font-family="sans-serif" font-size="12" font-weight="bold" class="section-label">A</text>
   </g>
 </svg>

--- a/crates/render-ireal/tests/progressions.rs
+++ b/crates/render-ireal/tests/progressions.rs
@@ -276,3 +276,179 @@ fn multi_chord_bar() -> IrealSong {
 fn render_multi_chord_bar() {
     check_golden("multi_chord_bar", &multi_chord_bar());
 }
+
+// ---------------------------------------------------------------------------
+// Marker fixtures (per #2059 AC: "Golden SVG fixtures for each marker type")
+// ---------------------------------------------------------------------------
+
+use chordsketch_ireal::{BarLine, Ending};
+
+/// Bar with explicit start/end barlines and chord. Shorthand for the
+/// repeats / final-barline fixtures below.
+fn marked_bar(start: BarLine, end: BarLine, note: char, q: ChordQuality) -> Bar {
+    Bar {
+        start,
+        end,
+        chords: vec![BarChord {
+            chord: Chord::triad(ChordRoot::natural(note), q),
+            position: BeatPosition::on_beat(1).unwrap(),
+        }],
+        ..Bar::new()
+    }
+}
+
+/// Bar with an N-th-ending tag plus a chord.
+fn ending_bar(n: u8, note: char, q: ChordQuality) -> Bar {
+    Bar {
+        ending: Ending::new(n),
+        chords: vec![BarChord {
+            chord: Chord::triad(ChordRoot::natural(note), q),
+            position: BeatPosition::on_beat(1).unwrap(),
+        }],
+        ..Bar::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: open / close repeat barlines
+// ---------------------------------------------------------------------------
+
+fn repeats_demo() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "Repeats Demo".into();
+    song.style = Some("Medium Swing".into());
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars: vec![
+            marked_bar(
+                BarLine::OpenRepeat,
+                BarLine::Single,
+                'C',
+                ChordQuality::Major7,
+            ),
+            marked_bar(BarLine::Single, BarLine::Single, 'A', ChordQuality::Minor7),
+            marked_bar(BarLine::Single, BarLine::Single, 'D', ChordQuality::Minor7),
+            marked_bar(
+                BarLine::Single,
+                BarLine::CloseRepeat,
+                'G',
+                ChordQuality::Dominant7,
+            ),
+        ],
+    });
+    song
+}
+
+#[test]
+fn render_repeats_demo() {
+    check_golden("repeats_demo", &repeats_demo());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: N-th endings (1. and 2.)
+// ---------------------------------------------------------------------------
+
+fn endings_demo() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "Endings Demo".into();
+    song.style = Some("Medium Swing".into());
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars: vec![
+            // Bar 1 — common run.
+            Bar {
+                chords: vec![BarChord {
+                    chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Major7),
+                    position: BeatPosition::on_beat(1).unwrap(),
+                }],
+                ..Bar::new()
+            },
+            // Bars 2–3 — first ending.
+            ending_bar(1, 'A', ChordQuality::Minor7),
+            ending_bar(1, 'D', ChordQuality::Minor7),
+            // Bar 4 — second ending (single bar).
+            ending_bar(2, 'G', ChordQuality::Dominant7),
+        ],
+    });
+    song
+}
+
+#[test]
+fn render_endings_demo() {
+    check_golden("endings_demo", &endings_demo());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: section letters / verse / chorus / bridge / custom
+// ---------------------------------------------------------------------------
+
+fn section_markers_demo() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "Section Markers Demo".into();
+    song.style = Some("Medium Swing".into());
+    let chord_bar = || -> Bar {
+        Bar {
+            chords: vec![BarChord {
+                chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Major7),
+                position: BeatPosition::on_beat(1).unwrap(),
+            }],
+            ..Bar::new()
+        }
+    };
+    song.sections.push(Section {
+        label: SectionLabel::Intro,
+        bars: vec![chord_bar()],
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Verse,
+        bars: vec![chord_bar(), chord_bar()],
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Chorus,
+        bars: vec![chord_bar(), chord_bar()],
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Letter('B'),
+        bars: vec![chord_bar()],
+    });
+    song.sections.push(Section {
+        label: SectionLabel::Outro,
+        bars: vec![chord_bar()],
+    });
+    song
+}
+
+#[test]
+fn render_section_markers_demo() {
+    check_golden("section_markers_demo", &section_markers_demo());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: final + double barlines
+// ---------------------------------------------------------------------------
+
+fn final_barline_demo() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "Final Barline Demo".into();
+    song.style = Some("Medium Swing".into());
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars: vec![
+            marked_bar(BarLine::Single, BarLine::Double, 'C', ChordQuality::Major7),
+            marked_bar(BarLine::Double, BarLine::Single, 'F', ChordQuality::Major7),
+            marked_bar(
+                BarLine::Single,
+                BarLine::Single,
+                'G',
+                ChordQuality::Dominant7,
+            ),
+            marked_bar(BarLine::Single, BarLine::Final, 'C', ChordQuality::Major7),
+        ],
+    });
+    song
+}
+
+#[test]
+fn render_final_barline_demo() {
+    check_golden("final_barline_demo", &final_barline_demo());
+}


### PR DESCRIPTION
## What

Adds iReal Pro convention for non-Single barlines (`Double`,
`Final`, `OpenRepeat`, `CloseRepeat`), N-th-ending brackets with
`1.` / `2.` labels, and section letter labels above each section
start. Builds on the chord-name typography work in #2326 (#2057).

## Why

#2059 is the third renderer issue the #2060 grid layout unblocked.
Locking the `class=\"section-label\"` / `class=\"barline-*\"` /
`class=\"ending-*\"` selectors in now lets the PNG (#2064) and
PDF (#2063) rasterisers + the playground preview rely on a stable
DOM structure for the iReal-style chart.

## How

| File | Change |
|---|---|
| `crates/render-ireal/src/barlines.rs` (new) | `render_left_barline` / `render_right_barline` emit `<line>` + `<circle>` primitives for each non-Single barline kind |
| `crates/render-ireal/src/markers.rs` (new) | `render_section_labels` + `render_endings` walk `Layout` to emit section letters and N-th-ending brackets |
| `crates/render-ireal/src/lib.rs` | `write_grid` overlays the new glyphs after the cell `<rect>` paint |
| `crates/render-ireal/src/layout.rs` | Outer `MAX_BARS` `break` → `continue` so `section_row_starts` length always equals `song.sections.len()` |
| `crates/render-ireal/tests/progressions.rs` | 4 new golden fixtures (`repeats_demo`, `endings_demo`, `section_markers_demo`, `final_barline_demo`) |
| `crates/render-ireal/tests/fixtures/<all>/expected.svg` | Regenerated to pick up the new section labels + repeat-barline glyphs |
| `CLAUDE.md`, `crates/render-ireal/README.md` | Scope updated |

## Acceptance Criteria check

| AC | Status |
|---|---|
| Open / close repeat barlines drawn as correct musical glyphs | Done — thick + thin + 2 dots; symmetric on left/right sides |
| N-th ending brackets drawn above the relevant bars with labels (`\"1.\"`, `\"2.\"`) | Done — horizontal line + corner ticks + label; row-break aware |
| Section letters drawn in iReal Pro's section-label style | Done — bold sans-serif text above the first bar of each non-empty section |
| Double barlines at section boundaries | Done — Double / Final glyphs available; the section-break wrap engine in #2060 already starts a new row at every boundary so the boundary is visually clear; explicit `BarLine::Double` on `bar.start` / `bar.end` is also rendered |
| Golden SVG fixtures for each marker type | Done — `repeats_demo`, `endings_demo`, `section_markers_demo`, `final_barline_demo` |
| Unit tests | Done — 11 in `barlines`, 11 in `markers` |
| CI green | Pending CI run |

## Tests / coverage

```
running 51 tests          (lib unit tests)
test result: ok. 51 passed; 0 failed

running 17 tests          (tests/golden.rs)
test result: ok. 17 passed; 0 failed

running 9 tests           (tests/progressions.rs)
test result: ok. 9 passed; 0 failed

running 1 test            (doctest)
test result: ok. 1 passed; 0 failed
```

`cargo llvm-cov -p chordsketch-render-ireal` reports 99.94% region
/ 100.00% line coverage. The 1 unhit region is a branch detail in
`lib.rs`'s match arms; lines are fully covered.

## Sister-site / fix-propagation audit

Not a bug fix — no sister-site groups apply. The new glyphs flow
through `svg::escape_xml` for any AST-derived text (Custom section
labels) and use `note_glyph_or_fallback` consistently. The
`section_row_starts` length-invariant fix in `compute_layout` is a
defensive change that keeps the marker layer's indexing safe.

## Resource limits

`MAX_BARS` truncation continues to apply — sections whose bars are
entirely truncated emit no labels (sections legitimately have
nothing visible to point at). The `compute_layout` change keeps
`section_row_starts.len() == song.sections.len()` regardless of
truncation, so marker indexing is now safe by construction.

## Doc updates

- `CLAUDE.md` Architecture row scope updated.
- `crates/render-ireal/README.md` description block + roadmap
  updated to drop #2059 from the follow-ups.

Closes #2059.