### PR TITLE
feat(ui-irealb-editor): bar popover for chord/barline/ending/symbol

### DIFF
--- a/packages/ui-irealb-editor/README.md
+++ b/packages/ui-irealb-editor/README.md
@@ -8,16 +8,21 @@ This is a private workspace package; not published to npm.
 
 ## Status
 
-First iteration (#2363):
+Shipped:
 
-- Header form: title, composer, style, key (root + accidental + mode),
-  time signature (numerator / denominator), tempo, transpose.
-- Bar grid: read-only display of each bar's chords joined by spaces,
-  4 bars per line, with section labels.
+- #2363 — header form (title / composer / style / key + accidental +
+  mode / time numerator + denominator / tempo / transpose) plus a
+  4-bars-per-line grid of section + bar cells.
+- #2364 — clicking a bar cell opens a modal popover (W3C APG dialog
+  pattern: focus trap, Escape / outside-click dismissal) that edits
+  every field of the underlying `Bar`: start / end barlines, chord
+  rows (root + accidental + 12 named qualities + Custom string +
+  optional `/X` bass + beat position 1 / 1.5 / … / 4.5, with
+  add / remove / reorder), N-th ending number (1–9, empty = none),
+  and musical symbol (None / Segno / Coda / D.C. / D.S. / Fine).
 
 Subsequent iterations:
 
-- #2364 — bar popover for chord / barline / ending / musical symbol.
 - #2365 — section management and bar add / remove / reorder.
 - #2366 — `@chordsketch/ui-web` runtime swap + iRealb input toggle.
 - #2367 — desktop integration (Open / Save dispatch + View menu).

--- a/packages/ui-irealb-editor/package-lock.json
+++ b/packages/ui-irealb-editor/package-lock.json
@@ -13,7 +13,7 @@
         "vitest": "^2.1.8"
       },
       "peerDependencies": {
-        "@chordsketch/wasm": "0.3.0"
+        "@chordsketch/wasm": "^0.3.0"
       },
       "peerDependenciesMeta": {
         "@chordsketch/wasm": {

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -13,12 +13,15 @@
 //      URL via `wasm.serializeIrealb` and dispatches the resulting
 //      string to every `onChange` subscriber.
 //
-// This first iteration intentionally leaves the bar grid read-only.
-// Bar-popover editing arrives in #2364, structural section / bar
-// edits in #2365, keyboard navigation + ARIA in #2368.
+// As of #2364, bar cells are interactive — clicking opens a popover
+// dialog that edits every field of the underlying `Bar` (start /
+// end barlines, chord rows, optional N-th ending number, optional
+// musical symbol). Structural section / bar edits arrive in #2365,
+// keyboard navigation + ARIA in #2368.
 
-import type { IrealSong } from './ast.js';
+import type { Bar, IrealSong } from './ast.js';
 import { clearChildren } from './dom.js';
+import { openBarPopover, type BarPopoverHandle } from './popover.js';
 import { render, type RenderHandle } from './render.js';
 import { IrealbEditorState, type IrealbWasm, makeStateFromUrl } from './state.js';
 
@@ -75,6 +78,7 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
 
   const changeHandlers = new Set<(value: string) => void>();
   let renderHandle: RenderHandle | null = null;
+  let popoverHandle: BarPopoverHandle | null = null;
   let destroyed = false;
 
   const fireUserEdit = (): void => {
@@ -92,12 +96,50 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
     for (const handler of changeHandlers) handler(url);
   };
 
+  // Bar-popover open callback. The renderer hands us the `bar` plus
+  // its (sectionIndex, barIndex) so we can splice the saved value
+  // back into the AST without rebuilding it from object identity
+  // (which would break after a setValue rebuild). One popover at a
+  // time — clicking a second cell while a popover is open closes
+  // the first; this avoids stacked dialogs and keeps focus
+  // management deterministic.
+  const handleOpenPopover = (
+    bar: Bar,
+    anchor: HTMLElement,
+    secIndex: number,
+    barIndex: number,
+  ): void => {
+    if (destroyed) return;
+    if (popoverHandle !== null) {
+      popoverHandle.dispose();
+      popoverHandle = null;
+    }
+    popoverHandle = openBarPopover({
+      container: element,
+      bar,
+      anchor,
+      onSave: (next: Bar) => {
+        const section = state.song.sections[secIndex];
+        if (!section) return;
+        if (barIndex < 0 || barIndex >= section.bars.length) return;
+        section.bars[barIndex] = next;
+        // Re-render so the bar cell reflects the new chord/text and
+        // so the next click anchors on the freshly-mounted button.
+        renderNow();
+        fireUserEdit();
+      },
+      onClose: () => {
+        popoverHandle = null;
+      },
+    });
+  };
+
   const renderNow = (): void => {
     if (renderHandle !== null) {
       renderHandle.dispose();
       renderHandle = null;
     }
-    renderHandle = render(element, state, fireUserEdit);
+    renderHandle = render(element, state, fireUserEdit, handleOpenPopover);
   };
 
   renderNow();
@@ -120,7 +162,13 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       // Per `EditorAdapter` contract: setValue MUST NOT fire
       // onChange — it represents a host-driven load, not a user
       // edit. We rebuild the DOM (so form fields reflect the new
-      // state) but do not call `fireUserEdit`.
+      // state) but do not call `fireUserEdit`. Any open popover
+      // is dismissed: it would otherwise reference a Bar from the
+      // pre-load AST and on Save corrupt the freshly-loaded chart.
+      if (popoverHandle !== null) {
+        popoverHandle.dispose();
+        popoverHandle = null;
+      }
       if (value.length === 0) {
         state.song = makeEmptySong();
       } else {
@@ -137,6 +185,10 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
     destroy(): void {
       if (destroyed) return;
       destroyed = true;
+      if (popoverHandle !== null) {
+        popoverHandle.dispose();
+        popoverHandle = null;
+      }
       if (renderHandle !== null) {
         renderHandle.dispose();
         renderHandle = null;

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -126,6 +126,20 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
         // Re-render so the bar cell reflects the new chord/text and
         // so the next click anchors on the freshly-mounted button.
         renderNow();
+        // Return focus to the rebuilt bar cell so keyboard users
+        // keep their navigation position. The original `anchor`
+        // button is detached by `renderNow()` (clearChildren +
+        // full grid rebuild), so `dispose()` cannot return focus
+        // there; we must locate the new cell before `dispose()`
+        // runs. Compute the cell's global index by summing bar
+        // counts for all preceding sections.
+        let globalOffset = 0;
+        for (let s = 0; s < secIndex; s++) {
+          globalOffset += state.song.sections[s]?.bars.length ?? 0;
+        }
+        const cells = element.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar');
+        const newCell = cells[globalOffset + barIndex];
+        if (newCell) newCell.focus();
         fireUserEdit();
       },
       onClose: () => {

--- a/packages/ui-irealb-editor/src/popover.ts
+++ b/packages/ui-irealb-editor/src/popover.ts
@@ -172,6 +172,14 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
   const chordsSection = el('div', { class: 'irealb-editor__popover-chords' });
   body.appendChild(chordsSection);
 
+  // `listen` pushes to the outer `cleanups` array, which means each
+  // `renderChordsSection` call adds listeners for newly-created chord
+  // row elements while old stale entries (from the previous render)
+  // remain in `cleanups`. Those stale entries are safe no-ops in
+  // `dispose()`: `removeEventListener` on a detached element is a
+  // silent no-op per the spec. The accumulation is bounded to the
+  // number of chord-row interactions in one popover session, so the
+  // memory overhead is negligible in practice.
   const renderChordsSection = (): void => {
     clearChildren(chordsSection);
     chordsSection.appendChild(el('h4', { text: 'Chords' }));

--- a/packages/ui-irealb-editor/src/popover.ts
+++ b/packages/ui-irealb-editor/src/popover.ts
@@ -1,0 +1,600 @@
+// Bar-edit popover: a modal-ish dialog that opens next to a clicked
+// bar cell and edits every field of `Bar` (start/end barlines, the
+// `BarChord` list, optional N-th `Ending` number, optional
+// `MusicalSymbol`). Save commits the edits back to the live AST and
+// fires the user-edit callback; Cancel discards the working copy.
+//
+// The popover is structurally a `<div role="dialog" aria-modal="true">`
+// with a focus trap, Escape / outside-click dismissal, and the W3C
+// APG dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/dialog/).
+// It is rendered directly under the editor root so the host's
+// stacking context owns z-index. ARIA grid semantics on the
+// underlying bar grid arrive in #2368; the popover trigger does not
+// depend on them.
+
+import type {
+  Accidental,
+  Bar,
+  BarChord,
+  BarLine,
+  BeatPosition,
+  Chord,
+  ChordQuality,
+  ChordRoot,
+  MusicalSymbol,
+} from './ast.js';
+import { clearChildren, el, field, FieldIdMinter } from './dom.js';
+
+/** Subset of beat positions the popover offers in its dropdown.
+ * 1 / 1.5 / 2 / 2.5 / 3 / 3.5 / 4 / 4.5 — i.e. on-the-beat plus
+ * the "and-of" subdivisions for a 4-beat bar. Values outside this
+ * set (rarer subdivisions, 5+/4 / 7/8 charts) keep their AST value
+ * untouched on round-trip; the dropdown shows the closest match
+ * but does not normalise. The tightly-bounded list mirrors what the
+ * iReal Pro app accepts in its own editor. */
+const BEAT_POSITION_OPTIONS: ReadonlyArray<{ value: string; beat: number; subdivision: number }> = [
+  { value: '1', beat: 1, subdivision: 0 },
+  { value: '1.5', beat: 1, subdivision: 1 },
+  { value: '2', beat: 2, subdivision: 0 },
+  { value: '2.5', beat: 2, subdivision: 1 },
+  { value: '3', beat: 3, subdivision: 0 },
+  { value: '3.5', beat: 3, subdivision: 1 },
+  { value: '4', beat: 4, subdivision: 0 },
+  { value: '4.5', beat: 4, subdivision: 1 },
+];
+
+const BARLINE_OPTIONS: ReadonlyArray<{ value: BarLine; label: string }> = [
+  { value: 'single', label: 'Single │' },
+  { value: 'double', label: 'Double ‖' },
+  { value: 'final', label: 'Final ‖|' },
+  { value: 'open_repeat', label: 'Open repeat |:' },
+  { value: 'close_repeat', label: 'Close repeat :|' },
+];
+
+const QUALITY_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: 'major', label: 'Major' },
+  { value: 'minor', label: 'Minor' },
+  { value: 'diminished', label: 'Diminished' },
+  { value: 'augmented', label: 'Augmented' },
+  { value: 'major7', label: 'Major 7' },
+  { value: 'minor7', label: 'Minor 7' },
+  { value: 'dominant7', label: 'Dominant 7' },
+  { value: 'half_diminished', label: 'Half-diminished (m7♭5)' },
+  { value: 'diminished7', label: 'Diminished 7' },
+  { value: 'suspended2', label: 'Sus 2' },
+  { value: 'suspended4', label: 'Sus 4' },
+  { value: 'custom', label: 'Custom…' },
+];
+
+const SYMBOL_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: '', label: 'None' },
+  { value: 'segno', label: 'Segno 𝄋' },
+  { value: 'coda', label: 'Coda 𝄌' },
+  { value: 'da_capo', label: 'D.C.' },
+  { value: 'dal_segno', label: 'D.S.' },
+  { value: 'fine', label: 'Fine' },
+];
+
+const ACCIDENTAL_OPTIONS: ReadonlyArray<{ value: Accidental; label: string }> = [
+  { value: 'natural', label: '♮' },
+  { value: 'sharp', label: '♯' },
+  { value: 'flat', label: '♭' },
+];
+
+const NOTE_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G'] as const;
+
+/** Options accepted by {@link openBarPopover}. */
+export interface BarPopoverOptions {
+  /** Container the popover is appended to. Sits inside the editor
+   * root so `destroy()` cleans it up alongside the rest of the DOM. */
+  container: HTMLElement;
+  /** The `Bar` to edit. The popover does NOT mutate this object
+   * directly until the user hits Save — it works against a deep
+   * copy and commits in one shot. */
+  bar: Bar;
+  /** Anchor element (the clicked bar cell). The popover positions
+   * itself relative to this element and returns focus here on close. */
+  anchor: HTMLElement;
+  /** Called with the edited `Bar` when the user clicks Save.
+   * Implementations write the new value back into `state.song`
+   * (i.e. replace the bar at the right index). */
+  onSave: (next: Bar) => void;
+  /** Called when the popover closes (Save, Cancel, Escape, or
+   * outside-click). Used by the editor adapter to fire the
+   * user-edit callback when `onSave` was the cause of closure. */
+  onClose: () => void;
+}
+
+/** Handle returned by {@link openBarPopover}. `dispose` closes the
+ * popover and removes its DOM + listeners; idempotent. */
+export interface BarPopoverHandle {
+  /** The dialog root element. Exposed for tests so they can assert
+   * structure (focus, aria attributes, child queries). */
+  element: HTMLElement;
+  /** Close the popover and release every listener registered by the
+   * factory. Calling twice is a safe no-op. */
+  dispose(): void;
+}
+
+/** Build and mount the popover. Returns a handle so the caller (the
+ * grid click handler in render.ts) can dismiss programmatically. */
+export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
+  const { container, bar, anchor, onSave, onClose } = options;
+
+  // Working copy: deep clone via JSON round-trip. The Bar type is
+  // pure-data (no functions / no Maps / no Dates) so JSON cloning
+  // preserves it byte-equal. Mutations target this copy until Save.
+  const draft: Bar = JSON.parse(JSON.stringify(bar)) as Bar;
+
+  const minter = new FieldIdMinter();
+  const cleanups: Array<() => void> = [];
+  let disposed = false;
+
+  const listen = <K extends keyof HTMLElementEventMap>(
+    target: HTMLElement,
+    type: K,
+    handler: (ev: HTMLElementEventMap[K]) => void,
+  ): void => {
+    target.addEventListener(type, handler);
+    cleanups.push(() => target.removeEventListener(type, handler));
+  };
+
+  // ---- Dialog shell --------------------------------------------------------
+  const dialog = el('div', {
+    class: 'irealb-editor__popover',
+    attrs: {
+      role: 'dialog',
+      'aria-modal': 'true',
+      'aria-label': 'Edit bar',
+      tabindex: '-1',
+    },
+  });
+
+  const body = el('div', { class: 'irealb-editor__popover-body' });
+  dialog.appendChild(body);
+
+  // Slot containers — re-rendered when the chord row list changes.
+  // Keeping the static fields (barlines, ending, symbol) outside
+  // the chords slot avoids re-creating their inputs on row add /
+  // remove and lets the user keep typing without losing focus.
+  const startSelect = makeBarLineSelect(draft.start);
+  listen(startSelect, 'change', () => {
+    draft.start = startSelect.value as BarLine;
+  });
+  body.appendChild(field('Start barline', startSelect, minter));
+
+  const endSelect = makeBarLineSelect(draft.end);
+  listen(endSelect, 'change', () => {
+    draft.end = endSelect.value as BarLine;
+  });
+  body.appendChild(field('End barline', endSelect, minter));
+
+  const chordsSection = el('div', { class: 'irealb-editor__popover-chords' });
+  body.appendChild(chordsSection);
+
+  const renderChordsSection = (): void => {
+    clearChildren(chordsSection);
+    chordsSection.appendChild(el('h4', { text: 'Chords' }));
+
+    draft.chords.forEach((bc, index) => {
+      chordsSection.appendChild(renderChordRow(bc, index));
+    });
+
+    const addBtn = el('button', {
+      class: 'irealb-editor__popover-addrow',
+      attrs: { type: 'button' },
+      text: '+ Add chord',
+    });
+    listen(addBtn, 'click', () => {
+      draft.chords.push(makeDefaultBarChord());
+      renderChordsSection();
+    });
+    chordsSection.appendChild(addBtn);
+  };
+
+  // Build one chord-row cluster: root + accidental + quality +
+  // optional Custom string + optional bass note + position +
+  // up/down/remove buttons. Each row is a `<div>` so CSS can lay
+  // them out as a horizontal grid.
+  const renderChordRow = (bc: BarChord, index: number): HTMLElement => {
+    const row = el('div', {
+      class: 'irealb-editor__popover-chordrow',
+      attrs: { 'data-row-index': String(index) },
+    });
+
+    // Root note letter
+    const rootSelect = makeNoteLetterSelect(bc.chord.root.note);
+    listen(rootSelect, 'change', () => {
+      bc.chord.root.note = rootSelect.value;
+    });
+    row.appendChild(field('Root', rootSelect, minter));
+
+    // Root accidental
+    const accSelect = makeAccidentalSelect(bc.chord.root.accidental);
+    listen(accSelect, 'change', () => {
+      bc.chord.root.accidental = accSelect.value as Accidental;
+    });
+    row.appendChild(field('Acc.', accSelect, minter));
+
+    // Quality (and Custom string)
+    const qualitySelect = makeQualitySelect(bc.chord.quality);
+    const customInput = el('input', {
+      attrs: {
+        type: 'text',
+        placeholder: 'e.g. 7♯9',
+        value: bc.chord.quality.kind === 'custom' ? bc.chord.quality.value : '',
+      },
+      class: 'irealb-editor__input',
+    });
+    customInput.style.display = bc.chord.quality.kind === 'custom' ? '' : 'none';
+    listen(qualitySelect, 'change', () => {
+      const v = qualitySelect.value;
+      if (v === 'custom') {
+        bc.chord.quality = { kind: 'custom', value: customInput.value };
+        customInput.style.display = '';
+      } else {
+        bc.chord.quality = { kind: v } as ChordQuality;
+        customInput.style.display = 'none';
+      }
+    });
+    listen(customInput, 'input', () => {
+      if (bc.chord.quality.kind === 'custom') {
+        bc.chord.quality.value = customInput.value;
+      }
+    });
+    row.appendChild(field('Quality', qualitySelect, minter));
+    row.appendChild(field('Custom', customInput, minter));
+
+    // Bass note (optional). Single text input "X" / "X♭" / "" rather
+    // than a paired letter+accidental select to keep the row narrow;
+    // parses on save / blur.
+    const bassInput = el('input', {
+      attrs: {
+        type: 'text',
+        placeholder: '/X (optional)',
+        value: bc.chord.bass !== null ? formatBass(bc.chord.bass) : '',
+      },
+      class: 'irealb-editor__input',
+    });
+    listen(bassInput, 'input', () => {
+      const parsed = parseBassInput(bassInput.value);
+      bc.chord.bass = parsed;
+    });
+    row.appendChild(field('Bass', bassInput, minter));
+
+    // Beat position
+    const posSelect = makeBeatPositionSelect(bc.position);
+    listen(posSelect, 'change', () => {
+      const opt = BEAT_POSITION_OPTIONS.find((o) => o.value === posSelect.value);
+      if (!opt) {
+        // The dropdown is the only producer of values reaching this
+        // handler; an unrecognised value is a contract violation.
+        throw new Error(`bar popover: invalid beat position: ${posSelect.value}`);
+      }
+      bc.position = { beat: opt.beat, subdivision: opt.subdivision };
+    });
+    row.appendChild(field('Pos.', posSelect, minter));
+
+    // Reorder + remove
+    const upBtn = el('button', {
+      class: 'irealb-editor__popover-rowbtn',
+      attrs: { type: 'button', 'aria-label': 'Move chord up' },
+      text: '↑',
+    });
+    if (index === 0) upBtn.setAttribute('disabled', '');
+    listen(upBtn, 'click', () => {
+      if (index === 0) return;
+      const tmp = draft.chords[index - 1];
+      const cur = draft.chords[index];
+      if (!tmp || !cur) return;
+      draft.chords[index - 1] = cur;
+      draft.chords[index] = tmp;
+      renderChordsSection();
+    });
+    row.appendChild(upBtn);
+
+    const downBtn = el('button', {
+      class: 'irealb-editor__popover-rowbtn',
+      attrs: { type: 'button', 'aria-label': 'Move chord down' },
+      text: '↓',
+    });
+    if (index === draft.chords.length - 1) downBtn.setAttribute('disabled', '');
+    listen(downBtn, 'click', () => {
+      if (index === draft.chords.length - 1) return;
+      const tmp = draft.chords[index + 1];
+      const cur = draft.chords[index];
+      if (!tmp || !cur) return;
+      draft.chords[index + 1] = cur;
+      draft.chords[index] = tmp;
+      renderChordsSection();
+    });
+    row.appendChild(downBtn);
+
+    const removeBtn = el('button', {
+      class: 'irealb-editor__popover-rowbtn',
+      attrs: { type: 'button', 'aria-label': 'Remove chord' },
+      text: '×',
+    });
+    listen(removeBtn, 'click', () => {
+      draft.chords.splice(index, 1);
+      renderChordsSection();
+    });
+    row.appendChild(removeBtn);
+
+    return row;
+  };
+
+  renderChordsSection();
+
+  // Ending number (NonZeroU8 range, 1..=9 in the form; empty = None).
+  const endingInput = el('input', {
+    attrs: {
+      type: 'number',
+      min: 1,
+      max: 9,
+      step: 1,
+      value: draft.ending ?? '',
+      placeholder: 'None',
+    },
+    class: 'irealb-editor__input',
+  });
+  listen(endingInput, 'input', () => {
+    const v = endingInput.value;
+    if (v === '') {
+      draft.ending = null;
+      return;
+    }
+    const n = Number.parseInt(v, 10);
+    if (!Number.isFinite(n) || n < 1 || n > 9) {
+      // Out-of-range / non-numeric values are dropped; the AST keeps
+      // its previous value until a valid number is entered. The
+      // `min`/`max` HTML attributes already constrain the spinner UI.
+      return;
+    }
+    draft.ending = n;
+  });
+  body.appendChild(field('N-th ending', endingInput, minter));
+
+  // Musical symbol
+  const symbolSelect = makeSymbolSelect(draft.symbol);
+  listen(symbolSelect, 'change', () => {
+    const v = symbolSelect.value;
+    draft.symbol = v === '' ? null : (v as MusicalSymbol);
+  });
+  body.appendChild(field('Symbol', symbolSelect, minter));
+
+  // ---- Footer: Save / Cancel ----------------------------------------------
+  const footer = el('div', { class: 'irealb-editor__popover-footer' });
+
+  const cancelBtn = el('button', {
+    class: 'irealb-editor__popover-cancel',
+    attrs: { type: 'button' },
+    text: 'Cancel',
+  });
+  listen(cancelBtn, 'click', () => {
+    dispose();
+  });
+  footer.appendChild(cancelBtn);
+
+  const saveBtn = el('button', {
+    class: 'irealb-editor__popover-save',
+    attrs: { type: 'button' },
+    text: 'Save',
+  });
+  listen(saveBtn, 'click', () => {
+    onSave(draft);
+    dispose();
+  });
+  footer.appendChild(saveBtn);
+
+  dialog.appendChild(footer);
+
+  // ---- Focus trap + dismissal ---------------------------------------------
+  // Outside-click dismissal: any pointerdown that does not land on
+  // the dialog or the original anchor closes. Anchor exclusion is
+  // important so a click on the bar cell does not immediately close
+  // the freshly-opened popover (the click event fires after
+  // pointerdown, but we listen on pointerdown to be ahead of any
+  // re-entry).
+  const onDocumentPointerDown = (ev: PointerEvent): void => {
+    const target = ev.target as Node | null;
+    if (!target) return;
+    if (dialog.contains(target)) return;
+    if (anchor.contains(target)) return;
+    dispose();
+  };
+  document.addEventListener('pointerdown', onDocumentPointerDown, true);
+  cleanups.push(() => document.removeEventListener('pointerdown', onDocumentPointerDown, true));
+
+  // Escape closes.
+  const onKeyDown = (ev: KeyboardEvent): void => {
+    if (ev.key === 'Escape') {
+      ev.preventDefault();
+      dispose();
+      return;
+    }
+    if (ev.key === 'Tab') {
+      // Focus trap: keep Tab cycling inside the dialog. Find the
+      // first / last focusable element each Tab press so a row
+      // add/remove that changed the focus order is reflected.
+      const focusables = collectFocusables(dialog);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
+      const active = document.activeElement;
+      if (ev.shiftKey && active === first) {
+        ev.preventDefault();
+        last.focus();
+      } else if (!ev.shiftKey && active === last) {
+        ev.preventDefault();
+        first.focus();
+      }
+    }
+  };
+  dialog.addEventListener('keydown', onKeyDown);
+  cleanups.push(() => dialog.removeEventListener('keydown', onKeyDown));
+
+  // ---- Mount + initial focus ----------------------------------------------
+  container.appendChild(dialog);
+  positionPopover(dialog, anchor);
+
+  // Move focus into the dialog so keyboard users land inside it.
+  // Prefer the first focusable; fall back to the dialog itself.
+  const initialFocus = collectFocusables(dialog)[0] ?? dialog;
+  initialFocus.focus();
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    for (const cleanup of cleanups) cleanup();
+    cleanups.length = 0;
+    if (dialog.parentNode !== null) {
+      dialog.parentNode.removeChild(dialog);
+    }
+    // Return focus to the trigger anchor — APG dialog pattern. The
+    // host re-renders the bar cell after onSave (rebuild-on-demand
+    // model), so the original `anchor` may have been detached; in
+    // that case `focus()` is a silent no-op.
+    if (document.contains(anchor)) {
+      anchor.focus();
+    }
+    onClose();
+  }
+
+  return {
+    element: dialog,
+    dispose,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBarLineSelect(current: BarLine): HTMLSelectElement {
+  return makeSelect(BARLINE_OPTIONS, current);
+}
+
+function makeNoteLetterSelect(current: string): HTMLSelectElement {
+  return makeSelect(
+    NOTE_LETTERS.map((l) => ({ value: l, label: l })),
+    current,
+  );
+}
+
+function makeAccidentalSelect(current: Accidental): HTMLSelectElement {
+  return makeSelect(ACCIDENTAL_OPTIONS, current);
+}
+
+function makeQualitySelect(current: ChordQuality): HTMLSelectElement {
+  return makeSelect(QUALITY_OPTIONS, current.kind);
+}
+
+function makeSymbolSelect(current: MusicalSymbol | null): HTMLSelectElement {
+  return makeSelect(SYMBOL_OPTIONS, current ?? '');
+}
+
+function makeBeatPositionSelect(pos: BeatPosition): HTMLSelectElement {
+  // Find the option whose (beat, subdivision) match the AST. If the
+  // chart has a position outside the dropdown's set (e.g.
+  // 32nd-note subdivisions), the value-not-in-list path of
+  // makeSelect kicks in and the form shows option[0] visually
+  // while the AST keeps its real value. The user has to explicitly
+  // pick a new value to overwrite the AST.
+  const match = BEAT_POSITION_OPTIONS.find(
+    (o) => o.beat === pos.beat && o.subdivision === pos.subdivision,
+  );
+  return makeSelect(
+    BEAT_POSITION_OPTIONS.map((o) => ({ value: o.value, label: o.value })),
+    match ? match.value : '',
+  );
+}
+
+function makeSelect<T extends string>(
+  options: ReadonlyArray<{ value: T; label: string }>,
+  current: T | string,
+): HTMLSelectElement {
+  const select = el('select', { class: 'irealb-editor__select' });
+  let matched = false;
+  for (const o of options) {
+    const opt = el('option', { attrs: { value: o.value }, text: o.label });
+    if (o.value === current) {
+      opt.selected = true;
+      matched = true;
+    }
+    select.appendChild(opt);
+  }
+  if (!matched && options.length > 0) {
+    select.selectedIndex = 0;
+  }
+  return select;
+}
+
+function makeDefaultBarChord(): BarChord {
+  return {
+    chord: {
+      root: { note: 'C', accidental: 'natural' },
+      quality: { kind: 'major' },
+      bass: null,
+    },
+    position: { beat: 1, subdivision: 0 },
+  };
+}
+
+/** Render `ChordRoot` as a string for the bass-input field. Inverse of
+ * {@link parseBassInput}. */
+function formatBass(root: ChordRoot): string {
+  const acc = root.accidental === 'sharp' ? '♯' : root.accidental === 'flat' ? '♭' : '';
+  return `${root.note}${acc}`;
+}
+
+/** Parse a free-text bass entry into a `ChordRoot` or `null` for
+ * empty input. Accepts `A`–`G` followed by optional `♭`/`♯`/`b`/`#`.
+ * Returns the previous value's null on unrecognised input so the
+ * AST stays well-formed; the input keeps the typed string for
+ * the user to correct. */
+function parseBassInput(s: string): ChordRoot | null {
+  const trimmed = s.trim();
+  if (trimmed === '') return null;
+  const note = trimmed.charAt(0).toUpperCase();
+  if (note < 'A' || note > 'G') return null;
+  const rest = trimmed.slice(1);
+  let accidental: Accidental = 'natural';
+  if (rest === '♯' || rest === '#') accidental = 'sharp';
+  else if (rest === '♭' || rest === 'b') accidental = 'flat';
+  else if (rest !== '') return null;
+  return { note, accidental };
+}
+
+/** Collect every focusable element inside `root` in DOM order.
+ * Used by the focus trap and by the initial-focus heuristic. */
+function collectFocusables(root: HTMLElement): HTMLElement[] {
+  const selector =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  return Array.from(root.querySelectorAll<HTMLElement>(selector));
+}
+
+/** Position the popover next to `anchor`. Falls back to centre-of-
+ * container if the anchor has no measurable bounding box (e.g.
+ * jsdom returns zero rects). The anchor's bounding rect drives
+ * placement so the popover follows the anchor's actual on-screen
+ * position rather than its DOM-tree neighbours. */
+function positionPopover(dialog: HTMLElement, anchor: HTMLElement): void {
+  const rect = anchor.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) {
+    // jsdom / detached anchor: leave default CSS positioning. The
+    // production CSS sets the popover to absolute positioning
+    // anchored to the editor root; callers running in a real
+    // browser will see real coordinates.
+    return;
+  }
+  // Place below the anchor by default. The CSS keeps it inside the
+  // editor scroll container; if the editor is short and the anchor
+  // is near the bottom, the user sees the popover overflow rather
+  // than the popover flipping above — flip-up logic is deferred to
+  // a follow-up if that becomes a real-world annoyance.
+  dialog.style.position = 'absolute';
+  dialog.style.top = `${rect.bottom + window.scrollY + 4}px`;
+  dialog.style.left = `${rect.left + window.scrollX}px`;
+}

--- a/packages/ui-irealb-editor/src/popover.ts
+++ b/packages/ui-irealb-editor/src/popover.ts
@@ -127,7 +127,15 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
   const draft: Bar = JSON.parse(JSON.stringify(bar)) as Bar;
 
   const minter = new FieldIdMinter();
+  // `cleanups` runs once on dispose. `chordCleanups` is reset on
+  // every `renderChordsSection` rebuild — without that scoping,
+  // adding / removing / reordering rows N times pushes O(N) dead
+  // listener references onto `cleanups` (each row registers ~5
+  // listeners, the old DOM is detached but the handler entries
+  // linger until dispose). Splitting them keeps the rebuild cycle
+  // memory-bounded even across long popover sessions.
   const cleanups: Array<() => void> = [];
+  const chordCleanups: Array<() => void> = [];
   let disposed = false;
 
   const listen = <K extends keyof HTMLElementEventMap>(
@@ -137,6 +145,18 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
   ): void => {
     target.addEventListener(type, handler);
     cleanups.push(() => target.removeEventListener(type, handler));
+  };
+
+  /** Register a listener that lives only until the next chord-rows
+   * rebuild. Used for per-row handlers that `renderChordsSection`
+   * rebuilds. */
+  const listenChord = <K extends keyof HTMLElementEventMap>(
+    target: HTMLElement,
+    type: K,
+    handler: (ev: HTMLElementEventMap[K]) => void,
+  ): void => {
+    target.addEventListener(type, handler);
+    chordCleanups.push(() => target.removeEventListener(type, handler));
   };
 
   // ---- Dialog shell --------------------------------------------------------
@@ -181,6 +201,11 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
   // number of chord-row interactions in one popover session, so the
   // memory overhead is negligible in practice.
   const renderChordsSection = (): void => {
+    // Drain listeners from the previous rebuild so they do not
+    // accumulate on the popover-wide `cleanups` list.
+    for (const c of chordCleanups) c();
+    chordCleanups.length = 0;
+
     clearChildren(chordsSection);
     chordsSection.appendChild(el('h4', { text: 'Chords' }));
 
@@ -193,7 +218,7 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
       attrs: { type: 'button' },
       text: '+ Add chord',
     });
-    listen(addBtn, 'click', () => {
+    listenChord(addBtn, 'click', () => {
       draft.chords.push(makeDefaultBarChord());
       renderChordsSection();
     });
@@ -212,19 +237,24 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
 
     // Root note letter
     const rootSelect = makeNoteLetterSelect(bc.chord.root.note);
-    listen(rootSelect, 'change', () => {
+    listenChord(rootSelect, 'change', () => {
       bc.chord.root.note = rootSelect.value;
     });
     row.appendChild(field('Root', rootSelect, minter));
 
     // Root accidental
     const accSelect = makeAccidentalSelect(bc.chord.root.accidental);
-    listen(accSelect, 'change', () => {
+    listenChord(accSelect, 'change', () => {
       bc.chord.root.accidental = accSelect.value as Accidental;
     });
     row.appendChild(field('Acc.', accSelect, minter));
 
-    // Quality (and Custom string)
+    // Quality (and Custom string). The Custom field is wrapped in a
+    // `<div class="irealb-editor__field">` containing both the
+    // `<label>Custom</label>` and the `<input>`. Toggling
+    // `customInput.style.display` alone leaves the label visible
+    // hovering above empty space, so we hide / show the wrapping
+    // div instead.
     const qualitySelect = makeQualitySelect(bc.chord.quality);
     const customInput = el('input', {
       attrs: {
@@ -234,28 +264,39 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
       },
       class: 'irealb-editor__input',
     });
-    customInput.style.display = bc.chord.quality.kind === 'custom' ? '' : 'none';
-    listen(qualitySelect, 'change', () => {
+    const customField = field('Custom', customInput, minter);
+    customField.style.display = bc.chord.quality.kind === 'custom' ? '' : 'none';
+    listenChord(qualitySelect, 'change', () => {
       const v = qualitySelect.value;
       if (v === 'custom') {
         bc.chord.quality = { kind: 'custom', value: customInput.value };
-        customInput.style.display = '';
+        customField.style.display = '';
       } else {
         bc.chord.quality = { kind: v } as ChordQuality;
-        customInput.style.display = 'none';
+        customField.style.display = 'none';
       }
     });
-    listen(customInput, 'input', () => {
+    listenChord(customInput, 'input', () => {
       if (bc.chord.quality.kind === 'custom') {
         bc.chord.quality.value = customInput.value;
       }
     });
     row.appendChild(field('Quality', qualitySelect, minter));
-    row.appendChild(field('Custom', customInput, minter));
+    row.appendChild(customField);
 
     // Bass note (optional). Single text input "X" / "X♭" / "" rather
     // than a paired letter+accidental select to keep the row narrow;
-    // parses on save / blur.
+    // parses on every keystroke. Three input states matter:
+    //
+    //   - empty           -> bass cleared (`null`)
+    //   - valid (A..G + optional accidental) -> ChordRoot assigned
+    //   - invalid         -> AST untouched, error class on the input
+    //                        so the user sees the input is rejected
+    //                        instead of silently losing the previous
+    //                        bass value (the pre-fix behaviour
+    //                        nullified `bass` on every unparseable
+    //                        keystroke — `code-style.md` Silent
+    //                        Fallback violation).
     const bassInput = el('input', {
       attrs: {
         type: 'text',
@@ -264,15 +305,20 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
       },
       class: 'irealb-editor__input',
     });
-    listen(bassInput, 'input', () => {
-      const parsed = parseBassInput(bassInput.value);
-      bc.chord.bass = parsed;
+    listenChord(bassInput, 'input', () => {
+      const result = parseBassInput(bassInput.value);
+      if (result === 'invalid') {
+        bassInput.classList.add('irealb-editor__input--invalid');
+        return;
+      }
+      bassInput.classList.remove('irealb-editor__input--invalid');
+      bc.chord.bass = result;
     });
     row.appendChild(field('Bass', bassInput, minter));
 
     // Beat position
     const posSelect = makeBeatPositionSelect(bc.position);
-    listen(posSelect, 'change', () => {
+    listenChord(posSelect, 'change', () => {
       const opt = BEAT_POSITION_OPTIONS.find((o) => o.value === posSelect.value);
       if (!opt) {
         // The dropdown is the only producer of values reaching this
@@ -290,7 +336,7 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
       text: '↑',
     });
     if (index === 0) upBtn.setAttribute('disabled', '');
-    listen(upBtn, 'click', () => {
+    listenChord(upBtn, 'click', () => {
       if (index === 0) return;
       const tmp = draft.chords[index - 1];
       const cur = draft.chords[index];
@@ -307,7 +353,7 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
       text: '↓',
     });
     if (index === draft.chords.length - 1) downBtn.setAttribute('disabled', '');
-    listen(downBtn, 'click', () => {
+    listenChord(downBtn, 'click', () => {
       if (index === draft.chords.length - 1) return;
       const tmp = draft.chords[index + 1];
       const cur = draft.chords[index];
@@ -323,7 +369,7 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
       attrs: { type: 'button', 'aria-label': 'Remove chord' },
       text: '×',
     });
-    listen(removeBtn, 'click', () => {
+    listenChord(removeBtn, 'click', () => {
       draft.chords.splice(index, 1);
       renderChordsSection();
     });
@@ -455,6 +501,8 @@ export function openBarPopover(options: BarPopoverOptions): BarPopoverHandle {
   function dispose(): void {
     if (disposed) return;
     disposed = true;
+    for (const cleanup of chordCleanups) cleanup();
+    chordCleanups.length = 0;
     for (const cleanup of cleanups) cleanup();
     cleanups.length = 0;
     if (dialog.parentNode !== null) {
@@ -557,21 +605,30 @@ function formatBass(root: ChordRoot): string {
   return `${root.note}${acc}`;
 }
 
-/** Parse a free-text bass entry into a `ChordRoot` or `null` for
- * empty input. Accepts `A`–`G` followed by optional `♭`/`♯`/`b`/`#`.
- * Returns the previous value's null on unrecognised input so the
- * AST stays well-formed; the input keeps the typed string for
- * the user to correct. */
-function parseBassInput(s: string): ChordRoot | null {
+/** Parse a free-text bass entry into one of three outcomes:
+ *
+ *   - `null`     — empty input; the chord is no longer a slash chord.
+ *   - `ChordRoot` — `A`..`G` followed by optional `♭` / `♯` / `b` / `#`.
+ *   - `'invalid'` — anything else; the caller should NOT mutate the
+ *                   AST (the previous bass stays intact) and SHOULD
+ *                   surface the rejection visually (e.g. an
+ *                   `--invalid` modifier class on the input).
+ *
+ * The pre-fix version returned `null` for both empty input and
+ * garbage, which silently wiped a previously-valid bass on any
+ * unparseable keystroke (`code-style.md` Silent Fallback). The
+ * three-valued return distinguishes the cases at the type level so
+ * the call site can act differently. */
+function parseBassInput(s: string): ChordRoot | null | 'invalid' {
   const trimmed = s.trim();
   if (trimmed === '') return null;
   const note = trimmed.charAt(0).toUpperCase();
-  if (note < 'A' || note > 'G') return null;
+  if (note < 'A' || note > 'G') return 'invalid';
   const rest = trimmed.slice(1);
   let accidental: Accidental = 'natural';
   if (rest === '♯' || rest === '#') accidental = 'sharp';
   else if (rest === '♭' || rest === 'b') accidental = 'flat';
-  else if (rest !== '') return null;
+  else if (rest !== '') return 'invalid';
   return { note, accidental };
 }
 

--- a/packages/ui-irealb-editor/src/render.ts
+++ b/packages/ui-irealb-editor/src/render.ts
@@ -25,6 +25,20 @@ import type {
 import { clearChildren, el, field, FieldIdMinter } from './dom.js';
 import type { IrealbEditorState } from './state.js';
 
+/** Callback signature used by the bar grid to delegate "user clicked
+ * a bar cell" up to the editor adapter. The adapter opens the
+ * popover (built in `popover.ts`), which on Save replaces the bar
+ * via `(secIndex, barIndex, next)` and then triggers a full
+ * re-render plus the user-edit notification. Threading the
+ * callback through render avoids importing `popover.ts` here —
+ * `render.ts` stays the pure-DOM half of the package. */
+export type OpenBarPopover = (
+  bar: Bar,
+  anchor: HTMLElement,
+  secIndex: number,
+  barIndex: number,
+) => void;
+
 /** Result returned by {@link render}. `dispose` removes every event
  * listener registered during this render pass; call before
  * re-rendering or before tearing the editor down. */
@@ -33,14 +47,18 @@ export interface RenderHandle {
   dispose(): void;
 }
 
-/** Build the form + read-only bar grid into `root` from `state`.
- * `onUserEdit` is called after every successful user-initiated
- * mutation; the editor adapter wraps that in a re-serialise +
- * onChange dispatch. */
+/** Build the form + bar grid into `root` from `state`. `onUserEdit`
+ * fires after every successful user-initiated mutation;
+ * `openBarPopover` fires when a user clicks a bar cell — the
+ * editor adapter passes a callback that opens the bar-edit popover
+ * (#2364). The adapter is responsible for the popover's mount
+ * container, focus management, and the post-save re-render +
+ * onUserEdit dispatch. */
 export function render(
   root: HTMLElement,
   state: IrealbEditorState,
   onUserEdit: () => void,
+  openBarPopover: OpenBarPopover,
 ): RenderHandle {
   clearChildren(root);
   const cleanups: Array<() => void> = [];
@@ -180,11 +198,11 @@ export function render(
 
   root.appendChild(header);
 
-  // ---- Bar grid (read-only) -------------------------------------------------
+  // ---- Bar grid -------------------------------------------------------------
   const grid = el('div', { class: 'irealb-editor__grid' });
-  for (const section of state.song.sections) {
-    grid.appendChild(renderSection(section));
-  }
+  state.song.sections.forEach((section, secIndex) => {
+    grid.appendChild(renderSection(section, secIndex, openBarPopover, listen));
+  });
   root.appendChild(grid);
 
   return {
@@ -199,7 +217,16 @@ export function render(
 // Section / bar rendering
 // ---------------------------------------------------------------------------
 
-function renderSection(section: Section): HTMLElement {
+function renderSection(
+  section: Section,
+  secIndex: number,
+  openBarPopover: OpenBarPopover,
+  listen: <K extends keyof HTMLElementEventMap>(
+    target: HTMLElement,
+    type: K,
+    handler: (ev: HTMLElementEventMap[K]) => void,
+  ) => void,
+): HTMLElement {
   const wrapper = el('div', { class: 'irealb-editor__section' });
   const heading = el('h3', {
     class: 'irealb-editor__section-label',
@@ -207,26 +234,46 @@ function renderSection(section: Section): HTMLElement {
   });
   wrapper.appendChild(heading);
 
-  // 4-bars-per-line CSS grid. The grid template lives in style.css; we
-  // just emit a flat list of `<div>` cells. CSS handles the wrap.
+  // 4-bars-per-line CSS grid. The grid template lives in style.css;
+  // we emit a flat list of `<button>` cells (button so click +
+  // keyboard activation come for free; ARIA grid semantics arrive
+  // in #2368).
   const row = el('div', { class: 'irealb-editor__bars' });
-  for (const bar of section.bars) {
-    row.appendChild(renderBar(bar));
-  }
+  section.bars.forEach((bar, barIndex) => {
+    row.appendChild(renderBar(bar, secIndex, barIndex, openBarPopover, listen));
+  });
   wrapper.appendChild(row);
   return wrapper;
 }
 
-function renderBar(bar: Bar): HTMLElement {
+function renderBar(
+  bar: Bar,
+  secIndex: number,
+  barIndex: number,
+  openBarPopover: OpenBarPopover,
+  listen: <K extends keyof HTMLElementEventMap>(
+    target: HTMLElement,
+    type: K,
+    handler: (ev: HTMLElementEventMap[K]) => void,
+  ) => void,
+): HTMLElement {
   const text = bar.chords.map((c) => formatChord(c.chord)).join(' ');
-  // The bar cell is structural — read-only is enforced by the cell
-  // not being an input at all (no `<input disabled>` round-trip,
-  // tabindex stays default, ARIA stays implicit). #2364 turns the
-  // cell into a popover trigger; #2368 layers ARIA grid semantics.
-  return el('div', {
+  // `<button type="button">` so the cell announces as a button to
+  // screen readers and so Enter / Space activation works without
+  // explicit keyboard handlers. ARIA grid semantics on the wrapping
+  // grid (`role="grid"` / `gridcell`) are deferred to #2368.
+  const cell = el('button', {
     class: 'irealb-editor__bar',
+    attrs: {
+      type: 'button',
+      'aria-label': `Edit bar ${barIndex + 1}`,
+    },
     text: text || ' ', // U+00A0 keeps empty cells height-stable.
   });
+  listen(cell, 'click', () => {
+    openBarPopover(bar, cell, secIndex, barIndex);
+  });
+  return cell;
 }
 
 function formatSectionLabel(label: SectionLabel): string {

--- a/packages/ui-irealb-editor/src/style.css
+++ b/packages/ui-irealb-editor/src/style.css
@@ -98,8 +98,133 @@
   text-align: center;
   color: #1f2933;
   border-radius: 3px;
-  /* Cell is structurally read-only: no `<input>` inside, default
-   * cursor, no focus ring. #2364 will add a click handler that
-   * opens the chord-edit popover. */
+  /* As of #2364 the cell is a real <button> — the click opens the
+   * bar-edit popover. Cursor + hover + focus affordances reflect
+   * that. */
+  cursor: pointer;
   user-select: none;
+  font: inherit;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.irealb-editor__bar:hover {
+  background: #e4ebf1;
+}
+
+.irealb-editor__bar:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 1px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Bar-edit popover (#2364). Rendered as a child of `.irealb-editor` so
+ * the host's stacking context owns z-index. Positioned absolutely
+ * via inline styles set by `popover.ts` (top / left = anchor's
+ * bounding rect); the rules below only handle look + intra-popover
+ * layout.
+ * --------------------------------------------------------------------------- */
+
+.irealb-editor__popover {
+  position: absolute;
+  z-index: 100;
+  background: #ffffff;
+  border: 1px solid #9aa5b1;
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.16);
+  padding: 0.75rem;
+  min-width: 320px;
+  max-width: 540px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.irealb-editor__popover-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 60vh;
+  overflow: auto;
+}
+
+.irealb-editor__popover-chords {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border-top: 1px solid #e4e7eb;
+  padding-top: 0.4rem;
+}
+
+.irealb-editor__popover-chords h4 {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  color: #52606d;
+  letter-spacing: 0.04em;
+}
+
+.irealb-editor__popover-chordrow {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr)) auto auto auto;
+  gap: 0.3rem;
+  align-items: end;
+}
+
+.irealb-editor__popover-rowbtn {
+  background: #ffffff;
+  border: 1px solid #cbd2d9;
+  border-radius: 4px;
+  padding: 0.35rem 0.55rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+.irealb-editor__popover-rowbtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.irealb-editor__popover-addrow {
+  align-self: flex-start;
+  background: #f5f7fa;
+  border: 1px dashed #cbd2d9;
+  border-radius: 4px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  font: inherit;
+  color: #1f2933;
+}
+
+.irealb-editor__popover-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  border-top: 1px solid #e4e7eb;
+  padding-top: 0.5rem;
+}
+
+.irealb-editor__popover-cancel,
+.irealb-editor__popover-save {
+  font: inherit;
+  padding: 0.45rem 0.9rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.irealb-editor__popover-cancel {
+  background: #ffffff;
+  border: 1px solid #cbd2d9;
+  color: #1f2933;
+}
+
+.irealb-editor__popover-save {
+  background: #4c6ef5;
+  border: 1px solid #4c6ef5;
+  color: #ffffff;
+}
+
+.irealb-editor__popover-save:hover {
+  background: #3b5bdb;
+  border-color: #3b5bdb;
 }

--- a/packages/ui-irealb-editor/src/style.css
+++ b/packages/ui-irealb-editor/src/style.css
@@ -58,6 +58,19 @@
   border-color: #4c6ef5;
 }
 
+/* Applied by `popover.ts` when the bass input cannot be parsed. The
+ * AST keeps its previous bass value while the visual cue tells the
+ * user the field is rejected. */
+.irealb-editor__input--invalid {
+  border-color: #c92a2a;
+  background: #fff5f5;
+}
+
+.irealb-editor__input--invalid:focus {
+  outline-color: #c92a2a;
+  border-color: #c92a2a;
+}
+
 .irealb-editor__grid {
   display: flex;
   flex-direction: column;
@@ -90,7 +103,12 @@
 }
 
 .irealb-editor__bar {
+  /* As of #2364 the cell is a real <button>, which inherits from a
+   * UA stylesheet rather than the editor root. Re-establish the
+   * monospace stack and 1rem size explicitly so the cell text
+   * matches the pre-#2364 <div> rendering byte-for-byte. */
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 1rem;
   border: 1px solid #cbd2d9;
   background: #f5f7fa;
   padding: 0.6rem 0.5rem;
@@ -98,13 +116,8 @@
   text-align: center;
   color: #1f2933;
   border-radius: 3px;
-  /* As of #2364 the cell is a real <button> — the click opens the
-   * bar-edit popover. Cursor + hover + focus affordances reflect
-   * that. */
   cursor: pointer;
   user-select: none;
-  font: inherit;
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
 
 .irealb-editor__bar:hover {

--- a/packages/ui-irealb-editor/tests/popover.test.ts
+++ b/packages/ui-irealb-editor/tests/popover.test.ts
@@ -369,6 +369,71 @@ describe('bar-edit popover', () => {
     editor.destroy();
   });
 
+  test('invalid bass input keeps the previous bass intact and flags the field', () => {
+    // Per `parseBassInput`'s three-valued contract, garbage input
+    // does NOT clobber an existing bass — the AST keeps its
+    // previous value and the input gains the `--invalid` modifier
+    // class so the user can see the rejection. Empty input still
+    // clears the bass (intentional difference between "user typed
+    // nothing" and "user typed garbage").
+    const wasm = makeStubWasm();
+    // Seed the first chord with a bass so the assertion has
+    // something to preserve.
+    const seed: IrealSong = JSON.parse(JSON.stringify(SAMPLE_SONG));
+    const firstChord = seed.sections[0]?.bars[0]?.chords[0];
+    if (!firstChord) throw new Error('seed chord missing');
+    firstChord.chord.bass = { note: 'G', accidental: 'natural' };
+    const seedUrl = `irealb://json:${encodeURIComponent(JSON.stringify(seed))}`;
+    const editor = createIrealbEditor({ initialValue: seedUrl, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const row = dialog.querySelector<HTMLElement>('[data-row-index="0"]');
+    if (!row) throw new Error('first chord row not rendered');
+    const bassInput = inputIn(row, 'input[placeholder^="/X"]');
+
+    // Garbage input — the input gains the invalid class; the AST
+    // bass stays at G natural.
+    bassInput.value = 'ZZZ';
+    bassInput.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(bassInput.classList.contains('irealb-editor__input--invalid')).toBe(true);
+    clickButton(dialog, 'Save');
+    expect(readSong(editor).sections[0]?.bars[0]?.chords[0]?.chord.bass).toEqual({
+      note: 'G',
+      accidental: 'natural',
+    });
+
+    // Reopen, type a valid value -> invalid class is cleared and
+    // AST takes the new bass.
+    bar(editor, 0).click();
+    const dialog2 = popoverOf(editor);
+    const row2 = dialog2.querySelector<HTMLElement>('[data-row-index="0"]');
+    if (!row2) throw new Error('first chord row not rendered after reopen');
+    const bassInput2 = inputIn(row2, 'input[placeholder^="/X"]');
+    bassInput2.value = 'A♭';
+    bassInput2.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(bassInput2.classList.contains('irealb-editor__input--invalid')).toBe(false);
+    clickButton(dialog2, 'Save');
+    expect(readSong(editor).sections[0]?.bars[0]?.chords[0]?.chord.bass).toEqual({
+      note: 'A',
+      accidental: 'flat',
+    });
+
+    // Empty string still clears the bass — distinguishes the
+    // intentional "no slash chord" case from garbage.
+    bar(editor, 0).click();
+    const dialog3 = popoverOf(editor);
+    const row3 = dialog3.querySelector<HTMLElement>('[data-row-index="0"]');
+    if (!row3) throw new Error('first chord row not rendered after second reopen');
+    const bassInput3 = inputIn(row3, 'input[placeholder^="/X"]');
+    bassInput3.value = '';
+    bassInput3.dispatchEvent(new Event('input', { bubbles: true }));
+    clickButton(dialog3, 'Save');
+    expect(readSong(editor).sections[0]?.bars[0]?.chords[0]?.chord.bass).toBeNull();
+
+    editor.destroy();
+  });
+
   test('beat position select updates BarChord.position on save', () => {
     const wasm = makeStubWasm();
     const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });

--- a/packages/ui-irealb-editor/tests/popover.test.ts
+++ b/packages/ui-irealb-editor/tests/popover.test.ts
@@ -442,6 +442,40 @@ describe('bar-edit popover', () => {
     editor.destroy();
   });
 
+  test('Save restores focus to the rebuilt bar cell at (secIndex, barIndex)', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    // Open popover on bar 0 (section 0, bar 0), save without edits.
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    clickButton(dialog, 'Save');
+
+    // Popover gone; focus should land on the rebuilt bar-0 cell.
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+    expect(document.activeElement).toBe(bar(editor, 0));
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Save on bar 1 restores focus to bar 1 (correct global offset)', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    // Bar 1 is section 0, barIndex 1.
+    bar(editor, 1).click();
+    const dialog = popoverOf(editor);
+    clickButton(dialog, 'Save');
+
+    expect(document.activeElement).toBe(bar(editor, 1));
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
   test('opening a second popover closes the first (one-at-a-time)', () => {
     const wasm = makeStubWasm();
     const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });

--- a/packages/ui-irealb-editor/tests/popover.test.ts
+++ b/packages/ui-irealb-editor/tests/popover.test.ts
@@ -1,0 +1,489 @@
+// Unit tests for the bar-edit popover (#2364). Wasm bridge is
+// stubbed identically to `editor.test.ts`; these tests exercise the
+// popover's open / mutate / save / cancel paths through the public
+// `createIrealbEditor` factory rather than `openBarPopover` directly,
+// so we cover both the dialog itself and the integration with
+// `index.ts` (Bar splice on save, re-render, fireUserEdit, focus
+// return on close, dismissal paths).
+
+import { describe, expect, test, vi } from 'vitest';
+import { createIrealbEditor, type IrealbWasm } from '../src/index';
+import type { Bar, IrealSong } from '../src/ast';
+
+// A two-section, three-bar fixture so reorder, splice, and per-bar
+// targeting are all exercisable. Section A has two bars; section B
+// has one.
+const SAMPLE_SONG: IrealSong = {
+  title: 'Popover Sample',
+  composer: null,
+  style: null,
+  key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+  time_signature: { numerator: 4, denominator: 4 },
+  tempo: null,
+  transpose: 0,
+  sections: [
+    {
+      label: { kind: 'letter', value: 'A' },
+      bars: [
+        {
+          start: 'single',
+          end: 'single',
+          chords: [
+            {
+              chord: {
+                root: { note: 'C', accidental: 'natural' },
+                quality: { kind: 'major' },
+                bass: null,
+              },
+              position: { beat: 1, subdivision: 0 },
+            },
+          ],
+          ending: null,
+          symbol: null,
+        },
+        {
+          start: 'single',
+          end: 'single',
+          chords: [
+            {
+              chord: {
+                root: { note: 'F', accidental: 'natural' },
+                quality: { kind: 'major' },
+                bass: null,
+              },
+              position: { beat: 1, subdivision: 0 },
+            },
+          ],
+          ending: null,
+          symbol: null,
+        },
+      ],
+    },
+    {
+      label: { kind: 'letter', value: 'B' },
+      bars: [
+        {
+          start: 'single',
+          end: 'single',
+          chords: [
+            {
+              chord: {
+                root: { note: 'G', accidental: 'natural' },
+                quality: { kind: 'dominant7' },
+                bass: null,
+              },
+              position: { beat: 1, subdivision: 0 },
+            },
+          ],
+          ending: null,
+          symbol: null,
+        },
+      ],
+    },
+  ],
+};
+const SAMPLE_URL = 'irealb://popover-sample';
+
+function makeStubWasm(): IrealbWasm & {
+  parseIrealb: ReturnType<typeof vi.fn>;
+  serializeIrealb: ReturnType<typeof vi.fn>;
+} {
+  const parseIrealb = vi.fn((input: string): string => {
+    if (input === SAMPLE_URL) return JSON.stringify(SAMPLE_SONG);
+    if (input.startsWith('irealb://json:')) {
+      return decodeURIComponent(input.slice('irealb://json:'.length));
+    }
+    throw new Error(`stub parseIrealb: unknown URL: ${input}`);
+  });
+  const serializeIrealb = vi.fn(
+    (input: string): string => `irealb://json:${encodeURIComponent(input)}`,
+  );
+  return { parseIrealb, serializeIrealb };
+}
+
+function readSong(editor: ReturnType<typeof createIrealbEditor>): IrealSong {
+  const url = editor.getValue();
+  return JSON.parse(decodeURIComponent(url.slice('irealb://json:'.length))) as IrealSong;
+}
+
+function bar(editor: ReturnType<typeof createIrealbEditor>, n: number): HTMLButtonElement {
+  const cells = editor.element.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar');
+  const target = cells[n];
+  if (!target) throw new Error(`bar #${n} not rendered (have ${cells.length})`);
+  return target;
+}
+
+function popoverOf(
+  editor: ReturnType<typeof createIrealbEditor>,
+): HTMLElement {
+  const dialog = editor.element.querySelector<HTMLElement>('.irealb-editor__popover');
+  if (!dialog) throw new Error('popover not mounted');
+  return dialog;
+}
+
+function selectIn(root: HTMLElement, n: number): HTMLSelectElement {
+  const selects = root.querySelectorAll<HTMLSelectElement>('select');
+  const target = selects[n];
+  if (!target) throw new Error(`select #${n} not in popover (have ${selects.length})`);
+  return target;
+}
+
+function inputIn(root: HTMLElement, selector: string): HTMLInputElement {
+  const target = root.querySelector<HTMLInputElement>(selector);
+  if (!target) throw new Error(`input ${selector} not in popover`);
+  return target;
+}
+
+function clickButton(root: HTMLElement, label: string): HTMLButtonElement {
+  const btns = Array.from(root.querySelectorAll<HTMLButtonElement>('button'));
+  const target = btns.find((b) => b.textContent?.trim() === label);
+  if (!target) throw new Error(`button "${label}" not in dialog`);
+  target.click();
+  return target;
+}
+
+describe('bar-edit popover', () => {
+  test('clicking a bar cell mounts the dialog with role and modal attrs', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    expect(dialog.getAttribute('role')).toBe('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-label')).toBe('Edit bar');
+
+    editor.destroy();
+  });
+
+  test('Save commits start/end barline edits to the AST and fires onChange', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    const onChange = vi.fn();
+    editor.onChange(onChange);
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    // First two selects are start/end barlines (form rendered in
+    // declaration order).
+    const startSelect = selectIn(dialog, 0);
+    const endSelect = selectIn(dialog, 1);
+    startSelect.value = 'open_repeat';
+    startSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    endSelect.value = 'close_repeat';
+    endSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    clickButton(dialog, 'Save');
+
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars[0]?.start).toBe('open_repeat');
+    expect(song.sections[0]?.bars[0]?.end).toBe('close_repeat');
+    // Other bars untouched.
+    expect(song.sections[0]?.bars[1]?.start).toBe('single');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    // Popover dismissed after Save.
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+
+    editor.destroy();
+  });
+
+  test('Cancel discards edits and does not fire onChange', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    const onChange = vi.fn();
+    editor.onChange(onChange);
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const startSelect = selectIn(dialog, 0);
+    startSelect.value = 'final';
+    startSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    clickButton(dialog, 'Cancel');
+
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars[0]?.start).toBe('single'); // unchanged
+    expect(onChange).not.toHaveBeenCalled();
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+
+    editor.destroy();
+  });
+
+  test('Escape dismisses the popover without committing', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    const onChange = vi.fn();
+    editor.onChange(onChange);
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const startSelect = selectIn(dialog, 0);
+    startSelect.value = 'double';
+    startSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(readSong(editor).sections[0]?.bars[0]?.start).toBe('single');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+
+    editor.destroy();
+  });
+
+  test('outside-click dismisses the popover without committing', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    const onChange = vi.fn();
+    editor.onChange(onChange);
+
+    bar(editor, 0).click();
+    expect(editor.element.querySelector('.irealb-editor__popover')).not.toBeNull();
+
+    // Pointerdown anywhere in document.body that is not the dialog
+    // and not the bar cell — the popover's dismissal listener
+    // closes it. jsdom does not implement PointerEvent, so dispatch
+    // a plain Event with the matching type — listeners are
+    // registered by event-name and accept any Event subclass.
+    document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('add chord row, edit it, save -> AST gains the new BarChord', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    expect(readSong(editor).sections[0]?.bars[0]?.chords.length).toBe(1);
+    clickButton(dialog, '+ Add chord');
+
+    // The new row's selects come AFTER the existing row, so they
+    // are the second cluster. Match by `data-row-index="1"`.
+    const newRow = dialog.querySelector<HTMLElement>('[data-row-index="1"]');
+    if (!newRow) throw new Error('new chord row not rendered');
+    const rootSelect = selectIn(newRow, 0); // root letter
+    const accSelect = selectIn(newRow, 1); // accidental
+    const qualitySelect = selectIn(newRow, 2); // quality
+    rootSelect.value = 'A';
+    rootSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    accSelect.value = 'flat';
+    accSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    qualitySelect.value = 'minor7';
+    qualitySelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+    clickButton(dialog, 'Save');
+
+    const chords = readSong(editor).sections[0]?.bars[0]?.chords ?? [];
+    expect(chords.length).toBe(2);
+    expect(chords[1]?.chord.root).toEqual({ note: 'A', accidental: 'flat' });
+    expect(chords[1]?.chord.quality).toEqual({ kind: 'minor7' });
+
+    editor.destroy();
+  });
+
+  test('reorder chord rows up/down', () => {
+    const wasm = makeStubWasm();
+    // Seed with two chords in the first bar so reorder has something
+    // to swap.
+    const seed: IrealSong = JSON.parse(JSON.stringify(SAMPLE_SONG));
+    const firstBar = seed.sections[0]?.bars[0] as Bar;
+    firstBar.chords.push({
+      chord: {
+        root: { note: 'D', accidental: 'natural' },
+        quality: { kind: 'minor' },
+        bass: null,
+      },
+      position: { beat: 3, subdivision: 0 },
+    });
+    const seedUrl = `irealb://json:${encodeURIComponent(JSON.stringify(seed))}`;
+    const editor = createIrealbEditor({ initialValue: seedUrl, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const row1 = dialog.querySelector<HTMLElement>('[data-row-index="1"]');
+    if (!row1) throw new Error('second chord row not rendered');
+    // Click "↑" on the second row to swap with the first.
+    const upBtn = Array.from(row1.querySelectorAll<HTMLButtonElement>('button')).find(
+      (b) => b.getAttribute('aria-label') === 'Move chord up',
+    );
+    if (!upBtn) throw new Error('up button missing');
+    upBtn.click();
+    clickButton(dialog, 'Save');
+
+    const chords = readSong(editor).sections[0]?.bars[0]?.chords ?? [];
+    expect(chords[0]?.chord.root.note).toBe('D');
+    expect(chords[1]?.chord.root.note).toBe('C');
+
+    editor.destroy();
+  });
+
+  test('Custom quality input becomes visible and round-trips', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const row = dialog.querySelector<HTMLElement>('[data-row-index="0"]');
+    if (!row) throw new Error('first chord row not rendered');
+    const qualitySelect = selectIn(row, 2);
+    qualitySelect.value = 'custom';
+    qualitySelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+    // Custom input is the only text input inside this row (bass
+    // input is also text but has placeholder /X). Distinguish by
+    // placeholder.
+    const customInput = inputIn(row, 'input[placeholder^="e.g."]');
+    expect(customInput.style.display).not.toBe('none');
+    customInput.value = '7♯9';
+    customInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    clickButton(dialog, 'Save');
+
+    const quality = readSong(editor).sections[0]?.bars[0]?.chords[0]?.chord.quality;
+    expect(quality).toEqual({ kind: 'custom', value: '7♯9' });
+
+    editor.destroy();
+  });
+
+  test('bass input parses A–G + sharp/flat into a ChordRoot', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const row = dialog.querySelector<HTMLElement>('[data-row-index="0"]');
+    if (!row) throw new Error('first chord row not rendered');
+    const bassInput = inputIn(row, 'input[placeholder^="/X"]');
+    bassInput.value = 'G♭';
+    bassInput.dispatchEvent(new Event('input', { bubbles: true }));
+    clickButton(dialog, 'Save');
+
+    expect(readSong(editor).sections[0]?.bars[0]?.chords[0]?.chord.bass).toEqual({
+      note: 'G',
+      accidental: 'flat',
+    });
+
+    editor.destroy();
+  });
+
+  test('beat position select updates BarChord.position on save', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const row = dialog.querySelector<HTMLElement>('[data-row-index="0"]');
+    if (!row) throw new Error('first chord row not rendered');
+    const posSelect = selectIn(row, 3);
+    posSelect.value = '2.5';
+    posSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    clickButton(dialog, 'Save');
+
+    expect(readSong(editor).sections[0]?.bars[0]?.chords[0]?.position).toEqual({
+      beat: 2,
+      subdivision: 1,
+    });
+
+    editor.destroy();
+  });
+
+  test('Ending input updates Bar.ending; empty becomes null', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    const endingInput = inputIn(dialog, 'input[type="number"][min="1"]');
+    endingInput.value = '2';
+    endingInput.dispatchEvent(new Event('input', { bubbles: true }));
+    clickButton(dialog, 'Save');
+    expect(readSong(editor).sections[0]?.bars[0]?.ending).toBe(2);
+
+    bar(editor, 0).click();
+    const dialog2 = popoverOf(editor);
+    const endingInput2 = inputIn(dialog2, 'input[type="number"][min="1"]');
+    endingInput2.value = '';
+    endingInput2.dispatchEvent(new Event('input', { bubbles: true }));
+    clickButton(dialog2, 'Save');
+    expect(readSong(editor).sections[0]?.bars[0]?.ending).toBeNull();
+
+    editor.destroy();
+  });
+
+  test('MusicalSymbol select round-trips None / segno / fine', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    const dialog = popoverOf(editor);
+    // Symbol select is the LAST select in the popover body (after
+    // start/end barlines + per-row selects + ending input).
+    const symbolSelects = dialog.querySelectorAll<HTMLSelectElement>('select');
+    const symbolSelect = symbolSelects[symbolSelects.length - 1];
+    if (!symbolSelect) throw new Error('symbol select missing');
+    symbolSelect.value = 'segno';
+    symbolSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    clickButton(dialog, 'Save');
+    expect(readSong(editor).sections[0]?.bars[0]?.symbol).toBe('segno');
+
+    bar(editor, 0).click();
+    const dialog2 = popoverOf(editor);
+    const symbolSelect2Set = dialog2.querySelectorAll<HTMLSelectElement>('select');
+    const symbolSelect2 = symbolSelect2Set[symbolSelect2Set.length - 1];
+    if (!symbolSelect2) throw new Error('symbol select missing on reopen');
+    symbolSelect2.value = '';
+    symbolSelect2.dispatchEvent(new Event('change', { bubbles: true }));
+    clickButton(dialog2, 'Save');
+    expect(readSong(editor).sections[0]?.bars[0]?.symbol).toBeNull();
+
+    editor.destroy();
+  });
+
+  test('opening a second popover closes the first (one-at-a-time)', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    const first = popoverOf(editor);
+    expect(editor.element.querySelectorAll('.irealb-editor__popover').length).toBe(1);
+    bar(editor, 1).click();
+    expect(editor.element.querySelectorAll('.irealb-editor__popover').length).toBe(1);
+    // The new dialog is a fresh node, not the first one.
+    const second = popoverOf(editor);
+    expect(second).not.toBe(first);
+
+    editor.destroy();
+  });
+
+  test('setValue() while popover open dismisses the popover', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    bar(editor, 0).click();
+    expect(editor.element.querySelector('.irealb-editor__popover')).not.toBeNull();
+
+    // Programmatic load — must dismiss the popover so a stale Bar
+    // reference does not corrupt the freshly-loaded chart on Save.
+    const otherSong: IrealSong = { ...SAMPLE_SONG, title: 'Loaded' };
+    editor.setValue(`irealb://json:${encodeURIComponent(JSON.stringify(otherSong))}`);
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+
+    editor.destroy();
+  });
+
+  test('destroy() while popover open removes it', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    bar(editor, 0).click();
+    expect(editor.element.querySelector('.irealb-editor__popover')).not.toBeNull();
+    editor.destroy();
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+
+    editor.element.remove();
+  });
+});


### PR DESCRIPTION
Closes #2364. Part of #2357.

## Summary

Clicking a bar cell in the read-only grid (#2363) now opens a modal
popover that edits every field of the underlying \`Bar\`:

- Start / end barlines (Single / Double / Final / Open repeat / Close
  repeat).
- Chord rows: root letter (A-G), accidental (♮ / ♯ / ♭),
  12 named qualities + Custom string fallback, optional \`/X\` bass
  (parses A-G with optional ♭ / ♯ / b / #), beat position
  (1 / 1.5 / 2 / 2.5 / 3 / 3.5 / 4 / 4.5). Rows are addable, removable,
  and reorderable via per-row up / down buttons.
- N-th ending number (1-9, empty = None; matches the AST's
  \`NonZeroU8\` range).
- Musical symbol (None / Segno / Coda / D.C. / D.S. / Fine).

Dialog follows the W3C APG dialog pattern: \`role=\"dialog\"\`,
\`aria-modal=\"true\"\`, focus moves into the dialog on open and back
to the trigger anchor on close, Tab cycles via a focus trap,
Escape and outside-click dismiss without committing.

## Why

Foundation sub-issue under tracker #2357. The read-only grid from
#2363 needs an editing affordance before #2365 (structural
section / bar edits), #2366 (playground / desktop runtime swap),
and #2367 (desktop integration) can land — those iterations rely on
this popover for their edit UX.

## Design notes

- Working on a deep-cloned \`Bar\` (JSON round-trip) means partial
  edits never corrupt the live AST until Save. Save commits as a
  single splice into the section's bar list, then triggers
  re-render + \`fireUserEdit\`.
- Bar cells become \`<button type=\"button\">\` so click + keyboard
  activation work without explicit handlers. Grid-level ARIA
  (\`role=\"grid\"\` / \`gridcell\`) is deferred to #2368.
- One popover at a time: opening a second cell dismisses the first;
  \`setValue\` / \`destroy\` also dismiss to prevent stale-\`Bar\` Save
  corruption.
- Position helper uses \`getBoundingClientRect\` + scroll offsets;
  jsdom's empty rect short-circuits so unit tests do not depend on
  layout.

## What was done

- New \`packages/ui-irealb-editor/src/popover.ts\` (450 lines)
  implementing the dialog, focus trap, dismissal listeners, and
  field handlers.
- \`render.ts\`: bar cells become buttons, gain a click handler, and
  thread an \`OpenBarPopover\` callback up to \`index.ts\`.
- \`index.ts\`: wires the popover up to \`renderNow\` + \`fireUserEdit\`
  on Save; dismisses on \`setValue\` and \`destroy\`.
- \`style.css\`: popover skin (absolute positioning, modal shadow,
  chord-row grid, footer buttons).
- \`README.md\`: shipped / deferred lists updated.

## Test results

\`\`\`
$ npm run typecheck
> tsc --noEmit
(no errors)

$ npm test
✓ tests/editor.test.ts (13 tests)
✓ tests/popover.test.ts (15 tests)
Test Files  2 passed (2)
     Tests  28 passed (28)
\`\`\`

15 new vitest cases cover: dialog mount + ARIA attrs, Save commit
for barlines / chord rows / ending / symbol, Cancel / Escape /
outside-click dismissal, Custom quality round-trip, bass parse,
beat position commit, add / reorder, one-popover-at-a-time
invariant, and dismissal on \`setValue\` / \`destroy\`. The 13
pre-existing tests continue to pass unchanged.

## Review summary

Sister-site audit: no equivalent dialog elsewhere yet. Per-renderer
parity is N/A (no renderer touched). Dependency policy unchanged.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm test\` (28 tests pass)
- [ ] CI ui-irealb-editor workflow green
- [ ] Bar popover visually verified in playground after #2366

🤖 Generated with [Claude Code](https://claude.com/claude-code)