### PR TITLE
test(bindings): backfill Python + Kotlin smoke for parse_irealb / serialize_irealb (#2343)

### DIFF
--- a/packages/kotlin/lib/src/test/kotlin/uniffi/chordsketch/ChordSketchTest.kt
+++ b/packages/kotlin/lib/src/test/kotlin/uniffi/chordsketch/ChordSketchTest.kt
@@ -85,6 +85,29 @@ class ChordSketchTest {
         )
     }
 
+    // iReal Pro AST round-trip (#2067 Phase 2b).
+
+    @Test
+    fun testParseIrealb() {
+        val json = parseIrealb(tinyIrealUrl)
+        assertTrue(json.startsWith("{"), "expected JSON object, got: ${json.take(200)}")
+        assertTrue(json.contains("\"sections\""), "JSON must include the sections array")
+        assertTrue(json.contains("\"key_signature\""), "JSON must include the key_signature field")
+    }
+
+    @Test
+    fun testSerializeIrealbRoundTrip() {
+        val json1 = parseIrealb(tinyIrealUrl)
+        val url2 = serializeIrealb(json1)
+        assertTrue(url2.startsWith("irealb://"), "unexpected output: $url2")
+        val json2 = parseIrealb(url2)
+        assertEquals(
+            json1,
+            json2,
+            "AST JSON must be stable across a parse → serialize → parse round-trip",
+        )
+    }
+
     // iReal Pro PNG / PDF render (#2067 Phase 2c).
 
     @Test

--- a/scripts/smoke-test-python.py
+++ b/scripts/smoke-test-python.py
@@ -67,6 +67,21 @@ svg = chordsketch.render_ireal_svg(TINY_IREAL_URL)
 assert "<svg" in svg, f"expected SVG document, got: {svg[:200]}"
 print("render_ireal_svg: OK")
 
+# iReal Pro AST round-trip (#2067 Phase 2b).
+json_ast = chordsketch.parse_irealb(TINY_IREAL_URL)
+assert json_ast.startswith("{"), f"expected JSON object, got: {json_ast[:200]}"
+assert '"sections"' in json_ast, "JSON must include the sections array"
+assert '"key_signature"' in json_ast, "JSON must include the key_signature field"
+print("parse_irealb: OK")
+
+url2 = chordsketch.serialize_irealb(json_ast)
+assert url2.startswith("irealb://"), f"unexpected output: {url2}"
+json_ast2 = chordsketch.parse_irealb(url2)
+assert json_ast == json_ast2, (
+    "AST JSON must be stable across a parse → serialize → parse round-trip"
+)
+print("serialize_irealb (round-trip): OK")
+
 # iReal Pro PNG render (#2067 Phase 2c).
 png = chordsketch.render_ireal_png(TINY_IREAL_URL)
 assert isinstance(png, bytes), f"expected bytes, got {type(png)}"


### PR DESCRIPTION
## What

Adds Phase 2b iReal Pro AST coverage (\`parse_irealb\` happy path + \`serialize_irealb\` round-trip) to the two language-runtime smoke files that were missing it: \`scripts/smoke-test-python.py\` and \`packages/kotlin/lib/src/test/kotlin/uniffi/chordsketch/ChordSketchTest.kt\`. Swift and Ruby already cover this surface; this PR restores sister-binding parity.

## Why

A 2026-04-30 audit during PR #2342 (Phase 2c) surfaced that Phase 2b PR #2341 added \`parse_irealb\` / \`serialize_irealb\` exports across all four UniFFI bindings (re-exports in \`crates/ffi/chordsketch/__init__.py\`, generated symbols in the Kotlin / Swift / Ruby packages) but did not extend the per-language smoke files in lockstep. Swift gained \`testParseIrealbEmitsAstJson\` + \`testSerializeIrealbRoundTrip\`, Ruby gained \`test_parse_irealb_emits_ast_json\` + \`test_serialize_irealb_round_trip\`, but Python and Kotlin stopped at Phase 2a (\`render_ireal_svg\`).

Per \`.claude/rules/fix-propagation.md\` (Bindings group), this is a sister-site parity defect — Severity Low because the Rust-level FFI tests in \`crates/ffi/src/lib.rs\` already cover the underlying logic; the gap is observability through the language-runtime smoke jobs (\`python.yml\`, \`kotlin.yml\`).

## How

Both new test bodies mirror the Swift / Ruby precedent verbatim:

- \`parse_irealb(TINY_IREAL_URL)\` returns a string that begins with \`{\` and contains \`\"sections\"\` and \`\"key_signature\"\`.
- \`serialize_irealb(parse_irealb(url))\` produces an \`irealb://\` URL whose re-parse is byte-equal to the original JSON (the round-trip stability promise from the public docstring).

The new assertions reuse the \`TINY_IREAL_URL\` / \`tinyIrealUrl\` fixture already in each file.

## Sister-site audit

| Binding | Phase 2b smoke before | After |
|---|---|---|
| Python (\`scripts/smoke-test-python.py\`) | ✗ | ✓ |
| Kotlin (\`ChordSketchTest.kt\`) | ✗ | ✓ |
| Swift (\`ChordSketchTests.swift\`) | ✓ (pre-existing) | ✓ |
| Ruby (\`test_chordsketch.rb\`) | ✓ (pre-existing) | ✓ |
| FFI native tests (\`crates/ffi/src/lib.rs\`) | ✓ (pre-existing) | ✓ |

## Test results

- \`python3 -c \"import ast; ast.parse(open('scripts/smoke-test-python.py').read())\"\`: syntax OK
- The Kotlin file's existing testRenderIrealSvg / testRenderIrealPng / testRenderIrealPdf blocks compile against the same \`uniffi.chordsketch\` import, so the new \`parseIrealb\` / \`serializeIrealb\` calls resolve through the same path.
- CI (python.yml, kotlin.yml) will exercise the new assertions end-to-end.

## Review summary

Self-review pre-PR:
- Documentation (READMEs) already lists \`parse_irealb\` / \`serialize_irealb\` for both Python and Kotlin, so no docs drift.
- The new tests do not introduce any new fixture data — they reuse the \`TINY_IREAL_URL\` constant already present in each file.

Closes #2343