### PR TITLE
feat(render-ireal): PNG rasterisation via resvg (#2064)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,16 @@ jobs:
 
       - name: Build docs (warnings as errors)
         # See the clippy job for the `chordsketch-desktop` exclusion rationale.
-        run: cargo doc --workspace --exclude chordsketch-desktop --no-deps
+        #
+        # `--features chordsketch-render-ireal/png` doc-checks the
+        # feature-gated `png` module (#2064) too. Without it, broken
+        # intra-doc links inside that module would not surface, and a
+        # link from the always-on crate root into the gated module
+        # would fail rustdoc's broken-link check anyway because the
+        # gated module would not be in the rendered tree.
+        run: |
+          cargo doc --workspace --exclude chordsketch-desktop \
+            --features chordsketch-render-ireal/png --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,14 @@ jobs:
         # coverage is tracked in #2077.
         run: cargo clippy --workspace --exclude chordsketch-desktop --all-targets -- -D warnings
 
+      - name: Clippy lints (chordsketch-render-ireal --features png)
+        # The `png` feature is off by default (#2064); the workspace
+        # clippy run above does not exercise it, so a clippy
+        # regression inside the feature-gated module would not
+        # surface. Mirror the feature-gated test step in the test
+        # job and lint it explicitly.
+        run: cargo clippy -p chordsketch-render-ireal --features png --all-targets -- -D warnings
+
   doc:
     name: Docs
     runs-on: ubuntu-latest
@@ -177,6 +185,14 @@ jobs:
       - name: Run tests
         # See the clippy job for the `chordsketch-desktop` exclusion rationale.
         run: cargo test --workspace --exclude chordsketch-desktop
+
+      - name: Run feature-gated tests (chordsketch-render-ireal --features png)
+        # The `png` feature is off by default to keep the
+        # transitive-dep surface small for SVG-only consumers
+        # (#2064). Without an explicit feature pass here the
+        # `tests/png.rs` suite never compiles in CI; a regression in
+        # the `render_png` pipeline would slip through unnoticed.
+        run: cargo test -p chordsketch-render-ireal --features png
 
   desktop-smoke:
     name: Desktop smoke (Linux)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,16 @@ jobs:
         # `chordsketch-desktop` is excluded (Tauri scaffold, covered by
         # `desktop-smoke` in ci.yml). See the matching exclusions in
         # ci.yml and .claude/rules/ci-parallelization.md.
-        run: cargo llvm-cov --workspace --exclude chordsketch-desktop --lcov --output-path lcov.info
+        #
+        # `--features chordsketch-render-ireal/png` turns on the PNG
+        # rasteriser (#2064) so its module compiles and the
+        # feature-gated `tests/png.rs` suite runs — without this,
+        # the patch coverage gate would skip the new lines because
+        # they would not be in the compiled crate.
+        run: |
+          cargo llvm-cov --workspace --exclude chordsketch-desktop \
+            --features chordsketch-render-ireal/png \
+            --lcov --output-path lcov.info
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "askama"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +771,8 @@ name = "chordsketch-render-ireal"
 version = "0.3.0"
 dependencies = [
  "chordsketch-ireal",
+ "resvg",
+ "tiny-skia",
 ]
 
 [[package]]
@@ -862,6 +882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +985,15 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
  "libc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1117,6 +1152,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deranged"
@@ -1424,6 +1465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1549,12 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
@@ -1523,6 +1579,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1842,6 +1921,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2204,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2320,6 +2409,22 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"
@@ -2532,6 +2637,17 @@ dependencies = [
  "html5ever 0.29.1",
  "indexmap 2.13.1",
  "selectors 0.24.0",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid 0.22.14",
+ "smallvec",
 ]
 
 [[package]]
@@ -2767,6 +2883,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,7 +2964,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -3303,7 +3428,7 @@ dependencies = [
  "adobe-cmap-parser",
  "cff-parser",
  "encoding_rs",
- "euclid",
+ "euclid 0.20.14",
  "log",
  "lopdf",
  "postscript",
@@ -3505,6 +3630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,6 +3711,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,7 +3787,7 @@ checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
- "float-cmp",
+ "float-cmp 0.10.0",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -3742,6 +3886,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4013,6 +4163,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4037,6 +4204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,6 +4224,21 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4156,6 +4347,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "same-file"
@@ -4543,6 +4752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,6 +4777,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -4643,6 +4870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp 0.9.0",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4713,6 +4949,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher 1.0.2",
+]
 
 [[package]]
 name = "swift-rs"
@@ -4930,7 +5176,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5314,6 +5560,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.18.1",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,7 +5934,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -5679,6 +5951,9 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "type1-encoding-parser"
@@ -5760,6 +6035,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5781,10 +6068,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -5960,6 +6259,34 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher 1.0.2",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -7008,6 +7335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7188,6 +7521,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,7 +1586,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree 0.20.0",
+ "roxmltree",
 ]
 
 [[package]]
@@ -1925,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2293,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png 0.17.16",
+ "png",
 ]
 
 [[package]]
@@ -2422,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "indexmap"
@@ -2641,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.13.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
  "euclid 0.22.14",
@@ -2964,7 +2964,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -3711,19 +3711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.11.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4164,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.47.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
  "gif",
  "image-webp",
@@ -4231,15 +4218,6 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
-
-[[package]]
-name = "roxmltree"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "rustc-hash"
@@ -4952,9 +4930,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svgtypes"
-version = "0.16.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo",
  "siphasher 1.0.2",
@@ -5176,7 +5154,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png 0.17.16",
+ "png",
  "proc-macro2",
  "quote",
  "semver",
@@ -5561,24 +5539,24 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia"
-version = "0.12.0"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
 dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
  "cfg-if",
  "log",
- "png 0.18.1",
+ "png",
  "tiny-skia-path",
 ]
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.12.0"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -5934,7 +5912,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -6263,9 +6241,9 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.47.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
 dependencies = [
  "base64 0.22.1",
  "data-url",
@@ -6275,14 +6253,13 @@ dependencies = [
  "kurbo",
  "log",
  "pico-args",
- "roxmltree 0.21.1",
+ "roxmltree",
  "rustybuzz",
  "simplecss",
  "siphasher 1.0.2",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
- "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -7524,15 +7501,15 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.15"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]

--- a/crates/render-ireal/Cargo.toml
+++ b/crates/render-ireal/Cargo.toml
@@ -25,8 +25,14 @@ chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
 # applies here because pure-Rust SVG rasterisation has no zero-dep
 # alternative, and the feature gate keeps the cost off any caller
 # that does not need PNG output.
-resvg = { version = "0.47", optional = true }
-tiny-skia = { version = "0.12", optional = true }
+#
+# Pinned to 0.45.x (resvg) and 0.11.x (tiny-skia) because the
+# 0.46.0 / 0.47.0 line bumps the resvg MSRV to 1.87, but this
+# workspace's `rust-version = "1.85"` (set in the top-level
+# `[workspace.package]`) is exercised by the CI test matrix.
+# Lifting either pin requires raising the workspace MSRV first.
+resvg = { version = "0.45", optional = true }
+tiny-skia = { version = "0.11", optional = true }
 
 [features]
 # Enables the `render_png` function. Off by default to keep the

--- a/crates/render-ireal/Cargo.toml
+++ b/crates/render-ireal/Cargo.toml
@@ -14,3 +14,21 @@ readme = "README.md"
 
 [dependencies]
 chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
+
+# `resvg` and `tiny-skia` are pulled in only when the `png` feature is
+# enabled. Without the gate the default build stays at the same lean
+# transitive-dep surface as the SVG-only renderer (just
+# `chordsketch-ireal`); turning the feature on adds the SVG parser
+# (`usvg`, re-exported by `resvg`) and the rasteriser (`tiny-skia`)
+# plus their image-encoding stack. The renderer-crate dependency
+# carve-out in `CLAUDE.md` ("minimal external crates when justified")
+# applies here because pure-Rust SVG rasterisation has no zero-dep
+# alternative, and the feature gate keeps the cost off any caller
+# that does not need PNG output.
+resvg = { version = "0.47", optional = true }
+tiny-skia = { version = "0.12", optional = true }
+
+[features]
+# Enables the `render_png` function. Off by default to keep the
+# transitive-dep surface small for the SVG-only common case.
+png = ["dep:resvg", "dep:tiny-skia"]

--- a/crates/render-ireal/README.md
+++ b/crates/render-ireal/README.md
@@ -62,6 +62,33 @@ assert!(svg.contains("<svg "));
 | `compute_layout` | `fn compute_layout(song: &IrealSong) -> Layout` | Computes per-bar coordinates without rendering — useful to drive a non-SVG layout (e.g. canvas, web component grid). |
 | `chord_to_typography` | `fn chord_to_typography(chord: &Chord) -> ChordTypography` | Splits a chord into root/extension/slash/bass `<tspan>`-ready spans. Public so the future PNG (#2064) / PDF (#2063) layers can compute alternative layouts. |
 | `page::*` | `pub const i32` / `pub const usize` | Page-layout constants (`PAGE_WIDTH`, `PAGE_HEIGHT`, `MARGIN_X`, `MARGIN_Y`, `HEADER_BAND_HEIGHT`, `GRID_TOP`, `BARS_PER_ROW`, `BAR_ROW_HEIGHT`, `MAX_BARS`, `MAX_CHORDS_PER_BAR`, `CHORD_FONT_SIZE_BASE`, `CHORD_FONT_SIZE_SUPERSCRIPT`, `CHORD_SUPERSCRIPT_DY`). Changing any of them is a behavioural change that requires a fixture regen. |
+| `png::render_png` | `fn render_png(song: &IrealSong, options: &PngOptions) -> Result<Vec<u8>, PngError>` | PNG rasteriser; gated behind the `png` cargo feature. Internally calls `render_svg` and rasterises via `resvg` at the supplied DPI (default 300). |
+| `png::PngOptions` | `#[non_exhaustive]` struct, `Default`, `with_dpi(u32)` | DPI configuration for `render_png`. |
+| `png::PngError` | enum, `Debug + Display + Error` | `DpiOutOfRange`, `SvgParse`, `PixmapAlloc`, `PngEncode`. |
+
+## Cargo features
+
+| Feature | Default? | Notes |
+|---|---|---|
+| `png` | off | Enables `png::render_png` + `PngOptions` + `PngError`. Pulls in `resvg` and `tiny-skia`. Off by default to keep the SVG-only consumer's transitive-dep surface small. |
+
+## PNG rasterisation
+
+```rust,ignore
+// Cargo.toml: chordsketch-render-ireal = { version = "VERSION", features = ["png"] }
+use chordsketch_ireal::IrealSong;
+use chordsketch_render_ireal::png::{render_png, PngOptions};
+
+let song = IrealSong::new();
+let png = render_png(&song, &PngOptions::default())?;            // 300 DPI
+let lo  = render_png(&song, &PngOptions::with_dpi(150))?;        // half resolution
+# Ok::<(), chordsketch_render_ireal::png::PngError>(())
+```
+
+DPI scaling assumes the SVG viewBox is in CSS px (1 px = 1/96 inch),
+matching the [CSS Values 4](https://www.w3.org/TR/css-values-4/#absolute-lengths)
+absolute-length definition. The supported DPI range is `1..=1200`;
+out-of-range values return `PngError::DpiOutOfRange`.
 
 ## Layout
 
@@ -88,7 +115,6 @@ divided into:
 | Feature | Tracking issue |
 |---|---|
 | Bravura SMuFL font for high-fidelity music glyphs | [#2062](https://github.com/koedame/chordsketch/issues/2062) (deferred — current SVG primitive approximations avoid embedding a megabyte-scale font in every export; measure the subset before re-proposing) |
-| PNG rasterization via resvg | [#2064](https://github.com/koedame/chordsketch/issues/2064) |
 | PDF output layer | [#2063](https://github.com/koedame/chordsketch/issues/2063) |
 
 ## Regenerating the golden fixtures

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -46,6 +46,17 @@
 //! mirrors the zero-external-dep posture of `chordsketch-chordpro`
 //! / `chordsketch-ireal`.
 //!
+//! Enabling the `png` cargo feature additionally pulls in `resvg`
+//! and `tiny-skia` for the [`png::render_png`] rasteriser. The
+//! feature is off by default; SVG-only consumers stay on the
+//! single-dep build.
+//!
+//! # Cargo features
+//!
+//! | Feature | Default? | Notes |
+//! |---|---|---|
+//! | `png` | off | Enables [`png::render_png`] (rasterises the SVG via `resvg`). |
+//!
 //! # Stability
 //!
 //! Pre-1.0. The SVG output structure is expected to grow new
@@ -86,6 +97,8 @@ pub mod layout;
 mod markers;
 mod music_symbols;
 pub mod page;
+#[cfg(feature = "png")]
+pub mod png;
 mod svg;
 
 use chordsketch_ireal::{Accidental, BarChord, IrealSong, KeyMode};

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -47,15 +47,18 @@
 //! / `chordsketch-ireal`.
 //!
 //! Enabling the `png` cargo feature additionally pulls in `resvg`
-//! and `tiny-skia` for the [`png::render_png`] rasteriser. The
+//! and `tiny-skia` for the `png::render_png` rasteriser. The
 //! feature is off by default; SVG-only consumers stay on the
-//! single-dep build.
+//! single-dep build. (Inline code-span — not an intra-doc link —
+//! because the `png` module is `#[cfg(feature = "png")]` and a
+//! crate-level rustdoc link would break the default-features `cargo
+//! doc --no-deps` run that gates CI.)
 //!
 //! # Cargo features
 //!
 //! | Feature | Default? | Notes |
 //! |---|---|---|
-//! | `png` | off | Enables [`png::render_png`] (rasterises the SVG via `resvg`). |
+//! | `png` | off | Enables `png::render_png` (rasterises the SVG via `resvg`). |
 //!
 //! # Stability
 //!

--- a/crates/render-ireal/src/png.rs
+++ b/crates/render-ireal/src/png.rs
@@ -131,6 +131,7 @@ impl std::error::Error for PngError {}
 /// let bytes = render_png(&song, &PngOptions::default()).unwrap();
 /// assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
 /// ```
+#[must_use = "the PNG bytes produced by render_png are expected to be consumed"]
 pub fn render_png(song: &IrealSong, options: &PngOptions) -> Result<Vec<u8>, PngError> {
     let dpi = options.dpi.unwrap_or(DEFAULT_DPI);
     if dpi == 0 || dpi > MAX_DPI {

--- a/crates/render-ireal/src/png.rs
+++ b/crates/render-ireal/src/png.rs
@@ -1,0 +1,164 @@
+//! PNG rasteriser for the iReal Pro chart renderer.
+//!
+//! Wraps [`crate::render_svg`] in a `usvg` parse + `resvg` render
+//! pipeline so callers can produce a PNG byte stream from an
+//! [`IrealSong`] without leaving the crate. Compiled only when the
+//! `png` cargo feature is enabled — see [`crate`] for the feature
+//! gate rationale.
+//!
+//! # DPI semantics
+//!
+//! The SVG document produced by [`crate::render_svg`] uses a fixed
+//! `595 × 842` viewBox (in CSS pixels). PNG rasterisation scales the
+//! output by `dpi / 96.0` because the CSS px definition fixes 1 px =
+//! `1/96` inch (per the [CSS Values 4][1] spec, §6.1). A `dpi` of
+//! 300 therefore produces a `(595 × 300/96) × (842 × 300/96)`-pixel
+//! image (≈ 1860 × 2632), suitable for printing without resampling.
+//!
+//! [1]: https://www.w3.org/TR/css-values-4/#absolute-lengths
+
+use crate::{RenderOptions, render_svg};
+use chordsketch_ireal::IrealSong;
+use std::fmt;
+
+/// CSS px → physical inch conversion factor: 1 inch = 96 CSS px.
+const CSS_PX_PER_INCH: f32 = 96.0;
+
+/// Default rasterisation density in DPI when [`PngOptions::dpi`] is
+/// `None`. Matches the AC for #2064 ("Configurable DPI (default 300)").
+pub const DEFAULT_DPI: u32 = 300;
+
+/// Hard ceiling on the rasterisation density. Caps the pixmap
+/// allocation at roughly `(595 × 1200/96) × (842 × 1200/96) × 4 B`
+/// = ~330 MiB, which is the largest size we are willing to allocate
+/// before returning [`PngError::DpiOutOfRange`]. Keeps adversarial
+/// `dpi` values from producing a multi-gigabyte allocation.
+pub const MAX_DPI: u32 = 1200;
+
+/// Caller-supplied PNG-rasterisation configuration.
+///
+/// Constructed via [`PngOptions::default`] — the struct is
+/// `#[non_exhaustive]` so future fields are non-breaking. The single
+/// field `dpi` controls the output resolution in dots-per-inch.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct PngOptions {
+    /// Output density in DPI. `None` selects [`DEFAULT_DPI`] (300).
+    /// Must be in `1 ..= MAX_DPI` when `Some`; values outside that
+    /// range cause [`render_png`] to return
+    /// [`PngError::DpiOutOfRange`].
+    pub dpi: Option<u32>,
+}
+
+impl PngOptions {
+    /// Creates a [`PngOptions`] with the supplied DPI.
+    ///
+    /// `dpi` is recorded verbatim — this constructor performs no
+    /// range validation. Out-of-range values surface as
+    /// [`PngError::DpiOutOfRange`] from [`render_png`] so the rule
+    /// that "validation lives at the public boundary" (per
+    /// `.claude/rules/defensive-inputs.md`) has a single
+    /// implementation site at the rendering boundary rather than
+    /// duplicated copies on the constructor and the renderer.
+    ///
+    /// Construction does not fail; pass any `u32`. Use
+    /// [`PngOptions::default`] when the default DPI is fine.
+    #[must_use]
+    pub const fn with_dpi(dpi: u32) -> Self {
+        Self { dpi: Some(dpi) }
+    }
+}
+
+/// Errors produced by [`render_png`].
+#[derive(Debug)]
+pub enum PngError {
+    /// The supplied DPI is `0` or exceeds [`MAX_DPI`]. The contained
+    /// value is the offending input.
+    DpiOutOfRange(u32),
+    /// `usvg` rejected the SVG produced by [`render_svg`]. The
+    /// renderer is supposed to emit only well-formed SVG, so a
+    /// surface here is an internal-consistency bug — the variant
+    /// exists so we can surface the underlying message rather than
+    /// panicking.
+    SvgParse(String),
+    /// Pixel-buffer allocation failed. `tiny_skia::Pixmap::new`
+    /// returns `None` when the requested dimensions overflow the
+    /// internal buffer-size invariant; the contained tuple is
+    /// `(width, height)` in pixels.
+    PixmapAlloc(u32, u32),
+    /// PNG encoding failed. The contained string is the underlying
+    /// `tiny_skia` error message.
+    PngEncode(String),
+}
+
+impl fmt::Display for PngError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DpiOutOfRange(dpi) => {
+                write!(f, "dpi {dpi} is out of the supported range 1..={MAX_DPI}")
+            }
+            Self::SvgParse(msg) => write!(f, "SVG parse failed: {msg}"),
+            Self::PixmapAlloc(w, h) => write!(f, "pixmap allocation failed for {w} x {h} pixels"),
+            Self::PngEncode(msg) => write!(f, "PNG encode failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for PngError {}
+
+/// Renders an iReal Pro chart as a PNG byte stream.
+///
+/// Internally calls [`render_svg`] and rasterises the result via
+/// `resvg` at the supplied DPI (default 300). Returns the encoded
+/// PNG bytes.
+///
+/// # Errors
+///
+/// - [`PngError::DpiOutOfRange`] — `options.dpi` is `0` or above
+///   [`MAX_DPI`].
+/// - [`PngError::SvgParse`] — `usvg` could not parse the SVG. This
+///   indicates an internal renderer bug; please file an issue.
+/// - [`PngError::PixmapAlloc`] — pixel buffer allocation failed.
+/// - [`PngError::PngEncode`] — PNG encoding failed.
+///
+/// # Example
+///
+/// ```no_run
+/// use chordsketch_ireal::IrealSong;
+/// use chordsketch_render_ireal::png::{PngOptions, render_png};
+///
+/// let song = IrealSong::new();
+/// let bytes = render_png(&song, &PngOptions::default()).unwrap();
+/// assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+/// ```
+pub fn render_png(song: &IrealSong, options: &PngOptions) -> Result<Vec<u8>, PngError> {
+    let dpi = options.dpi.unwrap_or(DEFAULT_DPI);
+    if dpi == 0 || dpi > MAX_DPI {
+        return Err(PngError::DpiOutOfRange(dpi));
+    }
+    let svg = render_svg(song, &RenderOptions::default());
+    let usvg_options = resvg::usvg::Options::default();
+    let tree = resvg::usvg::Tree::from_str(&svg, &usvg_options)
+        .map_err(|e| PngError::SvgParse(e.to_string()))?;
+
+    // The SVG document carries dimensions in CSS px (96 DPI). Scaling
+    // by `dpi / 96` turns those into the requested print density.
+    let scale = dpi as f32 / CSS_PX_PER_INCH;
+    let svg_size = tree.size();
+    // `ceil` so a non-integer scaled dimension does not chop the
+    // last partial row / column. Casting after `ceil` is safe because
+    // the inputs are bounded: `svg_size <= page::PAGE_*` (842 max)
+    // and `scale <= MAX_DPI / CSS_PX_PER_INCH` (12.5), so the product
+    // fits in `u32` with comfort.
+    let width = (svg_size.width() * scale).ceil() as u32;
+    let height = (svg_size.height() * scale).ceil() as u32;
+    let mut pixmap =
+        tiny_skia::Pixmap::new(width, height).ok_or(PngError::PixmapAlloc(width, height))?;
+
+    let transform = tiny_skia::Transform::from_scale(scale, scale);
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+    pixmap
+        .encode_png()
+        .map_err(|e| PngError::PngEncode(e.to_string()))
+}

--- a/crates/render-ireal/tests/png.rs
+++ b/crates/render-ireal/tests/png.rs
@@ -1,0 +1,187 @@
+//! PNG rasteriser tests.
+//!
+//! Uses **structural** assertions rather than byte- or pixel-hash
+//! equality. Font rasterisation is non-deterministic across
+//! `fontdb` populations (CI Linux fonts vs developer macOS fonts vs
+//! Windows fonts), so a strict pixel-hash snapshot would either be
+//! permanently flaky on non-Linux runners or force the test to skip
+//! on every platform that does not match the snapshot author's box.
+//! Structural checks let every supported platform exercise the full
+//! rasterisation pipeline (`render_svg` → `usvg::Tree::from_str` →
+//! `resvg::render` → `tiny_skia::Pixmap::encode_png`) and catch the
+//! defect classes the PNG output is meant to guard against:
+//!
+//! - SVG produced by `render_svg` becomes invalid (parse failure).
+//! - The image dimensions drift from the documented DPI scaling.
+//! - The encoder stops emitting a valid PNG header / IEND marker.
+
+#![cfg(feature = "png")]
+
+use chordsketch_ireal::{
+    Accidental, Bar, BarChord, BarLine, BeatPosition, Chord, ChordQuality, ChordRoot, IrealSong,
+    KeyMode, KeySignature, MusicalSymbol, Section, SectionLabel, TimeSignature,
+};
+use chordsketch_render_ireal::{
+    PAGE_HEIGHT, PAGE_WIDTH,
+    png::{DEFAULT_DPI, MAX_DPI, PngError, PngOptions, render_png},
+};
+
+const PNG_SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'];
+
+/// Decodes a PNG header to `(width, height)` in pixels. Panics on
+/// malformed input — the test suite only feeds output from
+/// [`render_png`], which must always be well-formed.
+fn png_dimensions(bytes: &[u8]) -> (u32, u32) {
+    assert!(bytes.len() >= 24, "PNG too short: {}", bytes.len());
+    assert_eq!(&bytes[..8], &PNG_SIGNATURE, "missing PNG signature");
+    // Bytes 8..12 are the IHDR length (always 13). 12..16 = "IHDR".
+    assert_eq!(&bytes[12..16], b"IHDR", "first chunk is not IHDR");
+    let width = u32::from_be_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]);
+    let height = u32::from_be_bytes([bytes[20], bytes[21], bytes[22], bytes[23]]);
+    (width, height)
+}
+
+/// Asserts the trailing 12 bytes are the IEND chunk
+/// (`00 00 00 00 49 45 4E 44 AE 42 60 82`).
+fn assert_png_iend(bytes: &[u8]) {
+    let tail = &bytes[bytes.len() - 12..];
+    assert_eq!(
+        tail,
+        &[0, 0, 0, 0, b'I', b'E', b'N', b'D', 0xAE, 0x42, 0x60, 0x82],
+        "missing IEND footer"
+    );
+}
+
+fn build_basic_song() -> IrealSong {
+    let chord = Chord::triad(ChordRoot::natural('C'), ChordQuality::Minor7);
+    let bar_chord = BarChord {
+        chord,
+        position: BeatPosition::on_beat(1).unwrap(),
+    };
+    let bar = Bar {
+        start: BarLine::OpenRepeat,
+        end: BarLine::CloseRepeat,
+        chords: vec![bar_chord],
+        ending: None,
+        symbol: Some(MusicalSymbol::Segno),
+    };
+    IrealSong {
+        title: "Autumn Leaves".into(),
+        composer: Some("Joseph Kosma".into()),
+        style: Some("Medium Swing".into()),
+        key_signature: KeySignature {
+            root: ChordRoot {
+                note: 'E',
+                accidental: Accidental::Natural,
+            },
+            mode: KeyMode::Minor,
+        },
+        time_signature: TimeSignature::default(),
+        tempo: Some(120),
+        transpose: 0,
+        sections: vec![Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar],
+        }],
+    }
+}
+
+#[test]
+fn empty_song_produces_well_formed_png_at_default_dpi() {
+    let song = IrealSong::new();
+    let bytes = render_png(&song, &PngOptions::default()).expect("render_png");
+    assert!(!bytes.is_empty());
+    let (width, height) = png_dimensions(&bytes);
+    // Default DPI = 300; CSS px/inch = 96; the SVG viewBox is
+    // `PAGE_WIDTH × PAGE_HEIGHT` in CSS px. Use ceiling division so
+    // the assertion matches the renderer's `ceil()` rounding.
+    let expected_w = ((PAGE_WIDTH as u32) * DEFAULT_DPI).div_ceil(96);
+    let expected_h = ((PAGE_HEIGHT as u32) * DEFAULT_DPI).div_ceil(96);
+    assert_eq!(
+        (width, height),
+        (expected_w, expected_h),
+        "PNG dimensions diverged from DPI scaling"
+    );
+    assert_png_iend(&bytes);
+}
+
+#[test]
+fn basic_song_produces_well_formed_png() {
+    let song = build_basic_song();
+    let bytes = render_png(&song, &PngOptions::default()).expect("render_png");
+    assert!(
+        bytes.len() > 1024,
+        "PNG suspiciously small: {} bytes",
+        bytes.len()
+    );
+    let (width, height) = png_dimensions(&bytes);
+    let expected_w = ((PAGE_WIDTH as u32) * DEFAULT_DPI).div_ceil(96);
+    let expected_h = ((PAGE_HEIGHT as u32) * DEFAULT_DPI).div_ceil(96);
+    assert_eq!((width, height), (expected_w, expected_h));
+    assert_png_iend(&bytes);
+}
+
+#[test]
+fn custom_dpi_changes_pixel_dimensions() {
+    let song = IrealSong::new();
+    let opts = PngOptions::with_dpi(150);
+    let bytes = render_png(&song, &opts).expect("render_png");
+    let (width, height) = png_dimensions(&bytes);
+    let expected_w = ((PAGE_WIDTH as u32) * 150).div_ceil(96);
+    let expected_h = ((PAGE_HEIGHT as u32) * 150).div_ceil(96);
+    assert_eq!(
+        (width, height),
+        (expected_w, expected_h),
+        "150 DPI did not produce the expected dimensions"
+    );
+}
+
+#[test]
+fn dpi_zero_returns_dpi_out_of_range() {
+    let song = IrealSong::new();
+    let bad = PngOptions::with_dpi(0);
+    let err = render_png(&song, &bad).expect_err("zero DPI must error");
+    assert!(matches!(err, PngError::DpiOutOfRange(0)));
+}
+
+#[test]
+fn dpi_above_max_returns_dpi_out_of_range() {
+    let song = IrealSong::new();
+    let bad = PngOptions::with_dpi(MAX_DPI + 1);
+    let err = render_png(&song, &bad).expect_err("oversized DPI must error");
+    assert!(matches!(err, PngError::DpiOutOfRange(d) if d == MAX_DPI + 1));
+}
+
+#[test]
+fn dpi_at_boundary_succeeds() {
+    let song = IrealSong::new();
+    let one_dpi = PngOptions::with_dpi(1);
+    let bytes = render_png(&song, &one_dpi).expect("dpi=1 is in range");
+    let (width, height) = png_dimensions(&bytes);
+    let expected_w = (PAGE_WIDTH as u32).div_ceil(96);
+    let expected_h = (PAGE_HEIGHT as u32).div_ceil(96);
+    assert_eq!((width, height), (expected_w, expected_h));
+}
+
+#[test]
+fn default_options_use_default_dpi() {
+    let song = IrealSong::new();
+    let default_bytes = render_png(&song, &PngOptions::default()).expect("default");
+    let explicit = PngOptions::with_dpi(DEFAULT_DPI);
+    let explicit_bytes = render_png(&song, &explicit).expect("explicit default");
+    assert_eq!(
+        default_bytes, explicit_bytes,
+        "PngOptions::default() must equal explicit DEFAULT_DPI"
+    );
+}
+
+#[test]
+fn png_error_display_includes_dpi() {
+    let err = PngError::DpiOutOfRange(9999);
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("9999"),
+        "error message dropped DPI value: {msg}"
+    );
+    assert!(msg.contains(&MAX_DPI.to_string()));
+}

--- a/crates/render-ireal/tests/png.rs
+++ b/crates/render-ireal/tests/png.rs
@@ -185,3 +185,27 @@ fn png_error_display_includes_dpi() {
     );
     assert!(msg.contains(&MAX_DPI.to_string()));
 }
+
+#[test]
+fn png_error_display_covers_remaining_variants() {
+    // The other three variants (`SvgParse`, `PixmapAlloc`,
+    // `PngEncode`) only fire on internal-consistency / OOM bugs that
+    // are not reachable via `render_png` with any production input.
+    // Construct each variant directly and assert the `Display` arm
+    // includes the diagnostic payload — this is the only path that
+    // exercises the formatter for those branches and keeps the
+    // patch-coverage gate from regressing if a maintainer tweaks one
+    // of the messages.
+    let svg = format!("{}", PngError::SvgParse("unexpected token".into()));
+    assert!(svg.contains("SVG parse failed"));
+    assert!(svg.contains("unexpected token"));
+
+    let alloc = format!("{}", PngError::PixmapAlloc(123, 456));
+    assert!(alloc.contains("123"));
+    assert!(alloc.contains("456"));
+    assert!(alloc.contains("pixmap allocation failed"));
+
+    let encode = format!("{}", PngError::PngEncode("io error".into()));
+    assert!(encode.contains("PNG encode failed"));
+    assert!(encode.contains("io error"));
+}


### PR DESCRIPTION
## What

Adds `chordsketch_render_ireal::png::render_png` behind a new `png`
cargo feature. The rasteriser internally calls `render_svg`, parses
the SVG with `usvg::Tree::from_str`, and rasterises with `resvg::render`
into a `tiny_skia::Pixmap`, returning encoded PNG bytes.

`PngOptions::dpi` is configurable (default 300, range `1..=1200`);
out-of-range values surface as `PngError::DpiOutOfRange`. DPI scaling
follows the [CSS Values 4 absolute-length](https://www.w3.org/TR/css-values-4/#absolute-lengths)
definition (1 px = 1/96 inch), so the SVG viewBox in CSS px maps
cleanly to physical-density print output.

## Why

The iReal Pro tracker (#2050) needs a PNG output to round out the
non-SVG export surface alongside PDF (#2063). PNG rasterisation
unblocks downstream binding work (#2067) and gives the playground
preview / future Tauri desktop chart export a printable raster path.

The feature is **off by default**. Without the gate the SVG-only
consumer keeps the same single-dependency build; turning it on adds
`resvg` / `usvg` / `tiny-skia` and their image-encoding stack. The
renderer-crate dependency carve-out in `CLAUDE.md` ("minimal
external crates when justified") covers this — pure-Rust SVG
rasterisation has no zero-dep alternative, and the feature gate
keeps the cost off any caller that does not need PNG output.

## Bravura note

The AC mentions "Bravura font embedded symbols render correctly in
PNG"; per the deferred decision recorded in `CLAUDE.md`
(render-ireal Roadmap section), the music-symbol glyphs use SVG
primitive approximations (not Bravura SMuFL). The PNG rasteriser
inherits whatever the SVG layer produces, so the existing primitive
glyphs rasterise the same way they render in the SVG viewer.

## Test results

- `cargo test -p chordsketch-render-ireal --features png` — 8 PNG
  tests pass (structural PNG signature / IHDR / IEND assertions
  across DPI 1, 150, 300 and the boundary error cases).
- `cargo test --workspace --exclude chordsketch-desktop` — no SVG
  regressions.
- `cargo clippy -p chordsketch-render-ireal --features png
  --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p chordsketch-render-ireal
  --features png --no-deps` — clean (intra-doc links resolve).

## Tests use structural, not pixel-hash, equality

Font rasterisation is non-deterministic across `fontdb` populations
(CI Linux fonts vs developer macOS fonts vs Windows fonts). A
strict pixel-hash snapshot would either be permanently flaky on
non-Linux runners or force the test to skip on every platform that
does not match the snapshot author's box. Structural checks
(PNG signature, IHDR-derived dimensions, IEND footer) let every
supported platform exercise the full pipeline (`render_svg` →
`usvg::Tree::from_str` → `resvg::render` →
`tiny_skia::Pixmap::encode_png`) and catch the defect classes the
PNG output is meant to guard against.

## CI changes

- `ci.yml` test job: appended `cargo test -p
  chordsketch-render-ireal --features png` after the workspace test
  step (so the feature-gated `tests/png.rs` actually compiles).
- `ci.yml` clippy job: appended `cargo clippy -p
  chordsketch-render-ireal --features png --all-targets -- -D
  warnings` after the workspace clippy step.
- `coverage.yml`: collection runs with `--features
  chordsketch-render-ireal/png` so the new module is in both the
  numerator and denominator of the patch coverage gate.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`:

- **Renderers (text / HTML / PDF)** — N/A. The PNG rasteriser is on
  the `chordsketch-render-ireal` crate, which is a separate
  rendering target from the ChordPro renderers and does not share
  match arms or directive validation.
- **Bindings (FFI / WASM / NAPI)** — none currently consume
  `chordsketch-render-ireal`. Exposing the PNG API across bindings
  is #2067 territory.
- **External tool invocations** — N/A.
- **Sanitiser functions / blocklists** — N/A.

The DPI clamp lives at the public boundary in `render_png`
(`.claude/rules/defensive-inputs.md`) and is the only validation
site; the constructor `PngOptions::with_dpi` does not duplicate the
check, so there is one source of truth.

Closes #2064.