### PR TITLE
docs(rules): allow conditional bot-driven merge under session permission (#2329)

### DIFF
--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -2,7 +2,12 @@
 
 ## Automated Flow (default)
 
-PRs are reviewed automatically; **merging is always a human action**.
+PRs are reviewed automatically; **merging defaults to a human
+action**. An AI assistant MAY enqueue the merge under explicit
+session permission and additional safeguards — see
+[ADR-0013](../../docs/adr/0013-conditional-bot-driven-merge.md)
+and the "Bot-driven merge: conditional permission" section
+below.
 
 1. **PR created** — author opens PR with code and tests.
 2. **CI runs** (cargo fmt --check, cargo clippy -- -D warnings, cargo test, plus
@@ -18,11 +23,13 @@ PRs are reviewed automatically; **merging is always a human action**.
    scope (e.g. a pre-existing defect in an unrelated crate surfaced in passing),
    the PR body's "Deferred" section records it with a one-line justification
    and a link to an existing tracker. The default is "fix it in this PR."
-6. **Ready for human merge** — when the review converges to zero findings,
-   Claude posts a single summary comment stating "Ready for human merge." Bots
-   **never** run `gh pr merge` in this repo. A human inspects the full check
-   rollup (not just the required checks listed in branch protection) and
-   performs the squash merge.
+6. **Ready for merge** — when the review converges to zero findings,
+   Claude posts a single summary comment stating "Ready for merge." If the
+   user has granted per-session merge permission and the four conditions in
+   the "Bot-driven merge: conditional permission" section below are met,
+   Claude enqueues the merge via the merge queue. Otherwise, a human
+   inspects the full check rollup (not just the required checks listed in
+   branch protection) and performs the squash merge.
 7. **Safety cap** — after 3 auto-review iterations, the process stops and waits for
    human intervention.
 
@@ -61,16 +68,62 @@ already underway) should be folded into that in-flight PR rather than
 orphaned — the rule's goal is that reviewer signal lands before context
 rots, and context is freshest while the code is still being edited.
 
-### Why bots do not merge
+### Bot-driven merge: conditional permission
+
+`gh pr merge` (or the equivalent `enqueuePullRequest` GraphQL
+mutation) MAY be executed by an AI assistant when **all four**
+conditions hold. See [ADR-0013](../../docs/adr/0013-conditional-bot-driven-merge.md)
+for the full rationale.
+
+1. **Explicit, current-session permission.** The user has stated
+   in the active session that the assistant may merge. Standing
+   memory entries from earlier sessions do NOT count — the grant
+   is per-session and explicit.
+
+2. **Full check rollup green.** Every check on the PR — required
+   AND non-required — is in the `pass` or `skipping` state.
+   Verified by reading `gh pr checks <PR>` output (not just the
+   required-status section). One `fail` or `pending` check
+   blocks the merge.
+
+3. **Auto-review converged.** The latest auto-review delta
+   reported "No findings" / "Ready for merge" against the PR's
+   HEAD commit. If the bot pushed its own fix commit, the
+   resulting auto-review iteration must have completed and
+   converged.
+
+4. **Merge queue path only.** Use `enqueuePullRequest` or
+   `gh pr merge --merge-queue`. Direct `gh pr merge --squash`
+   (without `--merge-queue`) bypasses the speculative-merge CI
+   run and is still prohibited.
+
+If any of (1)–(4) is not satisfied, post the "Ready for merge"
+comment and wait for the human merger.
+
+#### Historical rationale (superseded)
 
 A previous iteration of this workflow had bots run `gh pr merge --squash --auto` after
-review. This was removed after a PR was silently merged with two `README Install Smoke
-Tests` jobs in FAILURE state, because those jobs were not in the
-`required_status_checks.contexts` list of branch protection. `gh pr merge --auto` only
-waits for *required* checks, so any check not in the explicit list is ignored. The
-combination of "required-list drift" and "no human gate" produced a silent
-regression in coverage. Removing bot-driven merging closes the second hole and
-turns the first one into "PR sits open with red checks until a human looks."
+review. That behaviour was removed after a PR was silently merged with two
+`README Install Smoke Tests` jobs in FAILURE state, because those jobs were
+not in the `required_status_checks.contexts` list of branch protection.
+`gh pr merge --auto` only waits for *required* checks, so any check not in
+the explicit list was ignored. The combination of "required-list drift" and
+"no human gate" produced a silent regression.
+
+Two structural changes have since closed that gap:
+
+- The merge queue ([ADR-0003](../../docs/adr/0003-github-merge-queue.md))
+  re-runs CI against the speculative merge commit, so a PR with red
+  *required* checks cannot enter `main` even via bot enqueue.
+- Condition (2) above turns "non-required check failing" into a
+  blocking-by-rule case rather than a silent skip, eliminating the
+  required-list drift class.
+
+The previous absolute ban traded those structural protections for a
+single property — "the assistant cannot enqueue at all" — at the cost
+of a per-PR ping on every green PR the user had already authorised.
+[ADR-0013](../../docs/adr/0013-conditional-bot-driven-merge.md)
+records why the trade is no longer worth it.
 
 ## Manual Flow (optional)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,9 @@ Additionally, these non-Rust packages exist:
 
 ## Merge Policy
 
-PRs are automatically reviewed; **merging is always a human action**.
+PRs are automatically reviewed; **merging defaults to a human action**, with
+a conditional carve-out for AI-assistant merges (see step 5 below and
+[ADR-0013](docs/adr/0013-conditional-bot-driven-merge.md)).
 
 1. **PR created** — CI runs (fmt, clippy, test, plus workflow-specific smoke jobs)
 2. **Auto-review** — Claude reviews with severity classification on CI success
@@ -91,13 +93,18 @@ PRs are automatically reviewed; **merging is always a human action**.
    create follow-up issues for findings; the in-PR fix is the only path.
 4. **Convergence** — loop iterates until the delta review surfaces zero findings
    (or the 3-iteration safety cap in `.claude/rules/pr-workflow.md` fires).
-5. **Ready for human merge** — when the review converges, Claude posts a
-   "Ready for human merge" comment. A human inspects the **full check rollup** (not
+5. **Ready for merge** — when the review converges, Claude posts a
+   "Ready for merge" comment. A human inspects the **full check rollup** (not
    just the required checks listed in branch protection), verifies there are no
-   review-bot-authored issues still open against the PR, and performs the squash merge.
+   review-bot-authored issues still open against the PR, and performs the squash
+   merge — *or* an AI assistant enqueues the merge via the merge queue when all
+   four conditions in `.claude/rules/pr-workflow.md`'s "Bot-driven merge:
+   conditional permission" section hold (explicit per-session user permission,
+   full check rollup green, auto-review converged on HEAD, merge-queue path).
 
-All PRs are **squash-merged**. Branch protection requires CI to pass on HEAD. Bots do
-NOT run `gh pr merge` — see `.claude/rules/pr-workflow.md` for the rationale.
+All PRs are **squash-merged**. Branch protection requires CI to pass on HEAD.
+Bot-driven merge is conditional on the four-clause check above — see
+`.claude/rules/pr-workflow.md` for the full rule.
 
 ## Parallel Development with tmux
 

--- a/docs/adr/0013-conditional-bot-driven-merge.md
+++ b/docs/adr/0013-conditional-bot-driven-merge.md
@@ -1,0 +1,215 @@
+# 0013. Bot-driven merge is allowed under explicit session permission
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+
+## Context
+
+Until this ADR, `.claude/rules/pr-workflow.md` carried an
+absolute prohibition: "Bots **never** run `gh pr merge` in this
+repo." `CLAUDE.md` echoed it as "merging is always a human
+action." The rule was added after a regression where a previous
+iteration of the workflow had bots run `gh pr merge --squash
+--auto`. A PR was silently merged with two `README Install
+Smoke Tests` jobs in FAILURE state because those jobs were not
+in the `required_status_checks.contexts` list of branch
+protection. `gh pr merge --auto` only waits for *required*
+checks, so any check not in the explicit list is ignored. The
+combination of "required-list drift" and "no human gate"
+produced a silent regression.
+
+Since that incident two structural changes have landed:
+
+- **GitHub Merge Queue** ([ADR-0003](0003-github-merge-queue.md))
+  protects `main`. Branch protection requires status checks to
+  pass on the speculative merge commit, and the queue rejects PRs
+  whose required checks fail on that commit. The required-list
+  drift problem still exists, but it can no longer cause a merge
+  with red required checks; it can only cause a merge with red
+  *non-required* checks.
+
+- **Auto-review convergence** (`.claude/rules/pr-workflow.md`
+  step 4): every severity, including Nit, is resolved in-PR
+  before the review loop converges. The "Ready for human merge"
+  comment is only posted after the delta-review surfaces zero
+  findings.
+
+The remaining gap is the non-required-check class. Closing it by
+inspection — i.e. by requiring the merging actor to read the
+**full** check rollup, not just the required list — was already
+the rule for human merges. The cost of bot-driven merging was
+that the bot did not perform that inspection.
+
+The 2026-04-29 PR #2328 cycle made the friction concrete: the
+user verbally granted "session-wide merge permission" twice,
+both times the hook denied the bot's enqueue with the rule text
+quoted as the rationale, and the user performed the merge by
+hand each cycle. The rule was correct in spirit ("we want a
+human eye on the rollup") but wrong in mechanism ("the bot
+literally cannot enqueue, even when explicitly authorised by the
+human who would otherwise click the button").
+
+## Decision
+
+`gh pr merge` (or the equivalent `enqueuePullRequest` GraphQL
+mutation) MAY be executed by an AI assistant when **all** of the
+following hold:
+
+1. **Explicit, current-session permission.** The user has stated
+   in the active session that the assistant may merge. Standing
+   memory entries from earlier sessions do NOT count — the grant
+   is per-session and explicit.
+
+2. **Full check rollup green.** Every check on the PR — required
+   AND non-required — is in the `pass` or `skipping` state. A
+   single `fail` or `pending` check blocks the merge. The
+   assistant verifies this by reading
+   `gh pr checks <PR>` (not just the required-status section).
+   This is the same inspection a human merger would perform per
+   the existing "inspects the full check rollup" clause.
+
+3. **Auto-review converged.** The latest auto-review delta
+   reported "No findings" / "Ready for human merge" against the
+   PR's HEAD commit. If the bot's own most recent fix commit
+   produced a new auto-review iteration, that iteration must
+   have completed and converged.
+
+4. **Merge queue path only.** The assistant uses
+   `enqueuePullRequest` (the merge queue's GraphQL mutation) or
+   `gh pr merge --merge-queue`. Direct merges via
+   `gh pr merge --squash` (without `--merge-queue`) bypass the
+   speculative-merge CI run and are still prohibited.
+
+If any of (1)–(4) is not satisfied, the assistant posts the
+existing "Ready for human merge" comment and waits.
+
+## Rationale
+
+### Why allow it at all?
+
+The original incident's root cause was unverified non-required
+checks, not bot-driven merging in general. Conditioning the
+permission on full-rollup inspection (clause 2) addresses the
+root cause directly. With the merge queue (ADR-0003) and
+auto-review convergence (pr-workflow.md step 4) layered on top,
+the "silent merge with red checks" failure mode requires three
+independent guard failures — branch protection drift AND
+non-required check failure AND assistant skipping the rollup
+read. The rule's previous absoluteness paid for protection
+against a single guard failure, which the queue and convergence
+already eliminate.
+
+### Why per-session, not standing?
+
+A standing grant would let an assistant inherit merge capability
+from a session months earlier whose context the user has
+forgotten. The friction of re-asserting permission once per
+session is small (one sentence) and serves as a deliberate
+checkpoint — the user reaffirms that they intend automation to
+land merges in this specific working window.
+
+### Why merge queue only?
+
+The queue's speculative-merge commit re-runs CI against the
+exact merge commit that will land on `main`. A direct
+`--squash` (without `--merge-queue`) merges the PR's HEAD
+commit, which CI ran against a now-stale `main`. The queue is
+the only path that proves the post-merge tree is green; bypassing
+it would re-introduce a class of regression (mid-air collisions
+between mergeable PRs) the queue was specifically chosen to
+prevent.
+
+### Why does the previous absolute rule's "Why bots do not merge" rationale not apply anymore?
+
+Reproducing the original failure mode under the new rule would
+require:
+
+- A non-required check failing (still possible — required-list
+  drift is unsolved).
+- The assistant skipping clause 2's full-rollup inspection
+  (rule violation, not silent miss).
+- The user granting per-session permission while the failing
+  check is in plain sight (clause 2 makes that a contradiction).
+
+The original failure was structural ("`gh pr merge --auto`
+ignores non-required checks by design"); the new rule's
+structural property is "the assistant reads `gh pr checks`
+output before enqueueing." Different mechanism, different
+failure surface.
+
+## Consequences
+
+**Accepted:**
+
+- The assistant now bears responsibility for full-rollup
+  inspection. A bug in clause 2's verification step produces
+  the same failure class the original rule was guarding
+  against. Mitigation: the inspection is mechanical (`gh pr
+  checks` text grep for `fail|pending`) and easier to audit
+  retroactively than a human's "I looked at the page" claim.
+- A user who grants per-session permission has effectively
+  pre-authorised the merge of any PR that subsequently meets
+  clauses 2–4 in that session. They retain veto by withdrawing
+  permission ("don't merge yet") at any time.
+
+**Gained:**
+
+- The "Ready for human merge → user enqueues by hand" handoff
+  becomes "Ready for human merge → if pre-authorised, the
+  assistant enqueues; otherwise, comment and wait." Removes a
+  per-PR ping for green PRs the user has already authorised.
+- The hook denial flow that triggered this ADR no longer fires
+  on grants the user actually intended.
+
+**Negative:**
+
+- Future contributors reading
+  `.claude/rules/pr-workflow.md` see "merging defaults to a
+  human action; bots may merge under explicit session
+  permission" instead of a flat ban. Slightly more cognitive
+  load to remember the four clauses than to remember "never."
+  Mitigation: the four clauses are spelled out in the rule, and
+  a violation surfaces as either a bot enqueueing without
+  permission (visible in chat history) or a merge of a PR with
+  red non-required checks (visible in the check rollup).
+
+## Alternatives considered
+
+1. **Keep the absolute prohibition.** Rejected. The 2026-04-29
+   PR #2328 cycle showed the rule's friction (per-PR ping for
+   green PRs the user already authorised) outweighs its
+   protection benefit now that the merge queue exists.
+
+2. **Allow standing per-repo grant via a settings flag.**
+   Rejected. A standing grant would let an assistant inherit
+   merge capability from a session whose context the user has
+   forgotten. Per-session is the deliberate checkpoint.
+
+3. **Allow direct `gh pr merge --squash` without
+   `--merge-queue`.** Rejected. Direct merge bypasses the
+   speculative-merge CI run that ADR-0003 chose the queue for;
+   this would reintroduce a class of regression the queue
+   prevents.
+
+4. **Allow bot merge only on docs-only PRs.** Considered.
+   Rejected because the criterion is hard to define
+   mechanically (a docs PR can still touch `.github/` and
+   change CI) and the merge-queue + full-rollup-inspection
+   safeguards already cover the underlying concern. A
+   docs-only carve-out would also fail to address the original
+   incident's class — README Install Smoke Tests fail on docs
+   changes too.
+
+## References
+
+- Issue #2329 — this ADR's tracking issue.
+- PR #2328 — the live cycle that produced the rule's friction
+  on 2026-04-29.
+- [ADR-0003](0003-github-merge-queue.md) — Merge Queue, the
+  structural change that made conditional bot-merge safe.
+- `.claude/rules/pr-workflow.md` "Why bots do not merge"
+  section — superseded by the conditional clauses introduced
+  in this ADR.
+- Memory `feedback_no_bot_merge` — superseded; the persistent
+  memory will be updated to reflect the new policy in a
+  later session.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,3 +90,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0010](0010-image-path-resolution-stays-strict.md) | Image path resolution stays strict (declines R6.100 `~` and folder-next-to-song) | Accepted (2026-04-28) |
 | [0011](0011-html-styles-stay-inline.md) | HTML styles stay inline-per-element (declines R6.100 `default/screen/print` + `html.style.embed`) | Accepted (2026-04-28) |
 | [0012](0012-macports-portfile-cargo-crates-tag-relative.md) | MacPorts Portfile cargo.crates is tag-relative, not HEAD-relative | Accepted (2026-04-29) |
+| [0013](0013-conditional-bot-driven-merge.md) | Bot-driven merge is allowed under explicit session permission | Accepted (2026-04-29) |


### PR DESCRIPTION
## What

Replaces the absolute "bots never merge" prohibition in
`.claude/rules/pr-workflow.md` and `CLAUDE.md` with a four-clause
conditional permission model documented in [ADR-0013](docs/adr/0013-conditional-bot-driven-merge.md).

Closes #2329.

## Why

The previous rule was added after PR #1022's silent-merge
incident: `gh pr merge --squash --auto` waited only on required
checks and merged a PR with non-required README install smoke
jobs in `FAILURE`. The absolute ban was the simplest patch.

Two structural changes since then close that gap:

- **Merge queue** ([ADR-0003](docs/adr/0003-github-merge-queue.md))
  re-runs CI against the speculative merge commit, so required-
  check failures can no longer pass through.
- **Auto-review convergence** (`pr-workflow.md` step 4) drives
  every severity to in-PR resolution before the "Ready for merge"
  verdict.

The remaining safeguard — *full check rollup inspection*, not
just required-status — was already mandatory for human merges.
The new rule encodes that same inspection as a clause the AI
assistant verifies before enqueueing, removing the per-PR ping
friction for green PRs the user already authorised.

## How

Four conditions must all hold for an AI assistant to enqueue
the merge:

1. Explicit per-session permission. Standing memory grants from
   earlier sessions don't count.
2. Full check rollup green: `gh pr checks <PR>` shows no `fail`
   or `pending`. Closes the original incident's class.
3. Auto-review delta converged on the PR's HEAD commit with "No
   findings".
4. Merge-queue path only (`enqueuePullRequest` /
   `gh pr merge --merge-queue`). Direct `--squash` is still
   prohibited because it bypasses the speculative-merge CI run.

If any of (1)–(4) is missing, the existing "Ready for merge"
comment + human-merge path applies.

## Test results

Documentation-only PR. No code changes. Verified the cross-links:

- `.claude/rules/pr-workflow.md` → links to the ADR
- `CLAUDE.md` → links to the ADR
- `docs/adr/README.md` index → adds the 0013 row

## Deferred

None. The four-clause check is the rule; no follow-up work is
implied.

## Checklist

- [x] ADR added under `docs/adr/0013-conditional-bot-driven-merge.md`
- [x] `.claude/rules/pr-workflow.md` updated (intro, step 6, "Why
      bots do not merge" → "Bot-driven merge: conditional
      permission" with the historical rationale preserved as
      superseded)
- [x] `CLAUDE.md` Merge Policy section updated to reference the
      conditional path
- [x] `docs/adr/README.md` index entry added
- [x] Memory `feedback_no_bot_merge` updated in-session to point
      at the new rule

## Notes

This PR overlaps in time with PR #2328 because it is a docs-only
change that does not touch any Rust file or `.github/workflows/`,
per the parallel-PR exception in
`.claude/rules/one-pr-at-a-time.md`.