### PR TITLE
feat(ui-irealb-editor): section management and bar structural editing

### DIFF
--- a/packages/ui-irealb-editor/README.md
+++ b/packages/ui-irealb-editor/README.md
@@ -20,13 +20,21 @@ Shipped:
   optional `/X` bass + beat position 1 / 1.5 / … / 4.5, with
   add / remove / reorder), N-th ending number (1–9, empty = none),
   and musical symbol (None / Segno / Coda / D.C. / D.S. / Fine).
+- #2365 — structural editing via per-section + per-bar UI buttons:
+  Add Section (with label prompt), Rename / Delete (with confirm) /
+  Move up / Move down per section; Add Bar / Delete bar / Move bar
+  left + right within each section. The two host hooks
+  `promptSectionLabel` and `confirmDeleteSection` default to
+  `window.prompt` / `window.confirm` and can be overridden by the
+  host (or by tests).
 
 Subsequent iterations:
 
-- #2365 — section management and bar add / remove / reorder.
 - #2366 — `@chordsketch/ui-web` runtime swap + iRealb input toggle.
 - #2367 — desktop integration (Open / Save dispatch + View menu).
 - #2368 — keyboard navigation + ARIA grid semantics.
+- #2376 — keyboard shortcuts for bar delete / reorder (deferred from
+  #2365 so binding decisions stay deliberate).
 
 ## Design
 

--- a/packages/ui-irealb-editor/src/dom.ts
+++ b/packages/ui-irealb-editor/src/dom.ts
@@ -17,9 +17,20 @@ export function el<K extends keyof HTMLElementTagNameMap>(
 ): HTMLElementTagNameMap[K] {
   const node = document.createElement(tag);
   if (init?.class !== undefined) {
-    const classes = Array.isArray(init.class) ? init.class : [init.class];
-    for (const c of classes) {
-      if (c) node.classList.add(c);
+    // Accept either an array (`['a', 'b']`) or a single string —
+    // and a single string may contain multiple whitespace-
+    // separated class names (`'a b'`), the same shape as the HTML
+    // `class=` attribute. Splitting on whitespace keeps call sites
+    // tidy when adding modifier classes (`'foo foo--danger'`)
+    // without having to allocate an array literal each time.
+    // `classList.add` rejects names containing whitespace, so we
+    // must split before calling it.
+    const raw = Array.isArray(init.class) ? init.class : [init.class];
+    for (const entry of raw) {
+      if (!entry) continue;
+      for (const c of entry.split(/\s+/)) {
+        if (c) node.classList.add(c);
+      }
     }
   }
   if (init?.attrs) {

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -433,10 +433,10 @@ function formatSectionLabelForPrompt(label: SectionLabel): string {
 
 /** Parse a free-text section label into the closest `SectionLabel`
  * variant. Empty input is treated as cancellation (returns `null`).
- * Single A..Z letter -> `Letter`; named variants
- * (`verse`/`chorus`/`intro`/`outro`/`bridge`, case-insensitive)
- * map to their dedicated variant; anything else falls into
- * `Custom` so unusual labels survive the round trip. */
+ * Single A–Z letter (case-insensitive, normalised to uppercase) ->
+ * `Letter`; named variants (`verse`/`chorus`/`intro`/`outro`/`bridge`,
+ * case-insensitive) map to their dedicated variant; anything else
+ * falls into `Custom` so unusual labels survive the round trip. */
 export function parseSectionLabel(s: string): SectionLabel | null {
   const trimmed = s.trim();
   if (trimmed === '') return null;

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -19,10 +19,10 @@
 // musical symbol). Structural section / bar edits arrive in #2365,
 // keyboard navigation + ARIA in #2368.
 
-import type { Bar, IrealSong } from './ast.js';
+import type { Bar, IrealSong, Section, SectionLabel } from './ast.js';
 import { clearChildren } from './dom.js';
 import { openBarPopover, type BarPopoverHandle } from './popover.js';
-import { render, type RenderHandle } from './render.js';
+import { render, type RenderHandle, type StructuralOps } from './render.js';
 import { IrealbEditorState, type IrealbWasm, makeStateFromUrl } from './state.js';
 
 export type { IrealSong } from './ast.js';
@@ -62,12 +62,29 @@ export interface CreateIrealbEditorOptions {
    * tests) supplies an object whose two methods come from
    * `@chordsketch/wasm`'s `parseIrealb` / `serializeIrealb`. */
   wasm: IrealbWasm;
+  /** Optional override for the section-label prompt (#2365). The
+   * default uses `window.prompt` to ask for `"A"` / `"Verse"` /
+   * `"Chorus"` / `"Intro"` / `"Outro"` / `"Bridge"` / single
+   * letter / arbitrary text; tests inject a stub that returns a
+   * canned label without blocking on the modal prompt. Returning
+   * `null` cancels the operation (no AST mutation). */
+  promptSectionLabel?: (current: SectionLabel | null) => SectionLabel | null;
+  /** Optional override for the delete-section confirmation
+   * (#2365). Defaults to `window.confirm`. Tests inject a stub
+   * that returns a canned boolean. Returning `false` cancels the
+   * delete (no AST mutation). */
+  confirmDeleteSection?: (label: SectionLabel) => boolean;
 }
 
 /** Build an `EditorAdapter` mounted inside a freshly-created `<div>`.
  * Caller appends `adapter.element` into the desired DOM container. */
 export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAdapter {
-  const { initialValue, wasm } = options;
+  const {
+    initialValue,
+    wasm,
+    promptSectionLabel = defaultPromptSectionLabel,
+    confirmDeleteSection = defaultConfirmDeleteSection,
+  } = options;
 
   const element = document.createElement('div');
   element.classList.add('irealb-editor');
@@ -148,12 +165,131 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
     });
   };
 
+  // Structural ops (#2365). Each mutation closes the popover (a
+  // grid rebuild detaches the popover's anchor anyway), splices /
+  // mutates `state.song`, then re-renders + fires onChange. The
+  // "delete section" path consults the host-supplied
+  // `confirmDeleteSection`; the "rename" / "add section" paths
+  // consult `promptSectionLabel`. Rename uses the existing label
+  // as the prompt seed; add uses `null` to signal "no current
+  // label."
+  const dismissPopover = (): void => {
+    if (popoverHandle !== null) {
+      popoverHandle.dispose();
+      popoverHandle = null;
+    }
+  };
+
+  const ops: StructuralOps = {
+    addSection: () => {
+      if (destroyed) return;
+      const label = promptSectionLabel(null);
+      if (label === null) return;
+      dismissPopover();
+      state.song.sections.push(makeDefaultSection(label));
+      renderNow();
+      fireUserEdit();
+    },
+    renameSection: (secIndex, current) => {
+      if (destroyed) return;
+      const section = state.song.sections[secIndex];
+      if (!section) return;
+      const next = promptSectionLabel(current);
+      if (next === null) return;
+      dismissPopover();
+      section.label = next;
+      renderNow();
+      fireUserEdit();
+    },
+    deleteSection: (secIndex) => {
+      if (destroyed) return;
+      const section = state.song.sections[secIndex];
+      if (!section) return;
+      if (!confirmDeleteSection(section.label)) return;
+      dismissPopover();
+      state.song.sections.splice(secIndex, 1);
+      renderNow();
+      fireUserEdit();
+    },
+    moveSectionUp: (secIndex) => {
+      if (destroyed) return;
+      if (secIndex <= 0 || secIndex >= state.song.sections.length) return;
+      dismissPopover();
+      const cur = state.song.sections[secIndex];
+      const prev = state.song.sections[secIndex - 1];
+      if (!cur || !prev) return;
+      state.song.sections[secIndex - 1] = cur;
+      state.song.sections[secIndex] = prev;
+      renderNow();
+      fireUserEdit();
+    },
+    moveSectionDown: (secIndex) => {
+      if (destroyed) return;
+      if (secIndex < 0 || secIndex >= state.song.sections.length - 1) return;
+      dismissPopover();
+      const cur = state.song.sections[secIndex];
+      const next = state.song.sections[secIndex + 1];
+      if (!cur || !next) return;
+      state.song.sections[secIndex + 1] = cur;
+      state.song.sections[secIndex] = next;
+      renderNow();
+      fireUserEdit();
+    },
+    addBar: (secIndex) => {
+      if (destroyed) return;
+      const section = state.song.sections[secIndex];
+      if (!section) return;
+      dismissPopover();
+      section.bars.push(makeDefaultBar());
+      renderNow();
+      fireUserEdit();
+    },
+    deleteBar: (secIndex, barIndex) => {
+      if (destroyed) return;
+      const section = state.song.sections[secIndex];
+      if (!section) return;
+      if (barIndex < 0 || barIndex >= section.bars.length) return;
+      dismissPopover();
+      section.bars.splice(barIndex, 1);
+      renderNow();
+      fireUserEdit();
+    },
+    moveBarLeft: (secIndex, barIndex) => {
+      if (destroyed) return;
+      const section = state.song.sections[secIndex];
+      if (!section) return;
+      if (barIndex <= 0 || barIndex >= section.bars.length) return;
+      dismissPopover();
+      const cur = section.bars[barIndex];
+      const prev = section.bars[barIndex - 1];
+      if (!cur || !prev) return;
+      section.bars[barIndex - 1] = cur;
+      section.bars[barIndex] = prev;
+      renderNow();
+      fireUserEdit();
+    },
+    moveBarRight: (secIndex, barIndex) => {
+      if (destroyed) return;
+      const section = state.song.sections[secIndex];
+      if (!section) return;
+      if (barIndex < 0 || barIndex >= section.bars.length - 1) return;
+      dismissPopover();
+      const cur = section.bars[barIndex];
+      const next = section.bars[barIndex + 1];
+      if (!cur || !next) return;
+      section.bars[barIndex + 1] = cur;
+      section.bars[barIndex] = next;
+      renderNow();
+      fireUserEdit();
+    },
+  };
+
   const renderNow = (): void => {
     if (renderHandle !== null) {
       renderHandle.dispose();
       renderHandle = null;
     }
-    renderHandle = render(element, state, fireUserEdit, handleOpenPopover);
+    renderHandle = render(element, state, fireUserEdit, handleOpenPopover, ops);
   };
 
   renderNow();
@@ -233,4 +369,91 @@ function makeEmptySong(): IrealSong {
     transpose: 0,
     sections: [],
   };
+}
+
+/** Default new bar — single barlines, no chords, no ending, no
+ * symbol. Used by `addBar` and by `addSection` (which seeds the
+ * new section with one starter bar so the user can immediately
+ * click to open the popover). */
+function makeDefaultBar(): Bar {
+  return {
+    start: 'single',
+    end: 'single',
+    chords: [],
+    ending: null,
+    symbol: null,
+  };
+}
+
+/** Default new section: the supplied label + one default bar. */
+function makeDefaultSection(label: SectionLabel): Section {
+  return { label, bars: [makeDefaultBar()] };
+}
+
+/** Default `promptSectionLabel`: ask via `window.prompt`, parse the
+ * reply into a `SectionLabel`. Empty / cancelled returns `null`.
+ * The rules mirror the named variants in `ast.ts` so a user typing
+ * `"Verse"` ends up with `{kind: 'verse'}` rather than `{kind:
+ * 'custom', value: 'Verse'}`. */
+function defaultPromptSectionLabel(current: SectionLabel | null): SectionLabel | null {
+  const seed = current !== null ? formatSectionLabelForPrompt(current) : 'A';
+  const reply = window.prompt(
+    'Section label (A–Z, Verse, Chorus, Intro, Outro, Bridge, or any text):',
+    seed,
+  );
+  if (reply === null) return null;
+  return parseSectionLabel(reply);
+}
+
+/** Default delete-section confirmation. */
+function defaultConfirmDeleteSection(label: SectionLabel): boolean {
+  return window.confirm(`Delete section "${formatSectionLabelForPrompt(label)}"?`);
+}
+
+/** Map a `SectionLabel` to the string form `defaultPromptSectionLabel`
+ * round-trips through. */
+function formatSectionLabelForPrompt(label: SectionLabel): string {
+  switch (label.kind) {
+    case 'letter':
+      return label.value;
+    case 'verse':
+      return 'Verse';
+    case 'chorus':
+      return 'Chorus';
+    case 'intro':
+      return 'Intro';
+    case 'outro':
+      return 'Outro';
+    case 'bridge':
+      return 'Bridge';
+    case 'custom':
+      return label.value;
+  }
+}
+
+/** Parse a free-text section label into the closest `SectionLabel`
+ * variant. Empty input is treated as cancellation (returns `null`).
+ * Single A..Z letter -> `Letter`; named variants
+ * (`verse`/`chorus`/`intro`/`outro`/`bridge`, case-insensitive)
+ * map to their dedicated variant; anything else falls into
+ * `Custom` so unusual labels survive the round trip. */
+export function parseSectionLabel(s: string): SectionLabel | null {
+  const trimmed = s.trim();
+  if (trimmed === '') return null;
+  if (trimmed.length === 1 && trimmed >= 'A' && trimmed <= 'Z') {
+    return { kind: 'letter', value: trimmed };
+  }
+  switch (trimmed.toLowerCase()) {
+    case 'verse':
+      return { kind: 'verse' };
+    case 'chorus':
+      return { kind: 'chorus' };
+    case 'intro':
+      return { kind: 'intro' };
+    case 'outro':
+      return { kind: 'outro' };
+    case 'bridge':
+      return { kind: 'bridge' };
+  }
+  return { kind: 'custom', value: trimmed };
 }

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -173,6 +173,17 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
   // consult `promptSectionLabel`. Rename uses the existing label
   // as the prompt seed; add uses `null` to signal "no current
   // label."
+  //
+  // Focus restoration: every op finishes with `renderNow()`, which
+  // detaches the just-clicked button. Without explicit follow-up,
+  // focus drops to <body> and a keyboard user repeating Move-up
+  // has to mouse back to the button between presses. The
+  // `focusAfterRender` helper locates the freshly-mounted button
+  // by `data-section-index` / `data-bar-index` (both already
+  // emitted by render.ts) so focus follows the moved item; for
+  // delete ops it falls back to the next-sibling item (or the
+  // previous, if the deleted item was last). Mirrors the popover
+  // Save focus-restoration introduced for #2364.
   const dismissPopover = (): void => {
     if (popoverHandle !== null) {
       popoverHandle.dispose();
@@ -180,15 +191,62 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
     }
   };
 
+  /** Re-focus the first non-disabled button matching one of
+   * `selectors` inside `element`, in priority order. Skips
+   * `<button disabled>` (jsdom + browsers both refuse to focus a
+   * disabled button) so a move op that lands an item on an
+   * endpoint (where the same-direction button is disabled) falls
+   * through to a sensible alternative. No-op if every selector
+   * misses or matches only disabled elements. */
+  const focusAfterRender = (selectors: string[]): void => {
+    for (const selector of selectors) {
+      const target = element.querySelector<HTMLElement>(selector);
+      if (!target) continue;
+      if (target instanceof HTMLButtonElement && target.disabled) continue;
+      target.focus();
+      return;
+    }
+  };
+
+  /** Locate the freshly-mounted "Move section up/down" / "Rename
+   * section" / "Delete section" button on a specific section. */
+  const sectionActionSelector = (secIndex: number, ariaLabel: string): string =>
+    `[data-section-index="${secIndex}"] button[aria-label="${ariaLabel}"]`;
+
+  /** Locate the freshly-mounted "Move bar left/right" / "Delete bar"
+   * button on a specific bar. */
+  const barActionSelector = (
+    secIndex: number,
+    barIndex: number,
+    ariaLabel: string,
+  ): string =>
+    `[data-section-index="${secIndex}"] [data-bar-index="${barIndex}"] button[aria-label="${ariaLabel}"]`;
+
+  // The op closures reference `renderNow` and `focusAfterRender`,
+  // which are declared further down in this function. The closures
+  // capture them lexically; reads happen only when an op fires
+  // (i.e. on user click), well after the `let` / `const` bindings
+  // are initialised, so the temporal-dead-zone window is unreachable
+  // in practice. Do NOT reorder the declarations to put `renderNow`
+  // above `ops` without first verifying nothing in the construction
+  // path calls into `ops`.
   const ops: StructuralOps = {
     addSection: () => {
       if (destroyed) return;
       const label = promptSectionLabel(null);
       if (label === null) return;
       dismissPopover();
+      const newIndex = state.song.sections.length;
       state.song.sections.push(makeDefaultSection(label));
       renderNow();
       fireUserEdit();
+      // Focus the new section's "Move section up" button — the
+      // closest analogue to the just-clicked "+ Add section"
+      // trailer (which does not exist on a per-section basis).
+      focusAfterRender([
+        sectionActionSelector(newIndex, 'Move section up'),
+        sectionActionSelector(newIndex, 'Rename section'),
+      ]);
     },
     renameSection: (secIndex, current) => {
       if (destroyed) return;
@@ -196,10 +254,15 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       if (!section) return;
       const next = promptSectionLabel(current);
       if (next === null) return;
+      // No-op if the label is structurally unchanged. Suppresses a
+      // duplicate-URL onChange dispatch that subscribers cannot
+      // distinguish from a real edit.
+      if (sectionLabelEquals(current, next)) return;
       dismissPopover();
       section.label = next;
       renderNow();
       fireUserEdit();
+      focusAfterRender([sectionActionSelector(secIndex, 'Rename section')]);
     },
     deleteSection: (secIndex) => {
       if (destroyed) return;
@@ -210,39 +273,67 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       state.song.sections.splice(secIndex, 1);
       renderNow();
       fireUserEdit();
+      // Focus the next-sibling section's "Delete section" button
+      // (the same kind that was just activated). If the deleted
+      // section was the last one, focus the new last section's
+      // button instead. If no sections remain, focus the
+      // "+ Add section" trailer.
+      const remaining = state.song.sections.length;
+      if (remaining === 0) {
+        focusAfterRender(['.irealb-editor__add-section']);
+      } else {
+        const nextIndex = secIndex < remaining ? secIndex : remaining - 1;
+        focusAfterRender([sectionActionSelector(nextIndex, 'Delete section')]);
+      }
     },
     moveSectionUp: (secIndex) => {
       if (destroyed) return;
       if (secIndex <= 0 || secIndex >= state.song.sections.length) return;
       dismissPopover();
-      const cur = state.song.sections[secIndex];
-      const prev = state.song.sections[secIndex - 1];
-      if (!cur || !prev) return;
+      const cur = state.song.sections[secIndex] as Section;
+      const prev = state.song.sections[secIndex - 1] as Section;
       state.song.sections[secIndex - 1] = cur;
       state.song.sections[secIndex] = prev;
       renderNow();
       fireUserEdit();
+      // The moved section is now at secIndex - 1. Focus its
+      // "Move section up" button so a repeat-press keeps moving
+      // the same section upward.
+      focusAfterRender([
+        sectionActionSelector(secIndex - 1, 'Move section up'),
+        sectionActionSelector(secIndex - 1, 'Move section down'),
+        sectionActionSelector(secIndex - 1, 'Rename section'),
+      ]);
     },
     moveSectionDown: (secIndex) => {
       if (destroyed) return;
       if (secIndex < 0 || secIndex >= state.song.sections.length - 1) return;
       dismissPopover();
-      const cur = state.song.sections[secIndex];
-      const next = state.song.sections[secIndex + 1];
-      if (!cur || !next) return;
+      const cur = state.song.sections[secIndex] as Section;
+      const next = state.song.sections[secIndex + 1] as Section;
       state.song.sections[secIndex + 1] = cur;
       state.song.sections[secIndex] = next;
       renderNow();
       fireUserEdit();
+      focusAfterRender([
+        sectionActionSelector(secIndex + 1, 'Move section down'),
+        sectionActionSelector(secIndex + 1, 'Move section up'),
+        sectionActionSelector(secIndex + 1, 'Rename section'),
+      ]);
     },
     addBar: (secIndex) => {
       if (destroyed) return;
       const section = state.song.sections[secIndex];
       if (!section) return;
       dismissPopover();
+      const newBarIndex = section.bars.length;
       section.bars.push(makeDefaultBar());
       renderNow();
       fireUserEdit();
+      // Focus the new bar's edit button (its <button class="bar">).
+      focusAfterRender([
+        `[data-section-index="${secIndex}"] [data-bar-index="${newBarIndex}"] .irealb-editor__bar`,
+      ]);
     },
     deleteBar: (secIndex, barIndex) => {
       if (destroyed) return;
@@ -253,6 +344,17 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       section.bars.splice(barIndex, 1);
       renderNow();
       fireUserEdit();
+      // Focus the next-sibling bar's Delete button (or the new
+      // last bar's, or the section's "+ Add bar" trailer).
+      const remaining = section.bars.length;
+      if (remaining === 0) {
+        focusAfterRender([
+          `[data-section-index="${secIndex}"] .irealb-editor__add-bar`,
+        ]);
+      } else {
+        const nextIndex = barIndex < remaining ? barIndex : remaining - 1;
+        focusAfterRender([barActionSelector(secIndex, nextIndex, 'Delete bar')]);
+      }
     },
     moveBarLeft: (secIndex, barIndex) => {
       if (destroyed) return;
@@ -260,13 +362,17 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       if (!section) return;
       if (barIndex <= 0 || barIndex >= section.bars.length) return;
       dismissPopover();
-      const cur = section.bars[barIndex];
-      const prev = section.bars[barIndex - 1];
-      if (!cur || !prev) return;
+      const cur = section.bars[barIndex] as Bar;
+      const prev = section.bars[barIndex - 1] as Bar;
       section.bars[barIndex - 1] = cur;
       section.bars[barIndex] = prev;
       renderNow();
       fireUserEdit();
+      focusAfterRender([
+        barActionSelector(secIndex, barIndex - 1, 'Move bar left'),
+        barActionSelector(secIndex, barIndex - 1, 'Move bar right'),
+        `[data-section-index="${secIndex}"] [data-bar-index="${barIndex - 1}"] .irealb-editor__bar`,
+      ]);
     },
     moveBarRight: (secIndex, barIndex) => {
       if (destroyed) return;
@@ -274,13 +380,17 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       if (!section) return;
       if (barIndex < 0 || barIndex >= section.bars.length - 1) return;
       dismissPopover();
-      const cur = section.bars[barIndex];
-      const next = section.bars[barIndex + 1];
-      if (!cur || !next) return;
+      const cur = section.bars[barIndex] as Bar;
+      const next = section.bars[barIndex + 1] as Bar;
       section.bars[barIndex + 1] = cur;
       section.bars[barIndex] = next;
       renderNow();
       fireUserEdit();
+      focusAfterRender([
+        barActionSelector(secIndex, barIndex + 1, 'Move bar right'),
+        barActionSelector(secIndex, barIndex + 1, 'Move bar left'),
+        `[data-section-index="${secIndex}"] [data-bar-index="${barIndex + 1}"] .irealb-editor__bar`,
+      ]);
     },
   };
 
@@ -388,6 +498,20 @@ function makeDefaultBar(): Bar {
 /** Default new section: the supplied label + one default bar. */
 function makeDefaultSection(label: SectionLabel): Section {
   return { label, bars: [makeDefaultBar()] };
+}
+
+/** Structural equality on `SectionLabel`. Used by `renameSection`
+ * to suppress a no-op edit (which would otherwise dispatch a
+ * duplicate-URL onChange that subscribers cannot distinguish from
+ * a real edit). */
+function sectionLabelEquals(a: SectionLabel | null, b: SectionLabel | null): boolean {
+  if (a === null || b === null) return a === b;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'letter' && b.kind === 'letter') return a.value === b.value;
+  if (a.kind === 'custom' && b.kind === 'custom') return a.value === b.value;
+  // The remaining kinds (`verse` / `chorus` / `intro` / `outro` /
+  // `bridge`) carry no payload, so kind equality is sufficient.
+  return true;
 }
 
 /** Default `promptSectionLabel`: ask via `window.prompt`, parse the

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -25,7 +25,7 @@ import { openBarPopover, type BarPopoverHandle } from './popover.js';
 import { render, type RenderHandle, type StructuralOps } from './render.js';
 import { IrealbEditorState, type IrealbWasm, makeStateFromUrl } from './state.js';
 
-export type { IrealSong } from './ast.js';
+export type { IrealSong, SectionLabel } from './ast.js';
 export type { IrealbWasm } from './state.js';
 export { SAMPLE_IREALB } from './sample.js';
 
@@ -440,8 +440,11 @@ function formatSectionLabelForPrompt(label: SectionLabel): string {
 export function parseSectionLabel(s: string): SectionLabel | null {
   const trimmed = s.trim();
   if (trimmed === '') return null;
-  if (trimmed.length === 1 && trimmed >= 'A' && trimmed <= 'Z') {
-    return { kind: 'letter', value: trimmed };
+  if (trimmed.length === 1) {
+    const upper = trimmed.toUpperCase();
+    if (upper >= 'A' && upper <= 'Z') {
+      return { kind: 'letter', value: upper };
+    }
   }
   switch (trimmed.toLowerCase()) {
     case 'verse':

--- a/packages/ui-irealb-editor/src/render.ts
+++ b/packages/ui-irealb-editor/src/render.ts
@@ -51,8 +51,9 @@ export interface StructuralOps {
   addSection(): void;
   /** Replace a section's label. */
   renameSection(secIndex: number, label: SectionLabel): void;
-  /** Delete a section after a confirmation prompt. The adapter shows
-   * the prompt; this method is only called once the user confirms. */
+  /** Delete a section. The adapter invokes `confirmDeleteSection`
+   * internally; returning `false` from that hook cancels the
+   * operation before any AST mutation occurs. */
   deleteSection(secIndex: number): void;
   /** Move a section one position up (lower index). No-op at index 0. */
   moveSectionUp(secIndex: number): void;

--- a/packages/ui-irealb-editor/src/render.ts
+++ b/packages/ui-irealb-editor/src/render.ts
@@ -39,6 +39,40 @@ export type OpenBarPopover = (
   barIndex: number,
 ) => void;
 
+/** Mutators the renderer invokes for structural edits (#2365). The
+ * editor adapter implements each one as a `state.song` mutation
+ * followed by `renderNow()` + `fireUserEdit()`. Threading them as a
+ * single object keeps `render`'s signature stable while letting the
+ * adapter own the rebuild + notification cycle. */
+export interface StructuralOps {
+  /** Append a new section after the last one. The label dialog is
+   * opened by the adapter; the new section starts with one default
+   * bar so the user can immediately click to edit. */
+  addSection(): void;
+  /** Replace a section's label. */
+  renameSection(secIndex: number, label: SectionLabel): void;
+  /** Delete a section after a confirmation prompt. The adapter shows
+   * the prompt; this method is only called once the user confirms. */
+  deleteSection(secIndex: number): void;
+  /** Move a section one position up (lower index). No-op at index 0. */
+  moveSectionUp(secIndex: number): void;
+  /** Move a section one position down (higher index). No-op at the
+   * last section. */
+  moveSectionDown(secIndex: number): void;
+  /** Append a fresh bar to a section. */
+  addBar(secIndex: number): void;
+  /** Delete a bar. The renderer does not require a confirm; the AST
+   * stores undo-equivalent state via the URL field that the host
+   * can re-load. */
+  deleteBar(secIndex: number, barIndex: number): void;
+  /** Move a bar one position left within its section. No-op at
+   * the first bar. */
+  moveBarLeft(secIndex: number, barIndex: number): void;
+  /** Move a bar one position right within its section. No-op at
+   * the last bar. */
+  moveBarRight(secIndex: number, barIndex: number): void;
+}
+
 /** Result returned by {@link render}. `dispose` removes every event
  * listener registered during this render pass; call before
  * re-rendering or before tearing the editor down. */
@@ -49,16 +83,18 @@ export interface RenderHandle {
 
 /** Build the form + bar grid into `root` from `state`. `onUserEdit`
  * fires after every successful user-initiated mutation;
- * `openBarPopover` fires when a user clicks a bar cell — the
- * editor adapter passes a callback that opens the bar-edit popover
- * (#2364). The adapter is responsible for the popover's mount
- * container, focus management, and the post-save re-render +
- * onUserEdit dispatch. */
+ * `openBarPopover` fires when a user clicks a bar cell (the
+ * adapter opens the bar-edit popover, #2364); `ops` exposes the
+ * structural mutations the per-section / per-bar UI buttons drive
+ * (#2365). The adapter owns the popover container, structural
+ * confirm dialogs, and the post-mutation re-render + onUserEdit
+ * dispatch. */
 export function render(
   root: HTMLElement,
   state: IrealbEditorState,
   onUserEdit: () => void,
   openBarPopover: OpenBarPopover,
+  ops: StructuralOps,
 ): RenderHandle {
   clearChildren(root);
   const cleanups: Array<() => void> = [];
@@ -200,9 +236,25 @@ export function render(
 
   // ---- Bar grid -------------------------------------------------------------
   const grid = el('div', { class: 'irealb-editor__grid' });
+  const sectionsCount = state.song.sections.length;
   state.song.sections.forEach((section, secIndex) => {
-    grid.appendChild(renderSection(section, secIndex, openBarPopover, listen));
+    grid.appendChild(
+      renderSection(section, secIndex, sectionsCount, openBarPopover, ops, listen),
+    );
   });
+
+  // "Add Section" trailer — always present so the user can append
+  // to an empty chart too. Click → the adapter opens the section-
+  // label dialog and then calls `ops.addSection`.
+  const addSectionBtn = el('button', {
+    class: 'irealb-editor__add-section',
+    attrs: { type: 'button' },
+    text: '+ Add section',
+  });
+  listen(addSectionBtn, 'click', () => {
+    ops.addSection();
+  });
+  grid.appendChild(addSectionBtn);
   root.appendChild(grid);
 
   return {
@@ -220,29 +272,97 @@ export function render(
 function renderSection(
   section: Section,
   secIndex: number,
+  sectionsCount: number,
   openBarPopover: OpenBarPopover,
+  ops: StructuralOps,
   listen: <K extends keyof HTMLElementEventMap>(
     target: HTMLElement,
     type: K,
     handler: (ev: HTMLElementEventMap[K]) => void,
   ) => void,
 ): HTMLElement {
-  const wrapper = el('div', { class: 'irealb-editor__section' });
+  const wrapper = el('div', {
+    class: 'irealb-editor__section',
+    attrs: { 'data-section-index': String(secIndex) },
+  });
+
+  // Section header: label + per-section action buttons (rename,
+  // delete, move up/down). The header sits inline with the label so
+  // the actions stay visually attached to their target section.
+  const headerRow = el('div', { class: 'irealb-editor__section-header' });
   const heading = el('h3', {
     class: 'irealb-editor__section-label',
     text: formatSectionLabel(section.label),
   });
-  wrapper.appendChild(heading);
+  headerRow.appendChild(heading);
 
-  // 4-bars-per-line CSS grid. The grid template lives in style.css;
-  // we emit a flat list of `<button>` cells (button so click +
-  // keyboard activation come for free; ARIA grid semantics arrive
-  // in #2368).
+  const renameBtn = el('button', {
+    class: 'irealb-editor__section-action',
+    attrs: { type: 'button', 'aria-label': 'Rename section' },
+    text: '✎',
+  });
+  listen(renameBtn, 'click', () => {
+    ops.renameSection(secIndex, section.label);
+  });
+  headerRow.appendChild(renameBtn);
+
+  const upBtn = el('button', {
+    class: 'irealb-editor__section-action',
+    attrs: { type: 'button', 'aria-label': 'Move section up' },
+    text: '↑',
+  });
+  if (secIndex === 0) upBtn.setAttribute('disabled', '');
+  listen(upBtn, 'click', () => {
+    ops.moveSectionUp(secIndex);
+  });
+  headerRow.appendChild(upBtn);
+
+  const downBtn = el('button', {
+    class: 'irealb-editor__section-action',
+    attrs: { type: 'button', 'aria-label': 'Move section down' },
+    text: '↓',
+  });
+  if (secIndex === sectionsCount - 1) downBtn.setAttribute('disabled', '');
+  listen(downBtn, 'click', () => {
+    ops.moveSectionDown(secIndex);
+  });
+  headerRow.appendChild(downBtn);
+
+  const deleteSectionBtn = el('button', {
+    class: 'irealb-editor__section-action irealb-editor__section-action--danger',
+    attrs: { type: 'button', 'aria-label': 'Delete section' },
+    text: '×',
+  });
+  listen(deleteSectionBtn, 'click', () => {
+    ops.deleteSection(secIndex);
+  });
+  headerRow.appendChild(deleteSectionBtn);
+
+  wrapper.appendChild(headerRow);
+
+  // 4-bars-per-line CSS grid. Emits a flat list of bar wrappers
+  // (each wrapper holds the bar `<button>` plus its delete /
+  // reorder controls). ARIA grid semantics arrive in #2368.
   const row = el('div', { class: 'irealb-editor__bars' });
+  const barsCount = section.bars.length;
   section.bars.forEach((bar, barIndex) => {
-    row.appendChild(renderBar(bar, secIndex, barIndex, openBarPopover, listen));
+    row.appendChild(
+      renderBar(bar, secIndex, barIndex, barsCount, openBarPopover, ops, listen),
+    );
   });
   wrapper.appendChild(row);
+
+  // Append-bar trailer.
+  const addBarBtn = el('button', {
+    class: 'irealb-editor__add-bar',
+    attrs: { type: 'button' },
+    text: '+ Add bar',
+  });
+  listen(addBarBtn, 'click', () => {
+    ops.addBar(secIndex);
+  });
+  wrapper.appendChild(addBarBtn);
+
   return wrapper;
 }
 
@@ -250,18 +370,26 @@ function renderBar(
   bar: Bar,
   secIndex: number,
   barIndex: number,
+  barsCount: number,
   openBarPopover: OpenBarPopover,
+  ops: StructuralOps,
   listen: <K extends keyof HTMLElementEventMap>(
     target: HTMLElement,
     type: K,
     handler: (ev: HTMLElementEventMap[K]) => void,
   ) => void,
 ): HTMLElement {
+  const wrapper = el('div', {
+    class: 'irealb-editor__bar-wrapper',
+    attrs: { 'data-bar-index': String(barIndex) },
+  });
+
   const text = bar.chords.map((c) => formatChord(c.chord)).join(' ');
   // `<button type="button">` so the cell announces as a button to
   // screen readers and so Enter / Space activation works without
   // explicit keyboard handlers. ARIA grid semantics on the wrapping
-  // grid (`role="grid"` / `gridcell`) are deferred to #2368.
+  // grid (`role="grid"` / `gridcell`) are deferred to #2368;
+  // keyboard shortcuts for delete / reorder are deferred to #2376.
   const cell = el('button', {
     class: 'irealb-editor__bar',
     attrs: {
@@ -273,7 +401,44 @@ function renderBar(
   listen(cell, 'click', () => {
     openBarPopover(bar, cell, secIndex, barIndex);
   });
-  return cell;
+  wrapper.appendChild(cell);
+
+  const actions = el('div', { class: 'irealb-editor__bar-actions' });
+
+  const leftBtn = el('button', {
+    class: 'irealb-editor__bar-action',
+    attrs: { type: 'button', 'aria-label': 'Move bar left' },
+    text: '←',
+  });
+  if (barIndex === 0) leftBtn.setAttribute('disabled', '');
+  listen(leftBtn, 'click', () => {
+    ops.moveBarLeft(secIndex, barIndex);
+  });
+  actions.appendChild(leftBtn);
+
+  const rightBtn = el('button', {
+    class: 'irealb-editor__bar-action',
+    attrs: { type: 'button', 'aria-label': 'Move bar right' },
+    text: '→',
+  });
+  if (barIndex === barsCount - 1) rightBtn.setAttribute('disabled', '');
+  listen(rightBtn, 'click', () => {
+    ops.moveBarRight(secIndex, barIndex);
+  });
+  actions.appendChild(rightBtn);
+
+  const deleteBtn = el('button', {
+    class: 'irealb-editor__bar-action irealb-editor__bar-action--danger',
+    attrs: { type: 'button', 'aria-label': 'Delete bar' },
+    text: '×',
+  });
+  listen(deleteBtn, 'click', () => {
+    ops.deleteBar(secIndex, barIndex);
+  });
+  actions.appendChild(deleteBtn);
+
+  wrapper.appendChild(actions);
+  return wrapper;
 }
 
 function formatSectionLabel(label: SectionLabel): string {

--- a/packages/ui-irealb-editor/src/style.css
+++ b/packages/ui-irealb-editor/src/style.css
@@ -83,23 +83,112 @@
   gap: 0.5rem;
 }
 
-.irealb-editor__section-label {
-  margin: 0;
-  font-size: 0.95rem;
-  color: #52606d;
+.irealb-editor__section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   border-bottom: 1px solid #e4e7eb;
   padding-bottom: 0.25rem;
 }
 
-/* 4 bars per line. Per the AC: each bar is rendered as a disabled
- * cell (no inputs yet — bar editing arrives in #2364). The grid
- * wraps when the section has more than 4 bars; sections with <4
- * bars right-pad with empty grid cells (handled by the implicit
- * `grid-template-columns` track count). */
+.irealb-editor__section-label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #52606d;
+  flex: 1;
+}
+
+/* Per-section action buttons (rename / move / delete) — added in
+ * #2365. Sit inline with the section heading so they stay visually
+ * attached to their target section. */
+.irealb-editor__section-action {
+  background: #ffffff;
+  border: 1px solid #cbd2d9;
+  border-radius: 4px;
+  padding: 0.2rem 0.45rem;
+  cursor: pointer;
+  font: inherit;
+  color: #1f2933;
+}
+
+.irealb-editor__section-action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.irealb-editor__section-action--danger {
+  border-color: #fab4b4;
+  color: #c92a2a;
+}
+
+.irealb-editor__section-action--danger:hover:not(:disabled) {
+  background: #fff5f5;
+}
+
+/* Add-section / add-bar trailers (#2365). Dashed outline so they
+ * read as "drop zone" rather than primary control. */
+.irealb-editor__add-section,
+.irealb-editor__add-bar {
+  align-self: flex-start;
+  background: #f5f7fa;
+  border: 1px dashed #cbd2d9;
+  border-radius: 4px;
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+  font: inherit;
+  color: #1f2933;
+}
+
+.irealb-editor__add-section:hover,
+.irealb-editor__add-bar:hover {
+  background: #e4ebf1;
+}
+
+/* 4 bars per line. The grid wraps when the section has more than
+ * 4 bars; sections with <4 bars right-pad with empty grid cells. */
 .irealb-editor__bars {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.25rem;
+}
+
+/* Bar wrapper holds the bar `<button>` plus the per-bar action
+ * micro-controls beneath it (#2365). */
+.irealb-editor__bar-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.irealb-editor__bar-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.15rem;
+}
+
+.irealb-editor__bar-action {
+  background: #ffffff;
+  border: 1px solid #cbd2d9;
+  border-radius: 3px;
+  padding: 0.1rem 0.35rem;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  color: #52606d;
+}
+
+.irealb-editor__bar-action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.irealb-editor__bar-action--danger {
+  border-color: #fab4b4;
+  color: #c92a2a;
+}
+
+.irealb-editor__bar-action--danger:hover:not(:disabled) {
+  background: #fff5f5;
 }
 
 .irealb-editor__bar {

--- a/packages/ui-irealb-editor/src/style.css
+++ b/packages/ui-irealb-editor/src/style.css
@@ -111,6 +111,10 @@
   color: #1f2933;
 }
 
+.irealb-editor__section-action:hover:not(:disabled) {
+  background: #f5f7fa;
+}
+
 .irealb-editor__section-action:disabled {
   opacity: 0.4;
   cursor: not-allowed;
@@ -175,6 +179,10 @@
   font: inherit;
   font-size: 0.75rem;
   color: #52606d;
+}
+
+.irealb-editor__bar-action:hover:not(:disabled) {
+  background: #f5f7fa;
 }
 
 .irealb-editor__bar-action:disabled {

--- a/packages/ui-irealb-editor/tests/structural.test.ts
+++ b/packages/ui-irealb-editor/tests/structural.test.ts
@@ -455,6 +455,170 @@ describe('bar structural management', () => {
     editor.destroy();
   });
 
+  test('Add bar in a section seeded with one default bar shows two bars after click', () => {
+    // Empty-section coverage: a section freshly created via Add
+    // Section starts with one default bar (per the seeding rule).
+    // Append-bar must work on it and bump the count to 2 — pinning
+    // the empty-to-non-empty boundary catches a regression where
+    // render skips the section's add-bar trailer for short
+    // sections, or where addBar mutates the wrong section.
+    const wasm = makeStubWasm();
+    const promptSectionLabel = vi.fn((): SectionLabel => ({ kind: 'verse' }));
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      promptSectionLabel,
+    });
+
+    clickByText(editor, '+ Add section');
+    const addBarBtns = Array.from(
+      editor.element.querySelectorAll<HTMLButtonElement>(
+        '.irealb-editor__add-bar',
+      ),
+    );
+    expect(addBarBtns.length).toBe(3); // one per section, including the new one
+    addBarBtns[2]?.click();
+
+    const song = readSong(editor);
+    expect(song.sections[2]?.bars.length).toBe(2);
+    // Other sections still have their original bar counts.
+    expect(song.sections[0]?.bars.length).toBe(2);
+    expect(song.sections[1]?.bars.length).toBe(1);
+
+    editor.destroy();
+  });
+
+  test('Rename section with the same label suppresses the onChange dispatch', () => {
+    // The user opens the rename prompt and submits the existing
+    // label unchanged (or types it identically). The AST does not
+    // drift, so onChange subscribers should NOT receive a
+    // duplicate URL — pinning this avoids dispatching a
+    // distinguishable-from-a-real-edit notification.
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const promptSectionLabel = vi.fn(
+      (current: SectionLabel | null): SectionLabel => current!,
+    );
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      promptSectionLabel,
+    });
+    editor.onChange(onChange);
+
+    clickAction(editor, 'Rename section', 0);
+    expect(promptSectionLabel).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+    // Label is unchanged in the AST as well.
+    expect(readSong(editor).sections[0]?.label).toEqual({
+      kind: 'letter',
+      value: 'A',
+    });
+
+    editor.destroy();
+  });
+
+  test('Move section up restores keyboard focus inside the moved section', () => {
+    // Focus follows the moved item so a repeat-press keeps the
+    // user's keyboard context on it. When the move lands the
+    // section at the top (index 0), the same-direction "Move
+    // section up" button is disabled, so the implementation falls
+    // back to the next non-disabled action button on the same
+    // section ("Move section down") per the focusAfterRender
+    // selector chain. Either way, the focused element belongs to
+    // the moved section. Mirrors the popover Save focus-restoration
+    // introduced for #2364.
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    clickAction(editor, 'Move section up', 1);
+    const focused = document.activeElement;
+    // The fallback chain for moveSectionUp at the new top is
+    // [Move up (disabled) -> Move down -> Rename]. jsdom skips
+    // the disabled button and lands on Move down.
+    expect(focused?.getAttribute('aria-label')).toBe('Move section down');
+    const sectionWrapper = focused?.closest<HTMLElement>('[data-section-index]');
+    expect(sectionWrapper?.getAttribute('data-section-index')).toBe('0');
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Move bar right restores keyboard focus inside the moved bar', () => {
+    // Section A's first bar moves right to position 1 (the last
+    // position in a 2-bar section), where "Move bar right" is
+    // disabled. The fallback chain selects "Move bar left" on the
+    // same wrapper.
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    clickAction(editor, 'Move bar right', 0);
+    const focused = document.activeElement;
+    expect(focused?.getAttribute('aria-label')).toBe('Move bar left');
+    const wrapper = focused?.closest<HTMLElement>('[data-bar-index]');
+    expect(wrapper?.getAttribute('data-bar-index')).toBe('1');
+    const sectionWrapper = focused?.closest<HTMLElement>('[data-section-index]');
+    expect(sectionWrapper?.getAttribute('data-section-index')).toBe('0');
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Move bar inside a 3-bar section keeps focus on the same-direction button', () => {
+    // When the move does NOT land on an endpoint, the
+    // same-direction button stays enabled and focus lands on it
+    // — the canonical "repeat-press keeps moving the same item"
+    // case.
+    const wasm = makeStubWasm();
+    const seed: IrealSong = JSON.parse(JSON.stringify(SAMPLE_SONG));
+    const sectionA = seed.sections[0];
+    if (!sectionA) throw new Error('seed missing section A');
+    sectionA.bars.push({
+      start: 'single',
+      end: 'single',
+      chords: [],
+      ending: null,
+      symbol: null,
+    });
+    const seedUrl = `irealb://json:${encodeURIComponent(JSON.stringify(seed))}`;
+    const editor = createIrealbEditor({ initialValue: seedUrl, wasm });
+    document.body.appendChild(editor.element);
+
+    // Move bar 0 right -> bar lands at index 1 (middle of 3
+    // bars). "Move bar right" stays enabled.
+    clickAction(editor, 'Move bar right', 0);
+    expect(document.activeElement?.getAttribute('aria-label')).toBe('Move bar right');
+    const wrapper = (document.activeElement as HTMLElement | null)?.closest<HTMLElement>(
+      '[data-bar-index]',
+    );
+    expect(wrapper?.getAttribute('data-bar-index')).toBe('1');
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Delete bar focuses the next-sibling bar (or the add-bar trailer if none remain)', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    // Section A has 2 bars. Delete bar 0 -> remaining bar is at
+    // index 0. Focus should land on the remaining bar's Delete.
+    clickAction(editor, 'Delete bar', 0);
+    expect(document.activeElement?.getAttribute('aria-label')).toBe('Delete bar');
+
+    // Now delete the last remaining bar in section A. Focus should
+    // fall back to that section's "+ Add bar" trailer.
+    clickAction(editor, 'Delete bar', 0);
+    const focused = document.activeElement;
+    expect(focused?.classList.contains('irealb-editor__add-bar')).toBe(true);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
   test('Structural ops dismiss any open bar popover', () => {
     const wasm = makeStubWasm();
     const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });

--- a/packages/ui-irealb-editor/tests/structural.test.ts
+++ b/packages/ui-irealb-editor/tests/structural.test.ts
@@ -1,0 +1,469 @@
+// Vitest cases for structural editing (#2365): section
+// add / rename / delete / reorder, bar add / delete / reorder.
+//
+// The host stubs `promptSectionLabel` + `confirmDeleteSection` so
+// the tests do not block on jsdom's window.prompt / window.confirm
+// (which throw "not implemented" by default).
+
+import { describe, expect, test, vi } from 'vitest';
+import {
+  createIrealbEditor,
+  parseSectionLabel,
+  type IrealbWasm,
+} from '../src/index';
+import type { IrealSong, SectionLabel } from '../src/ast';
+
+const SAMPLE_SONG: IrealSong = {
+  title: 'Structural Sample',
+  composer: null,
+  style: null,
+  key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+  time_signature: { numerator: 4, denominator: 4 },
+  tempo: null,
+  transpose: 0,
+  sections: [
+    {
+      label: { kind: 'letter', value: 'A' },
+      bars: [
+        {
+          start: 'single',
+          end: 'single',
+          chords: [],
+          ending: null,
+          symbol: null,
+        },
+        {
+          start: 'single',
+          end: 'single',
+          chords: [],
+          ending: null,
+          symbol: null,
+        },
+      ],
+    },
+    {
+      label: { kind: 'letter', value: 'B' },
+      bars: [
+        {
+          start: 'single',
+          end: 'single',
+          chords: [],
+          ending: null,
+          symbol: null,
+        },
+      ],
+    },
+  ],
+};
+const SAMPLE_URL = 'irealb://structural-sample';
+
+function makeStubWasm(): IrealbWasm & {
+  parseIrealb: ReturnType<typeof vi.fn>;
+  serializeIrealb: ReturnType<typeof vi.fn>;
+} {
+  const parseIrealb = vi.fn((input: string): string => {
+    if (input === SAMPLE_URL) return JSON.stringify(SAMPLE_SONG);
+    if (input.startsWith('irealb://json:')) {
+      return decodeURIComponent(input.slice('irealb://json:'.length));
+    }
+    throw new Error(`stub parseIrealb: unknown URL: ${input}`);
+  });
+  const serializeIrealb = vi.fn(
+    (input: string): string => `irealb://json:${encodeURIComponent(input)}`,
+  );
+  return { parseIrealb, serializeIrealb };
+}
+
+function readSong(editor: ReturnType<typeof createIrealbEditor>): IrealSong {
+  const url = editor.getValue();
+  return JSON.parse(decodeURIComponent(url.slice('irealb://json:'.length))) as IrealSong;
+}
+
+function clickAction(editor: ReturnType<typeof createIrealbEditor>, ariaLabel: string, n = 0): void {
+  const btns = Array.from(
+    editor.element.querySelectorAll<HTMLButtonElement>(
+      `button[aria-label="${ariaLabel}"]`,
+    ),
+  );
+  const target = btns[n];
+  if (!target) {
+    throw new Error(`button[aria-label="${ariaLabel}"][${n}] not rendered (have ${btns.length})`);
+  }
+  target.click();
+}
+
+function clickByText(editor: ReturnType<typeof createIrealbEditor>, label: string): void {
+  const btns = Array.from(editor.element.querySelectorAll<HTMLButtonElement>('button'));
+  const target = btns.find((b) => b.textContent?.trim() === label);
+  if (!target) throw new Error(`button "${label}" not rendered`);
+  target.click();
+}
+
+describe('parseSectionLabel', () => {
+  test('single letter A..Z -> Letter variant', () => {
+    expect(parseSectionLabel('A')).toEqual({ kind: 'letter', value: 'A' });
+    expect(parseSectionLabel('Z')).toEqual({ kind: 'letter', value: 'Z' });
+  });
+
+  test('named variants are case-insensitive', () => {
+    expect(parseSectionLabel('Verse')).toEqual({ kind: 'verse' });
+    expect(parseSectionLabel('chorus')).toEqual({ kind: 'chorus' });
+    expect(parseSectionLabel('INTRO')).toEqual({ kind: 'intro' });
+    expect(parseSectionLabel('Outro')).toEqual({ kind: 'outro' });
+    expect(parseSectionLabel('bridge')).toEqual({ kind: 'bridge' });
+  });
+
+  test('arbitrary text -> Custom variant', () => {
+    expect(parseSectionLabel('Pre-Chorus')).toEqual({
+      kind: 'custom',
+      value: 'Pre-Chorus',
+    });
+  });
+
+  test('empty / whitespace -> null (cancellation)', () => {
+    expect(parseSectionLabel('')).toBeNull();
+    expect(parseSectionLabel('   ')).toBeNull();
+  });
+
+  test('multi-letter all-caps falls into Custom (not Letter)', () => {
+    // The Letter variant is for single uppercase letters only;
+    // "AB" is not a valid jazz-form label, so it round-trips as
+    // a Custom value rather than getting silently truncated.
+    expect(parseSectionLabel('AB')).toEqual({ kind: 'custom', value: 'AB' });
+  });
+});
+
+describe('section management', () => {
+  test('Add section appends with prompted label and one default bar', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const promptSectionLabel = vi.fn(
+      (): SectionLabel => ({ kind: 'letter', value: 'C' }),
+    );
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      promptSectionLabel,
+    });
+    editor.onChange(onChange);
+
+    expect(readSong(editor).sections.length).toBe(2);
+    clickByText(editor, '+ Add section');
+
+    expect(promptSectionLabel).toHaveBeenCalledTimes(1);
+    expect(promptSectionLabel).toHaveBeenCalledWith(null);
+    const song = readSong(editor);
+    expect(song.sections.length).toBe(3);
+    expect(song.sections[2]?.label).toEqual({ kind: 'letter', value: 'C' });
+    expect(song.sections[2]?.bars.length).toBe(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Add section with cancelled prompt is a no-op', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const promptSectionLabel = vi.fn((): SectionLabel | null => null);
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      promptSectionLabel,
+    });
+    editor.onChange(onChange);
+
+    clickByText(editor, '+ Add section');
+    expect(readSong(editor).sections.length).toBe(2);
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+  });
+
+  test('Rename section replaces label and seeds prompt with current value', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const promptSectionLabel = vi.fn(
+      (): SectionLabel => ({ kind: 'verse' }),
+    );
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      promptSectionLabel,
+    });
+    editor.onChange(onChange);
+
+    clickAction(editor, 'Rename section', 0);
+    expect(promptSectionLabel).toHaveBeenCalledWith({ kind: 'letter', value: 'A' });
+    expect(readSong(editor).sections[0]?.label).toEqual({ kind: 'verse' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Delete section requires confirmation and removes the section', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const confirmDeleteSection = vi.fn(() => true);
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      confirmDeleteSection,
+    });
+    editor.onChange(onChange);
+
+    clickAction(editor, 'Delete section', 1);
+    expect(confirmDeleteSection).toHaveBeenCalledWith({ kind: 'letter', value: 'B' });
+    const song = readSong(editor);
+    expect(song.sections.length).toBe(1);
+    expect(song.sections[0]?.label).toEqual({ kind: 'letter', value: 'A' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Delete section with declined confirmation is a no-op', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const confirmDeleteSection = vi.fn(() => false);
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      confirmDeleteSection,
+    });
+    editor.onChange(onChange);
+
+    clickAction(editor, 'Delete section', 0);
+    expect(readSong(editor).sections.length).toBe(2);
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+  });
+
+  test('Move section up swaps with previous; first section button is disabled', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    editor.onChange(onChange);
+
+    // First section's "up" button is disabled.
+    const upButtons = editor.element.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label="Move section up"]',
+    );
+    expect(upButtons[0]?.disabled).toBe(true);
+    expect(upButtons[1]?.disabled).toBe(false);
+
+    // Click the second section's "up" button -> swap.
+    clickAction(editor, 'Move section up', 1);
+    const song = readSong(editor);
+    expect(song.sections[0]?.label).toEqual({ kind: 'letter', value: 'B' });
+    expect(song.sections[1]?.label).toEqual({ kind: 'letter', value: 'A' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Move section down swaps with next; last section button is disabled', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    editor.onChange(onChange);
+
+    const downButtons = editor.element.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label="Move section down"]',
+    );
+    expect(downButtons[0]?.disabled).toBe(false);
+    expect(downButtons[1]?.disabled).toBe(true);
+
+    clickAction(editor, 'Move section down', 0);
+    const song = readSong(editor);
+    expect(song.sections[0]?.label).toEqual({ kind: 'letter', value: 'B' });
+    expect(song.sections[1]?.label).toEqual({ kind: 'letter', value: 'A' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+});
+
+describe('bar structural management', () => {
+  test('Add bar appends to the targeted section only', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    editor.onChange(onChange);
+
+    expect(readSong(editor).sections[0]?.bars.length).toBe(2);
+    expect(readSong(editor).sections[1]?.bars.length).toBe(1);
+
+    // Click the first section's "+ Add bar" button. There are
+    // multiple add-bar buttons (one per section); index 0 is the
+    // first section's.
+    const addBarBtns = Array.from(
+      editor.element.querySelectorAll<HTMLButtonElement>(
+        '.irealb-editor__add-bar',
+      ),
+    );
+    expect(addBarBtns.length).toBe(2);
+    addBarBtns[0]?.click();
+
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars.length).toBe(3);
+    expect(song.sections[1]?.bars.length).toBe(1); // untouched
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Delete bar removes the targeted bar', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    editor.onChange(onChange);
+
+    // Section A has 2 bars, section B has 1, so 3 delete-bar buttons total.
+    clickAction(editor, 'Delete bar', 0);
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars.length).toBe(1);
+    expect(song.sections[1]?.bars.length).toBe(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Move bar left swaps with previous; first bar button is disabled', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    // Seed section 0 with two bars whose chord text differs so we
+    // can detect the swap by reading the bar text after the move.
+    const seed: IrealSong = JSON.parse(JSON.stringify(SAMPLE_SONG));
+    const sectionA = seed.sections[0];
+    if (!sectionA) throw new Error('seed missing section A');
+    const bar0 = sectionA.bars[0];
+    if (!bar0) throw new Error('seed missing bar 0');
+    bar0.chords.push({
+      chord: {
+        root: { note: 'C', accidental: 'natural' },
+        quality: { kind: 'major' },
+        bass: null,
+      },
+      position: { beat: 1, subdivision: 0 },
+    });
+    const bar1 = sectionA.bars[1];
+    if (!bar1) throw new Error('seed missing bar 1');
+    bar1.chords.push({
+      chord: {
+        root: { note: 'F', accidental: 'natural' },
+        quality: { kind: 'major' },
+        bass: null,
+      },
+      position: { beat: 1, subdivision: 0 },
+    });
+    const seedUrl = `irealb://json:${encodeURIComponent(JSON.stringify(seed))}`;
+    const editor = createIrealbEditor({ initialValue: seedUrl, wasm });
+    editor.onChange(onChange);
+
+    // First bar's "left" button is disabled.
+    const leftButtons = editor.element.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label="Move bar left"]',
+    );
+    expect(leftButtons[0]?.disabled).toBe(true);
+    expect(leftButtons[1]?.disabled).toBe(false);
+
+    clickAction(editor, 'Move bar left', 1);
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('F');
+    expect(song.sections[0]?.bars[1]?.chords[0]?.chord.root.note).toBe('C');
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Move bar right swaps with next; last bar button is disabled', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const seed: IrealSong = JSON.parse(JSON.stringify(SAMPLE_SONG));
+    const sectionA = seed.sections[0];
+    if (!sectionA) throw new Error('seed missing section A');
+    const bar0 = sectionA.bars[0];
+    if (!bar0) throw new Error('seed missing bar 0');
+    bar0.chords.push({
+      chord: {
+        root: { note: 'C', accidental: 'natural' },
+        quality: { kind: 'major' },
+        bass: null,
+      },
+      position: { beat: 1, subdivision: 0 },
+    });
+    const bar1 = sectionA.bars[1];
+    if (!bar1) throw new Error('seed missing bar 1');
+    bar1.chords.push({
+      chord: {
+        root: { note: 'F', accidental: 'natural' },
+        quality: { kind: 'major' },
+        bass: null,
+      },
+      position: { beat: 1, subdivision: 0 },
+    });
+    const seedUrl = `irealb://json:${encodeURIComponent(JSON.stringify(seed))}`;
+    const editor = createIrealbEditor({ initialValue: seedUrl, wasm });
+    editor.onChange(onChange);
+
+    const rightButtons = editor.element.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label="Move bar right"]',
+    );
+    // Section A: 2 bars (last has right-disabled). Section B: 1 bar
+    // (its right is also disabled — single-bar section).
+    expect(rightButtons[0]?.disabled).toBe(false); // A's first bar
+    expect(rightButtons[1]?.disabled).toBe(true); // A's second bar (last)
+    expect(rightButtons[2]?.disabled).toBe(true); // B's only bar
+
+    clickAction(editor, 'Move bar right', 0);
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('F');
+    expect(song.sections[0]?.bars[1]?.chords[0]?.chord.root.note).toBe('C');
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+  });
+
+  test('Add section starts with one default bar (clickable + editable)', () => {
+    const wasm = makeStubWasm();
+    const promptSectionLabel = vi.fn((): SectionLabel => ({ kind: 'verse' }));
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      promptSectionLabel,
+    });
+
+    clickByText(editor, '+ Add section');
+    const song = readSong(editor);
+    expect(song.sections.length).toBe(3);
+    const newSection = song.sections[2];
+    expect(newSection?.label).toEqual({ kind: 'verse' });
+    expect(newSection?.bars.length).toBe(1);
+    expect(newSection?.bars[0]?.start).toBe('single');
+    expect(newSection?.bars[0]?.end).toBe('single');
+    expect(newSection?.bars[0]?.chords).toEqual([]);
+
+    editor.destroy();
+  });
+
+  test('Structural ops dismiss any open bar popover', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+
+    // Open the popover by clicking bar 0.
+    const cells = editor.element.querySelectorAll<HTMLButtonElement>(
+      '.irealb-editor__bar',
+    );
+    cells[0]?.click();
+    expect(editor.element.querySelector('.irealb-editor__popover')).not.toBeNull();
+
+    // A structural op (delete bar) must dismiss it — the bar that
+    // the popover targets may have been deleted, and re-rendering
+    // detaches the popover anchor regardless.
+    clickAction(editor, 'Delete bar', 1); // delete a different bar
+    expect(editor.element.querySelector('.irealb-editor__popover')).toBeNull();
+
+    editor.destroy();
+  });
+});

--- a/packages/ui-irealb-editor/tests/structural.test.ts
+++ b/packages/ui-irealb-editor/tests/structural.test.ts
@@ -125,6 +125,14 @@ describe('parseSectionLabel', () => {
     expect(parseSectionLabel('   ')).toBeNull();
   });
 
+  test('single lowercase letter is normalised to uppercase Letter', () => {
+    // iReal Pro section labels are uppercase by convention; normalising
+    // prevents a user who types 'a' from accidentally creating a Custom
+    // label rather than the intended Letter variant.
+    expect(parseSectionLabel('a')).toEqual({ kind: 'letter', value: 'A' });
+    expect(parseSectionLabel('z')).toEqual({ kind: 'letter', value: 'Z' });
+  });
+
   test('multi-letter all-caps falls into Custom (not Letter)', () => {
     // The Letter variant is for single uppercase letters only;
     // "AB" is not a valid jazz-form label, so it round-trips as


### PR DESCRIPTION
Closes #2365. Part of #2357. Defers keyboard shortcuts to #2376.

## Summary

Adds per-section and per-bar UI buttons that drive every structural
mutation the AC requires:

- **Per-section header** gains four action buttons:
  - Rename — opens the section-label prompt seeded with the current
    label.
  - Move up / Move down — swap with neighbour; the endpoint button
    on each row is `disabled`.
  - Delete — confirms before splicing the section out.
- **Per-section trailer** "+ Add bar" appends a default bar.
- **Per-bar wrapper** holds the existing edit-popover trigger plus
  Move left / Move right (endpoint-disabled) and Delete.
- **Grid trailer** "+ Add section" prompts for a label and appends
  a fresh section seeded with one default bar.

Two host hooks land on \`CreateIrealbEditorOptions\`:
\`promptSectionLabel\` (default \`window.prompt\`) and
\`confirmDeleteSection\` (default \`window.confirm\`). Tests inject
stubs.

## Why

Foundation sub-issue under tracker #2357. The popover (#2364) edits
fields *within* a bar; this PR makes the chart structure
(sections + bar lists) editable so the user can build a new chart
or restructure an existing one without dropping back to text.

## Deferred

- **Cross-section bar move via drag-and-drop** — explicitly listed
  as deferred in #2357's Deferred section.
- **Keyboard shortcuts** (Delete on bar, Alt+Arrow to reorder) —
  deferred to #2376 per the project's keyboard-shortcuts opt-in
  convention so binding decisions stay deliberate. The same
  operations are already reachable via the per-bar UI buttons.

## Implementation notes

- A new \`StructuralOps\` interface in \`render.ts\` exposes the eight
  structural mutators. The renderer dispatches to them; the adapter
  in \`index.ts\` implements each one as a \`state.song\` mutation +
  \`renderNow()\` + \`fireUserEdit()\`.
- Each op closes any open bar popover before mutating — the bar
  the popover targets may be deleted, and re-rendering detaches
  the popover anchor regardless.
- \`parseSectionLabel\` is exported so consumers / tests can validate
  free-text labels: single A–Z -> \`Letter\`, named variants
  (case-insensitive) -> dedicated variant, anything else -> \`Custom\`,
  empty / whitespace -> \`null\` (cancellation).
- \`dom.ts\` \`el()\` now splits whitespace-separated \`class\` strings
  so \`'foo foo--danger'\` works as a single argument; \`classList.add\`
  rejects names with whitespace, so naive concatenation broke
  every render. All existing call sites still work.

## Test results

\`\`\`
$ npm run typecheck
> tsc --noEmit
(no errors)

$ npm test
✓ tests/editor.test.ts (13 tests)
✓ tests/structural.test.ts (18 tests)
✓ tests/popover.test.ts (18 tests)
Test Files  3 passed (3)
     Tests  49 passed (49)
\`\`\`

18 new vitest cases in \`tests/structural.test.ts\` cover
\`parseSectionLabel\` (5), section management (7: add / rename /
delete / move up / move down + cancel paths), and bar structural
ops (6: add / delete / move left / move right / disabled
endpoints / popover dismissal on structural mutation).

## Review summary

Sister-site audit: no equivalent surface elsewhere — first
structural-edit module. The renderer threading pattern mirrors
\`OpenBarPopover\` from #2364. The \`promptSectionLabel\` /
\`confirmDeleteSection\` injection pattern mirrors the wasm-bridge
injection from #2363.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm test\` (49 tests pass)
- [ ] CI ui-irealb-editor workflow green
- [ ] Visually verify per-section + per-bar buttons in playground
      after #2366 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)