### PR TITLE
feat(jetbrains+zed): register .irealb / .irealbook extensions

### DIFF
--- a/packages/jetbrains-plugin/src/main/resources/META-INF/plugin.xml
+++ b/packages/jetbrains-plugin/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@ project &mdash; a Rust implementation of the ChordPro file format.</p>
   <li>Syntax highlighting for directives, chords, comments, and delegate blocks</li>
   <li>File type recognition for .cho, .chordpro, and .chopro extensions</li>
   <li>Bracket matching and auto-closing for { } and [ ]</li>
+  <li>Recognises .irealb / .irealbook (iReal Pro) files as a separate language id; no grammar registered yet</li>
 </ul>
     ]]></description>
 

--- a/packages/jetbrains-plugin/textmate/chordpro/irealb-language-configuration.json
+++ b/packages/jetbrains-plugin/textmate/chordpro/irealb-language-configuration.json
@@ -1,0 +1,3 @@
+{
+  "$comment": "iReal Pro file body is a single percent-encoded URL line. There are no comment markers, brackets, surroundingPairs, or autoClosingPairs in the format — only the URL string. This stub exists so the JetBrains TextMate plugin recognises `.irealb` / `.irealbook` files as their own language id rather than mis-applying the chordpro grammar (#2360). Mirrors the package-local sibling at `syntaxes/irealb-language-configuration.json` (#2359). Syntax highlighting via a dedicated TextMate grammar is intentionally deferred to a future PR per the parent tracker #2357."
+}

--- a/packages/jetbrains-plugin/textmate/chordpro/package.json
+++ b/packages/jetbrains-plugin/textmate/chordpro/package.json
@@ -7,6 +7,12 @@
                 "aliases": ["ChordPro"],
                 "extensions": [".cho", ".chordpro", ".chopro"],
                 "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "irealb",
+                "aliases": ["iReal Pro"],
+                "extensions": [".irealb", ".irealbook"],
+                "configuration": "./irealb-language-configuration.json"
             }
         ],
         "grammars": [

--- a/packages/zed-extension/languages/irealb/config.toml
+++ b/packages/zed-extension/languages/irealb/config.toml
@@ -1,0 +1,12 @@
+name = "iReal Pro"
+path_suffixes = ["irealb", "irealbook"]
+# No `grammar` field is set: an iReal Pro file body is a single
+# percent-encoded `irealb://` URL line, not a tree-sitter grammar.
+# Registering the language id without a grammar is enough to stop
+# the chordpro grammar from being misapplied to `.irealb` files
+# (which would happen if the chordpro language claimed those
+# suffixes). Syntax highlighting via a dedicated grammar is
+# tracked under #2357. (#2360)
+line_comments = []
+block_comment = []
+brackets = []


### PR DESCRIPTION
## What

Sister-site parity with the VS Code registration in PR #2371. Stop
the chordpro grammar from misapplying to a percent-encoded
`irealb://` URL line in JetBrains IDEs and Zed.

- **JetBrains plugin** (`packages/jetbrains-plugin/textmate/chordpro/`):
  extend the existing chordpro bundle's `contributes.languages`
  array with a second entry — id `irealb`, extensions
  `[.irealb, .irealbook]`, alias `iReal Pro`, configuration
  `./irealb-language-configuration.json`. New stub config file
  mirrors `syntaxes/irealb-language-configuration.json` (already
  shipped in PR #2371). The chordpro grammar's `language:
  "chordpro"` declaration only applies to language id `chordpro`,
  so even if IntelliJ fully wires the new language entry, the
  chordpro grammar is NOT applied to `.irealb` files — same
  isolation property the VS Code registration relies on.
- **JetBrains plugin manifest**
  (`src/main/resources/META-INF/plugin.xml`): one-line bullet in
  the Marketplace description noting `.irealb` / `.irealbook`
  recognition, with the explicit "no grammar registered yet"
  caveat.
- **Zed extension**
  (`packages/zed-extension/languages/irealb/config.toml`, new):
  language entry with `name = "iReal Pro"`,
  `path_suffixes = ["irealb", "irealbook"]`, and explicitly empty
  `line_comments` / `block_comment` / `brackets`. No `grammar`
  field is set; the chordpro tree-sitter grammar is therefore not
  applied to `.irealb` files. Confirmed against
  `zed-industries/zed/crates/language/src/language_registry.rs` —
  the loader accepts a `None` grammar via the `Option<Arc<str>>`
  branch.
- **`syntaxes/`**: already covered by PR #2371 — the canonical
  `irealb-language-configuration.json` lives there. The AC's
  "stub config only if the package layout requires it" item is
  satisfied without further changes here.
- **`tree-sitter-chordpro`**: intentionally NOT modified per the
  parent tracker's note that iRealb is not a ChordPro dialect.

## Decision: extend chordpro bundle vs sibling bundle (JetBrains)

The AC permits either. **Extended the existing chordpro bundle**
(this PR) because:

1. The IntelliJ TextMate plugin's `ChordProBundleProvider` would
   otherwise need to grow into a multi-bundle list, and the
   provider's path resolution code (`pluginPath.resolve("textmate")
   .resolve("chordpro")`) would have to learn about a second
   `irealb/` directory.
2. The chordpro grammar's `language: "chordpro"` scope already
   gates which language id receives highlighting, so keeping the
   irealb language entry inside the chordpro bundle does NOT
   leak the chordpro grammar to `.irealb` files.
3. The package layout stays simpler: one TextMate bundle per
   plugin, multiple language declarations within it.

A sibling bundle would make sense once the irealb language gains
its own TextMate grammar (#2357 deferral); the provider can be
split then without touching this PR.

## Sister-site audit (per `.claude/rules/fix-propagation.md`)

The "register `.irealb` extension across editors" group:

- [x] **VS Code** — PR #2371.
- [x] **JetBrains TextMate plugin** — this PR.
- [x] **Zed extension** — this PR.
- [x] **`syntaxes/`** — already shipped in PR #2371; not modified
      here.
- [x] **`packages/tree-sitter-chordpro/`** — intentionally NOT
      modified.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` validates the
      modified JetBrains bundle JSON and the new stub config.
- [x] `python3 -c "import tomllib; tomllib.load(...)"` validates
      the new Zed TOML.
- [x] CI: `jetbrains.yml` (build the plugin) and the Zed build
      pipeline exercise these manifests on every PR.
- [ ] Manual: install the JetBrains plugin in IntelliJ, open a
      `.irealb` file, confirm the language picker shows "iReal Pro".
      Same for Zed. (Deferred — see Deferred section below.)

## Deferred

- **JetBrains runtime registration verification.** The IntelliJ
  TextMate plugin's documented behaviour is grammar-driven syntax
  highlighting. Whether it actively *registers* a TextMate
  bundle's `languages` entry that has no matching `grammars`
  entry as a separate file type in IntelliJ's File Type picker is
  not documented and was not validated in a sandbox `runIde` for
  this PR. The behaviour is benign in either case:
  - **If the TextMate plugin honours grammar-less language
    entries**: `.irealb` files surface as "iReal Pro" in the
    picker — the desired outcome.
  - **If it silently ignores them**: `.irealb` files fall through
    to IntelliJ's default file-type detection (plain text, no
    syntax highlighting). The chordpro grammar is still NOT
    applied because the chordpro bundle's grammar entry is scoped
    to language id `chordpro`. The goal of "prevent grammar
    misapplication" is achieved regardless.
  A proper IntelliJ `<fileType>` extension would unconditionally
  register the file type, but it requires Kotlin code (a
  `FileType` implementation) outside the AC's textmate-bundle
  scope. That is the right follow-up if a future audit of the
  installed plugin shows IntelliJ does not surface the language
  in the picker — tracked under parent issue #2357.
- **README updates** for `packages/jetbrains-plugin/README.md`
  and `packages/zed-extension/README.md` to mention iRealb
  recognition. These belong to **#2361** (`docs+tests: .irealb
  extension convention + sister-site audit`), which is the
  dedicated docs PR for this same group.

Closes #2360

🤖 Generated with [Claude Code](https://claude.com/claude-code)