### PR TITLE
docs: document .irealb / .irealbook extension convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ into a structured AST and rendering to plain text, HTML, and PDF.
 - Image directive
 - Multi-page PDF with page control
 - iReal Pro support: parse `irealb://` URLs, render charts to SVG / PNG /
-  PDF, and convert bidirectionally between ChordPro and iReal Pro
+  PDF, and convert bidirectionally between ChordPro and iReal Pro.
+  ChordSketch establishes `.irealb` (single song) and `.irealbook`
+  (multi-song collection) as project-local file extensions; both are
+  picked up by the CLI sniff, the desktop OS file associations, and
+  the editor integrations (VS Code, JetBrains, Zed).
 
 ## Try it Online
 

--- a/crates/ireal/FORMAT.md
+++ b/crates/ireal/FORMAT.md
@@ -24,6 +24,25 @@ Both prefixes carry the same body grammar. iReal generates
 `irealbook://` when the export holds a named playlist; `irealb://`
 appears for single charts.
 
+### File extension convention
+
+The upstream iReal Pro app does not register a file extension —
+URLs are typically pasted into clipboard / email / chat without a
+backing file. ChordSketch establishes the following project-local
+convention so the URL can be saved to disk and round-tripped:
+
+| Extension | Body | URL prefix |
+|---|---|---|
+| `.irealb` | Single song — one `irealb://...` URL on a single line | `irealb://` |
+| `.irealbook` | Multi-song collection — one `irealbook://...` URL on a single line | `irealbook://` |
+
+`parse_collection` accepts both prefixes; the extension distinction
+is for dialog filters, OS associations, and editor-mode hints only.
+Sister sites that consume this convention: the CLI sniff
+(`crates/cli/src/main.rs`), the Tauri desktop file associations
+(`apps/desktop/src-tauri/tauri.conf.json`), and the VS Code /
+JetBrains / Zed editor integrations.
+
 ## Top-level body structure
 
 After percent-decoding the URL body, songs are separated by `===`:

--- a/crates/ireal/README.md
+++ b/crates/ireal/README.md
@@ -77,6 +77,27 @@ Validating constructors: `TimeSignature::new`, `Ending::new`,
 mutation bypasses these checks — see the module-level "Public-field
 mutation contract" comment in `ast.rs`.
 
+## File extension convention
+
+The upstream iReal Pro app does not register a file extension —
+URLs are typically pasted into clipboard / email / chat without a
+backing file. ChordSketch establishes the following project-local
+convention so the URL can be saved to disk and round-tripped:
+
+| Extension | Body | URL prefix |
+|---|---|---|
+| `.irealb` | Single song — one `irealb://...` URL on a single line | `irealb://` |
+| `.irealbook` | Multi-song collection — one `irealbook://...` URL on a single line | `irealbook://` |
+
+`parse_collection` accepts both prefixes; the extension distinction
+is for dialog filters, OS associations, and editor-mode hints. The
+authoritative grammar reference is [`FORMAT.md`](./FORMAT.md). The
+convention is consumed by the CLI sniff
+([`crates/cli/src/main.rs`](../cli/src/main.rs)), the Tauri desktop
+file associations
+([`apps/desktop/src-tauri/tauri.conf.json`](../../apps/desktop/src-tauri/tauri.conf.json)),
+and the VS Code / JetBrains / Zed editor integrations.
+
 ## Configuration / limits
 
 The deserializer enforces hard caps to keep adversarial input

--- a/crates/render-ireal/README.md
+++ b/crates/render-ireal/README.md
@@ -56,8 +56,9 @@ assert!(svg.contains("<svg "));
 
 ## Input format
 
-The renderer takes an in-memory `IrealSong` (and a slice of them
-for multi-song collections). Upstream parsing from the on-disk
+The renderer takes a single in-memory `IrealSong`; for multi-song
+collections callers invoke the renderer once per song. Upstream
+parsing from the on-disk
 `.irealb` (single song) / `.irealbook` (multi-song collection)
 file extensions is the responsibility of `chordsketch-ireal`'s
 `parse` / `parse_collection`. See

--- a/crates/render-ireal/README.md
+++ b/crates/render-ireal/README.md
@@ -54,6 +54,17 @@ assert!(svg.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
 assert!(svg.contains("<svg "));
 ```
 
+## Input format
+
+The renderer takes an in-memory `IrealSong` (and a slice of them
+for multi-song collections). Upstream parsing from the on-disk
+`.irealb` (single song) / `.irealbook` (multi-song collection)
+file extensions is the responsibility of `chordsketch-ireal`'s
+`parse` / `parse_collection`. See
+[`crates/ireal/FORMAT.md`](../ireal/FORMAT.md) §"File extension
+convention" for the project-local convention these extensions
+encode.
+
 ## API
 
 | Item | Signature | Notes |


### PR DESCRIPTION
## What

Capture the project-local file extension convention introduced by
PR #2358 (CLI sniff + Tauri association) in every doc that lists
ChordPro file types or iReal Pro inputs.

- `README.md` (root): iReal Pro Features bullet now names
  `.irealb` (single song) / `.irealbook` (collection) and points
  at the CLI / desktop / editor sister sites.
- `crates/ireal/FORMAT.md` §"URL shape": new "File extension
  convention" subsection explaining the upstream gap (iReal Pro
  has no native extension) and the project-local convention
  table.
- `crates/ireal/README.md`: new "File extension convention"
  section between "API" and "Configuration / limits" with the
  same table and cross-references to the CLI sniff and Tauri
  association.
- `crates/render-ireal/README.md`: new "Input format" subsection
  pointing at `chordsketch-ireal::parse_collection` for upstream
  parsing, and at `crates/ireal/FORMAT.md` for the convention.

The `crates/cli/README.md` already documents the convention via
the Quick Start examples (`chordsketch song.irealb` / `songs.irealbook`)
and the `--from auto` row that landed with PR #2369; no further
edit needed here.

Per `.claude/rules/readme-sync.md`, the
`.github/snapshots/readme-commands.txt` snapshot was checked
against the regenerated output (md5sum matches the in-tree
snapshot) — no install or usage commands changed, so the snapshot
does not need updating.

## Sister-site audit (per `.claude/rules/fix-propagation.md`)

The "consume the `.irealb` extension convention" group:

- [x] **CLI sniff** (`crates/cli/src/main.rs`) — shipped in #2369.
- [x] **Tauri filter** (`apps/desktop/src/main.ts`) — shipped in
      #2369.
- [x] **Tauri association**
      (`apps/desktop/src-tauri/tauri.conf.json`) — shipped in
      #2369.
- [x] **VS Code**
      (`packages/vscode-extension/package.json`) — shipped in
      #2371.
- [x] **JetBrains TextMate**
      (`packages/jetbrains-plugin/textmate/...`) — shipped in
      #2372.
- [x] **Zed extension** (`packages/zed-extension/...`) — shipped
      in #2372.
- [x] **All four READMEs** (root + cli + ireal + render-ireal) +
      `FORMAT.md` — this PR.

## Test plan

- [x] `python3 scripts/extract-readme-commands.py` output is
      byte-equal to `.github/snapshots/readme-commands.txt`
      (md5sum verified) — no snapshot regen needed.
- [x] CI: `readme-sync.yml` runs the extractor with `--check` on
      every PR that touches `README.md` and will fail the build
      if the snapshot drifts.

## Deferred

- Editor-extension READMEs (`packages/vscode-extension/README.md`,
  `packages/jetbrains-plugin/README.md`,
  `packages/zed-extension/README.md`) were briefly considered for
  parity but the AC for #2361 lists only the four READMEs above
  + `FORMAT.md`. The VS Code README was already updated in
  PR #2371; the JetBrains and Zed READMEs do not have feature
  lists that explicitly enumerate file types and so no drift was
  introduced by #2372.

Closes #2361

🤖 Generated with [Claude Code](https://claude.com/claude-code)