### PR TITLE
ci(readme-smoke): retry transient `snap install` failures (#2345)

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -495,7 +495,28 @@ jobs:
       - name: Install via Snap
         run: |
           set -euo pipefail
-          sudo snap install chordsketch
+          # `sudo snap install` consults `api.snapcraft.io` and the
+          # Snap Store CDN. Both have non-trivial transient-failure
+          # rates — status.snapcraft.io logged 12+ short Snap Store
+          # incidents on 2026-05-01 alone, plus one multi-hour
+          # outage that day that blocked PR #2344 (an unrelated
+          # test-only change) from merging for 5+ hours. Retry with
+          # the same shape as the `winget` and `library-smoke`
+          # steps in this file so a sub-2.5-min Snap Store flake
+          # does not block an otherwise green PR's merge-queue
+          # eligibility. A sustained outage (>2.5 min) still surfaces
+          # as a real failure via `report-failure`'s tracking-issue
+          # path. See #2345.
+          attempt=0
+          until sudo snap install chordsketch; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 3 ]; then
+              echo "snap install failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "snap install attempt $attempt failed; retrying in 10s" >&2
+            sleep 10
+          done
           chordsketch --version
 
       - name: Render smoke


### PR DESCRIPTION
## What

Wraps the \`Snap (Linux)\` smoke job's \`sudo snap install chordsketch\` in a 3-attempt × 10s-backoff retry loop, mirroring the retry shape already used by \`winget\` (lines 437–449) and \`library-smoke\` (lines 600–608) in the same workflow.

## Why

Today's PR #2344 was held outside the merge queue for 5+ hours despite all 8 required checks being green from the first attempt. The blocker was \`Snap (Linux)\` failing 3× with \`error: unable to contact snap store\` — caused by a Snap Store major outage that started 2026-04-30 23:47 UTC and was acknowledged on [status.snapcraft.io](https://status.snapcraft.io/).

The same status page shows the Snap Store backend logged **12+ short incidents on 2026-05-01 alone**, durations ranging from 49 seconds to 1h17m. A workflow without retry absorbs every overlap between those incident windows and an active PR's CI run as a hard merge block, which is incongruent with end-user installability being a *steady-state* property of the package.

## How

```bash
attempt=0
until sudo snap install chordsketch; do
  attempt=$((attempt + 1))
  if [ "\$attempt" -ge 3 ]; then
    echo "snap install failed after \$attempt attempts" >&2
    exit 1
  fi
  echo "snap install attempt \$attempt failed; retrying in 10s" >&2
  sleep 10
done
chordsketch --version
```

- **3 attempts**: matches the existing \`winget\` and \`library-smoke\` retry shape exactly — no new convention to maintain.
- **10s fixed backoff**: same as winget / library-smoke; total ceiling ~2.5 min.
- **\`snap install\` is idempotent**: a re-invocation after a partial download is a no-op once the snap is already installed, so the retry is safe.
- **Sustained outages still surface**: \`report-failure\`'s tracking-issue creation runs after 3 hard failures, so genuine multi-hour Snap Store breakage still produces an alerting issue. The retry only absorbs sub-2.5-min flakes — exactly the class that dominates the status-page incident log.

A leading bash comment cites the motivating incident and the sister-step precedent, so future contributors don't have to reconstruct the rationale from \`git blame\`.

## Sister-site audit

Per \`.claude/rules/fix-propagation.md\` (External tool invocations / smoke jobs), I checked every install step in \`readme-smoke.yml\`:

| Step | Has retry? | Action |
|---|---|---|
| \`winget\` (Windows) | ✓ 3-attempt × 10s | unchanged |
| \`library-smoke\` (Linux \`cargo run\`) | ✓ 3-attempt × 10s | unchanged |
| \`snap\` (Linux) | ✗ → ✓ in this PR | added |
| \`homebrew\` (macOS) | ✗ | deferred — \`brew\` flakes haven't been observed in CI history; revisit if a similar incident surfaces |
| \`scoop\` (Windows) | ✗ | deferred — same rationale |
| \`docker\` (Linux \`docker pull\`) | (registry pulls retry inside the daemon by default) | unchanged |

Deferring \`homebrew\` / \`scoop\` keeps this PR scoped; \`#2345\`'s body explicitly carves them out, and a follow-up issue can pick them up if their backends show similar patterns.

## Test results

- \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/readme-smoke.yml'))\"\`: YAML parses cleanly.
- \`bash -n\` over the new retry block: no syntax errors.
- The new step still has \`set -euo pipefail\` at top, so failure semantics on the success path are unchanged.

## Review summary

Self-review pre-PR:
- Workflow file change only — no Rust, no docs, no tests in this PR. (\`readme-smoke.yml\` is not in any required-check coverage floor.)
- Concurrency block, \`needs:\` graph, and \`continue-on-error\` posture for the \`snap\` job are all unchanged.
- The cited 2026-05-01 status.snapcraft.io activity is concrete and verifiable; the comment block references it without naming individuals.

Closes #2345