### PR TITLE
ci(readme-smoke): drop winget continue-on-error after baseline (#2216)

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -419,27 +419,21 @@ jobs:
   winget:
     name: winget (Windows)
     runs-on: windows-latest
-    # `winget install` starts with a source refresh against
-    # Microsoft's CDN; the CDN occasionally returns "Failed in
-    # attempting to update the source: winget" on the hosted
-    # Windows runners. This bubbles up as `CommandNotFoundException`
-    # on the subsequent `chordsketch --version`, which is an infra
-    # flake, not a breakage we can fix in-repo. Soft-fail on
-    # scheduled runs so a single flake does not page the maintainer;
-    # keep fail-fast on PRs so a PR that actually breaks the winget
-    # manifest still surfaces. Filed as #2208.
-    continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install via winget
         shell: powershell
         run: |
-          # Explicit retry loop for the transient source-refresh
-          # failure documented in #2208. Three attempts with a
-          # 10-second backoff covers the typical CDN blip; the
-          # `continue-on-error` gate above is the final safety net
-          # if all three still fail on a scheduled run.
+          # `winget install` starts with a source refresh against
+          # Microsoft's CDN; the CDN occasionally returns "Failed
+          # in attempting to update the source: winget" on the
+          # hosted Windows runners, which bubbles up as
+          # `CommandNotFoundException` on the subsequent
+          # `chordsketch --version`. The retry loop below absorbs
+          # that transient flake (#2208); a sustained failure across
+          # all three attempts now surfaces via `report-failure` so
+          # genuine winget manifest breakage is not masked (#2216).
           $attempt = 0
           while ($true) {
             $attempt++


### PR DESCRIPTION
## What

Remove `continue-on-error: ${{ github.event_name != 'pull_request' }}` from the `winget` job in `.github/workflows/readme-smoke.yml`. The 3-attempt retry loop introduced by #2217 stays in place as the per-run safety net.

Closes #2216.

## Why

#2216 AC1 asks for "a clean source-refresh success baseline (e.g. 7 consecutive scheduled runs where every winget install attempt succeeded on the first try)" before dropping the soft-fail gate. The retry loop landed in `main` at 2026-04-23 17:10 UTC (#2217), so the post-retry baseline starts with the next scheduled run.

Job-level data for the six consecutive scheduled runs since then:

| Date (UTC) | Run | Job duration | First-try success? |
|---|---|---|---|
| 2026-04-29 | [25098375387](https://github.com/koedame/chordsketch/actions/runs/25098375387) | 16s | yes |
| 2026-04-28 | [25042245984](https://github.com/koedame/chordsketch/actions/runs/25042245984) | 26s | yes |
| 2026-04-27 | [24984568106](https://github.com/koedame/chordsketch/actions/runs/24984568106) | 22s | yes |
| 2026-04-26 | [24951410246](https://github.com/koedame/chordsketch/actions/runs/24951410246) | 17s | yes |
| 2026-04-25 | [24925548366](https://github.com/koedame/chordsketch/actions/runs/24925548366) | 15s | yes |
| 2026-04-24 | [24879118949](https://github.com/koedame/chordsketch/actions/runs/24879118949) | 24s | yes |

Each job log contains exactly one `Successfully installed` line and zero `attempt N failed; retrying` lines, confirming the retry loop has not been exercised in production over this window. With `Start-Sleep -Seconds 10` between attempts, a single retry would push the job past 26s, so the duration column is itself an upper-bound check on first-try success.

The "e.g. 7" target in AC1 is illustrative; six consecutive first-try wins immediately following the retry-loop merge is the cleanest baseline reachable today, and keeping the soft-fail gate longer trades catching real winget-manifest breakage (#1030 / `report-failure`) for additional days of waiting on a CDN-flake count that has already settled to zero.

The job retains the retry loop (AC3 of #2216), so a transient CDN blip that recovers within the same job still soft-succeeds. A sustained failure across all three attempts will now propagate to `report-failure` and auto-file a tracking issue.

This mirrors the `library-smoke` posture after #2169 (#2316): retry loop without `continue-on-error`.

Sister-site audit (per `.claude/rules/fix-propagation.md`):
- `library-smoke` — already in target shape via #2169 (#2316); no change needed.
- `chocolatey` — `if: false` + `continue-on-error: true` is gated on the moderation backlog tracked under #1852 / #1776, not on flake resilience; out of scope for this PR.

## Test results

- YAML schema parse — `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/readme-smoke.yml'))\"` clean.
- The `report-failure` job's `needs:` already lists `winget`; with `continue-on-error` removed, a `failure` conclusion on `winget` will propagate as workflow failure on scheduled runs and trigger the auto-managed tracking issue path.
- README sync — the retry loop and install command are unchanged, so `.github/snapshots/readme-commands.txt` does not need refreshing.

## Review summary

In-PR review pending; this PR will iterate per `.claude/rules/pr-workflow.md` step 4 until the auto-review converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)