### PR TITLE
docs(rules): add release-time documentation sync gate

### DIFF
--- a/.claude/rules/doc-maintenance.md
+++ b/.claude/rules/doc-maintenance.md
@@ -9,6 +9,15 @@ Updates are **event-driven**, not periodic. After a PR merges to `main`, evaluat
 whether any of the triggers below apply and, if so, open a dedicated documentation PR
 promptly.
 
+This rule covers per-PR documentation hygiene. Release-time
+documentation sync (verifying every cross-reference still matches
+workspace state before a version bump) is a separate hard gate
+defined in [`release-doc-sync.md`](release-doc-sync.md). Per-PR
+authors should expect the release-time check to catch any drift
+they leave behind here, but should not rely on it — the cost of
+fixing drift at release time, against ~30+ accumulated commits, is
+much higher than fixing it in the originating PR.
+
 ## Update Triggers
 
 | Event | What to update |

--- a/.claude/rules/release-doc-sync.md
+++ b/.claude/rules/release-doc-sync.md
@@ -56,9 +56,11 @@ deferred to "the next release."
   entry)`).
 - The "all renderers" / "all foundations" shorthand, where used,
   expands to the full set currently in the workspace.
-- Verify per crate:
+- Verify per crate (scoped to `[dependencies]` only — excludes
+  `[dev-dependencies]` and `[build-dependencies]`):
   ```bash
-  grep -E '^chordsketch-[a-z-]+ = ' crates/<NAME>/Cargo.toml
+  awk '/^\[dependencies\]/{p=1;next} /^\[/{p=0} p && /^chordsketch-/' \
+    crates/<NAME>/Cargo.toml
   ```
 
 ### 4. `README.md` Features section

--- a/.claude/rules/release-doc-sync.md
+++ b/.claude/rules/release-doc-sync.md
@@ -1,0 +1,131 @@
+# Release-Time Documentation Sync
+
+Documentation that cross-references workspace state — crate count,
+dependency graph, public feature list, published API surface — MUST
+match reality at the release-cut commit. This is a hard pre-release
+gate, not a best-effort review.
+
+[`doc-maintenance.md`](doc-maintenance.md) defines event-driven
+triggers (per-PR), but those rely on every PR author remembering to
+update CLAUDE.md / CHANGELOG / etc. as part of their feature PR. This
+rule is the forcing function: even when individual PRs omit a row,
+the next release-cut commit catches the drift.
+
+## Required cross-reference checks
+
+Before changing `## [X.Y.Z] - Unreleased` to
+`## [X.Y.Z] - YYYY-MM-DD` in `CHANGELOG.md` (Step 2 of
+`docs/releasing.md`), the release maintainer MUST verify each of the
+following. Any drift found is fixed in the same release PR — never
+deferred to "the next release."
+
+### 1. CHANGELOG completeness
+
+- `[Unreleased]` is non-empty.
+- Every commit on `main` since the previous release tag whose subject
+  matches `^(feat|fix)\(` has either a corresponding bullet or a
+  deliberate exclusion reason recorded in the release PR body.
+- Verify:
+  ```bash
+  git log <previous-tag>..origin/main --pretty='%s' \
+    | grep -E '^(feat|fix)\('
+  ```
+- Internal-only commits (`ci`, `chore`, `test`, `refactor`, `docs`)
+  do not need bullets unless they introduce a user-visible behaviour
+  change.
+
+### 2. `docs/releasing.md` crate references
+
+- `## Versioning Policy` crate count matches `ls -d crates/*/ | wc -l`.
+- Step 1 manifest list lists every `crates/*/Cargo.toml`.
+- Step 6 `cargo publish` bash snippet covers every published crate in
+  a topological order valid against each crate's `[dependencies]`
+  block (NOT `[dev-dependencies]` — those do not gate `cargo publish`).
+- `## crates.io Publishing Order` numbered list and Step 6 bash
+  snippet agree on the same crate set, in the same order.
+- `## Distribution Channels` table's "N lib crates" / "N bin crates"
+  counts match the workspace.
+
+### 3. `CLAUDE.md` Architecture table
+
+- One row exists for every `crates/*/` directory.
+- Each row's Dependencies column lists every `chordsketch-*` entry
+  declared in that crate's `[dependencies]` block in `Cargo.toml`.
+  `[dev-dependencies]` are not in scope; if a row mentions a dev-dep
+  it MUST flag it explicitly (e.g., `(... is a [dev-dependencies]
+  entry)`).
+- The "all renderers" / "all foundations" shorthand, where used,
+  expands to the full set currently in the workspace.
+- Verify per crate:
+  ```bash
+  grep -E '^chordsketch-[a-z-]+ = ' crates/<NAME>/Cargo.toml
+  ```
+
+### 4. `README.md` Features section
+
+- Every public-facing feature shipping in this release is mentioned by
+  at least one bullet, OR is explicitly out of scope (e.g.,
+  LSP-only features may go in `docs/editors.md` instead).
+- The CLI README (`crates/cli/README.md`), if it lists features that
+  the root README does not, has a deliberate reason — otherwise the
+  root README is out of sync.
+
+### 5. Binding READMEs
+
+- Each language binding's README at the public surface lists every
+  function exported from the corresponding manifest in this release:
+  - `crates/{wasm,napi,ffi}/README.md` ↔ each crate's exported
+    functions in `lib.rs` / `*.udl` / `index.d.ts`.
+  - `packages/{npm,swift,kotlin,ruby}/README.md` ↔ the surface their
+    binding generator publishes.
+- Pay special attention to functions added inside the release window
+  (every `feat(bindings):` commit since the previous tag).
+
+## Verification procedure
+
+Today this is a manual checklist. The intent is to migrate to a
+scripted check (`scripts/check-release-doc-sync.py`) that asserts the
+crate-graph invariants automatically; until that script ships, the
+release maintainer SHOULD:
+
+1. Enumerate the commit set:
+   ```bash
+   git log <previous-tag>..origin/main --pretty=oneline
+   ```
+2. Run through §§1–5 above against that commit set.
+3. Open a single docs PR fixing every drift found before the
+   release-cut commit lands.
+4. In the release-cut commit message, cite the verification:
+   `release-doc-sync.md §§1–5 verified at <SHA>`.
+
+A drift discovered AFTER the release-cut commit MUST be fixed by a
+follow-up docs PR before the next release window opens. Do not
+silently absorb the drift into the next release window — that is
+how this rule's failure mode (the v0.3.0 → next-release drift)
+reproduces.
+
+## Why
+
+In the v0.3.0 → next-release window (2026-04-25 → 2026-05-02), 39
+user-visible commits landed and four documentation cross-references
+drifted silently:
+
+- `CHANGELOG.md` `[Unreleased]` was empty despite the 39 commits
+  (`git log v0.3.0..origin/main --pretty='%s' | grep -cE '^(feat|fix)\('`
+  returns 39).
+- `docs/releasing.md` claimed "ten Rust crates" while the workspace
+  had thirteen. The Step 6 publish list omitted three crates that the
+  CLI depends on, which would have broken `cargo publish -p chordsketch`
+  at release time with `no matching package named "chordsketch-ireal"
+  found`.
+- `README.md` Features list omitted iReal Pro support even though
+  `crates/cli/README.md` already documented it.
+- `CLAUDE.md` Architecture table's Dependencies column lagged behind
+  the actual `Cargo.toml` declarations on five of thirteen rows
+  (`chordsketch-convert`, CLI, wasm, ffi, napi).
+
+The drift was caught only because an unrelated audit session
+triggered #2353 / PR #2354. Without this rule, the next release
+would have either shipped docs that lie about the product, or burned
+~30 minutes at release-cut time reconstructing what shipped from
+`git log` — at the worst possible moment.

--- a/.claude/rules/release-doc-sync.md
+++ b/.claude/rules/release-doc-sync.md
@@ -16,8 +16,13 @@ the next release-cut commit catches the drift.
 Before changing `## [X.Y.Z] - Unreleased` to
 `## [X.Y.Z] - YYYY-MM-DD` in `CHANGELOG.md` (Step 2 of
 `docs/releasing.md`), the release maintainer MUST verify each of the
-following. Any drift found is fixed in the same release PR — never
-deferred to "the next release."
+following. Any drift found MUST be fixed in the same release PR;
+deferring drift to a later release window is prohibited and reproduces
+this rule's documented failure mode.
+
+All commands assume the workspace root as the current working
+directory (the repository's top level — the directory containing
+`Cargo.toml`, `crates/`, and `docs/`).
 
 ### 1. CHANGELOG completeness
 
@@ -25,9 +30,11 @@ deferred to "the next release."
 - Every commit on `main` since the previous release tag whose subject
   matches `^(feat|fix)\(` has either a corresponding bullet or a
   deliberate exclusion reason recorded in the release PR body.
-- Verify:
+- Verify (`<release-cut-ref>` is the commit that will become the
+  release tag — typically `HEAD` of the release-cut branch, or
+  `origin/main` if the release is being cut directly from main):
   ```bash
-  git log <previous-tag>..origin/main --pretty='%s' \
+  git log <previous-tag>..<release-cut-ref> --pretty='%s' \
     | grep -E '^(feat|fix)\('
   ```
 - Internal-only commits (`ci`, `chore`, `test`, `refactor`, `docs`)
@@ -74,14 +81,42 @@ deferred to "the next release."
 
 ### 5. Binding READMEs
 
-- Each language binding's README at the public surface lists every
-  function exported from the corresponding manifest in this release:
-  - `crates/{wasm,napi,ffi}/README.md` ↔ each crate's exported
-    functions in `lib.rs` / `*.udl` / `index.d.ts`.
-  - `packages/{npm,swift,kotlin,ruby}/README.md` ↔ the surface their
-    binding generator publishes.
+- Every binding crate listed in `CLAUDE.md`'s Architecture table that
+  exposes a public surface (any `cdylib` / `staticlib`, plus the CLI
+  bin crate's `crates/cli/README.md`) has its `README.md` API list
+  matching the actual exported functions.
+- Every consumer-facing language package listed in `CLAUDE.md`'s
+  Additionally-these-non-Rust-packages table that ships its own README
+  (`packages/<lang>/README.md`) has its API list matching the surface
+  the binding generator publishes (UniFFI for swift / kotlin / ruby /
+  python, napi-rs for `@chordsketch/node`, wasm-bindgen for
+  `@chordsketch/wasm`).
+- The current set at the time of writing is `crates/{wasm,napi,ffi}/`
+  and `packages/{npm,swift,kotlin,ruby}/`. New bindings added later
+  inherit the rule automatically — derive the check set from the
+  CLAUDE.md table at verification time, not from this list.
 - Pay special attention to functions added inside the release window
   (every `feat(bindings):` commit since the previous tag).
+
+### 6. Release-time security ADR alignment
+
+Release-time is when stale signing-/credential-handling docs would
+mislead an on-call maintainer the most. Before the release-cut, verify
+that every release-process ADR still matches its referent workflow on
+disk:
+
+- ADR-0007 (Tauri updater key with password) ↔
+  `.github/workflows/desktop-release.yml` updater-bundle signing step
+  + `apps/desktop/src-tauri/tauri.conf.json` updater public-key field.
+- ADR-0008 (npm publishing is local) ↔ no `npm publish` invocation in
+  any `.github/workflows/*.yml`. Verify with
+  `grep -RnE 'npm[[:space:]]+publish' .github/workflows/`.
+- ADR-0009 (release-event cascade credential) ↔ `release.yml` and
+  `desktop-release.yml` use `secrets.RELEASE_DISPATCH_TOKEN` (NOT
+  `secrets.GITHUB_TOKEN`) on every `gh release create` step.
+
+A drift here is a §6 finding regardless of CHANGELOG / Cargo.toml
+state and blocks the release-cut commit identically.
 
 ## Verification procedure
 
@@ -92,13 +127,16 @@ release maintainer SHOULD:
 
 1. Enumerate the commit set:
    ```bash
-   git log <previous-tag>..origin/main --pretty=oneline
+   git log <previous-tag>..<release-cut-ref> --pretty=oneline
    ```
-2. Run through §§1–5 above against that commit set.
+2. Run through §§1–6 above against that commit set.
 3. Open a single docs PR fixing every drift found before the
    release-cut commit lands.
 4. In the release-cut commit message, cite the verification:
-   `release-doc-sync.md §§1–5 verified at <SHA>`.
+   `release-doc-sync.md §§1–6 verified against <verification-SHA>`,
+   where `<verification-SHA>` is the workspace tip at the moment the
+   checklist was run (typically the parent of the release-cut commit
+   itself).
 
 A drift discovered AFTER the release-cut commit MUST be fixed by a
 follow-up docs PR before the next release window opens. Do not
@@ -108,9 +146,9 @@ reproduces.
 
 ## Why
 
-In the v0.3.0 → next-release window (2026-04-25 → 2026-05-02), 39
-user-visible commits landed and four documentation cross-references
-drifted silently:
+In the window between v0.3.0 (2026-04-25) and the audit that produced
+this rule, 39 user-visible commits landed and four documentation
+cross-references drifted silently:
 
 - `CHANGELOG.md` `[Unreleased]` was empty despite the 39 commits
   (`git log v0.3.0..origin/main --pretty='%s' | grep -cE '^(feat|fix)\('`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -60,6 +60,13 @@ at post-release verification rather than before the tag is cut.
    ```bash
    python3 scripts/check-version-consistency.py
    ```
+5. **Release-time documentation sync.** Run the §§1–6 cross-reference
+   checks in [`.claude/rules/release-doc-sync.md`](../.claude/rules/release-doc-sync.md)
+   against the release-cut commit. This catches CHANGELOG /
+   `docs/releasing.md` / `CLAUDE.md` / `README.md` / binding-README /
+   release-process-ADR drift before the version-bump commit lands. The
+   rule's §Why documents the v0.3.0 → next-release window failure that
+   motivated it.
 
 ### Checklist
 


### PR DESCRIPTION
## What

Adds `.claude/rules/release-doc-sync.md` — a hard pre-release gate that verifies six documentation cross-references still match workspace state before the `## [X.Y.Z] - Unreleased` → `## [X.Y.Z] - YYYY-MM-DD` flip in `CHANGELOG.md` (Step 2 of `docs/releasing.md`).

The six checks:

1. **CHANGELOG completeness** against `git log <prev-tag>..<release-cut-ref>` — every `feat|fix` commit has a bullet or a documented exclusion.
2. **`docs/releasing.md` crate references** — Versioning Policy count, Step 1 manifest list, Step 6 publish snippet, §"crates.io Publishing Order" numbered list, and Distribution Channels counts all agree on the same crate set.
3. **`CLAUDE.md` Architecture table** — one row per `crates/*/`; each row's Dependencies column matches the corresponding `[dependencies]` block in `Cargo.toml`. `[dev-dependencies]` are explicitly out of scope (and must be flagged when mentioned).
4. **`README.md` Features section** — every public-facing release feature has a bullet or a documented exclusion (e.g., LSP-only features may live in `docs/editors.md`).
5. **Binding READMEs** — derived from `CLAUDE.md`'s Architecture table + non-Rust packages table at verification time (so new bindings inherit the rule automatically).
6. **Release-time security ADR alignment** — ADR-0007 / 0008 / 0009 still match `desktop-release.yml`, `release.yml`, and the absence of `npm publish` in any workflow.

`.claude/rules/doc-maintenance.md` is updated to cross-reference the new rule so per-PR authors and release-time checkers see the connection. `docs/releasing.md` Pre-release sanity gains a §5 entry that points the maintainer at the new rule.

## Why

In the window between v0.3.0 (2026-04-25) and the audit that produced this rule, 39 user-visible commits landed and four cross-references drifted silently — the empty `[Unreleased]` section, "ten Rust crates" while the workspace had thirteen, missing iReal Pro in `README.md` Features, and the CLAUDE.md Architecture table lagging on five of thirteen rows. The drift was caught only because an unrelated audit triggered #2353 / PR #2354.

`.claude/rules/doc-maintenance.md` already lists per-PR triggers, but it is event-driven and relies on every PR author remembering. The release-time rule is a forcing function: even when individual PRs omit a CLAUDE.md row, the next release-cut commit catches it.

The §Why section of the new rule cites the v0.3.0 incident directly so future contributors and AI-assistant sessions see the concrete failure mode the rule prevents.

## Test plan

- [x] Both files are valid Markdown (manual review).
- [x] `release-doc-sync.md` cross-references `doc-maintenance.md` and vice versa with no broken intra-doc link.
- [x] §3 `awk` snippet output matches the row's Dependencies column for every `crates/*/Cargo.toml` against the post-#2354 `CLAUDE.md` (sampled `crates/convert`, `crates/cli`, `crates/wasm`).
- [x] §6 ADR-0009 check `grep -RnE 'gh release create' .github/workflows/{release,desktop-release}.yml` returns the expected `RELEASE_DISPATCH_TOKEN` references.
- [x] No code changes; CI fmt / clippy / test workflows are unaffected.
- [ ] CI workflows on the merge-queue speculative-merge commit.

## Review summary

Ran `/review`, `/security-review`, and a project-rule-conformance pass in parallel against the initial commit (`e243f2a`). The auto-review bot also pushed a fix-commit (`851ad9b`, now rebased to `5955ddd`) tightening the §3 grep to `[dependencies]` only.

| Severity | Source | Issue | Resolution |
|---|---|---|---|
| Medium | code review | §5 hard-coded the binding set; new bindings would silently bypass the check | `d8fb2fa`: reframed §5 to derive the binding/package list from `CLAUDE.md` at verification time; current set demoted to illustrative example |
| Medium | auto-review bot | §3 verification command matched all TOML sections including `[dev-dependencies]`, contradicting the rule's own scope statement | `5955ddd`: replaced `grep` with an awk that activates only inside `[dependencies]` |
| Low | security review | Scope coverage gap — release-process ADR drift (ADR-0007 / 0008 / 0009) was not in the checklist even though release-time is when stale signing-/credential-handling docs would mislead most | `d8fb2fa`: added §6 covering the three release-process ADRs |
| Low | code review | `§Why` embedded the specific end-date "2026-05-02"; future readers would treat it as a session-date artefact (per the project's PR-body neutral-voice rule) | `d8fb2fa`: dropped the end date; window now described as "between v0.3.0 and the audit that produced this rule" |
| Nit | code review | §1 verify snippet hard-coded `origin/main`, missing the cherry-pick / release-branch case | `d8fb2fa`: replaced with `<release-cut-ref>` and explained the placeholder |
| Nit | code review | §Verification procedure step 4 cited a bare `<SHA>` ambiguous between the release-cut commit and the workspace verification tip | `d8fb2fa`: clarified to `<verification-SHA>` with an explicit definition |
| Nit | code review | "deferred to 'the next release'" was narrative rather than normative MUST | `d8fb2fa`: lifted to normative `MUST be fixed in the same release PR; deferring is prohibited` |
| Nit | conformance | §§1–6 commands implicitly assumed cwd at the workspace root | `d8fb2fa`: added an explicit "all commands assume the workspace root as cwd" preamble |
| Nit | conformance | `adr-discipline.md` trigger 3 ("project-wide convention not yet captured in `.claude/rules/`") arguably fires; no ADR was written | Waiver: this rule is a mechanical extension of `doc-maintenance.md` to a release-time forcing function. It does not reject an alternative that a future contributor might reasonably re-propose (the alternative is "leave it event-driven", and the §Why grounds why that has empirically failed). Per `adr-discipline.md` §"When an ADR is NOT needed" — "Decisions already covered by an existing rule in `.claude/rules/`" — the parent rule (`doc-maintenance.md`) carries the rationale, and this rule's §Why supplies the failure-mode evidence. No new ADR is needed |

Security review reported one Low (the §6 scope gap, now resolved) and zero High / Medium / High-impact findings.

The originally-deferred wire-in to `docs/releasing.md` Pre-release sanity §5 has now been folded in (PR #2354 merged at 12:16 UTC, closing the rebase-conflict window).

A follow-up tracker for `scripts/check-release-doc-sync.py` will be filed once this lands.

Closes #2355