### PR TITLE
feat(cli)+feat(desktop): extension-aware iRealb dispatch and OS file associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New crate `chordsketch-convert` — bidirectional ChordPro ↔ iReal Pro
   conversion. (#2051, #2053, #2061)
 - CLI auto-detects ChordPro vs `irealb://` input. (#2335)
+- CLI: `.irealb` (single song) and `.irealbook` (collection) file
+  extensions are authoritative for iReal-pipeline dispatch
+  (case-insensitive); the existing first-KiB content sniffer is
+  retained as fallback for untyped files. (#2358)
+- Desktop (Tauri): Open / Save dialogs surface a dedicated iReal Pro
+  filter group, and `bundle.fileAssociations` registers `.irealb` /
+  `.irealbook` as OS-level associations on macOS, Windows, and Linux.
+  (#2358)
 
 #### Bindings (multi-format track, #2067)
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -45,6 +45,22 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
+    ],
+    "fileAssociations": [
+      {
+        "ext": ["irealb"],
+        "name": "iReal Pro Song",
+        "description": "iReal Pro Song",
+        "mimeType": "application/vnd.chordsketch.irealb",
+        "role": "Editor"
+      },
+      {
+        "ext": ["irealbook"],
+        "name": "iReal Pro Collection",
+        "description": "iReal Pro Collection",
+        "mimeType": "application/vnd.chordsketch.irealbook",
+        "role": "Editor"
+      }
     ]
   }
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -41,9 +41,28 @@ const UNTITLED_LABEL = 'Untitled';
 const MAX_RECENTS = 10;
 const RECENTS_STORAGE_KEY = 'chordsketch-desktop-recent-files';
 
+// Open / Save dialogs surface ChordPro and iReal Pro files side by
+// side so a user with a mixed library can pick either format from
+// the same picker. The first filter group is the default selection
+// on every platform — keep ChordPro first so the existing default
+// stays.
+//
+// `.irealb` is the project-local convention for a single iReal Pro
+// song (one `irealb://...` URL per file); `.irealbook` is the
+// multi-song collection variant (one `irealbook://...` URL). The
+// upstream iReal Pro app does not register a file extension, so
+// these are first-class to ChordSketch's pipeline only.
 const CHORDPRO_FILTERS = [
   { name: 'ChordPro', extensions: ['cho', 'chopro', 'crd', 'chordpro'] },
-  { name: 'All files', extensions: ['*'] },
+];
+const IREALB_FILTERS = [
+  { name: 'iReal Pro', extensions: ['irealb', 'irealbook'] },
+];
+const ALL_FILES_FILTER = { name: 'All files', extensions: ['*'] };
+const OPEN_SAVE_FILTERS = [
+  ...CHORDPRO_FILTERS,
+  ...IREALB_FILTERS,
+  ALL_FILES_FILTER,
 ];
 
 const EXPORT_FILTERS: Record<
@@ -194,7 +213,7 @@ async function runOpen(
     const picked = await open({
       multiple: false,
       directory: false,
-      filters: CHORDPRO_FILTERS,
+      filters: OPEN_SAVE_FILTERS,
     });
     if (typeof picked === 'string') target = picked;
     if (!target) return; // User cancelled.
@@ -291,7 +310,7 @@ async function runSaveAs(
 ): Promise<void> {
   const picked = await save({
     defaultPath: currentPath ?? `${UNTITLED_LABEL.toLowerCase()}.cho`,
-    filters: CHORDPRO_FILTERS,
+    filters: OPEN_SAVE_FILTERS,
   });
   if (!picked) return;
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -67,6 +67,8 @@ chordsketch convert --to musicxml song.cho -o song.xml
 
 # Render an iReal Pro export — pass the URL directly or a file containing it
 chordsketch 'irealb://%54=…'
+chordsketch song.irealb            # `.irealb` (single song) routes through the iReal pipeline
+chordsketch songs.irealbook        # `.irealbook` (multi-song collection) renders one chart per song
 chordsketch chart.txt              # auto-detected if the body starts with irealb://
 chordsketch chart.txt --from ireal # force the iReal pipeline
 ```
@@ -85,7 +87,7 @@ chordsketch chart.txt --from ireal # force the iReal pipeline
 | Flag | Value | Description |
 |---|---|---|
 | `-f`, `--format` | `text` \| `html` \| `pdf` | Output format for the default render command. Defaults to `text`. (Ignored when the input is an iReal Pro `irealb://` URL — the iReal pipeline always emits SVG.) |
-| `--from` | `auto` \| `chordpro` \| `ireal` | Input format. `auto` (the default) sniffs each argument: strings starting with `irealb://` / `irealbook://` (or files whose first non-whitespace bytes match) route through the iReal renderer. `chordpro` and `ireal` force detection. |
+| `--from` | `auto` \| `chordpro` \| `ireal` | Input format. `auto` (the default) sniffs each argument: inline `irealb://` / `irealbook://` URLs, files whose path ends in `.irealb` / `.irealbook` (case-insensitive), or files whose first non-whitespace bytes match the same prefix all route through the iReal renderer. `chordpro` and `ireal` force detection. |
 | `-o`, `--output` | *path* | Write output to a file instead of stdout. For `-f pdf` this writes the binary PDF stream. |
 | `-t`, `--transpose` | *i8* | Transpose every chord by N semitones. Combines additively with any `{transpose: N}` directive in the file. |
 | `-c`, `--config` | *path* or *preset* | Load a custom config file or the named built-in preset (`default`, `ukulele`, `piano`, `guitar`, …). May be repeated — later values override earlier ones. Paths are trusted; do not pass attacker-supplied values. |

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -262,16 +262,17 @@ enum Format {
 
 /// Input-format detection for the `render` mode.
 ///
-/// Auto-detection inspects the first non-whitespace bytes of the
-/// argument: a URL or file body that starts with `irealb://` or
-/// `irealbook://` is treated as an iReal Pro export and routed
-/// through `chordsketch-ireal` + `chordsketch-render-ireal`;
-/// anything else parses as ChordPro source.
+/// Auto-detection checks each argument in order: (1) a string that
+/// starts with `irealb://` / `irealbook://` is an inline iReal URL;
+/// (2) a file whose path ends in `.irealb` / `.irealbook`
+/// (case-insensitive) is routed through the iReal pipeline on the
+/// strength of its extension; (3) for all other files, the first KiB
+/// of content is sniffed for the same URL prefix. Anything that does
+/// not match any of these three checks is treated as ChordPro source.
 ///
 /// The flag forces detection — useful when a piece of ChordPro
 /// happens to start with an `irealb://`-shaped URL inside lyrics,
-/// or when an iReal export is stored without the `.cho` extension
-/// the auto-sniffer might otherwise miss.
+/// or when an iReal export is stored with a non-standard extension.
 #[derive(Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 enum InputFormat {
     /// Detect from the first bytes of each argument (URL prefix
@@ -530,10 +531,9 @@ fn main() -> ExitCode {
 /// through the iReal pipeline.
 ///
 /// `--from chordpro` / `--from ireal` short-circuit detection.
-/// On `auto` we sniff each argument: a string that itself starts
-/// with `irealb://` / `irealbook://` is an iReal URL passed inline,
-/// otherwise we read the file's first non-whitespace bytes and
-/// check the same prefix. A mix of iReal and ChordPro arguments
+/// On `auto` we call `sniff_is_ireal` for each argument, which
+/// checks (in order): inline URL prefix → file extension →
+/// first-KiB content sniff. A mix of iReal and ChordPro arguments
 /// returns `false` here; the per-file dispatch below errors with a
 /// clear message rather than silently choosing one path.
 fn should_route_to_ireal(input_format: &InputFormat, files: &[String]) -> bool {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -165,10 +165,11 @@ struct Cli {
     warnings_json: bool,
 
     /// Input format. `auto` (the default) sniffs each argument:
-    /// strings starting with `irealb://` / `irealbook://` (or
-    /// files whose first non-whitespace bytes match) are routed
-    /// through the iReal Pro renderer (#2066). Use `chordpro` or
-    /// `ireal` to force detection.
+    /// inline `irealb://` / `irealbook://` URLs, files whose path
+    /// ends in `.irealb` / `.irealbook` (case-insensitive), and
+    /// files whose first non-whitespace bytes match the same
+    /// prefix all route through the iReal Pro renderer (#2066,
+    /// #2358). Use `chordpro` or `ireal` to force detection.
     ///
     /// When the input is iReal, the output is always SVG; the
     /// `--format text|html|pdf` flag (which selects the ChordPro
@@ -543,15 +544,46 @@ fn should_route_to_ireal(input_format: &InputFormat, files: &[String]) -> bool {
     }
 }
 
+/// Returns `true` if `path`'s file extension matches the iReal
+/// convention — `.irealb` (single song) or `.irealbook` (collection),
+/// case-insensitive so a Windows-exported `FOO.IREALB` matches.
+///
+/// `Path::extension` returns only the final extension component, so
+/// `foo.irealb.txt` returns the `txt` extension and is NOT classified
+/// as iReal — the file's content sniffer is the canonical fallback for
+/// such untyped or compound-suffix names.
+fn ireal_extension(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            ext.eq_ignore_ascii_case("irealb") || ext.eq_ignore_ascii_case("irealbook")
+        })
+}
+
 /// Returns `true` if the argument is — or names a file whose body
 /// begins with — an `irealb://` / `irealbook://` URL.
 ///
-/// Reads at most the first KiB of the file before sniffing so an
-/// adversarial caller cannot force a multi-GiB read just to make
-/// the detection decision.
+/// Detection order:
+///
+/// 1. Inline URL — a string starting with `irealb://` /
+///    `irealbook://` is iReal regardless of how it would resolve as
+///    a file path.
+/// 2. File extension — `.irealb` / `.irealbook` (case-insensitive)
+///    is authoritative on every OS; the body is parsed by the iReal
+///    pipeline whether or not the file is currently readable, so
+///    typo-ed paths still surface a clear iReal-side error rather
+///    than being silently routed through the ChordPro parser.
+/// 3. Content sniff — for untyped files (no recognised extension),
+///    reads at most the first KiB and matches the same prefix as
+///    step 1. An adversarial caller cannot force a multi-GiB read
+///    just to make the detection decision.
 fn sniff_is_ireal(arg: &str) -> bool {
     let trimmed = arg.trim_start();
     if trimmed.starts_with("irealb://") || trimmed.starts_with("irealbook://") {
+        return true;
+    }
+    if ireal_extension(arg) {
         return true;
     }
     // Fall back to reading the file's first KiB. Errors during

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1013,6 +1013,106 @@ fn ireal_nonexistent_file_with_forced_ireal_reports_error() {
         .stderr(predicate::str::contains("error"));
 }
 
+// `.irealb` (single song) and `.irealbook` (collection) are
+// authoritative file extensions — the iReal pipeline runs based
+// on the extension regardless of whether the file is currently
+// readable, with the existing content sniffer kept as fallback for
+// untyped files. (#2358)
+
+#[test]
+fn ireal_dot_irealb_extension_routes_to_ireal_pipeline() {
+    // A `.irealb` file routes through the iReal pipeline on the
+    // strength of its extension alone — extension dispatch is
+    // authoritative on every OS.
+    let mut file = tempfile::Builder::new()
+        .suffix(".irealb")
+        .tempfile()
+        .unwrap();
+    write!(file, "{TINY_IREAL_URL}").unwrap();
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .arg(file.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<svg "));
+}
+
+#[test]
+fn ireal_dot_irealbook_extension_routes_collection() {
+    // A `.irealbook` file holding a multi-song collection URL
+    // produces one SVG chart per song. Re-uses the
+    // `chordsketch-ireal` parser fixture so the assertion stays
+    // honest if the fixture grows or shrinks (the count below
+    // tracks the fixture name, not a hardcoded literal).
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../ireal/tests/fixtures/parser/three_songs/url.txt");
+    let collection_url = std::fs::read_to_string(&fixture_path)
+        .unwrap_or_else(|e| panic!("read {}: {}", fixture_path.display(), e))
+        .trim()
+        .to_owned();
+    let mut file = tempfile::Builder::new()
+        .suffix(".irealbook")
+        .tempfile()
+        .unwrap();
+    write!(file, "{collection_url}").unwrap();
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .arg(file.path())
+        .assert()
+        .success()
+        .stdout(predicate::function(|out: &str| {
+            // The fixture name asserts three songs; the renderer
+            // emits one `<svg ` element per song.
+            out.matches("<svg ").count() == 3
+        }));
+}
+
+#[test]
+fn ireal_untyped_extension_falls_back_to_content_sniff() {
+    // Regression guard: a file whose extension is neither
+    // `.irealb` nor `.irealbook` must still be routed via the
+    // first-KiB content sniffer when the body starts with
+    // `irealb://`. The extension-aware shortcut MUST NOT break
+    // content-only detection for untyped files.
+    let mut file = tempfile::Builder::new().suffix(".txt").tempfile().unwrap();
+    write!(file, "{TINY_IREAL_URL}").unwrap();
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .arg(file.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<svg "));
+}
+
+#[test]
+fn from_chordpro_overrides_irealb_extension() {
+    // `--from chordpro` is a force override; the iReal pipeline
+    // must NOT run even when the file's extension would otherwise
+    // route there. Mirrors the existing inline-URL override test
+    // (`from_chordpro_overrides_ireal_url_detection`).
+    let mut file = tempfile::Builder::new()
+        .suffix(".irealb")
+        .tempfile()
+        .unwrap();
+    write!(file, "{TINY_IREAL_URL}").unwrap();
+    let output = Command::cargo_bin("chordsketch")
+        .unwrap()
+        .args([
+            file.path().to_str().unwrap(),
+            "--from",
+            "chordpro",
+            "--format",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("<svg "),
+        "iReal pipeline must not run when --from chordpro is forced; got stdout:\n{stdout}"
+    );
+}
+
 #[test]
 fn ireal_multi_arg_produces_single_xml_declaration() {
     // Two separate single-song iReal URLs as arguments must produce

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1020,21 +1020,43 @@ fn ireal_nonexistent_file_with_forced_ireal_reports_error() {
 // untyped files. (#2358)
 
 #[test]
-fn ireal_dot_irealb_extension_routes_to_ireal_pipeline() {
-    // A `.irealb` file routes through the iReal pipeline on the
-    // strength of its extension alone — extension dispatch is
-    // authoritative on every OS.
-    let mut file = tempfile::Builder::new()
+fn ireal_dot_irealb_extension_authoritative_over_content() {
+    // An empty `.irealb` file MUST route through the iReal
+    // pipeline on the strength of its extension alone, surfacing
+    // the iReal parser's `MissingPrefix` error. This is the
+    // unique signal that the extension shortcut fired — without
+    // it, an empty body would fall through to the ChordPro
+    // pipeline (which renders an empty file as a successful
+    // exit-0 noop).
+    let file = tempfile::Builder::new()
         .suffix(".irealb")
         .tempfile()
         .unwrap();
-    write!(file, "{TINY_IREAL_URL}").unwrap();
     Command::cargo_bin("chordsketch")
         .unwrap()
         .arg(file.path())
         .assert()
-        .success()
-        .stdout(predicate::str::contains("<svg "));
+        .failure()
+        .stderr(predicate::str::contains("irealb://"));
+}
+
+#[test]
+fn ireal_extension_match_is_case_insensitive() {
+    // Windows-exported iReal libraries sometimes uppercase the
+    // file extension. `.IREALB` MUST be treated identically to
+    // `.irealb`. Re-uses the empty-body trick from above so the
+    // assertion proves the extension shortcut, not the content
+    // sniffer.
+    let file = tempfile::Builder::new()
+        .suffix(".IREALB")
+        .tempfile()
+        .unwrap();
+    Command::cargo_bin("chordsketch")
+        .unwrap()
+        .arg(file.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("irealb://"));
 }
 
 #[test]
@@ -1088,14 +1110,16 @@ fn ireal_untyped_extension_falls_back_to_content_sniff() {
 fn from_chordpro_overrides_irealb_extension() {
     // `--from chordpro` is a force override; the iReal pipeline
     // must NOT run even when the file's extension would otherwise
-    // route there. Mirrors the existing inline-URL override test
-    // (`from_chordpro_overrides_ireal_url_detection`).
+    // route there. The ChordPro renderer is forgiving and prints
+    // the irealb URL as plain-text body (exit 0), so the assertion
+    // is "succeeded but emitted no SVG" — uniquely proving the
+    // iReal path was bypassed.
     let mut file = tempfile::Builder::new()
         .suffix(".irealb")
         .tempfile()
         .unwrap();
     write!(file, "{TINY_IREAL_URL}").unwrap();
-    let output = Command::cargo_bin("chordsketch")
+    Command::cargo_bin("chordsketch")
         .unwrap()
         .args([
             file.path().to_str().unwrap(),
@@ -1104,13 +1128,10 @@ fn from_chordpro_overrides_irealb_extension() {
             "--format",
             "text",
         ])
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("<svg "),
-        "iReal pipeline must not run when --from chordpro is forced; got stdout:\n{stdout}"
-    );
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<svg ").not())
+        .stdout(predicate::str::contains("<?xml ").not());
 }
 
 #[test]


### PR DESCRIPTION
## What

Promote `.irealb` (single song) and `.irealbook` (multi-song collection)
to first-class file extensions across the CLI sniff and the Tauri
desktop integration. Inline `irealb://` URLs and the existing first-KiB
content sniffer remain as fallbacks for untyped files.

- `crates/cli/src/main.rs`: new `ireal_extension(path)` helper using
  `Path::extension` + `eq_ignore_ascii_case`, so `FOO.IREALB` from a
  Windows-exported library matches and `foo.irealb.txt` does not.
  `sniff_is_ireal` consults the helper before falling back to content
  sniffing.
- `crates/cli/README.md`: Quick Start and `--from` row updated to name
  the new extensions.
- `apps/desktop/src/main.ts`: dedicated `IREALB_FILTERS` group surfaces
  alongside `CHORDPRO_FILTERS` in the Open / Save pickers; ChordPro
  filters remain first (default selection unchanged).
- `apps/desktop/src-tauri/tauri.conf.json`: `bundle.fileAssociations`
  registers both extensions for all three platforms with `role: Editor`
  and a `mimeType` that drives the macOS UTI / Linux `.desktop` MIME
  binding. Verified against https://schema.tauri.app/config/2.
- `crates/cli/tests/cli.rs`: five cases exercise extension dispatch —
  empty-body extension authority (single + case-insensitive), the
  multi-song collection happy path, the untyped-file fallback, and
  `--from chordpro` overriding a `.irealb` extension.
- `CHANGELOG.md`: `[Unreleased]` gains two bullets per
  `release-doc-sync.md` §1.

## Why

The pre-existing CLI relied on first-KiB content sniffing only — a
correctness gap for empty or content-pending iReal files, and a UX
gap for desktop users whose OS shell could not associate the file
type. Extension dispatch is the OS-level convention every other
file type in this project uses (e.g. `.cho` / `.chordpro` for
ChordPro). The `.irealb` / `.irealbook` extensions are project-local
because the upstream iReal Pro app does not register one itself.

## Sister-site audit (per `.claude/rules/fix-propagation.md`)

The detection / dialog / association group:

- [x] **CLI sniff** — `crates/cli/src/main.rs` `sniff_is_ireal` now
      checks the extension first, falls back to content.
- [x] **Tauri filter** — `apps/desktop/src/main.ts` `IREALB_FILTERS`
      added; both `runOpen` and `runSaveAs` use the combined
      `OPEN_SAVE_FILTERS` list.
- [x] **Tauri association** — `tauri.conf.json`
      `bundle.fileAssociations` registers both extensions with mime
      types and Editor role.

Bindings (`crates/wasm`, `crates/ffi`, `crates/napi`) accept iReal
URL strings directly and do not classify by file extension, so they
are not sister sites for this fix. The editor-integration sister
sites (VS Code language id, JetBrains TextMate bundle, Zed
extension, syntaxes/) are tracked under **#2359** and **#2360** and
are intentionally out of scope per the parent tracker's
implementation order — they ship as docs-overlap PRs after this
code lands.

## Test plan

- [x] `cargo test -p chordsketch` — all `ireal_*` cases pass
      (13 tests including the new 5; verified locally).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `tauri.conf.json` validates as JSON; `fileAssociations` matches
      the v2 schema (`ext` array required; `name`, `description`,
      `mimeType`, `role` all on the type).
- [ ] Manual: build a local Tauri bundle, double-click a `.irealb`
      file, confirm it launches ChordSketch. (Deferred to release
      verification — `desktop-build.yml` and `desktop-smoke` exercise
      the manifest at PR time.)

## Deferred

- **Tauri runtime file-open handler** — registering
  `bundle.fileAssociations` makes the OS recognise ChordSketch as the
  handler for `.irealb` / `.irealbook`, but `apps/desktop/src-tauri/src/main.rs`
  has no `RunEvent::Opened` arm and no deep-link plugin, so a
  double-clicked file currently launches the app without populating
  the editor. Registering the OS association is the prerequisite for
  the handler — the handler itself is tracked by **#2367** ("Tauri
  desktop integration: Open/Save dispatch + View menu"), which sits
  downstream of this PR in the tracker's implementation order.
- **ADR for `.irealb` / `.irealbook` extension convention** — per
  `.claude/rules/adr-discipline.md`, establishing a project-wide
  convention warrants an ADR. The convention is currently described
  in tracker **#2357**'s body. Since this PR introduces three follow-up
  sub-issues that consume the convention (#2359 / #2360 / #2367), a
  formal ADR is worth filing before those PRs land. Tracking as a
  follow-up; not blocking this PR because the convention is already
  consensus-stable in #2357.

Closes #2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)