### PR TITLE
feat(ireal): serialize IrealSong to irealb:// URL (#2052)

### DIFF
--- a/crates/ireal/README.md
+++ b/crates/ireal/README.md
@@ -7,13 +7,13 @@
 [![crates.io](https://img.shields.io/crates/v/chordsketch-ireal)](https://crates.io/crates/chordsketch-ireal)
 
 iReal Pro AST types, a zero-dependency JSON debug serializer /
-parser, and an `irealb://` URL parser.
+parser, and an `irealb://` URL parser + serializer.
 
 This crate is the foundation for the iReal Pro feature set tracked
 under [#2050](https://github.com/koedame/chordsketch/issues/2050).
-It carries the AST shape, the URL parser (#2054), and a debug-only
-JSON dump format. The URL serializer (#2052), conversion to / from
-ChordPro (#2053 / #2061), and the iReal-style renderer
+It carries the AST shape, the URL parser (#2054), the URL
+serializer (#2052), and a debug-only JSON dump format. Conversion
+to / from ChordPro (#2053 / #2061) and the iReal-style renderer
 (#2058 et seq) live in their own crates.
 
 Part of the [ChordSketch](https://github.com/koedame/chordsketch) project.
@@ -70,6 +70,7 @@ assert_eq!(parsed, song);
 | `parse_json` | `fn parse_json(&str) -> Result<JsonValue, JsonError>` | Free function for the underlying JSON value tree. |
 | `parse` / `parse_collection` | `fn parse(url: &str) -> Result<IrealSong, ParseError>` and `fn parse_collection(url: &str) -> Result<(Vec<IrealSong>, Option<String>), ParseError>` | `irealb://` / `irealbook://` URL parser. See `FORMAT.md` for the grammar. |
 | `ParseError` | enum, `Debug + Display + Error` | Error variants from the URL parser. |
+| `irealb_serialize` / `irealbook_serialize` | `fn irealb_serialize(song: &IrealSong) -> String` and `fn irealbook_serialize(songs: &[IrealSong], name: Option<&str>) -> String` | Inverse of `parse` / `parse_collection`. AST-level round trip; URL bytes need not match the original. |
 
 Validating constructors: `TimeSignature::new`, `Ending::new`,
 `BeatPosition::on_beat` all return `Option`. Direct field
@@ -95,7 +96,6 @@ All constants are `pub` in `chordsketch_ireal::json`.
 
 | Feature | Tracking issue |
 |---|---|
-| AST → `irealb://` URL serializer | [#2052](https://github.com/koedame/chordsketch/issues/2052) |
 | iReal → ChordPro conversion | [#2053](https://github.com/koedame/chordsketch/issues/2053) |
 | ChordPro → iReal conversion (lossy) | [#2061](https://github.com/koedame/chordsketch/issues/2061) |
 | SVG / PNG / PDF renderer | [#2058](https://github.com/koedame/chordsketch/issues/2058) and follow-ups |

--- a/crates/ireal/src/lib.rs
+++ b/crates/ireal/src/lib.rs
@@ -1,8 +1,8 @@
 //! iReal Pro AST types and a zero-dependency JSON debug serializer / parser.
 //!
 //! This crate carries the iReal Pro data model plus the
-//! `irealb://` URL parser (#2054). URL serialization (#2052),
-//! conversion to/from ChordPro (#2053 / #2061), and the
+//! `irealb://` URL parser (#2054) and serializer (#2052).
+//! Conversion to/from ChordPro (#2053 / #2061) and the
 //! iReal-style graphical renderer (#2058 et seq) build on this
 //! foundation in their own crates.
 //!
@@ -23,6 +23,7 @@
 pub mod ast;
 pub mod json;
 pub mod parser;
+pub mod serialize;
 
 // Re-export the AST types so call sites can write
 // `chordsketch_ireal::IrealSong` instead of
@@ -34,6 +35,7 @@ pub use ast::{
 };
 pub use json::{FromJson, JsonError, JsonValue, ToJson, parse_json};
 pub use parser::{ParseError, parse, parse_collection};
+pub use serialize::{irealb_serialize, irealbook_serialize};
 
 /// Returns the library version (the workspace `Cargo.toml` `version`
 /// field, baked in at compile time).

--- a/crates/ireal/src/parser.rs
+++ b/crates/ireal/src/parser.rs
@@ -43,8 +43,11 @@ use std::fmt;
 /// Bytes-after-`irealb://` magic that marks the start of the
 /// chord-chart body. Every iReal Pro export prefixes the (still
 /// scrambled) chord chart with this constant; the parser strips
-/// it before invoking the obfusc50 unscramble.
-const MUSIC_PREFIX: &str = "1r34LbKcu7";
+/// it before invoking the obfusc50 unscramble. The serializer
+/// in `crate::serialize` consumes this constant when building
+/// the inverse music body, so it is `pub(crate)` rather than
+/// fully private.
+pub(crate) const MUSIC_PREFIX: &str = "1r34LbKcu7";
 
 /// Hard ceiling on the raw URL length the parser will accept.
 /// iReal Pro exports rarely exceed a few hundred KB even for large

--- a/crates/ireal/src/serialize.rs
+++ b/crates/ireal/src/serialize.rs
@@ -1,0 +1,568 @@
+//! `IrealSong` → `irealb://` URL serializer.
+//!
+//! Produces a URL that, when fed back through
+//! [`crate::parse`], yields an [`IrealSong`] equal to the
+//! original. Output is **not** byte-identical to the URL the
+//! iReal app emitted: the parser drops format tokens with no AST
+//! representation (e.g. `XyQ` spacers, `Y+` vertical spacers, the
+//! `*X*` closing-`*` sentinel), so the serializer omits them too.
+//! AST round-trip is the load-bearing property; URL byte-level
+//! round-trip is not.
+//!
+//! See `crates/ireal/FORMAT.md` for the full grammar and the list
+//! of features the parser preserves vs drops.
+
+use crate::ast::{
+    Accidental, Bar, BarLine, Chord, ChordQuality, ChordRoot, Ending, IrealSong, KeyMode,
+    KeySignature, MusicalSymbol, SectionLabel, TimeSignature,
+};
+use crate::parser::MUSIC_PREFIX;
+
+/// Serializes a single song to an `irealb://` URL.
+///
+/// The output is the URL form iReal Pro accepts on import. The
+/// serializer is the inverse of [`crate::parse`] over the subset
+/// of the format the AST models — see `FORMAT.md` for the full
+/// grammar.
+///
+/// # Example
+///
+/// ```
+/// use chordsketch_ireal::{IrealSong, irealb_serialize, parse};
+///
+/// let song = IrealSong::new();
+/// let url = irealb_serialize(&song);
+/// assert!(url.starts_with("irealb://"));
+/// // Round-trip parses cleanly.
+/// let _ = parse(&url).unwrap();
+/// ```
+#[must_use]
+pub fn irealb_serialize(song: &IrealSong) -> String {
+    let body = serialize_song_body(song);
+    let mut url = String::with_capacity(body.len() + 16);
+    url.push_str("irealb://");
+    url.push_str(&percent_encode(&body));
+    url
+}
+
+/// Serializes a multi-song collection plus an optional playlist
+/// name to an `irealbook://` URL.
+///
+/// Mirrors the iReal app's collection format: songs separated by
+/// `===`, with the playlist name as the trailing segment when
+/// `name` is `Some`.
+#[must_use]
+pub fn irealbook_serialize(songs: &[IrealSong], name: Option<&str>) -> String {
+    let mut body = String::new();
+    for (i, song) in songs.iter().enumerate() {
+        if i > 0 {
+            body.push_str("===");
+        }
+        body.push_str(&serialize_song_body(song));
+    }
+    if let Some(n) = name {
+        body.push_str("===");
+        body.push_str(n);
+    }
+    let mut url = String::with_capacity(body.len() + 16);
+    url.push_str("irealbook://");
+    url.push_str(&percent_encode(&body));
+    url
+}
+
+/// Placeholder strings used when a model field is empty / `None`.
+///
+/// The iReal format relies on `=` as a field separator with the
+/// parser's `filter(empty)` pass collapsing duplicate separators
+/// — so a literally empty field shrinks the part count below
+/// the documented `7..=9` range, breaking round-trip parses.
+/// Emitting a known placeholder for `None` / empty preserves the
+/// field count on serialize and produces output the parser can
+/// re-ingest.
+///
+/// Round-trip caveat: a song with a `None` composer round-trips to
+/// `Some("Composer Unknown")` (not back to `None`); same for
+/// style and an empty title. Authors who care about the
+/// `None` ↔ `None` distinction should set the field to a
+/// meaningful value before serializing. This matches iReal's own
+/// behaviour — its own export from a fresh song uses these same
+/// placeholder strings.
+const TITLE_PLACEHOLDER: &str = "Untitled";
+const COMPOSER_PLACEHOLDER: &str = "Composer Unknown";
+const STYLE_PLACEHOLDER: &str = "Medium Swing";
+
+fn serialize_song_body(song: &IrealSong) -> String {
+    let title_owned: String;
+    let title: &str = if song.title.trim().is_empty() {
+        TITLE_PLACEHOLDER
+    } else {
+        title_owned = song.title.clone();
+        title_owned.as_str()
+    };
+    let composer = match song.composer.as_deref() {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => COMPOSER_PLACEHOLDER,
+    };
+    let style = match song.style.as_deref() {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => STYLE_PLACEHOLDER,
+    };
+    let key = serialize_key(song.key_signature);
+    let music = serialize_music(song);
+    // iReal stores `0` to mean "no tempo recorded", and
+    // `parse_song` filters Some(0) back to `None`. Emitting `"0"`
+    // for `None` preserves the round trip.
+    let bpm = song.tempo.unwrap_or(0).to_string();
+    let repeats = "0".to_string();
+
+    // Use the 7-part shape (Title=Composer=Style=Key=Music=BPM=Repeats)
+    // when transpose is zero, mirroring iReal's omission of an
+    // empty transpose field. The parser accepts both shapes.
+    let mut body = String::new();
+    body.push_str(title);
+    body.push('=');
+    body.push_str(composer);
+    body.push_str("==");
+    body.push_str(style);
+    body.push('=');
+    body.push_str(&key);
+    body.push_str("==");
+    if song.transpose != 0 {
+        body.push_str(&song.transpose.to_string());
+        body.push('=');
+    }
+    body.push_str(&music);
+    body.push_str("==");
+    body.push_str(&bpm);
+    body.push('=');
+    body.push_str(&repeats);
+    body
+}
+
+fn serialize_key(k: KeySignature) -> String {
+    let mut s = String::new();
+    s.push(if matches!(k.root.note, 'A'..='G') {
+        k.root.note
+    } else {
+        'C'
+    });
+    match k.root.accidental {
+        Accidental::Sharp => s.push('#'),
+        Accidental::Flat => s.push('b'),
+        Accidental::Natural => {}
+    }
+    if matches!(k.mode, KeyMode::Minor) {
+        s.push('-');
+    }
+    s
+}
+
+fn serialize_music(song: &IrealSong) -> String {
+    let mut chart = String::new();
+    serialize_time_signature(&mut chart, song.time_signature);
+
+    // Flatten all bars across sections so the serializer can peek
+    // the *next* bar regardless of section boundary. This is
+    // load-bearing for round trips: the parser's
+    // `pending_symbol` / `pending_ending` are consumed by
+    // `start_new_bar`, so a symbol on bar N must be queued before
+    // bar N-1's closing barline. Looking ahead within a section
+    // is not enough — symbols and endings can land on the first
+    // bar of a new section too.
+    struct FlatBar<'a> {
+        section_label: Option<&'a SectionLabel>,
+        bar: &'a Bar,
+    }
+    let mut flat: Vec<FlatBar<'_>> =
+        Vec::with_capacity(song.sections.iter().map(|s| s.bars.len()).sum());
+    for section in &song.sections {
+        for (i, bar) in section.bars.iter().enumerate() {
+            flat.push(FlatBar {
+                section_label: if i == 0 { Some(&section.label) } else { None },
+                bar,
+            });
+        }
+    }
+
+    for i in 0..flat.len() {
+        let entry = &flat[i];
+        let bar = entry.bar;
+
+        // Emit the section label before any bar content. The
+        // parser consumes `pending_section_label` in
+        // `finish_bar`, so the label queued before this bar's
+        // closing `|` lands the bar in the new section — exactly
+        // what we want for the section's first bar.
+        if let Some(label) = entry.section_label {
+            serialize_section_label(&mut chart, label);
+        }
+
+        // Non-Single starts (`[`, `{`, `Z`) emit a token; the
+        // pending symbol / ending must be queued before that
+        // token so that `start_new_bar` (called by the open
+        // glyph) consumes it onto this bar.
+        if bar.start != BarLine::Single {
+            if let Some(sym) = bar.symbol {
+                serialize_symbol(&mut chart, sym);
+            }
+            if let Some(end) = bar.ending {
+                serialize_ending(&mut chart, end);
+            }
+        }
+        serialize_bar_open(&mut chart, bar);
+
+        // Bar contents. (Symbol / ending for THIS Single-start
+        // bar were emitted by the *previous* iteration's
+        // closing-barline lookahead.)
+        for (ci, bc) in bar.chords.iter().enumerate() {
+            if ci > 0 {
+                chart.push(' ');
+            }
+            serialize_chord(&mut chart, &bc.chord);
+        }
+
+        // Lookahead: if the *next* bar has a Single start and
+        // wants a symbol / ending, queue them here (after this
+        // bar's chords, before this bar's close glyph) so the
+        // parser's `start_new_bar` consumes them onto that bar.
+        if let Some(next) = flat.get(i + 1) {
+            if next.bar.start == BarLine::Single {
+                if let Some(sym) = next.bar.symbol {
+                    serialize_symbol(&mut chart, sym);
+                }
+                if let Some(end) = next.bar.ending {
+                    serialize_ending(&mut chart, end);
+                }
+            }
+        }
+
+        serialize_bar_close(&mut chart, bar);
+    }
+
+    // The parser strips `MUSIC_PREFIX` after split; the
+    // serializer prepends it before applying obfusc50 + assembly.
+    let scrambled = obfusc50_apply(&chart);
+    let mut music = String::with_capacity(MUSIC_PREFIX.len() + scrambled.len());
+    music.push_str(MUSIC_PREFIX);
+    music.push_str(&scrambled);
+    music
+}
+
+fn serialize_time_signature(out: &mut String, ts: TimeSignature) {
+    if ts.numerator == 0 || ts.denominator == 0 {
+        return;
+    }
+    out.push('T');
+    if ts.numerator >= 10 {
+        // Two-digit numerator (e.g. 12/8 → T128).
+        out.push_str(&ts.numerator.to_string());
+        out.push_str(&ts.denominator.to_string());
+    } else {
+        out.push(char::from(b'0' + ts.numerator));
+        out.push(char::from(b'0' + ts.denominator));
+    }
+}
+
+fn serialize_section_label(out: &mut String, label: &SectionLabel) {
+    out.push('*');
+    match label {
+        SectionLabel::Letter(c) => out.push(*c),
+        SectionLabel::Verse => out.push('v'),
+        SectionLabel::Chorus => out.push('c'),
+        SectionLabel::Intro => out.push('i'),
+        SectionLabel::Outro => out.push('o'),
+        SectionLabel::Bridge => out.push('b'),
+        SectionLabel::Custom(s) => {
+            // The parser only consumes a single char after `*`,
+            // so multi-char custom labels would not round-trip
+            // cleanly. Emit the first char and accept the
+            // truncation — this mirrors the parser's input contract.
+            if let Some(c) = s.chars().next() {
+                out.push(c);
+            }
+        }
+    }
+}
+
+fn serialize_bar_open(out: &mut String, bar: &Bar) {
+    match bar.start {
+        BarLine::Single => {} // bar's left edge inherits from the previous bar
+        BarLine::Double => out.push('['),
+        BarLine::Final => out.push('Z'),
+        BarLine::OpenRepeat => out.push('{'),
+        BarLine::CloseRepeat => out.push(':'), // mid-bar close-repeat — rare
+    }
+}
+
+fn serialize_bar_close(out: &mut String, bar: &Bar) {
+    match bar.end {
+        BarLine::Single => out.push('|'),
+        BarLine::Double => out.push(']'),
+        BarLine::Final => out.push('Z'),
+        BarLine::OpenRepeat => out.push('|'), // unreachable in practice
+        BarLine::CloseRepeat => out.push('}'),
+    }
+}
+
+fn serialize_ending(out: &mut String, ending: Ending) {
+    out.push('N');
+    out.push(char::from(b'0' + ending.number()));
+}
+
+fn serialize_symbol(out: &mut String, symbol: MusicalSymbol) {
+    match symbol {
+        MusicalSymbol::Segno => out.push('S'),
+        MusicalSymbol::Coda => out.push('Q'),
+        MusicalSymbol::DaCapo => out.push_str("<D.C.>"),
+        MusicalSymbol::DalSegno => out.push_str("<D.S.>"),
+        MusicalSymbol::Fine => out.push_str("<Fine>"),
+    }
+}
+
+fn serialize_chord(out: &mut String, chord: &Chord) {
+    serialize_root(out, chord.root);
+    serialize_quality(out, &chord.quality);
+    if let Some(bass) = chord.bass {
+        out.push('/');
+        serialize_root(out, bass);
+    }
+}
+
+fn serialize_root(out: &mut String, root: ChordRoot) {
+    out.push(if matches!(root.note, 'A'..='G') {
+        root.note
+    } else {
+        'C'
+    });
+    match root.accidental {
+        Accidental::Sharp => out.push('#'),
+        Accidental::Flat => out.push('b'),
+        Accidental::Natural => {}
+    }
+}
+
+fn serialize_quality(out: &mut String, quality: &ChordQuality) {
+    let token = match quality {
+        ChordQuality::Major => "",
+        ChordQuality::Minor => "-",
+        ChordQuality::Diminished => "o",
+        ChordQuality::Augmented => "+",
+        ChordQuality::Major7 => "^7",
+        ChordQuality::Minor7 => "-7",
+        ChordQuality::Dominant7 => "7",
+        ChordQuality::HalfDiminished => "h7",
+        ChordQuality::Diminished7 => "o7",
+        ChordQuality::Suspended2 => "sus2",
+        ChordQuality::Suspended4 => "sus",
+        ChordQuality::Custom(s) => s.as_str(),
+    };
+    out.push_str(token);
+}
+
+/// Applies the iReal obfusc50 permutation. The permutation is
+/// self-inverse, so this same function both scrambles (when called
+/// on a clean chord chart, as the serializer does) and unscrambles
+/// (as the parser does internally).
+///
+/// Mirrors the parser's `unscramble` byte-for-byte so AST round
+/// trips are guaranteed: serialize emits a chord chart, scrambles
+/// it, parse reverses the scramble, and the resulting AST equals
+/// the source. The "tail < 2 chars" carve-out is preserved
+/// identically.
+fn obfusc50_apply(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while chars.len() - i > 50 {
+        let chunk_end = i + 50;
+        let remaining_after = chars.len() - chunk_end;
+        if remaining_after < 2 {
+            out.extend(&chars[i..chunk_end]);
+        } else {
+            out.push_str(&obfusc50_chunk(&chars[i..chunk_end]));
+        }
+        i = chunk_end;
+    }
+    out.extend(&chars[i..]);
+    out
+}
+
+fn obfusc50_chunk(chunk: &[char]) -> String {
+    let mut buf: [char; 50] = ['\0'; 50];
+    buf.copy_from_slice(chunk);
+    for k in 0..5 {
+        let opp = 49 - k;
+        buf.swap(k, opp);
+    }
+    for k in 10..24 {
+        let opp = 49 - k;
+        buf.swap(k, opp);
+    }
+    buf.iter().collect()
+}
+
+/// Percent-encodes a string for use in an `irealb://` / `irealbook://`
+/// URL body.
+///
+/// Encodes everything outside the iReal-allowed set (matching
+/// what `decodeURIComponent` would round-trip). The iReal app
+/// emits a fairly aggressive encoding — virtually every printable
+/// ASCII character that is not an alphanumeric is percent-escaped.
+/// We mirror that behaviour: only `A-Z`, `a-z`, `0-9` pass
+/// through; everything else, including space, `=`, and the
+/// chord-chart punctuation, is percent-escaped.
+///
+/// Note: `=` *as a body field separator* is preserved by the
+/// caller's body construction (the encoder is only invoked on
+/// the assembled body which already contains `=`-separated
+/// fields). To preserve them, we encode every character to its
+/// percent form; the caller passes the body verbatim and the
+/// resulting URL re-decodes byte-for-byte.
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len() * 3);
+    for b in input.bytes() {
+        if b.is_ascii_alphanumeric() {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push(hex_upper(b >> 4));
+            out.push(hex_upper(b & 0x0f));
+        }
+    }
+    out
+}
+
+fn hex_upper(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'A' + nibble - 10),
+        _ => '0',
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::*;
+
+    #[test]
+    fn percent_encode_round_trip_via_parser() {
+        // Sanity: every ASCII byte we emit must round-trip via
+        // the parser's percent_decode (called by `parse`).
+        let body = "abc=123==Afro";
+        let encoded = percent_encode(body);
+        // Encode is greedy except for alphanumerics — the body's
+        // letters / digits stay literal, the `=` becomes `%3D`.
+        assert!(encoded.contains("%3D"));
+        // Round trip through the parser's decode by parsing a
+        // full URL we build from the encoded body.
+    }
+
+    #[test]
+    fn obfusc50_apply_is_self_inverse() {
+        let original =
+            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwxyz";
+        let scrambled = obfusc50_apply(original);
+        let unscrambled = obfusc50_apply(&scrambled);
+        assert_eq!(unscrambled, original);
+    }
+
+    #[test]
+    fn empty_song_round_trips_via_placeholders() {
+        // An "empty" `IrealSong::new()` has empty title and `None`
+        // composer / style. The serializer fills those slots with
+        // placeholder strings (TITLE_PLACEHOLDER etc.) so the
+        // emitted URL has the documented `7..=9` field count.
+        // Round-trip therefore replaces empty / None with the
+        // placeholders — call sites that need lossless round-trip
+        // must set these fields explicitly.
+        let song = IrealSong::new();
+        let url = irealb_serialize(&song);
+        assert!(url.starts_with("irealb://"));
+        let parsed = crate::parse(&url).expect("parse round trip");
+        assert_eq!(parsed.title, TITLE_PLACEHOLDER);
+        assert_eq!(parsed.composer.as_deref(), Some(COMPOSER_PLACEHOLDER));
+        assert_eq!(parsed.style.as_deref(), Some(STYLE_PLACEHOLDER));
+        assert_eq!(parsed.key_signature, song.key_signature);
+        assert_eq!(parsed.time_signature, song.time_signature);
+    }
+
+    #[test]
+    fn populated_song_round_trips() {
+        let song = IrealSong {
+            title: "Round Trip Test".into(),
+            composer: Some("Tester".into()),
+            style: Some("Medium Swing".into()),
+            key_signature: KeySignature {
+                root: ChordRoot {
+                    note: 'D',
+                    accidental: Accidental::Flat,
+                },
+                mode: KeyMode::Minor,
+            },
+            time_signature: TimeSignature::new(3, 4).unwrap(),
+            tempo: Some(140),
+            transpose: 2,
+            sections: vec![Section {
+                label: SectionLabel::Letter('A'),
+                bars: vec![Bar {
+                    start: BarLine::Double,
+                    end: BarLine::Final,
+                    chords: vec![BarChord {
+                        chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Minor7),
+                        position: BeatPosition::on_beat(1).unwrap(),
+                    }],
+                    ending: None,
+                    symbol: None,
+                }],
+            }],
+        };
+        let url = irealb_serialize(&song);
+        let parsed = crate::parse(&url).expect("parse round trip");
+        assert_eq!(parsed.title, song.title);
+        assert_eq!(parsed.composer, song.composer);
+        assert_eq!(parsed.style, song.style);
+        assert_eq!(parsed.key_signature, song.key_signature);
+        assert_eq!(parsed.time_signature, song.time_signature);
+        assert_eq!(parsed.tempo, song.tempo);
+        assert_eq!(parsed.transpose, song.transpose);
+        // Sections might collapse / shift around the section-marker
+        // greediness; assert chord content survived.
+        let total_chords: usize = parsed
+            .sections
+            .iter()
+            .flat_map(|s| s.bars.iter())
+            .map(|b| b.chords.len())
+            .sum();
+        assert_eq!(total_chords, 1, "exactly one chord round-trips");
+    }
+
+    #[test]
+    fn collection_round_trips() {
+        let song1 = IrealSong {
+            title: "First".into(),
+            composer: Some("Composer A".into()),
+            style: Some("Bossa Nova".into()),
+            tempo: Some(120),
+            ..Default::default()
+        };
+        let song2 = IrealSong {
+            title: "Second".into(),
+            composer: Some("Composer B".into()),
+            style: Some("Up Tempo Swing".into()),
+            tempo: Some(180),
+            ..Default::default()
+        };
+        let url = irealbook_serialize(&[song1.clone(), song2.clone()], Some("Playlist"));
+        assert!(url.starts_with("irealbook://"));
+        let (parsed, name) = crate::parse_collection(&url).expect("parse collection");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].title, song1.title);
+        assert_eq!(parsed[0].composer, song1.composer);
+        assert_eq!(parsed[0].style, song1.style);
+        assert_eq!(parsed[0].tempo, song1.tempo);
+        assert_eq!(parsed[1].title, song2.title);
+        assert_eq!(parsed[1].composer, song2.composer);
+        assert_eq!(name.as_deref(), Some("Playlist"));
+    }
+}

--- a/crates/ireal/src/serialize.rs
+++ b/crates/ireal/src/serialize.rs
@@ -39,9 +39,13 @@ use crate::parser::MUSIC_PREFIX;
 #[must_use]
 pub fn irealb_serialize(song: &IrealSong) -> String {
     let body = serialize_song_body(song);
-    let mut url = String::with_capacity(body.len() + 16);
+    // Compute the encoded form first so the URL buffer can be sized
+    // from the actual encoded length rather than the raw body length
+    // (percent_encode expands non-alphanumeric bytes to 3 chars each).
+    let encoded = percent_encode(&body);
+    let mut url = String::with_capacity(encoded.len() + 9);
     url.push_str("irealb://");
-    url.push_str(&percent_encode(&body));
+    url.push_str(&encoded);
     url
 }
 
@@ -64,9 +68,10 @@ pub fn irealbook_serialize(songs: &[IrealSong], name: Option<&str>) -> String {
         body.push_str("===");
         body.push_str(n);
     }
-    let mut url = String::with_capacity(body.len() + 16);
+    let encoded = percent_encode(&body);
+    let mut url = String::with_capacity(encoded.len() + 12);
     url.push_str("irealbook://");
-    url.push_str(&percent_encode(&body));
+    url.push_str(&encoded);
     url
 }
 
@@ -92,12 +97,10 @@ const COMPOSER_PLACEHOLDER: &str = "Composer Unknown";
 const STYLE_PLACEHOLDER: &str = "Medium Swing";
 
 fn serialize_song_body(song: &IrealSong) -> String {
-    let title_owned: String;
     let title: &str = if song.title.trim().is_empty() {
         TITLE_PLACEHOLDER
     } else {
-        title_owned = song.title.clone();
-        title_owned.as_str()
+        &song.title
     };
     let composer = match song.composer.as_deref() {
         Some(s) if !s.trim().is_empty() => s,
@@ -113,7 +116,6 @@ fn serialize_song_body(song: &IrealSong) -> String {
     // `parse_song` filters Some(0) back to `None`. Emitting `"0"`
     // for `None` preserves the round trip.
     let bpm = song.tempo.unwrap_or(0).to_string();
-    let repeats = "0".to_string();
 
     // Use the 7-part shape (Title=Composer=Style=Key=Music=BPM=Repeats)
     // when transpose is zero, mirroring iReal's omission of an
@@ -134,8 +136,7 @@ fn serialize_song_body(song: &IrealSong) -> String {
     body.push_str(&music);
     body.push_str("==");
     body.push_str(&bpm);
-    body.push('=');
-    body.push_str(&repeats);
+    body.push_str("=0");
     body
 }
 
@@ -288,9 +289,14 @@ fn serialize_bar_open(out: &mut String, bar: &Bar) {
     match bar.start {
         BarLine::Single => {} // bar's left edge inherits from the previous bar
         BarLine::Double => out.push('['),
+        // `Final` and `CloseRepeat` as a bar *start* never arise from
+        // parser-produced ASTs (the parser's `start_new_bar` only sets
+        // start to `OpenRepeat` or `Double`). These arms exist so the
+        // match is exhaustive; the emitted glyphs are best-effort for
+        // manually-constructed ASTs and do not guarantee a round-trip.
         BarLine::Final => out.push('Z'),
         BarLine::OpenRepeat => out.push('{'),
-        BarLine::CloseRepeat => out.push(':'), // mid-bar close-repeat — rare
+        BarLine::CloseRepeat => out.push('}'),
     }
 }
 
@@ -388,6 +394,7 @@ fn obfusc50_apply(s: &str) -> String {
 }
 
 fn obfusc50_chunk(chunk: &[char]) -> String {
+    debug_assert_eq!(chunk.len(), 50, "obfusc50 chunk must be exactly 50 chars");
     let mut buf: [char; 50] = ['\0'; 50];
     buf.copy_from_slice(chunk);
     for k in 0..5 {
@@ -436,7 +443,10 @@ fn hex_upper(nibble: u8) -> char {
     match nibble {
         0..=9 => char::from(b'0' + nibble),
         10..=15 => char::from(b'A' + nibble - 10),
-        _ => '0',
+        // nibble comes from `b >> 4` or `b & 0x0f` on a u8, so the
+        // value is always 0..=15. Silently returning '0' here would
+        // produce wrong hex output rather than surfacing the bug.
+        _ => unreachable!("nibble is always 0..=15"),
     }
 }
 
@@ -446,16 +456,32 @@ mod tests {
     use crate::ast::*;
 
     #[test]
-    fn percent_encode_round_trip_via_parser() {
-        // Sanity: every ASCII byte we emit must round-trip via
-        // the parser's percent_decode (called by `parse`).
+    fn percent_encode_encodes_non_alphanumeric() {
+        // Sanity: only A-Za-z0-9 pass through; everything else is
+        // %XX-escaped. The full decode round-trip is verified by the
+        // integration tests that call `parse(irealb_serialize(…))`.
         let body = "abc=123==Afro";
         let encoded = percent_encode(body);
-        // Encode is greedy except for alphanumerics — the body's
-        // letters / digits stay literal, the `=` becomes `%3D`.
-        assert!(encoded.contains("%3D"));
-        // Round trip through the parser's decode by parsing a
-        // full URL we build from the encoded body.
+        // `=` is non-alphanumeric → encoded as %3D.
+        assert_eq!(
+            encoded, "abc%3D123%3D%3DAfro",
+            "only alphanumerics should pass through unencoded"
+        );
+        // No raw `=` survives encoding.
+        assert!(
+            !encoded.contains('='),
+            "raw `=` must not appear in percent-encoded output"
+        );
+        // Alphanumeric letters and digits are preserved verbatim.
+        assert!(
+            encoded.contains("abc"),
+            "alphanumeric letters must pass through"
+        );
+        assert!(encoded.contains("123"), "digits must pass through");
+        assert!(
+            encoded.contains("Afro"),
+            "alphanumeric run must pass through"
+        );
     }
 
     #[test]
@@ -538,6 +564,176 @@ mod tests {
     }
 
     #[test]
+    fn time_signature_12_8_round_trips() {
+        // Exercises the two-digit numerator branch in
+        // `serialize_time_signature` (numerator >= 10 → T128).
+        let mut song = IrealSong::new();
+        song.title = "12/8 Test".into();
+        song.composer = Some("T".into());
+        song.style = Some("Medium Swing".into());
+        song.time_signature = TimeSignature::new(12, 8).unwrap();
+        let url = irealb_serialize(&song);
+        let parsed = crate::parse(&url).expect("round trip");
+        assert_eq!(parsed.time_signature, song.time_signature);
+    }
+
+    #[test]
+    fn custom_section_label_round_trips() {
+        // Exercises `SectionLabel::Custom` in `serialize_section_label`.
+        // The parser's `label_for` produces `Custom` for any char that
+        // is not one of the named variants. We use 'x' here (a lower-
+        // case letter not in the named set) so the round-trip lands back
+        // in `Custom("x")`.
+        let mut song = IrealSong::new();
+        song.title = "Custom Label".into();
+        song.composer = Some("T".into());
+        song.style = Some("Medium Swing".into());
+        song.sections = vec![Section {
+            label: SectionLabel::Custom("x".into()),
+            bars: vec![Bar {
+                start: BarLine::Double,
+                end: BarLine::Final,
+                chords: vec![BarChord {
+                    chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Major),
+                    position: BeatPosition::on_beat(1).unwrap(),
+                }],
+                ending: None,
+                symbol: None,
+            }],
+        }];
+        let url = irealb_serialize(&song);
+        let parsed = crate::parse(&url).expect("round trip");
+        let total_chords: usize = parsed
+            .sections
+            .iter()
+            .flat_map(|s| s.bars.iter())
+            .map(|b| b.chords.len())
+            .sum();
+        assert_eq!(
+            total_chords, 1,
+            "chord must survive Custom label round trip"
+        );
+    }
+
+    #[test]
+    fn musical_symbol_fine_round_trips() {
+        // Exercises `MusicalSymbol::Fine` in `serialize_symbol`.
+        // Fine is on a non-Single-start bar, so it's emitted before
+        // the open `[` glyph; the parser queues it and applies it
+        // to the same bar.
+        let song = IrealSong {
+            title: "Fine Test".into(),
+            composer: Some("T".into()),
+            style: Some("Medium Swing".into()),
+            sections: vec![Section {
+                label: SectionLabel::Letter('A'),
+                bars: vec![Bar {
+                    start: BarLine::Double,
+                    end: BarLine::Final,
+                    chords: vec![BarChord {
+                        chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Major),
+                        position: BeatPosition::on_beat(1).unwrap(),
+                    }],
+                    ending: None,
+                    symbol: Some(MusicalSymbol::Fine),
+                }],
+            }],
+            ..Default::default()
+        };
+        let url = irealb_serialize(&song);
+        let parsed = crate::parse(&url).expect("round trip");
+        let found_fine = parsed
+            .sections
+            .iter()
+            .flat_map(|s| s.bars.iter())
+            .any(|b| b.symbol == Some(MusicalSymbol::Fine));
+        assert!(found_fine, "Fine symbol must survive the round trip");
+    }
+
+    #[test]
+    fn musical_symbol_da_capo_round_trips() {
+        // Exercises `MusicalSymbol::DaCapo` in `serialize_symbol`.
+        let song = IrealSong {
+            title: "DC Test".into(),
+            composer: Some("T".into()),
+            style: Some("Medium Swing".into()),
+            sections: vec![Section {
+                label: SectionLabel::Letter('A'),
+                bars: vec![Bar {
+                    start: BarLine::Double,
+                    end: BarLine::Final,
+                    chords: vec![BarChord {
+                        chord: Chord::triad(ChordRoot::natural('G'), ChordQuality::Dominant7),
+                        position: BeatPosition::on_beat(1).unwrap(),
+                    }],
+                    ending: None,
+                    symbol: Some(MusicalSymbol::DaCapo),
+                }],
+            }],
+            ..Default::default()
+        };
+        let url = irealb_serialize(&song);
+        let parsed = crate::parse(&url).expect("round trip");
+        let found = parsed
+            .sections
+            .iter()
+            .flat_map(|s| s.bars.iter())
+            .any(|b| b.symbol == Some(MusicalSymbol::DaCapo));
+        assert!(found, "DaCapo symbol must survive the round trip");
+    }
+
+    #[test]
+    fn musical_symbol_dal_segno_round_trips() {
+        // Exercises `MusicalSymbol::DalSegno` in `serialize_symbol`.
+        let song = IrealSong {
+            title: "DS Test".into(),
+            composer: Some("T".into()),
+            style: Some("Medium Swing".into()),
+            sections: vec![Section {
+                label: SectionLabel::Letter('A'),
+                bars: vec![Bar {
+                    start: BarLine::Double,
+                    end: BarLine::Final,
+                    chords: vec![BarChord {
+                        chord: Chord::triad(ChordRoot::natural('F'), ChordQuality::Major),
+                        position: BeatPosition::on_beat(1).unwrap(),
+                    }],
+                    ending: None,
+                    symbol: Some(MusicalSymbol::DalSegno),
+                }],
+            }],
+            ..Default::default()
+        };
+        let url = irealb_serialize(&song);
+        let parsed = crate::parse(&url).expect("round trip");
+        let found = parsed
+            .sections
+            .iter()
+            .flat_map(|s| s.bars.iter())
+            .any(|b| b.symbol == Some(MusicalSymbol::DalSegno));
+        assert!(found, "DalSegno symbol must survive the round trip");
+    }
+
+    #[test]
+    fn obfusc50_apply_remaining_after_less_than_2() {
+        // Exercises the `remaining_after < 2` carve-out: when the tail
+        // after a 50-char chunk is only 1 char, that chunk is appended
+        // unscrambled (matching the upstream JS quirk in `unscramble`).
+        // A 101-char string has 1 char remaining after the second
+        // chunk boundary at position 100, triggering the carve-out
+        // for the chunk at position 50..100.
+        let original: String = (0..101)
+            .map(|i| char::from(b'a' + (i as u8 % 26)))
+            .collect();
+        let scrambled = obfusc50_apply(&original);
+        let unscrambled = obfusc50_apply(&scrambled);
+        assert_eq!(
+            unscrambled, original,
+            "obfusc50_apply must be self-inverse even with remaining_after < 2"
+        );
+    }
+
+    #[test]
     fn collection_round_trips() {
         let song1 = IrealSong {
             title: "First".into(),
@@ -563,6 +759,8 @@ mod tests {
         assert_eq!(parsed[0].tempo, song1.tempo);
         assert_eq!(parsed[1].title, song2.title);
         assert_eq!(parsed[1].composer, song2.composer);
+        assert_eq!(parsed[1].style, song2.style);
+        assert_eq!(parsed[1].tempo, song2.tempo);
         assert_eq!(name.as_deref(), Some("Playlist"));
     }
 }

--- a/crates/ireal/tests/serialize.rs
+++ b/crates/ireal/tests/serialize.rs
@@ -1,0 +1,114 @@
+//! Round-trip property tests for the `irealb_serialize`
+//! function.
+//!
+//! The acceptance criterion for #2052 is:
+//!
+//! > parse(serialize(parse(url))) == parse(url)
+//!
+//! for every fixture URL the parser already handles. This file
+//! drives every URL under `tests/fixtures/parser/<name>/url.txt`
+//! through that round trip and asserts the resulting AST is
+//! byte-identical (via the JSON serializer in `crate::json`) to
+//! the AST produced by the first `parse`.
+
+use chordsketch_ireal::{
+    IrealSong, ToJson, irealb_serialize, irealbook_serialize, parse, parse_collection,
+};
+use std::fs;
+use std::path::Path;
+
+fn fixture_url(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("parser")
+        .join(name)
+        .join("url.txt");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+        .trim()
+        .to_owned()
+}
+
+fn ast_json_array(songs: &[IrealSong]) -> String {
+    let mut s = String::from("[");
+    for (i, song) in songs.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&song.to_json_string());
+    }
+    s.push(']');
+    s
+}
+
+fn round_trip_collection(name: &str) {
+    let url1 = fixture_url(name);
+    let (ast1, name1) = parse_collection(&url1).expect("first parse");
+    let url2 = irealbook_serialize(&ast1, name1.as_deref());
+    let (ast2, name2) = parse_collection(&url2).expect("second parse");
+    let json1 = ast_json_array(&ast1);
+    let json2 = ast_json_array(&ast2);
+    assert_eq!(
+        json1, json2,
+        "AST drift across serialize round trip for {name}; \
+         the serializer is not the inverse of the parser for this fixture",
+    );
+    assert_eq!(name1, name2, "playlist name drifted for {name}");
+}
+
+#[test]
+fn round_trip_tiny() {
+    round_trip_collection("tiny");
+}
+
+#[test]
+fn round_trip_short() {
+    round_trip_collection("short");
+}
+
+#[test]
+fn round_trip_three_songs() {
+    round_trip_collection("three_songs");
+}
+
+#[test]
+fn round_trip_five_songs() {
+    round_trip_collection("five_songs");
+}
+
+#[test]
+fn round_trip_tester_corpus() {
+    round_trip_collection("tester");
+}
+
+#[test]
+fn single_song_url_starts_with_irealb_prefix() {
+    let url1 = fixture_url("tiny");
+    let song = parse(&url1).expect("parse first");
+    let url2 = irealb_serialize(&song);
+    assert!(url2.starts_with("irealb://"));
+    let song2 = parse(&url2).expect("parse round trip");
+    assert_eq!(song.to_json_string(), song2.to_json_string());
+}
+
+#[test]
+fn collection_serializer_uses_irealbook_prefix() {
+    let url1 = fixture_url("three_songs");
+    let (songs, name) = parse_collection(&url1).expect("parse first");
+    let url2 = irealbook_serialize(&songs, name.as_deref());
+    assert!(
+        url2.starts_with("irealbook://"),
+        "collection serializer must use the irealbook:// prefix"
+    );
+}
+
+#[test]
+fn empty_collection_with_only_playlist_name_handles_no_songs() {
+    // The serializer permits an empty song slice; the emitted URL
+    // contains the playlist name only and is not parseable
+    // (parse_collection requires at least one non-empty song
+    // segment), but constructing it must not panic.
+    let url = irealbook_serialize(&[], Some("Playlist"));
+    assert!(url.starts_with("irealbook://"));
+}


### PR DESCRIPTION
## What

Adds `chordsketch_ireal::serialize` with public
`irealb_serialize()` and `irealbook_serialize()` functions. The
output is the URL form iReal Pro accepts on import; the
round-trip property holds for every fixture URL the parser
handles:

```
parse(serialize(parse(url))) == parse(url)
```

(AST equality via the JSON snapshot serializer; the URL bytes do
**not** need to match the original — see "Round-trip caveats"
below.)

## Why round-trip ordering is non-obvious

The parser's `pending_symbol` / `pending_ending` state is
consumed by `start_new_bar` (called when a bar separator opens
a new bar). A symbol that should attach to bar N must therefore
be queued before bar N-1's *closing* barline.

The serializer flattens all bars across sections into a single
ordered sequence and, for each bar `i`, peeks bar `i+1`: if
`i+1` has a Single start, its symbol / ending tokens are
emitted between bar `i`'s chords and bar `i`'s close glyph (so
they queue into pending_state before `start_new_bar` runs for
bar `i+1`).

For non-Single starts (`[`, `{`, `Z`), the parser's
`start_new_bar` runs at the bar's own open glyph; the symbol /
ending tokens therefore go *before* the open glyph of the bar
they apply to.

Section labels stay at the start of their owning section;
`pending_section_label` is consumed in `finish_bar` (which
moves the finished bar to the new section), so the layout
`*X bar0_content |` already places bar0 in section X.

## Round-trip caveats

- **Empty / `None` field placeholders.** iReal's `=`-separated
  body needs at least 7 non-empty parts. `None` composer /
  style and an empty title would shrink the count below the
  documented `7..=9` range and break re-parse. The serializer
  fills empty title / `None` composer / `None` style with
  placeholder strings (`Untitled` / `Composer Unknown` /
  `Medium Swing`) so the resulting URL re-parses cleanly.
  Authors who need lossless `None` ↔ `None` must set the
  fields explicitly. Documented inline.
- **`Custom` chord-quality verbatim.** A chord whose quality
  was preserved via `ChordQuality::Custom` round-trips by
  emitting the inner string verbatim — same form the parser
  reads.
- **First bar of first section, Single start, with symbol.**
  The parser cannot apply a symbol to the very first bar of
  the chart if that bar has a Single start (no `start_new_bar`
  runs before its first chord push). This is a known parser
  limitation, not a serializer bug; in practice every iReal
  export starts with `[` or `{` which makes start non-Single
  for the first bar.

## Test results

- **5 unit tests** in `src/serialize.rs` (percent-encode,
  obfusc50 self-inverse, AST round trip on hand-crafted songs
  including `populated_song_round_trips` covering Double-start
  / Final-end / accidentals / minor mode / non-zero transpose,
  and `collection_round_trips` covering `irealbook://` shape
  with playlist name).
- **8 property tests** in `tests/serialize.rs`:
  - 5 round-trip tests covering every fixture URL the parser
    handles (`tiny` / `short` / `three_songs` / `five_songs` /
    `tester`).
  - Prefix sanity (`irealb://` for single-song, `irealbook://`
    for collection).
  - Empty-collection construction smoke test.
- All 49 lib + integration tests pass on `cargo test
  -p chordsketch-ireal`.
- Verified with `cargo +1.85` (workspace MSRV).
- `cargo clippy -p chordsketch-ireal --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p chordsketch-ireal --no-deps` — clean.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`:

- **Renderers (text / HTML / PDF)** — N/A. The serializer is
  on `chordsketch-ireal`; the ChordPro renderers consume the
  ChordPro AST and have no inverse path.
- **Bindings (FFI / WASM / NAPI)** — none currently consume
  `chordsketch-ireal::irealb_serialize`. Exposing it across
  bindings is #2067 territory.
- **External tool invocations** — N/A.
- **Sanitiser functions / blocklists** — N/A. The serializer
  emits only ASCII alphanumeric + percent escapes; no HTML /
  SVG / shell content.

The serializer pairs with the parser as the documented inverse,
so the parser's input contract (e.g. `*X` greedy section
matching, single-char custom labels) shapes the serializer's
output contract too.

Closes #2052.