### PR TITLE
feat(bindings): expose iReal AST parse/serialize APIs (#2067 Phase 2b)

### DIFF
--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -65,6 +65,8 @@ All render functions accept the same three arguments:
 | `convert_chordpro_to_irealb(input)` | `ConversionWithWarnings { output: str, warnings: list[str] }` | Convert ChordPro source to an `irealb://` URL (lossy — drops lyrics, fonts, capo) |
 | `convert_irealb_to_chordpro_text(input)` | `ConversionWithWarnings { output: str, warnings: list[str] }` | Convert an `irealb://` URL to rendered ChordPro text |
 | `render_ireal_svg(input)` | `str` (SVG document) | Render an `irealb://` URL as an iReal Pro-style SVG chart |
+| `parse_irealb(input)` | `str` (JSON) | Parse an `irealb://` URL into AST-shaped JSON (mirrors `IrealSong`) |
+| `serialize_irealb(input)` | `str` (URL) | Serialize an AST-shaped JSON string back into an `irealb://` URL (round-trips with `parse_irealb`) |
 
 `output` of `convert_irealb_to_chordpro_text` is the rendered text
 representation of the converted song (`chordsketch-render-text`

--- a/crates/ffi/chordsketch/__init__.py
+++ b/crates/ffi/chordsketch/__init__.py
@@ -8,7 +8,9 @@ from chordsketch._native import (
     parse_and_render_html,
     parse_and_render_pdf,
     parse_and_render_text,
+    parse_irealb,
     render_ireal_svg,
+    serialize_irealb,
     validate,
     version,
 )
@@ -21,7 +23,9 @@ __all__ = [
     "parse_and_render_html",
     "parse_and_render_pdf",
     "parse_and_render_text",
+    "parse_irealb",
     "render_ireal_svg",
+    "serialize_irealb",
     "validate",
     "version",
 ]

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -153,6 +153,32 @@ namespace chordsketch {
     /// SVG renderer is total once it has a parsed song.
     [Throws=ChordSketchError]
     string render_ireal_svg(string input);
+
+    /// Parse an `irealb://` URL into an AST-shaped JSON string
+    /// (#2067 Phase 2b).
+    ///
+    /// The returned JSON object mirrors the `IrealSong` AST in
+    /// `chordsketch-ireal`. Pair with `serialize_irealb` for the
+    /// inverse direction. Field additions are non-breaking; field
+    /// removals or renames require a major version bump.
+    ///
+    /// Throws `ConversionFailed` when the URL is not a valid
+    /// `irealb://` payload.
+    [Throws=ChordSketchError]
+    string parse_irealb(string input);
+
+    /// Serialize an AST-shaped JSON string into an `irealb://` URL
+    /// (#2067 Phase 2b).
+    ///
+    /// The input must match the JSON shape produced by
+    /// `parse_irealb`. Round-trip identity is guaranteed for any
+    /// JSON `parse_irealb` produced on the same library version.
+    ///
+    /// Throws `ConversionFailed` when the input is not valid JSON
+    /// or does not match the AST shape (missing required fields,
+    /// out-of-range values).
+    [Throws=ChordSketchError]
+    string serialize_irealb(string input);
 };
 
 /// Structured render result for text / HTML output.

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -588,6 +588,50 @@ pub fn render_ireal_svg(input: String) -> Result<String, ChordSketchError> {
     ))
 }
 
+/// Parse an `irealb://` URL into an AST-shaped JSON string
+/// (#2067 Phase 2b).
+///
+/// The returned JSON object mirrors the
+/// [`chordsketch_ireal::IrealSong`] AST. Pair with
+/// [`serialize_irealb`] for the inverse direction. Field
+/// additions are non-breaking; field removals or renames require
+/// a major version bump.
+///
+/// # Errors
+///
+/// Returns [`ChordSketchError::ConversionFailed`] when the URL is
+/// not a valid `irealb://` payload.
+pub fn parse_irealb(input: String) -> Result<String, ChordSketchError> {
+    use chordsketch_ireal::ToJson;
+    let song =
+        chordsketch_ireal::parse(&input).map_err(|e| ChordSketchError::ConversionFailed {
+            reason: e.to_string(),
+        })?;
+    Ok(song.to_json_string())
+}
+
+/// Serialize an AST-shaped JSON string into an `irealb://` URL
+/// (#2067 Phase 2b).
+///
+/// The input must match the JSON shape produced by
+/// [`parse_irealb`]. Round-trip identity is guaranteed for any
+/// JSON `parse_irealb` produced on the same library version.
+///
+/// # Errors
+///
+/// Returns [`ChordSketchError::ConversionFailed`] when the input
+/// is not valid JSON or does not match the AST shape (missing
+/// required fields, out-of-range values).
+pub fn serialize_irealb(input: String) -> Result<String, ChordSketchError> {
+    use chordsketch_ireal::FromJson;
+    let song = chordsketch_ireal::IrealSong::from_json_str(&input).map_err(|e| {
+        ChordSketchError::ConversionFailed {
+            reason: format!("invalid AST JSON: {e}"),
+        }
+    })?;
+    Ok(chordsketch_ireal::irealb_serialize(&song))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -960,6 +1004,71 @@ mod tests {
         // Sister-binding parity with
         // `test_convert_irealb_to_chordpro_text_invalid_url_errors`.
         let result = render_ireal_svg("not a url".to_string());
+        assert!(
+            matches!(result, Err(ChordSketchError::ConversionFailed { .. })),
+            "expected ConversionFailed; got {result:?}"
+        );
+    }
+
+    // ---- iReal Pro AST round-trip (#2067 Phase 2b) ----
+
+    #[test]
+    fn test_parse_irealb_emits_ast_json() {
+        let json = parse_irealb(TINY_IREAL_URL.to_string()).expect("parse succeeds");
+        assert!(json.starts_with('{'), "expected JSON object, got: {json}");
+        assert!(
+            json.contains("\"sections\""),
+            "JSON must include the sections array, got: {json}"
+        );
+        assert!(
+            json.contains("\"key_signature\""),
+            "JSON must include the key_signature field, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_parse_irealb_invalid_url_errors() {
+        let result = parse_irealb("not a url".to_string());
+        assert!(
+            matches!(result, Err(ChordSketchError::ConversionFailed { .. })),
+            "expected ConversionFailed; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_serialize_irealb_round_trip() {
+        // parse → serialize → parse must yield byte-equal JSON. The
+        // first → JSON edge is `chordsketch_ireal::ToJson`; the JSON
+        // → URL → JSON loop pins the wire-format contract advertised
+        // in the public docstring.
+        let json1 = parse_irealb(TINY_IREAL_URL.to_string()).expect("parse succeeds");
+        let url2 = serialize_irealb(json1.clone()).expect("serialize succeeds");
+        assert!(
+            url2.starts_with("irealb://"),
+            "expected irealb:// URL, got: {url2}"
+        );
+        let json2 = parse_irealb(url2).expect("re-parse succeeds");
+        assert_eq!(
+            json1, json2,
+            "AST JSON must be stable across a parse → serialize → parse round-trip"
+        );
+    }
+
+    #[test]
+    fn test_serialize_irealb_invalid_json_errors() {
+        let result = serialize_irealb("{ not real json".to_string());
+        assert!(
+            matches!(result, Err(ChordSketchError::ConversionFailed { .. })),
+            "expected ConversionFailed; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_serialize_irealb_missing_required_field_errors() {
+        // `IrealSong::from_json_value` requires every documented field.
+        // An empty object should be rejected, not silently filled with
+        // defaults.
+        let result = serialize_irealb("{}".to_string());
         assert!(
             matches!(result, Err(ChordSketchError::ConversionFailed { .. })),
             "expected ConversionFailed; got {result:?}"

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -493,6 +493,7 @@ fn format_conversion_warning(w: &chordsketch_convert::ConversionWarning) -> Stri
 ///
 /// Returns [`ChordSketchError::ConversionFailed`] when the
 /// converter rejects the source as unrepresentable in iReal.
+#[must_use = "callers must handle conversion errors"]
 pub fn convert_chordpro_to_irealb(
     input: String,
 ) -> Result<ConversionWithWarnings, ChordSketchError> {
@@ -541,6 +542,7 @@ pub fn convert_chordpro_to_irealb(
 ///
 /// Returns [`ChordSketchError::ConversionFailed`] when the URL
 /// is not a valid `irealb://` payload.
+#[must_use = "callers must handle conversion errors"]
 pub fn convert_irealb_to_chordpro_text(
     input: String,
 ) -> Result<ConversionWithWarnings, ChordSketchError> {
@@ -577,6 +579,7 @@ pub fn convert_irealb_to_chordpro_text(
 /// is not a valid `irealb://` payload. Successful renders never
 /// fail — the SVG renderer is total once it has a parsed
 /// [`chordsketch_ireal::IrealSong`].
+#[must_use = "callers must handle conversion errors"]
 pub fn render_ireal_svg(input: String) -> Result<String, ChordSketchError> {
     let ireal =
         chordsketch_ireal::parse(&input).map_err(|e| ChordSketchError::ConversionFailed {
@@ -601,6 +604,7 @@ pub fn render_ireal_svg(input: String) -> Result<String, ChordSketchError> {
 ///
 /// Returns [`ChordSketchError::ConversionFailed`] when the URL is
 /// not a valid `irealb://` payload.
+#[must_use = "callers must handle parse errors"]
 pub fn parse_irealb(input: String) -> Result<String, ChordSketchError> {
     use chordsketch_ireal::ToJson;
     let song =
@@ -622,6 +626,7 @@ pub fn parse_irealb(input: String) -> Result<String, ChordSketchError> {
 /// Returns [`ChordSketchError::ConversionFailed`] when the input
 /// is not valid JSON or does not match the AST shape (missing
 /// required fields, out-of-range values).
+#[must_use = "callers must handle serialization errors"]
 pub fn serialize_irealb(input: String) -> Result<String, ChordSketchError> {
     use chordsketch_ireal::FromJson;
     let song = chordsketch_ireal::IrealSong::from_json_str(&input).map_err(|e| {

--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -73,6 +73,8 @@ console.log(`ChordSketch ${version()}`);
 | `convertChordproToIrealb(source)` | `{ output: string, warnings: string[] }` | Convert ChordPro source to an `irealb://` URL (lossy — drops lyrics, fonts, capo) |
 | `convertIrealbToChordproText(url)` | `{ output: string, warnings: string[] }` | Convert an `irealb://` URL to rendered ChordPro text |
 | `renderIrealSvg(url)` | `string` (SVG document) | Render an `irealb://` URL as an iReal Pro-style SVG chart |
+| `parseIrealb(url)` | `string` (JSON) | Parse an `irealb://` URL into AST-shaped JSON (mirrors `IrealSong`) |
+| `serializeIrealb(json)` | `string` (URL) | Serialize an AST-shaped JSON string back into an `irealb://` URL (round-trips with `parseIrealb`) |
 
 The `output` of `convertIrealbToChordproText` is the
 `chordsketch-render-text` rendering of the converted song, not raw

--- a/crates/napi/__tests__/public-api.test.js
+++ b/crates/napi/__tests__/public-api.test.js
@@ -157,4 +157,45 @@ describe("NAPI public API surface", () => {
   test("renderIrealSvg throws on invalid URL", () => {
     expect(() => m.renderIrealSvg("not a url")).toThrow();
   });
+
+  // ---- iReal Pro AST round-trip (#2067 Phase 2b) ----
+
+  test("parseIrealb returns AST-shaped JSON", () => {
+    const json = m.parseIrealb(TINY_IREAL_URL);
+    expect(typeof json).toBe("string");
+    const obj = JSON.parse(json);
+    expect(typeof obj).toBe("object");
+    expect(obj).not.toBeNull();
+    // AST top-level fields the public docstring promises.
+    expect(obj).toHaveProperty("title");
+    expect(obj).toHaveProperty("sections");
+    expect(obj).toHaveProperty("key_signature");
+    expect(obj).toHaveProperty("time_signature");
+    expect(Array.isArray(obj.sections)).toBe(true);
+  });
+
+  test("parseIrealb throws on invalid URL", () => {
+    expect(() => m.parseIrealb("not a url")).toThrow();
+  });
+
+  test("serializeIrealb round-trips with parseIrealb", () => {
+    const json1 = m.parseIrealb(TINY_IREAL_URL);
+    const url2 = m.serializeIrealb(json1);
+    expect(typeof url2).toBe("string");
+    expect(url2.startsWith("irealb://")).toBe(true);
+    // Re-parse must produce the same AST JSON; pins the wire-format
+    // stability promise documented on parseIrealb.
+    const json2 = m.parseIrealb(url2);
+    expect(json2).toBe(json1);
+  });
+
+  test("serializeIrealb throws on invalid JSON", () => {
+    expect(() => m.serializeIrealb("{ not real json")).toThrow();
+  });
+
+  test("serializeIrealb throws on missing required fields", () => {
+    // Empty object lacks every documented IrealSong field; the
+    // deserializer must reject rather than fabricate defaults.
+    expect(() => m.serializeIrealb("{}")).toThrow();
+  });
 });

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -266,3 +266,29 @@ export function convertIrealbToChordproText(input: string): ConversionWithWarnin
  * @throws when the input is not a valid `irealb://` payload.
  */
 export function renderIrealSvg(input: string): string;
+
+/**
+ * Parse an `irealb://` URL into an AST-shaped JSON string
+ * (#2067 Phase 2b).
+ *
+ * The returned JSON object mirrors the `IrealSong` AST in
+ * `chordsketch-ireal`. Pair with {@link serializeIrealb} for the
+ * inverse direction. Field additions are non-breaking; field
+ * removals or renames require a major version bump.
+ *
+ * @throws when the input is not a valid `irealb://` payload.
+ */
+export function parseIrealb(input: string): string;
+
+/**
+ * Serialize an AST-shaped JSON string into an `irealb://` URL
+ * (#2067 Phase 2b).
+ *
+ * The input must match the JSON shape produced by
+ * {@link parseIrealb}. Round-trip identity is guaranteed for any
+ * JSON `parseIrealb` produced on the same library version.
+ *
+ * @throws when the input is not valid JSON or does not match the
+ *         AST shape (missing required fields, out-of-range values).
+ */
+export function serializeIrealb(input: string): string;

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -754,6 +754,59 @@ pub fn render_ireal_svg(input: String) -> Result<String> {
     do_render_ireal_svg(&input).map_err(|reason| Error::new(Status::GenericFailure, reason))
 }
 
+/// Run the iReal URL → AST JSON pipeline; native helper. See
+/// [`do_convert_chordpro_to_irealb`] for the `Result<_, String>`
+/// rationale.
+fn do_parse_irealb(input: &str) -> std::result::Result<String, String> {
+    use chordsketch_ireal::ToJson;
+    let song = chordsketch_ireal::parse(input).map_err(|e| format!("parse failed: {e}"))?;
+    Ok(song.to_json_string())
+}
+
+/// Run the AST JSON → iReal URL pipeline; native helper.
+fn do_serialize_irealb(input: &str) -> std::result::Result<String, String> {
+    use chordsketch_ireal::FromJson;
+    let song = chordsketch_ireal::IrealSong::from_json_str(input)
+        .map_err(|e| format!("invalid AST JSON: {e}"))?;
+    Ok(chordsketch_ireal::irealb_serialize(&song))
+}
+
+/// Parse an `irealb://` URL into an AST-shaped JSON string
+/// (#2067 Phase 2b).
+///
+/// The returned JSON object mirrors the `IrealSong` AST in
+/// `chordsketch-ireal`. Pair with [`serialize_irealb`] for the
+/// inverse direction. Field additions are non-breaking; field
+/// removals or renames require a major version bump.
+///
+/// # Errors
+///
+/// Rejects with status `GenericFailure` when the URL is not a
+/// valid `irealb://` payload.
+#[must_use = "callers must handle parse errors"]
+#[napi]
+pub fn parse_irealb(input: String) -> Result<String> {
+    do_parse_irealb(&input).map_err(|reason| Error::new(Status::GenericFailure, reason))
+}
+
+/// Serialize an AST-shaped JSON string into an `irealb://` URL
+/// (#2067 Phase 2b).
+///
+/// The input must match the JSON shape produced by
+/// [`parse_irealb`]. Round-trip identity is guaranteed for any
+/// JSON `parse_irealb` produced on the same library version.
+///
+/// # Errors
+///
+/// Rejects with status `GenericFailure` when the input is not
+/// valid JSON or does not match the AST shape (missing required
+/// fields, out-of-range values).
+#[must_use = "callers must handle serialization errors"]
+#[napi]
+pub fn serialize_irealb(input: String) -> Result<String> {
+    do_serialize_irealb(&input).map_err(|reason| Error::new(Status::GenericFailure, reason))
+}
+
 // Unit tests exercise the underlying rendering and parsing logic directly
 // via chordsketch_chordpro and renderer crates. The napi wrapper functions
 // cannot be tested natively because they depend on the Node.js runtime for
@@ -1130,6 +1183,59 @@ mod tests {
     #[test]
     fn test_render_ireal_svg_invalid_url_errors() {
         let result = super::do_render_ireal_svg("not a url");
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    // ---- iReal Pro AST round-trip (#2067 Phase 2b) ----
+
+    #[test]
+    fn test_parse_irealb_emits_ast_json() {
+        let json = super::do_parse_irealb(TINY_IREAL_URL).unwrap();
+        assert!(json.starts_with('{'), "expected JSON object, got: {json}");
+        assert!(
+            json.contains("\"sections\""),
+            "JSON must include the sections array, got: {json}"
+        );
+        assert!(
+            json.contains("\"key_signature\""),
+            "JSON must include the key_signature field, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_parse_irealb_invalid_url_errors() {
+        let result = super::do_parse_irealb("not a url");
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    #[test]
+    fn test_serialize_irealb_round_trip() {
+        // parse → serialize → parse must yield byte-equal JSON.
+        let json1 = super::do_parse_irealb(TINY_IREAL_URL).unwrap();
+        let url2 = super::do_serialize_irealb(&json1).unwrap();
+        assert!(
+            url2.starts_with("irealb://"),
+            "expected irealb:// URL, got: {url2}"
+        );
+        let json2 = super::do_parse_irealb(&url2).unwrap();
+        assert_eq!(
+            json1, json2,
+            "AST JSON must be stable across a parse → serialize → parse round-trip"
+        );
+    }
+
+    #[test]
+    fn test_serialize_irealb_invalid_json_errors() {
+        let result = super::do_serialize_irealb("{ not real json");
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    #[test]
+    fn test_serialize_irealb_missing_required_field_errors() {
+        // `IrealSong::from_json_value` requires every documented field.
+        // An empty object should be rejected, not silently filled with
+        // defaults.
+        let result = super::do_serialize_irealb("{}");
         assert!(result.is_err(), "expected error, got {result:?}");
     }
 }

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -75,6 +75,8 @@ The exported wasm-bindgen functions are:
 | `convertChordproToIrealb(input)` | Convert ChordPro source to an `irealb://` URL (lossy — drops lyrics, fonts, capo) | `{ output: string, warnings: string[] }` |
 | `convertIrealbToChordproText(input)` | Convert an `irealb://` URL to rendered ChordPro text | `{ output: string, warnings: string[] }` |
 | `renderIrealSvg(input)` | Render an `irealb://` URL as an iReal Pro-style SVG chart | `string` (SVG document) |
+| `parseIrealb(input)` | Parse an `irealb://` URL into AST-shaped JSON (mirrors `IrealSong`) | `string` (JSON) |
+| `serializeIrealb(input)` | Serialize an AST-shaped JSON string back into an `irealb://` URL (round-trip with `parseIrealb`) | `string` (URL) |
 | `version()` | Library version string | `string` |
 
 Each element of `warnings` is a plain UTF-8 string containing a

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -966,8 +966,7 @@ pub fn parse_irealb(input: &str) -> Result<String, JsValue> {
 ///
 /// The input must match the JSON shape produced by [`parse_irealb`].
 /// Round-trip identity is guaranteed for any JSON that came out of
-/// `parse_irealb` on the same library version (modulo URL-encoding
-/// differences inside the iReal serializer's own deterministic output).
+/// `parse_irealb` on the same library version.
 ///
 /// # Errors
 ///
@@ -1918,5 +1917,17 @@ mod wasm_tests {
     fn serialize_irealb_invalid_json_errors() {
         let result = serialize_irealb("{ not real json");
         assert!(result.is_err(), "expected JsValue Err for invalid JSON");
+    }
+
+    /// An empty JSON object (missing every required `IrealSong` field)
+    /// surfaces as a `JsValue` error, not a panic or a silently
+    /// default-filled song.
+    #[wasm_bindgen_test]
+    fn serialize_irealb_missing_required_field_errors() {
+        let result = serialize_irealb("{}");
+        assert!(
+            result.is_err(),
+            "expected JsValue Err for missing required fields"
+        );
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -948,7 +948,7 @@ fn do_serialize_irealb(input: &str) -> Result<String, String> {
 /// [`chordsketch_ireal::IrealSong`]. The format is the
 /// AST wire format and follows the AST's stability promise:
 /// new optional fields may appear in minor releases; renames or
-/// removals require a major bump. Pair with [`serializeIrealb`]
+/// removals require a major bump. Pair with [`serialize_irealb`]
 /// for the inverse direction.
 ///
 /// # Errors
@@ -964,9 +964,9 @@ pub fn parse_irealb(input: &str) -> Result<String, JsValue> {
 /// Serialize an AST-shaped JSON string into an `irealb://` URL
 /// (#2067 Phase 2b).
 ///
-/// The input must match the JSON shape produced by [`parseIrealb`].
+/// The input must match the JSON shape produced by [`parse_irealb`].
 /// Round-trip identity is guaranteed for any JSON that came out of
-/// `parseIrealb` on the same library version (modulo URL-encoding
+/// `parse_irealb` on the same library version (modulo URL-encoding
 /// differences inside the iReal serializer's own deterministic output).
 ///
 /// # Errors

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -924,6 +924,62 @@ pub fn render_ireal_svg(input: &str) -> Result<String, JsValue> {
     do_render_ireal_svg(input).map_err(|e| JsValue::from_str(&e))
 }
 
+/// Run the iReal URL → AST JSON pipeline; native helper used by the
+/// wasm wrapper and by Rust unit tests.
+fn do_parse_irealb(input: &str) -> Result<String, String> {
+    use chordsketch_ireal::ToJson;
+    let song = chordsketch_ireal::parse(input).map_err(|e| format!("parse failed: {e}"))?;
+    Ok(song.to_json_string())
+}
+
+/// Run the AST JSON → iReal URL pipeline; native helper used by the
+/// wasm wrapper and by Rust unit tests.
+fn do_serialize_irealb(input: &str) -> Result<String, String> {
+    use chordsketch_ireal::FromJson;
+    let song = chordsketch_ireal::IrealSong::from_json_str(input)
+        .map_err(|e| format!("invalid AST JSON: {e}"))?;
+    Ok(chordsketch_ireal::irealb_serialize(&song))
+}
+
+/// Parse an `irealb://` URL into an AST-shaped JSON string
+/// (#2067 Phase 2b).
+///
+/// Returns the song as a JSON object whose shape mirrors
+/// [`chordsketch_ireal::IrealSong`]. The format is the
+/// AST wire format and follows the AST's stability promise:
+/// new optional fields may appear in minor releases; renames or
+/// removals require a major bump. Pair with [`serializeIrealb`]
+/// for the inverse direction.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string when the URL is not a valid
+/// `irealb://` payload.
+#[must_use = "callers must handle parse errors"]
+#[wasm_bindgen(js_name = parseIrealb)]
+pub fn parse_irealb(input: &str) -> Result<String, JsValue> {
+    do_parse_irealb(input).map_err(|e| JsValue::from_str(&e))
+}
+
+/// Serialize an AST-shaped JSON string into an `irealb://` URL
+/// (#2067 Phase 2b).
+///
+/// The input must match the JSON shape produced by [`parseIrealb`].
+/// Round-trip identity is guaranteed for any JSON that came out of
+/// `parseIrealb` on the same library version (modulo URL-encoding
+/// differences inside the iReal serializer's own deterministic output).
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string when the input is not valid JSON
+/// or does not match the AST shape (e.g. missing required fields,
+/// out-of-range values).
+#[must_use = "callers must handle serialization errors"]
+#[wasm_bindgen(js_name = serializeIrealb)]
+pub fn serialize_irealb(input: &str) -> Result<String, JsValue> {
+    do_serialize_irealb(input).map_err(|e| JsValue::from_str(&e))
+}
+
 #[wasm_bindgen(typescript_custom_section)]
 const RENDER_IREAL_SVG_TS: &'static str = r#"
 /**
@@ -935,6 +991,35 @@ const RENDER_IREAL_SVG_TS: &'static str = r#"
  * @throws when the input is not a valid `irealb://` payload.
  */
 export function renderIrealSvg(input: string): string;
+"#;
+
+#[wasm_bindgen(typescript_custom_section)]
+const PARSE_SERIALIZE_IREALB_TS: &'static str = r#"
+/**
+ * Parse an `irealb://` URL into an AST-shaped JSON string
+ * (#2067 Phase 2b).
+ *
+ * The returned JSON mirrors the `IrealSong` AST in
+ * `chordsketch-ireal`. Pair with {@link serializeIrealb} for the
+ * inverse direction. Field additions are non-breaking; field
+ * removals or renames require a major version bump.
+ *
+ * @throws when the input is not a valid `irealb://` payload.
+ */
+export function parseIrealb(input: string): string;
+
+/**
+ * Serialize an AST-shaped JSON string into an `irealb://` URL
+ * (#2067 Phase 2b).
+ *
+ * The input must match the JSON shape produced by
+ * {@link parseIrealb}. Round-trips are stable for any JSON
+ * `parseIrealb` produced on the same library version.
+ *
+ * @throws when the input is not valid JSON or does not match the
+ *         AST shape.
+ */
+export function serializeIrealb(input: string): string;
 "#;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -1224,6 +1309,63 @@ mod tests {
     #[test]
     fn test_render_ireal_svg_invalid_url_errors() {
         let result = do_render_ireal_svg("not a url");
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    // ---- iReal Pro AST round-trip (#2067 Phase 2b) ----
+
+    #[test]
+    fn test_parse_irealb_emits_ast_json() {
+        let json = do_parse_irealb(TINY_IREAL_URL).unwrap();
+        assert!(json.starts_with('{'), "expected JSON object, got: {json}");
+        assert!(
+            json.contains("\"sections\""),
+            "JSON must include the sections array, got: {json}"
+        );
+        assert!(
+            json.contains("\"key_signature\""),
+            "JSON must include the key_signature field, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_parse_irealb_invalid_url_errors() {
+        let result = do_parse_irealb("not a url");
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    #[test]
+    fn test_serialize_irealb_round_trip() {
+        // parse → serialize → parse must yield byte-equal JSON. The
+        // first → JSON edge is `chordsketch_ireal::ToJson`; the JSON
+        // → URL → JSON loop pins the wire-format contract advertised
+        // in the public docstring.
+        let json1 = do_parse_irealb(TINY_IREAL_URL).unwrap();
+        let url2 = do_serialize_irealb(&json1).unwrap();
+        assert!(
+            url2.starts_with("irealb://"),
+            "expected irealb:// URL, got: {url2}"
+        );
+        let json2 = do_parse_irealb(&url2).unwrap();
+        assert_eq!(
+            json1, json2,
+            "AST JSON must be stable across a parse → serialize → parse round-trip"
+        );
+    }
+
+    #[test]
+    fn test_serialize_irealb_invalid_json_errors() {
+        let result = do_serialize_irealb("{ not real json");
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    #[test]
+    fn test_serialize_irealb_missing_required_field_errors() {
+        // `IrealSong::from_json_value` requires `title`, `composer`,
+        // `style`, `key_signature`, `time_signature`, `tempo`,
+        // `transpose`, `sections`. An empty object is missing all of
+        // them; the deserializer must reject rather than fabricate.
+        let result = do_serialize_irealb("{}");
         assert!(result.is_err(), "expected error, got {result:?}");
     }
 }
@@ -1729,5 +1871,52 @@ mod wasm_tests {
     fn render_ireal_svg_invalid_url_errors() {
         let result = render_ireal_svg("not a url");
         assert!(result.is_err(), "expected JsValue Err for invalid URL");
+    }
+
+    // ---- iReal Pro AST round-trip (#2067 Phase 2b) ----
+
+    /// `parseIrealb` returns a JSON string the JS side can `JSON.parse`,
+    /// and the parsed object exposes the AST-level fields (`title`,
+    /// `sections`, …). Confirms the boundary contract for the typed
+    /// d.ts wrapper without dragging in a serde DTO.
+    #[wasm_bindgen_test]
+    fn parse_irealb_emits_ast_json() {
+        let json = parse_irealb(TINY_IREAL_URL_WASM).unwrap();
+        assert!(json.starts_with('{'), "expected JSON object, got: {json}");
+        assert!(
+            json.contains("\"sections\""),
+            "JSON must include the sections array, got: {json}"
+        );
+    }
+
+    /// Invalid URL surfaces as a `JsValue` error, not a panic.
+    #[wasm_bindgen_test]
+    fn parse_irealb_invalid_url_errors() {
+        let result = parse_irealb("not a url");
+        assert!(result.is_err(), "expected JsValue Err for invalid URL");
+    }
+
+    /// Round-trip: `serializeIrealb(parseIrealb(url))` produces an
+    /// `irealb://` URL whose re-parse matches the original JSON.
+    #[wasm_bindgen_test]
+    fn serialize_irealb_round_trip() {
+        let json1 = parse_irealb(TINY_IREAL_URL_WASM).unwrap();
+        let url2 = serialize_irealb(&json1).unwrap();
+        assert!(
+            url2.starts_with("irealb://"),
+            "expected irealb:// URL, got: {url2}"
+        );
+        let json2 = parse_irealb(&url2).unwrap();
+        assert_eq!(
+            json1, json2,
+            "AST JSON must be stable across a parse → serialize → parse round-trip"
+        );
+    }
+
+    /// Invalid JSON surfaces as a `JsValue` error, not a panic.
+    #[wasm_bindgen_test]
+    fn serialize_irealb_invalid_json_errors() {
+        let result = serialize_irealb("{ not real json");
+        assert!(result.is_err(), "expected JsValue Err for invalid JSON");
     }
 }

--- a/packages/kotlin/README.md
+++ b/packages/kotlin/README.md
@@ -88,6 +88,8 @@ All render functions accept three parameters:
 | `convertChordproToIrealb(input)` | `ConversionWithWarnings` | `ChordSketchException` | ChordPro → `irealb://` URL (lossy: drops lyrics, fonts, capo) |
 | `convertIrealbToChordproText(input)` | `ConversionWithWarnings` | `ChordSketchException` | `irealb://` URL → rendered ChordPro text |
 | `renderIrealSvg(input)` | `String` (SVG document) | `ChordSketchException` | `irealb://` URL → iReal Pro-style SVG chart |
+| `parseIrealb(input)` | `String` (JSON) | `ChordSketchException` | `irealb://` URL → AST-shaped JSON mirroring `IrealSong` |
+| `serializeIrealb(input)` | `String` (URL) | `ChordSketchException` | AST-shaped JSON → `irealb://` URL (round-trips with `parseIrealb`) |
 
 `ConversionWithWarnings` exposes `output: String` and
 `warnings: List<String>`. Each warning is a

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -120,6 +120,8 @@ const html = render_html_with_options(input, {
 | `convertChordproToIrealb(input)` | ChordPro source | `{ output: string, warnings: string[] }` — `output` is an `irealb://` URL |
 | `convertIrealbToChordproText(input)` | `irealb://` URL | `{ output: string, warnings: string[] }` — `output` is rendered ChordPro text |
 | `renderIrealSvg(input)` | `irealb://` URL | `string` — full SVG document (iReal Pro-style chart) |
+| `parseIrealb(input)` | `irealb://` URL | `string` — AST-shaped JSON mirroring `IrealSong` |
+| `serializeIrealb(input)` | AST-shaped JSON | `string` — `irealb://` URL (round-trips with `parseIrealb`) |
 
 `convertChordproToIrealb` is lossy: lyrics, fonts / colours, and
 capo are dropped because iReal has no surface for them. Each

--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -79,6 +79,8 @@ All render methods accept three arguments:
 | `Chordsketch.convert_chordpro_to_irealb(input)` | `ConversionWithWarnings` | ChordPro → `irealb://` URL (lossy: drops lyrics, fonts, capo) |
 | `Chordsketch.convert_irealb_to_chordpro_text(input)` | `ConversionWithWarnings` | `irealb://` URL → rendered ChordPro text |
 | `Chordsketch.render_ireal_svg(input)` | `String` (SVG document) | `irealb://` URL → iReal Pro-style SVG chart |
+| `Chordsketch.parse_irealb(input)` | `String` (JSON) | `irealb://` URL → AST-shaped JSON mirroring `IrealSong` |
+| `Chordsketch.serialize_irealb(input)` | `String` (URL) | AST-shaped JSON → `irealb://` URL (round-trips with `parse_irealb`) |
 
 `ConversionWithWarnings` exposes `output` (String) and
 `warnings` (Array<String>). Each warning is a

--- a/packages/ruby/test/test_chordsketch.rb
+++ b/packages/ruby/test/test_chordsketch.rb
@@ -66,4 +66,22 @@ class TestChordSketch < Minitest::Test
     svg = Chordsketch.render_ireal_svg(TINY_IREAL_URL)
     assert svg.include?("<svg"), "expected SVG document, got: #{svg[0..200]}"
   end
+
+  # iReal Pro AST round-trip (#2067 Phase 2b).
+
+  def test_parse_irealb_emits_ast_json
+    json = Chordsketch.parse_irealb(TINY_IREAL_URL)
+    assert json.start_with?("{"), "expected JSON object, got: #{json[0..200]}"
+    assert_includes json, '"sections"'
+    assert_includes json, '"key_signature"'
+  end
+
+  def test_serialize_irealb_round_trip
+    json1 = Chordsketch.parse_irealb(TINY_IREAL_URL)
+    url2 = Chordsketch.serialize_irealb(json1)
+    assert url2.start_with?("irealb://"), "unexpected output: #{url2}"
+    json2 = Chordsketch.parse_irealb(url2)
+    assert_equal json1, json2,
+                 "AST JSON must be stable across a parse → serialize → parse round-trip"
+  end
 end

--- a/packages/swift/README.md
+++ b/packages/swift/README.md
@@ -114,6 +114,8 @@ All render functions accept three parameters:
 | `convertChordproToIrealb(input:)` | `ConversionWithWarnings` | `ChordSketchError` | ChordPro → `irealb://` URL (lossy: drops lyrics, fonts, capo) |
 | `convertIrealbToChordproText(input:)` | `ConversionWithWarnings` | `ChordSketchError` | `irealb://` URL → rendered ChordPro text |
 | `renderIrealSvg(input:)` | `String` (SVG document) | `ChordSketchError` | `irealb://` URL → iReal Pro-style SVG chart |
+| `parseIrealb(input:)` | `String` (JSON) | `ChordSketchError` | `irealb://` URL → AST-shaped JSON mirroring `IrealSong` |
+| `serializeIrealb(input:)` | `String` (URL) | `ChordSketchError` | AST-shaped JSON → `irealb://` URL (round-trips with `parseIrealb`) |
 
 `ConversionWithWarnings` exposes `output: String` and
 `warnings: [String]`. Each warning is a `"<kind>: <message>"`

--- a/packages/swift/Tests/ChordSketchTests.swift
+++ b/packages/swift/Tests/ChordSketchTests.swift
@@ -65,4 +65,22 @@ final class ChordSketchTests: XCTestCase {
             "expected SVG document, got: \(svg.prefix(200))"
         )
     }
+
+    // iReal Pro AST round-trip (#2067 Phase 2b).
+
+    func testParseIrealbEmitsAstJson() throws {
+        let json = try ChordSketch.parseIrealb(input: tinyIrealUrl)
+        XCTAssertTrue(json.hasPrefix("{"), "expected JSON object, got: \(json.prefix(200))")
+        XCTAssertTrue(json.contains("\"sections\""))
+        XCTAssertTrue(json.contains("\"key_signature\""))
+    }
+
+    func testSerializeIrealbRoundTrip() throws {
+        let json1 = try ChordSketch.parseIrealb(input: tinyIrealUrl)
+        let url2 = try ChordSketch.serializeIrealb(input: json1)
+        XCTAssertTrue(url2.hasPrefix("irealb://"), "unexpected output: \(url2)")
+        let json2 = try ChordSketch.parseIrealb(input: url2)
+        XCTAssertEqual(json1, json2,
+            "AST JSON must be stable across a parse → serialize → parse round-trip")
+    }
 }


### PR DESCRIPTION
## Summary

- Wraps `chordsketch_ireal::parse` + `irealb_serialize` paired with the crate's `ToJson` / `FromJson` trait impls through all three bindings, completing the AST round-trip path deferred in #2339's PR body.
- Public surface (str-in / str-out, JSON-as-wire-format):
  - WASM: `parseIrealb` / `serializeIrealb`
  - NAPI: `parseIrealb` / `serializeIrealb`
  - UniFFI: `parse_irealb` / `serialize_irealb` (camelCase in Swift / Kotlin)
- The JSON shape mirrors the `IrealSong` AST and follows the AST's stability promise: new optional fields may appear in minor releases; renames or removals require a major bump. Round-trip identity (`parse → serialize → parse` is byte-equal) is asserted in every binding's test suite.

## Why JSON, not opaque AST handles

A JSON wire format keeps each binding's public surface to two str-in / str-out functions (~30 lines per binding) and lets language-side wrappers add typed accessors via `JSON.parse` + per-language type definitions (`.d.ts`, dataclass, `Codable`, …) without forcing the AST's ~14 enum/struct shape through UniFFI's Object marshalling. Opaque handles can be layered on later as a thin typed-metadata API if concrete demand surfaces; the JSON path does not preclude it.

## Failure paths

- Invalid `irealb://` payload → `ConversionFailed` (FFI) / `napi::Error` (NAPI) / `JsValue` Err (WASM).
- Malformed JSON or missing required fields → same error variants. `IrealSong::from_json_value` enforces the documented value ranges (transpose `[-11, 11]`, time-signature denominator `{2, 4, 8}`, chord-root `A..=G`, …) so out-of-range values surface as errors instead of being silently fabricated.

## Sister-binding parity

- All three bindings ship native unit tests for: parse helper (asserts `"sections"` + `"key_signature"` substrings), invalid-URL error path, round-trip identity, invalid-JSON error path, and missing-required-field error path.
- WASM additionally exercises the `JsValue` boundary via `wasm_bindgen_test`, mirroring the Phase 2a `mod wasm_tests` pattern.
- NAPI Jest test asserts the public wrapper through the compiled `.node` artifact, including `JSON.parse` of the returned string with field-presence assertions.
- Swift `XCTest` and Ruby `Minitest` smoke tests each gain `parseIrealb` / `serializeIrealb` cases.
- Per-binding READMEs (`crates/wasm`, `@chordsketch/wasm`, `@chordsketch/node`, FFI / Python, Swift, Kotlin, Ruby) gain rows in the iReal Pro conversion table.
- Python `chordsketch/__init__.py` re-exports `parse_irealb` and `serialize_irealb` alongside the Phase-1 / Phase-2a entries.
- NAPI `index.d.ts` declares the new exports.
- WASM `typescript_custom_section` documents the new exports.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — all 1,932 tests pass; per-crate WASM (25), NAPI (29), FFI (37) include new Phase 2b cases.
- [ ] CI: NAPI Jest, Ruby Minitest, Swift XCTest exercises `parseIrealb` / `serializeIrealb` end-to-end through their respective generated bindings.
- [ ] CI: full-rollup green, including non-required smoke / language-binding jobs.

## Deferred

Phase 2c (`renderIrealPng` / `renderIrealPdf`) remains open against #2067 because PNG (#2064, behind `png` feature) and PDF (#2063, behind `pdf` feature) bindings add `resvg` / `svg2pdf` to the binding-crate transitive surface and binary marshalling shape; out of scope for this PR.

Refs #2067 (Phase 2b — Phase 2c for PNG / PDF stays open).