### PR TITLE
feat(render-ireal): PDF conversion via svg2pdf (#2063)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,15 @@ jobs:
         # coverage is tracked in #2077.
         run: cargo clippy --workspace --exclude chordsketch-desktop --all-targets -- -D warnings
 
-      - name: Clippy lints (chordsketch-render-ireal --features png)
-        # The `png` feature is off by default (#2064); the workspace
-        # clippy run above does not exercise it, so a clippy
-        # regression inside the feature-gated module would not
-        # surface. Mirror the feature-gated test step in the test
-        # job and lint it explicitly.
-        run: cargo clippy -p chordsketch-render-ireal --features png --all-targets -- -D warnings
+      - name: Clippy lints (chordsketch-render-ireal --features png,pdf)
+        # The `png` (#2064) and `pdf` (#2063) features are both off
+        # by default; the workspace clippy run above does not
+        # exercise them, so a clippy regression inside either
+        # feature-gated module would not surface. Lint with both
+        # features in one pass — they share the same `usvg` 0.43
+        # transitive line, so this does not double-compile the SVG
+        # parser.
+        run: cargo clippy -p chordsketch-render-ireal --features png,pdf --all-targets -- -D warnings
 
   doc:
     name: Docs
@@ -88,15 +90,17 @@ jobs:
       - name: Build docs (warnings as errors)
         # See the clippy job for the `chordsketch-desktop` exclusion rationale.
         #
-        # `--features chordsketch-render-ireal/png` doc-checks the
-        # feature-gated `png` module (#2064) too. Without it, broken
-        # intra-doc links inside that module would not surface, and a
-        # link from the always-on crate root into the gated module
-        # would fail rustdoc's broken-link check anyway because the
-        # gated module would not be in the rendered tree.
+        # `--features chordsketch-render-ireal/png,chordsketch-render-ireal/pdf`
+        # doc-checks the feature-gated `png` (#2064) and `pdf`
+        # (#2063) modules too. Without these, broken intra-doc
+        # links inside either module would not surface, and a link
+        # from the always-on crate root into a gated module would
+        # fail rustdoc's broken-link check anyway because the gated
+        # module would not be in the rendered tree.
         run: |
           cargo doc --workspace --exclude chordsketch-desktop \
-            --features chordsketch-render-ireal/png --no-deps
+            --features chordsketch-render-ireal/png,chordsketch-render-ireal/pdf \
+            --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
 
@@ -195,13 +199,16 @@ jobs:
         # See the clippy job for the `chordsketch-desktop` exclusion rationale.
         run: cargo test --workspace --exclude chordsketch-desktop
 
-      - name: Run feature-gated tests (chordsketch-render-ireal --features png)
-        # The `png` feature is off by default to keep the
-        # transitive-dep surface small for SVG-only consumers
-        # (#2064). Without an explicit feature pass here the
-        # `tests/png.rs` suite never compiles in CI; a regression in
-        # the `render_png` pipeline would slip through unnoticed.
-        run: cargo test -p chordsketch-render-ireal --features png
+      - name: Run feature-gated tests (chordsketch-render-ireal --features png,pdf)
+        # The `png` (#2064) and `pdf` (#2063) features are both off
+        # by default to keep the transitive-dep surface small for
+        # SVG-only consumers. Without an explicit feature pass here
+        # the `tests/png.rs` and `tests/pdf.rs` suites never compile
+        # in CI; a regression in either pipeline would slip through
+        # unnoticed. Both features share the same `usvg` 0.43 line
+        # so this single test run does not double-compile the SVG
+        # parser stack.
+        run: cargo test -p chordsketch-render-ireal --features png,pdf
 
   desktop-smoke:
     name: Desktop smoke (Linux)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,14 +67,15 @@ jobs:
         # `desktop-smoke` in ci.yml). See the matching exclusions in
         # ci.yml and .claude/rules/ci-parallelization.md.
         #
-        # `--features chordsketch-render-ireal/png` turns on the PNG
-        # rasteriser (#2064) so its module compiles and the
-        # feature-gated `tests/png.rs` suite runs — without this,
-        # the patch coverage gate would skip the new lines because
-        # they would not be in the compiled crate.
+        # `--features chordsketch-render-ireal/png,chordsketch-render-ireal/pdf`
+        # turns on the PNG rasteriser (#2064) and PDF converter
+        # (#2063) so both feature-gated modules compile and their
+        # respective test suites run — without this, the patch
+        # coverage gate would skip the new lines because they would
+        # not be in the compiled crate.
         run: |
           cargo llvm-cov --workspace --exclude chordsketch-desktop \
-            --features chordsketch-render-ireal/png \
+            --features chordsketch-render-ireal/png,chordsketch-render-ireal/pdf \
             --lcov --output-path lcov.info
 
       - name: Upload to Codecov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -772,6 +786,7 @@ version = "0.3.0"
 dependencies = [
  "chordsketch-ireal",
  "resvg",
+ "svg2pdf",
  "tiny-skia",
 ]
 
@@ -783,7 +798,7 @@ dependencies = [
  "flate2",
  "libc",
  "pdf-extract",
- "ttf-parser",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -1581,6 +1596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,16 +1615,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+checksum = "37be9fc20d966be438cd57a45767f73349477fb0f85ce86e000557f787298afb"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
+ "ttf-parser 0.24.1",
 ]
 
 [[package]]
@@ -1928,6 +1952,16 @@ name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2293,7 +2327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2411,10 +2445,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "image-webp"
-version = "0.2.4"
+name = "image"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif 0.14.2",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904"
 dependencies = [
  "byteorder-lite",
  "quick-error",
@@ -2651,6 +2702,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+dependencies = [
+ "arrayvec",
+ "euclid 0.22.14",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,7 +2854,7 @@ dependencies = [
  "sha2",
  "stringprep",
  "thiserror 2.0.18",
- "ttf-parser",
+ "ttf-parser 0.25.1",
  "weezl",
 ]
 
@@ -2950,6 +3012,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,7 +3036,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -3437,6 +3509,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdf-writer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df03c7d216de06f93f398ef06f1385a60f2c597bb96f8195c8d98e08a26b1d5"
+dependencies = [
+ "bitflags 2.11.0",
+ "itoa",
+ "memchr",
+ "ryu",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3711,6 +3795,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,6 +3972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,6 +4136,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "read-fonts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,11 +4264,11 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.45.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+checksum = "c7314563c59c7ce31c18e23ad3dd092c37b928a0fa4e1c0a1a6504351ab411d1"
 dependencies = [
- "gif",
+ "gif 0.13.3",
  "image-webp",
  "log",
  "pico-args",
@@ -4163,7 +4276,7 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -4328,21 +4441,27 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustybuzz"
-version = "0.20.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+checksum = "c85d1ccd519e61834798eb52c4e886e8c2d7d698dd3d6ce0b1b47eb8557f1181"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "core_maths",
  "log",
  "smallvec",
- "ttf-parser",
+ "ttf-parser 0.24.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
  "unicode-script",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4751,6 +4870,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skrifa"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,10 +5052,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subsetter"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6895a12ac5599bb6057362f00e8a3cf1daab4df33f553a55690a44e4fed8d0"
+dependencies = [
+ "kurbo 0.12.0",
+ "rustc-hash",
+ "skrifa",
+ "write-fonts",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svg2pdf"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5014c9dadcf318fb7ef8c16438e95abcc9de1ae24d60d5bccc64c55100c50364"
+dependencies = [
+ "fontdb",
+ "image",
+ "log",
+ "miniz_oxide",
+ "once_cell",
+ "pdf-writer",
+ "resvg",
+ "siphasher 1.0.2",
+ "subsetter",
+ "tiny-skia",
+ "ttf-parser 0.24.1",
+ "usvg",
+]
 
 [[package]]
 name = "svgtypes"
@@ -4934,7 +5095,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
  "siphasher 1.0.2",
 ]
 
@@ -5154,7 +5315,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5548,7 +5709,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -5912,7 +6073,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -5926,12 +6087,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.25.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
 dependencies = [
  "core_maths",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "type1-encoding-parser"
@@ -6014,15 +6181,15 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+checksum = "64af057ad7466495ca113126be61838d8af947f41d93a949980b2389a118082f"
 
 [[package]]
 name = "unicode-ccc"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+checksum = "260bc6647b3893a9a90668360803a15f96b85a5257b1c3a0c3daf6ae2496de42"
 
 [[package]]
 name = "unicode-ident"
@@ -6241,16 +6408,16 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.45.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+checksum = "6803057b5cbb426e9fb8ce2216f3a9b4ca1dd2c705ba3cbebc13006e437735fd"
 dependencies = [
  "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
  "roxmltree",
@@ -7231,6 +7398,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "write-fonts"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
+dependencies = [
+ "font-types",
+ "indexmap 2.13.1",
+ "kurbo 0.12.0",
+ "log",
+ "read-fonts",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7506,12 +7686,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-jpeg"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core 0.5.1",
 ]
 
 [[package]]

--- a/crates/render-ireal/Cargo.toml
+++ b/crates/render-ireal/Cargo.toml
@@ -15,26 +15,35 @@ readme = "README.md"
 [dependencies]
 chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
 
-# `resvg` and `tiny-skia` are pulled in only when the `png` feature is
-# enabled. Without the gate the default build stays at the same lean
-# transitive-dep surface as the SVG-only renderer (just
-# `chordsketch-ireal`); turning the feature on adds the SVG parser
-# (`usvg`, re-exported by `resvg`) and the rasteriser (`tiny-skia`)
-# plus their image-encoding stack. The renderer-crate dependency
-# carve-out in `CLAUDE.md` ("minimal external crates when justified")
-# applies here because pure-Rust SVG rasterisation has no zero-dep
-# alternative, and the feature gate keeps the cost off any caller
-# that does not need PNG output.
+# `resvg` / `tiny-skia` (PNG rasteriser, #2064) and `svg2pdf` (PDF
+# converter, #2063) are pulled in only when the corresponding
+# feature is enabled. Without either gate the default build stays
+# on the lean single-dep transitive surface (just
+# `chordsketch-ireal`).
 #
-# Pinned to 0.45.x (resvg) and 0.11.x (tiny-skia) because the
-# 0.46.0 / 0.47.0 line bumps the resvg MSRV to 1.87, but this
-# workspace's `rust-version = "1.85"` (set in the top-level
-# `[workspace.package]`) is exercised by the CI test matrix.
-# Lifting either pin requires raising the workspace MSRV first.
-resvg = { version = "0.45", optional = true }
+# All three are pinned to versions that share a usvg 0.43 line so
+# enabling both features does not bring two unrelated `usvg`
+# trees into the dep graph (svg2pdf 0.12 hard-requires resvg 0.43
+# / usvg 0.43 / tiny-skia 0.11). Keeping the PNG side on the same
+# 0.43 line as the PDF side means a single set of SVG-parsing
+# crates, instead of one set per feature, when both are enabled.
+#
+# The renderer-crate dependency carve-out in `CLAUDE.md`
+# ("minimal external crates when justified") covers each addition
+# — pure-Rust SVG rasterisation and SVG-to-PDF conversion both
+# have no zero-dep alternative, and the feature gates keep the
+# cost off any caller that does not need raster / PDF output.
+#
+# Lifting the pin requires raising the workspace MSRV first
+# (resvg 0.45+ requires Rust 1.87, the workspace pins 1.85).
+resvg = { version = "0.43", optional = true }
 tiny-skia = { version = "0.11", optional = true }
+svg2pdf = { version = "0.12", optional = true }
 
 [features]
 # Enables the `render_png` function. Off by default to keep the
 # transitive-dep surface small for the SVG-only common case.
 png = ["dep:resvg", "dep:tiny-skia"]
+# Enables the `render_pdf` function. Off by default for the same
+# reason as `png`.
+pdf = ["dep:svg2pdf"]

--- a/crates/render-ireal/README.md
+++ b/crates/render-ireal/README.md
@@ -65,12 +65,16 @@ assert!(svg.contains("<svg "));
 | `png::render_png` | `fn render_png(song: &IrealSong, options: &PngOptions) -> Result<Vec<u8>, PngError>` | PNG rasteriser; gated behind the `png` cargo feature. Internally calls `render_svg` and rasterises via `resvg` at the supplied DPI (default 300). |
 | `png::PngOptions` | `#[non_exhaustive]` struct, `Default`, `with_dpi(u32)` | DPI configuration for `render_png`. |
 | `png::PngError` | enum, `Debug + Display + Error` | `DpiOutOfRange`, `SvgParse`, `PixmapAlloc`, `PngEncode`. |
+| `pdf::render_pdf` | `fn render_pdf(song: &IrealSong, options: &PdfOptions) -> Result<Vec<u8>, PdfError>` | PDF converter; gated behind the `pdf` cargo feature. Internally calls `render_svg` and converts via `svg2pdf` to a single-page A4 PDF. |
+| `pdf::PdfOptions` | `#[non_exhaustive]` struct, `Default` | Configuration carrier for `render_pdf` (currently empty; struct kept for forward-compatibility). |
+| `pdf::PdfError` | enum, `Debug + Display + Error` | `SvgParse`, `Conversion`. |
 
 ## Cargo features
 
 | Feature | Default? | Notes |
 |---|---|---|
 | `png` | off | Enables `png::render_png` + `PngOptions` + `PngError`. Pulls in `resvg` and `tiny-skia`. Off by default to keep the SVG-only consumer's transitive-dep surface small. |
+| `pdf` | off | Enables `pdf::render_pdf` + `PdfOptions` + `PdfError`. Pulls in `svg2pdf` (and its transitive `usvg` / `pdf-writer` / `subsetter` stack). Off by default for the same reason as `png`. |
 
 ## PNG rasterisation
 
@@ -89,6 +93,25 @@ DPI scaling assumes the SVG viewBox is in CSS px (1 px = 1/96 inch),
 matching the [CSS Values 4](https://www.w3.org/TR/css-values-4/#absolute-lengths)
 absolute-length definition. The supported DPI range is `1..=1200`;
 out-of-range values return `PngError::DpiOutOfRange`.
+
+## PDF conversion
+
+```rust,ignore
+// Cargo.toml: chordsketch-render-ireal = { version = "VERSION", features = ["pdf"] }
+use chordsketch_ireal::IrealSong;
+use chordsketch_render_ireal::pdf::{render_pdf, PdfOptions};
+
+let song = IrealSong::new();
+let pdf = render_pdf(&song, &PdfOptions::default())?;
+assert_eq!(&pdf[..5], b"%PDF-");
+# Ok::<(), chordsketch_render_ireal::pdf::PdfError>(())
+```
+
+Emits a single-page A4 PDF (595 × 842 pt) with the chart as
+embedded vector content. Letter-sized output and multi-page
+overflow handling are deferred — the SVG renderer is itself
+single-page, so multi-page PDF would need SVG-side pagination
+first.
 
 ## Layout
 
@@ -115,7 +138,7 @@ divided into:
 | Feature | Tracking issue |
 |---|---|
 | Bravura SMuFL font for high-fidelity music glyphs | [#2062](https://github.com/koedame/chordsketch/issues/2062) (deferred — current SVG primitive approximations avoid embedding a megabyte-scale font in every export; measure the subset before re-proposing) |
-| PDF output layer | [#2063](https://github.com/koedame/chordsketch/issues/2063) |
+| Letter page size + multi-page PDF overflow | follow-up of [#2063](https://github.com/koedame/chordsketch/issues/2063) (current PDF emits single-page A4) |
 
 ## Regenerating the golden fixtures
 

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -47,18 +47,20 @@
 //! / `chordsketch-ireal`.
 //!
 //! Enabling the `png` cargo feature additionally pulls in `resvg`
-//! and `tiny-skia` for the `png::render_png` rasteriser. The
-//! feature is off by default; SVG-only consumers stay on the
-//! single-dep build. (Inline code-span — not an intra-doc link —
-//! because the `png` module is `#[cfg(feature = "png")]` and a
-//! crate-level rustdoc link would break the default-features `cargo
-//! doc --no-deps` run that gates CI.)
+//! and `tiny-skia` for the `png::render_png` rasteriser; enabling
+//! `pdf` pulls in `svg2pdf` for the `pdf::render_pdf` converter.
+//! Both features are off by default; SVG-only consumers stay on
+//! the single-dep build. (Inline code-spans — not intra-doc links —
+//! because the `png` and `pdf` modules are `#[cfg(feature = ...)]`
+//! and a crate-level rustdoc link would break the default-features
+//! `cargo doc --no-deps` run that gates CI.)
 //!
 //! # Cargo features
 //!
 //! | Feature | Default? | Notes |
 //! |---|---|---|
 //! | `png` | off | Enables `png::render_png` (rasterises the SVG via `resvg`). |
+//! | `pdf` | off | Enables `pdf::render_pdf` (converts the SVG to PDF via `svg2pdf`). |
 //!
 //! # Stability
 //!
@@ -100,6 +102,8 @@ pub mod layout;
 mod markers;
 mod music_symbols;
 pub mod page;
+#[cfg(feature = "pdf")]
+pub mod pdf;
 #[cfg(feature = "png")]
 pub mod png;
 mod svg;

--- a/crates/render-ireal/src/pdf.rs
+++ b/crates/render-ireal/src/pdf.rs
@@ -92,6 +92,7 @@ impl std::error::Error for PdfError {}
 /// let bytes = render_pdf(&song, &PdfOptions::default()).unwrap();
 /// assert_eq!(&bytes[..5], b"%PDF-");
 /// ```
+#[must_use = "the PDF bytes produced by render_pdf are expected to be consumed"]
 pub fn render_pdf(song: &IrealSong, _options: &PdfOptions) -> Result<Vec<u8>, PdfError> {
     let svg = render_svg(song, &RenderOptions::default());
     let usvg_options = svg2pdf::usvg::Options::default();

--- a/crates/render-ireal/src/pdf.rs
+++ b/crates/render-ireal/src/pdf.rs
@@ -1,0 +1,106 @@
+//! PDF converter for the iReal Pro chart renderer.
+//!
+//! Wraps [`crate::render_svg`] in a `usvg` parse + `svg2pdf::to_pdf`
+//! pipeline so callers can produce a PDF byte stream from an
+//! [`IrealSong`] without leaving the crate. Compiled only when the
+//! `pdf` cargo feature is enabled — see [`crate`] for the feature
+//! gate rationale.
+//!
+//! # Page geometry
+//!
+//! The SVG renderer's `595 × 842` viewBox in CSS px (1 px = 1/96
+//! inch) maps to `595 × 842` PDF user-space points at the assumed
+//! 72 DPI svg2pdf uses, which is exactly ISO 216 A4
+//! (210 × 297 mm = 595 × 842 pt). The output PDF therefore lands
+//! on A4 with the chart filling the page; no margin clipping or
+//! content scaling occurs.
+//!
+//! `Letter` (612 × 792 pt) is not in scope for this initial cut —
+//! see the `## Deferred` note in the PR body.
+//!
+//! # Single-page scope
+//!
+//! The current renderer emits one page. Multi-page support is
+//! deferred because the SVG renderer itself is single-page; an
+//! overflow path needs SVG-side pagination first. Charts longer
+//! than [`crate::page::MAX_BARS`] (256 bars) are truncated by the
+//! SVG renderer well before any PDF page would overflow.
+
+use crate::{RenderOptions, render_svg};
+use chordsketch_ireal::IrealSong;
+use std::fmt;
+
+/// `svg2pdf` assumes 72 DPI when converting an SVG with CSS-px
+/// dimensions to PDF user-space points; that matches our
+/// `PAGE_WIDTH × PAGE_HEIGHT = 595 × 842` viewBox to A4.
+const PDF_DPI: f32 = 72.0;
+
+/// Caller-supplied PDF-conversion configuration.
+///
+/// Constructed via [`PdfOptions::default`] — the struct is
+/// `#[non_exhaustive]` so future fields (e.g. `page_size`,
+/// `compression`) are non-breaking.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PdfOptions {}
+
+/// Errors produced by [`render_pdf`].
+#[derive(Debug)]
+pub enum PdfError {
+    /// `usvg` rejected the SVG produced by [`render_svg`]. The
+    /// renderer is supposed to emit only well-formed SVG, so a
+    /// surface here is an internal-consistency bug — the variant
+    /// exists so we can surface the underlying message rather than
+    /// panicking.
+    SvgParse(String),
+    /// `svg2pdf::to_pdf` failed to produce the PDF byte stream.
+    /// The contained string is the underlying message.
+    Conversion(String),
+}
+
+impl fmt::Display for PdfError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SvgParse(msg) => write!(f, "SVG parse failed: {msg}"),
+            Self::Conversion(msg) => write!(f, "PDF conversion failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for PdfError {}
+
+/// Renders an iReal Pro chart as a single-page A4 PDF byte stream.
+///
+/// Internally calls [`render_svg`], parses the result with
+/// `svg2pdf::usvg::Tree::from_str`, and converts via
+/// `svg2pdf::to_pdf`. The chart is embedded as vector content, so
+/// the PDF is resolution-independent (no DPI knob).
+///
+/// # Errors
+///
+/// - [`PdfError::SvgParse`] — `usvg` could not parse the SVG. This
+///   indicates an internal renderer bug; please file an issue.
+/// - [`PdfError::Conversion`] — PDF conversion failed.
+///
+/// # Example
+///
+/// ```no_run
+/// use chordsketch_ireal::IrealSong;
+/// use chordsketch_render_ireal::pdf::{PdfOptions, render_pdf};
+///
+/// let song = IrealSong::new();
+/// let bytes = render_pdf(&song, &PdfOptions::default()).unwrap();
+/// assert_eq!(&bytes[..5], b"%PDF-");
+/// ```
+pub fn render_pdf(song: &IrealSong, _options: &PdfOptions) -> Result<Vec<u8>, PdfError> {
+    let svg = render_svg(song, &RenderOptions::default());
+    let usvg_options = svg2pdf::usvg::Options::default();
+    let tree = svg2pdf::usvg::Tree::from_str(&svg, &usvg_options)
+        .map_err(|e| PdfError::SvgParse(e.to_string()))?;
+
+    let conversion_options = svg2pdf::ConversionOptions::default();
+    let page_options = svg2pdf::PageOptions { dpi: PDF_DPI };
+
+    svg2pdf::to_pdf(&tree, conversion_options, page_options)
+        .map_err(|e| PdfError::Conversion(e.to_string()))
+}

--- a/crates/render-ireal/tests/pdf.rs
+++ b/crates/render-ireal/tests/pdf.rs
@@ -1,0 +1,148 @@
+//! PDF converter tests.
+//!
+//! Uses **structural** assertions rather than byte- or content-hash
+//! equality. `svg2pdf` embeds the system `fontdb` snapshot in the
+//! output stream when text rendering is required, so a strict byte-
+//! exact snapshot would diverge across runner OSes the same way the
+//! PNG suite would (CI Linux fonts vs developer macOS fonts vs
+//! Windows fonts). Structural checks catch the defect classes the
+//! PDF output is meant to guard against:
+//!
+//! - SVG produced by `render_svg` becomes invalid (parse failure).
+//! - `svg2pdf::to_pdf` stops emitting the `%PDF-` header / `%%EOF`
+//!   trailer.
+//! - PDF dimensions stop matching the SVG viewBox at 72 DPI.
+
+#![cfg(feature = "pdf")]
+
+use chordsketch_ireal::{
+    Accidental, Bar, BarChord, BarLine, BeatPosition, Chord, ChordQuality, ChordRoot, IrealSong,
+    KeyMode, KeySignature, MusicalSymbol, Section, SectionLabel, TimeSignature,
+};
+use chordsketch_render_ireal::pdf::{PdfError, PdfOptions, render_pdf};
+
+const PDF_HEADER_PREFIX: &[u8] = b"%PDF-";
+const PDF_EOF_MARKER: &[u8] = b"%%EOF";
+
+/// Asserts the bytes look like a structurally valid PDF.
+///
+/// Confirms the `%PDF-X.Y` magic at offset 0, an `%%EOF` marker
+/// near the tail, and that the byte stream is non-trivial in size
+/// (svg2pdf produces at least a few KB for any real input). The
+/// EOF marker may be followed by a single trailing newline /
+/// carriage return per the PDF spec; scan the last 32 bytes rather
+/// than the absolute tail.
+fn assert_well_formed_pdf(bytes: &[u8]) {
+    assert!(
+        bytes.len() > 256,
+        "PDF suspiciously small: {} bytes",
+        bytes.len()
+    );
+    assert_eq!(
+        &bytes[..PDF_HEADER_PREFIX.len()],
+        PDF_HEADER_PREFIX,
+        "missing PDF header"
+    );
+    let tail_window = &bytes[bytes.len().saturating_sub(32)..];
+    assert!(
+        tail_window
+            .windows(PDF_EOF_MARKER.len())
+            .any(|w| w == PDF_EOF_MARKER),
+        "missing %%EOF marker in tail: {tail_window:?}"
+    );
+}
+
+fn build_basic_song() -> IrealSong {
+    let chord = Chord::triad(ChordRoot::natural('C'), ChordQuality::Minor7);
+    let bar_chord = BarChord {
+        chord,
+        position: BeatPosition::on_beat(1).unwrap(),
+    };
+    let bar = Bar {
+        start: BarLine::OpenRepeat,
+        end: BarLine::CloseRepeat,
+        chords: vec![bar_chord],
+        ending: None,
+        symbol: Some(MusicalSymbol::Segno),
+    };
+    IrealSong {
+        title: "Autumn Leaves".into(),
+        composer: Some("Joseph Kosma".into()),
+        style: Some("Medium Swing".into()),
+        key_signature: KeySignature {
+            root: ChordRoot {
+                note: 'E',
+                accidental: Accidental::Natural,
+            },
+            mode: KeyMode::Minor,
+        },
+        time_signature: TimeSignature::default(),
+        tempo: Some(120),
+        transpose: 0,
+        sections: vec![Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![bar],
+        }],
+    }
+}
+
+#[test]
+fn empty_song_produces_well_formed_pdf() {
+    let song = IrealSong::new();
+    let bytes = render_pdf(&song, &PdfOptions::default()).expect("render_pdf");
+    assert_well_formed_pdf(&bytes);
+}
+
+#[test]
+fn basic_song_produces_well_formed_pdf() {
+    let song = build_basic_song();
+    let bytes = render_pdf(&song, &PdfOptions::default()).expect("render_pdf");
+    assert_well_formed_pdf(&bytes);
+}
+
+#[test]
+fn pdf_version_is_a_known_release() {
+    // The header is `%PDF-X.Y\n` for some `X.Y` (e.g. `1.4`,
+    // `1.7`, `2.0`). Validate the digits after the prefix to catch
+    // svg2pdf shipping a malformed header. Don't pin the exact
+    // version because svg2pdf may bump it across patch releases.
+    let song = IrealSong::new();
+    let bytes = render_pdf(&song, &PdfOptions::default()).expect("render_pdf");
+    let header = &bytes[..16];
+    assert!(header.starts_with(PDF_HEADER_PREFIX));
+    let version_byte_a = header[5];
+    let dot = header[6];
+    let version_byte_b = header[7];
+    assert!(
+        version_byte_a.is_ascii_digit(),
+        "non-digit major in PDF version: {header:?}"
+    );
+    assert_eq!(dot, b'.', "missing dot in PDF version: {header:?}");
+    assert!(
+        version_byte_b.is_ascii_digit(),
+        "non-digit minor in PDF version: {header:?}"
+    );
+}
+
+#[test]
+fn pdf_options_default_construction_round_trips() {
+    let a = PdfOptions::default();
+    let b = PdfOptions::default();
+    assert_eq!(a, b);
+    assert_eq!(format!("{a:?}"), format!("{b:?}"));
+}
+
+#[test]
+fn pdf_error_display_covers_each_variant() {
+    // The two variants only fire on internal-consistency failures
+    // that no production input can reach via `render_pdf`.
+    // Construct directly so a `Display` regression cannot slip
+    // through.
+    let svg = format!("{}", PdfError::SvgParse("unexpected token".into()));
+    assert!(svg.contains("SVG parse failed"));
+    assert!(svg.contains("unexpected token"));
+
+    let conv = format!("{}", PdfError::Conversion("write failure".into()));
+    assert!(conv.contains("PDF conversion failed"));
+    assert!(conv.contains("write failure"));
+}


### PR DESCRIPTION
## What

Adds `chordsketch_render_ireal::pdf::render_pdf` behind a new
`pdf` cargo feature. Internally calls `render_svg`, parses the
result with `svg2pdf::usvg::Tree::from_str`, and converts via
`svg2pdf::to_pdf`, returning encoded PDF bytes.

The SVG renderer's `595 × 842` viewBox in CSS px (1 px = 1/96
inch) maps to `595 × 842` PDF user-space points at the 72 DPI
svg2pdf assumes — exactly ISO 216 A4 (210 × 297 mm = 595 × 842
pt). The output PDF therefore lands on A4 with the chart
filling the page; no margin clipping or content scaling occurs.

## Why

The iReal Pro tracker (#2050) needs a PDF output to round out
the non-SVG export surface alongside PNG (#2064, just landed).
PDF rasterisation gives the playground / desktop chart export
a print-ready vector path that PNG (raster) cannot serve.

The feature is **off by default**. Without the gate the
SVG-only consumer keeps the same single-dependency build;
turning it on adds `svg2pdf` and its transitive `usvg` /
`pdf-writer` / `subsetter` stack. The renderer-crate dependency
carve-out in `CLAUDE.md` ("minimal external crates when
justified") covers this — pure-Rust SVG-to-PDF conversion has
no zero-dep alternative, and the feature gate keeps the cost
off any caller that does not need PDF output.

## Why both `png` and `pdf` share `usvg` 0.43

Both features pin against the `usvg` 0.43 transitive line so
enabling both does not pull two unrelated `usvg` trees into the
dep graph. svg2pdf 0.12 hard-requires resvg 0.43 / usvg 0.43 /
tiny-skia 0.11; the PNG side moves from resvg 0.45 to 0.45 →
0.43 in this PR (one Cargo.toml line) so they align.

The API the PNG rasteriser uses (`Tree::from_str`, `render`,
`Pixmap::new`, `encode_png`) is identical between resvg 0.43
and 0.45, so no source changes are required for the PNG path.
Local verification: `cargo test -p chordsketch-render-ireal
--features png` passes on the downgraded resvg with no
golden-output drift.

## Deferred

Per `.claude/rules/pr-workflow.md` step 5 — recording AC items
not in scope for this initial cut so the rationale lives in
the durable PR record:

- **Letter page size.** AC nominates "A4 / Letter selectable";
  this PR ships A4 only. `svg2pdf 0.12`'s `to_pdf` derives the
  page size from the SVG viewBox, so Letter would need either
  SVG-side viewBox modification (rebuild the SVG with
  `612 × 792` dimensions) or a lower-level `pdf-writer`
  composition path. Both add real geometry-recompute work
  beyond this PR's scope; tracked via the README Roadmap entry
  pointing back at #2063.
- **Multi-page overflow.** AC nominates "Multi-page support
  when a tune overflows"; this PR ships single-page only. The
  SVG renderer itself is single-page (fixed `595 × 842`
  viewBox, bar count clamped to `MAX_BARS = 256`), so
  multi-page PDF needs SVG-side pagination first. Same
  Roadmap note.

## Test results

- `cargo test -p chordsketch-render-ireal --features pdf` —
  5 PDF tests pass (PDF signature / `%%EOF` trailer / version
  digit shape / `PdfOptions` round-trip / `PdfError` Display
  for both variants).
- `cargo test -p chordsketch-render-ireal --features png,pdf`
  — combined run passes (no PNG golden-output drift after
  resvg downgrade).
- `cargo clippy -p chordsketch-render-ireal --features
  png,pdf --all-targets -- -D warnings` — clean.
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p
  chordsketch-render-ireal --features png,pdf --no-deps` —
  clean.
- `cargo fmt --check` — clean.

## Tests use structural, not pixel-/byte-hash, equality

Same reasoning as PNG (#2064): `svg2pdf` embeds the system
`fontdb` snapshot when text rendering is required, so a
strict byte-exact snapshot would diverge across runner OSes.
Structural checks (`%PDF-` header, `%%EOF` trailer, version
digit shape) catch the defect classes the PDF output is
meant to guard against:

- SVG produced by `render_svg` becomes invalid (parse
  failure surfaces via `PdfError::SvgParse`).
- `svg2pdf::to_pdf` stops emitting the `%PDF-` header /
  `%%EOF` trailer.
- Encoder regression breaks the version digit format.

## CI changes

- `ci.yml` test job: `cargo test -p chordsketch-render-ireal
  --features png,pdf` (single run; both features share usvg
  0.43, so no double-compile).
- `ci.yml` clippy job: matching `--features png,pdf` lint.
- `ci.yml` docs job: matching `--features
  chordsketch-render-ireal/png,chordsketch-render-ireal/pdf`
  doc-check.
- `coverage.yml`: enables both features so the new module is
  in both numerator and denominator of the patch coverage gate.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`:

- **Renderers (text / HTML / PDF for ChordPro)** — N/A. The
  iReal PDF converter is on `chordsketch-render-ireal` and
  does not share match arms or directive validation with the
  ChordPro renderers. The `render-pdf` crate's PDF output is
  for ChordPro content with a wholly different geometry
  pipeline.
- **Bindings (FFI / WASM / NAPI)** — none currently consume
  `chordsketch-render-ireal`. Exposing the PDF API across
  bindings is #2067 territory.
- **External tool invocations** — N/A.
- **Sanitiser functions / blocklists** — N/A.

The sole shared concern with #2064 (PNG) is the `usvg` /
`resvg` version pin, which this PR aligns to a single 0.43
line so a future MSRV bump is a single Cargo.toml change.

Closes #2063.