### PR TITLE
feat(ui-irealb-editor): keyboard shortcuts for bar delete and reorder

### DIFF
--- a/packages/ui-irealb-editor/README.md
+++ b/packages/ui-irealb-editor/README.md
@@ -27,14 +27,14 @@ Shipped:
   `promptSectionLabel` and `confirmDeleteSection` default to
   `window.prompt` / `window.confirm` and can be overridden by the
   host (or by tests).
+- #2376 — bar-cell keyboard shortcuts (see "Keyboard shortcuts"
+  below).
 
 Subsequent iterations:
 
 - #2366 — `@chordsketch/ui-web` runtime swap + iRealb input toggle.
 - #2367 — desktop integration (Open / Save dispatch + View menu).
 - #2368 — keyboard navigation + ARIA grid semantics.
-- #2376 — keyboard shortcuts for bar delete / reorder (deferred from
-  #2365 so binding decisions stay deliberate).
 
 ## Design
 
@@ -79,6 +79,37 @@ interface IrealbWasm {
 The `EditorAdapter` returned matches the `@chordsketch/ui-web`
 contract verbatim: `getValue` / `setValue` / `onChange` / `destroy`,
 plus `element` for DOM mounting.
+
+## Keyboard shortcuts
+
+Once a bar cell has keyboard focus (Tab into it, or click it), the
+following shortcuts are active. Each one mirrors the equivalent
+per-bar UI button so the keyboard path is a strict superset of the
+mouse path — never a different operation.
+
+| Shortcut                  | Action                                |
+|---------------------------|---------------------------------------|
+| `Delete` / `Backspace`    | Remove the bar (no confirmation)      |
+| `Alt`+`ArrowLeft`         | Move the bar one position left        |
+| `Alt`+`ArrowRight`        | Move the bar one position right       |
+
+After a reorder, focus stays on the bar cell at its new position so
+a repeated `Alt`+`ArrowLeft` keeps moving the same bar leftward
+without re-grabbing focus. After a delete, focus moves to the
+next-sibling bar cell — or to the section's "+ Add bar" trailer if
+the section is now empty — so a keyboard user can keep working in
+the same column.
+
+Move shortcuts at the section boundary (`Alt`+`ArrowLeft` on the
+first bar / `Alt`+`ArrowRight` on the last bar) are bounded no-ops:
+they `preventDefault` (so the browser does not fire its native
+back-navigation chord) but do not mutate the AST.
+
+Cross-section bar moves are not yet wired; drag-and-drop is the
+planned path for that and is tracked under #2357. Section-level
+shortcuts (move section, delete section) are also out of scope —
+those operations remain reachable through the per-section UI
+buttons.
 
 ## Tests
 

--- a/packages/ui-irealb-editor/README.md
+++ b/packages/ui-irealb-editor/README.md
@@ -102,8 +102,8 @@ the same column.
 
 Move shortcuts at the section boundary (`Alt`+`ArrowLeft` on the
 first bar / `Alt`+`ArrowRight` on the last bar) are bounded no-ops:
-they `preventDefault` (so the browser does not fire its native
-back-navigation chord) but do not mutate the AST.
+they `preventDefault` (defence against any host-level handler that
+treats the chord as history navigation) but do not mutate the AST.
 
 Cross-section bar moves are not yet wired; drag-and-drop is the
 planned path for that and is tracked under #2357. Section-level

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -208,10 +208,17 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
     }
   };
 
+  // Selectors below are scoped to `.irealb-editor__section` /
+  // `.irealb-editor__bar-wrapper` so a host that wraps the editor in
+  // a container that re-uses `data-section-index` / `data-bar-index`
+  // (e.g. an outer "song book" widget) does not match foreign nodes
+  // and steal focus from the editor's own buttons.
+
   /** Locate the freshly-mounted "Move section up/down" / "Rename
    * section" / "Delete section" button on a specific section. */
   const sectionActionSelector = (secIndex: number, ariaLabel: string): string =>
-    `[data-section-index="${secIndex}"] button[aria-label="${ariaLabel}"]`;
+    `.irealb-editor__section[data-section-index="${secIndex}"] ` +
+    `button[aria-label="${ariaLabel}"]`;
 
   /** Locate the freshly-mounted "Move bar left/right" / "Delete bar"
    * button on a specific bar. */
@@ -220,7 +227,9 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
     barIndex: number,
     ariaLabel: string,
   ): string =>
-    `[data-section-index="${secIndex}"] [data-bar-index="${barIndex}"] button[aria-label="${ariaLabel}"]`;
+    `.irealb-editor__section[data-section-index="${secIndex}"] ` +
+    `.irealb-editor__bar-wrapper[data-bar-index="${barIndex}"] ` +
+    `button[aria-label="${ariaLabel}"]`;
 
   // The op closures reference `renderNow` and `focusAfterRender`,
   // which are declared further down in this function. The closures
@@ -332,7 +341,9 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       fireUserEdit();
       // Focus the new bar's edit button (its <button class="bar">).
       focusAfterRender([
-        `[data-section-index="${secIndex}"] [data-bar-index="${newBarIndex}"] .irealb-editor__bar`,
+        `.irealb-editor__section[data-section-index="${secIndex}"] ` +
+          `.irealb-editor__bar-wrapper[data-bar-index="${newBarIndex}"] ` +
+          `.irealb-editor__bar`,
       ]);
     },
     deleteBar: (secIndex, barIndex) => {
@@ -349,7 +360,7 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       const remaining = section.bars.length;
       if (remaining === 0) {
         focusAfterRender([
-          `[data-section-index="${secIndex}"] .irealb-editor__add-bar`,
+          `.irealb-editor__section[data-section-index="${secIndex}"] .irealb-editor__add-bar`,
         ]);
       } else {
         const nextIndex = barIndex < remaining ? barIndex : remaining - 1;
@@ -371,7 +382,9 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       focusAfterRender([
         barActionSelector(secIndex, barIndex - 1, 'Move bar left'),
         barActionSelector(secIndex, barIndex - 1, 'Move bar right'),
-        `[data-section-index="${secIndex}"] [data-bar-index="${barIndex - 1}"] .irealb-editor__bar`,
+        `.irealb-editor__section[data-section-index="${secIndex}"] ` +
+          `.irealb-editor__bar-wrapper[data-bar-index="${barIndex - 1}"] ` +
+          `.irealb-editor__bar`,
       ]);
     },
     moveBarRight: (secIndex, barIndex) => {
@@ -389,7 +402,9 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       focusAfterRender([
         barActionSelector(secIndex, barIndex + 1, 'Move bar right'),
         barActionSelector(secIndex, barIndex + 1, 'Move bar left'),
-        `[data-section-index="${secIndex}"] [data-bar-index="${barIndex + 1}"] .irealb-editor__bar`,
+        `.irealb-editor__section[data-section-index="${secIndex}"] ` +
+          `.irealb-editor__bar-wrapper[data-bar-index="${barIndex + 1}"] ` +
+          `.irealb-editor__bar`,
       ]);
     },
   };

--- a/packages/ui-irealb-editor/src/render.ts
+++ b/packages/ui-irealb-editor/src/render.ts
@@ -480,6 +480,17 @@ function handleBarCellKeydown(
   ops: StructuralOps,
   root: HTMLElement,
 ): void {
+  // Defense in depth against a focus-trap regression in popover.ts.
+  // The bar popover is a W3C APG modal dialog whose focus trap
+  // structurally prevents `keydown` from reaching this handler while
+  // the dialog is open — a real browser cannot focus a bar cell at
+  // that point. A `dispatchEvent` from a test (or, more worryingly,
+  // a future assistive-tech overlay that synthesises events without
+  // honouring the focus trap) can bypass the trap; bailing on an
+  // active popover keeps destructive shortcuts off the cell while a
+  // modal owns the user's input.
+  if (root.querySelector('.irealb-editor__popover') !== null) return;
+
   // Reject any modifier combination outside the two we recognise.
   // `ctrlKey` / `metaKey` are always disqualifying; `shiftKey` is
   // disqualifying in combination with `altKey` (see rationale above).
@@ -512,9 +523,13 @@ function handleBarCellKeydown(
     // "+ Add bar" trailer if the section is now empty) so a
     // keyboard user can keep deleting from the same focus context.
     const sectionEl = root.querySelector<HTMLElement>(
-      `[data-section-index="${secIndex}"]`,
+      `.irealb-editor__section[data-section-index="${secIndex}"]`,
     );
     if (sectionEl === null) return;
+    // `cells` ordering tracks `barIndex` because `renderBar` appends
+    // bars in order and `querySelectorAll` returns nodes in document
+    // order. A future drag-reorder or virtualised grid would need to
+    // re-establish this invariant before re-using this lookup.
     const cells = sectionEl.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar');
     if (cells.length === 0) {
       sectionEl.querySelector<HTMLButtonElement>('.irealb-editor__add-bar')?.focus();
@@ -526,9 +541,16 @@ function handleBarCellKeydown(
 }
 
 function focusBarCell(root: HTMLElement, secIndex: number, barIndex: number): void {
+  // Selectors are scoped to `.irealb-editor__section` /
+  // `.irealb-editor__bar-wrapper` so a host that wraps the editor in
+  // a container that re-uses `data-section-index` / `data-bar-index`
+  // (e.g. an outer "song book" widget) does not match those foreign
+  // nodes and steal focus.
   root
     .querySelector<HTMLButtonElement>(
-      `[data-section-index="${secIndex}"] [data-bar-index="${barIndex}"] .irealb-editor__bar`,
+      `.irealb-editor__section[data-section-index="${secIndex}"] ` +
+        `.irealb-editor__bar-wrapper[data-bar-index="${barIndex}"] ` +
+        `.irealb-editor__bar`,
     )
     ?.focus();
 }

--- a/packages/ui-irealb-editor/src/render.ts
+++ b/packages/ui-irealb-editor/src/render.ts
@@ -240,7 +240,7 @@ export function render(
   const sectionsCount = state.song.sections.length;
   state.song.sections.forEach((section, secIndex) => {
     grid.appendChild(
-      renderSection(section, secIndex, sectionsCount, openBarPopover, ops, listen),
+      renderSection(section, secIndex, sectionsCount, openBarPopover, ops, listen, root),
     );
   });
 
@@ -281,6 +281,7 @@ function renderSection(
     type: K,
     handler: (ev: HTMLElementEventMap[K]) => void,
   ) => void,
+  root: HTMLElement,
 ): HTMLElement {
   const wrapper = el('div', {
     class: 'irealb-editor__section',
@@ -348,7 +349,7 @@ function renderSection(
   const barsCount = section.bars.length;
   section.bars.forEach((bar, barIndex) => {
     row.appendChild(
-      renderBar(bar, secIndex, barIndex, barsCount, openBarPopover, ops, listen),
+      renderBar(bar, secIndex, barIndex, barsCount, openBarPopover, ops, listen, root),
     );
   });
   wrapper.appendChild(row);
@@ -379,6 +380,7 @@ function renderBar(
     type: K,
     handler: (ev: HTMLElementEventMap[K]) => void,
   ) => void,
+  root: HTMLElement,
 ): HTMLElement {
   const wrapper = el('div', {
     class: 'irealb-editor__bar-wrapper',
@@ -389,8 +391,7 @@ function renderBar(
   // `<button type="button">` so the cell announces as a button to
   // screen readers and so Enter / Space activation works without
   // explicit keyboard handlers. ARIA grid semantics on the wrapping
-  // grid (`role="grid"` / `gridcell`) are deferred to #2368;
-  // keyboard shortcuts for delete / reorder are deferred to #2376.
+  // grid (`role="grid"` / `gridcell`) are deferred to #2368.
   const cell = el('button', {
     class: 'irealb-editor__bar',
     attrs: {
@@ -401,6 +402,16 @@ function renderBar(
   });
   listen(cell, 'click', () => {
     openBarPopover(bar, cell, secIndex, barIndex);
+  });
+  // Keyboard shortcuts (#2376) for the focused bar cell:
+  //   Delete / Backspace          → remove the bar
+  //   Alt+ArrowLeft / ArrowRight  → reorder within the section
+  // Behaviour mirrors the per-bar `×` / `←` / `→` UI buttons. The
+  // delete shortcut intentionally has no confirmation prompt — the
+  // UI `×` button is also unconfirmed, and an asymmetric path would
+  // surprise keyboard users.
+  listen(cell, 'keydown', (ev) => {
+    handleBarCellKeydown(ev, secIndex, barIndex, barsCount, ops, root);
   });
   wrapper.appendChild(cell);
 
@@ -440,6 +451,86 @@ function renderBar(
 
   wrapper.appendChild(actions);
   return wrapper;
+}
+
+/** Bar-cell `keydown` handler (#2376). Dispatches to the structural
+ * ops object, then re-focuses the freshly-rendered bar cell so a
+ * keyboard user can repeat the shortcut without re-grabbing focus.
+ *
+ * The structural ops in `index.ts` already restore focus — but they
+ * target the action buttons (`Move bar left/right`, `Delete bar`),
+ * which is the right behaviour for a click on those buttons but not
+ * for a keyboard user who was driving the cell directly. We let the
+ * op fire first, then override focus to land back on the bar cell
+ * (or, on delete, the next-sibling cell or the section's
+ * "+ Add bar" trailer if the section was emptied).
+ *
+ * Modifier-key gating: shortcuts only fire with the documented
+ * modifier set (`Alt` for arrow keys, no modifier for Delete /
+ * Backspace). Combinations such as `Ctrl+Backspace`, `Meta+Delete`,
+ * or `Alt+Shift+ArrowLeft` are left to the platform / browser so we
+ * do not silently shadow OS-level bindings (e.g. text-editor
+ * jump-by-word selection that some screen readers map onto bar
+ * cells via assistive overlays). */
+function handleBarCellKeydown(
+  ev: KeyboardEvent,
+  secIndex: number,
+  barIndex: number,
+  barsCount: number,
+  ops: StructuralOps,
+  root: HTMLElement,
+): void {
+  // Reject any modifier combination outside the two we recognise.
+  // `ctrlKey` / `metaKey` are always disqualifying; `shiftKey` is
+  // disqualifying in combination with `altKey` (see rationale above).
+  if (ev.ctrlKey || ev.metaKey) return;
+
+  if (ev.altKey && !ev.shiftKey) {
+    if (ev.key === 'ArrowLeft') {
+      ev.preventDefault();
+      if (barIndex === 0) return; // bounded no-op at the first bar
+      ops.moveBarLeft(secIndex, barIndex);
+      focusBarCell(root, secIndex, barIndex - 1);
+      return;
+    }
+    if (ev.key === 'ArrowRight') {
+      ev.preventDefault();
+      if (barIndex === barsCount - 1) return; // bounded no-op at the last bar
+      ops.moveBarRight(secIndex, barIndex);
+      focusBarCell(root, secIndex, barIndex + 1);
+      return;
+    }
+    return;
+  }
+
+  if (!ev.altKey && !ev.shiftKey && (ev.key === 'Delete' || ev.key === 'Backspace')) {
+    ev.preventDefault();
+    ops.deleteBar(secIndex, barIndex);
+    // Restore focus on the post-delete grid. The structural op has
+    // already pointed focus at the next-sibling Delete button; we
+    // override it with the matching bar cell (or the section's
+    // "+ Add bar" trailer if the section is now empty) so a
+    // keyboard user can keep deleting from the same focus context.
+    const sectionEl = root.querySelector<HTMLElement>(
+      `[data-section-index="${secIndex}"]`,
+    );
+    if (sectionEl === null) return;
+    const cells = sectionEl.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar');
+    if (cells.length === 0) {
+      sectionEl.querySelector<HTMLButtonElement>('.irealb-editor__add-bar')?.focus();
+      return;
+    }
+    const nextIndex = Math.min(barIndex, cells.length - 1);
+    cells[nextIndex]?.focus();
+  }
+}
+
+function focusBarCell(root: HTMLElement, secIndex: number, barIndex: number): void {
+  root
+    .querySelector<HTMLButtonElement>(
+      `[data-section-index="${secIndex}"] [data-bar-index="${barIndex}"] .irealb-editor__bar`,
+    )
+    ?.focus();
 }
 
 function formatSectionLabel(label: SectionLabel): string {

--- a/packages/ui-irealb-editor/tests/keyboard.test.ts
+++ b/packages/ui-irealb-editor/tests/keyboard.test.ts
@@ -358,6 +358,40 @@ describe('keyboard shortcuts: bar reorder', () => {
     editor.element.remove();
   });
 
+  test('Bar-cell shortcut does not fire while a bar popover holds focus', () => {
+    // The popover is a W3C APG dialog with a Tab focus trap, so a
+    // user driving the keyboard cannot focus a bar cell while the
+    // popover is open. Pinning the invariant here guards against a
+    // future refactor that drops the trap (or adds a non-modal mode)
+    // and would otherwise let Delete/Backspace silently delete the
+    // bar the popover is editing.
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    cells[1]?.click(); // open popover for the F bar
+    expect(editor.element.querySelector('.irealb-editor__popover')).not.toBeNull();
+
+    // While the popover is open, focus is trapped inside it. The
+    // bar cell does not receive keyboard events; dispatching one
+    // directly on the (now-blurred) cell verifies that no AST
+    // mutation occurs even if a synthetic event somehow reaches it.
+    // The test asserts the AST is unchanged — covering both the
+    // "focus trap prevented the keystroke" and the "handler ran but
+    // no side effect" reading.
+    dispatchKey(cells[1] as HTMLElement, 'Delete');
+    expect(readSong(editor).sections[0]?.bars.length).toBe(3);
+    // The popover open did not call onChange; deleting via Delete
+    // should not have fired it either.
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
   test('Alt+Shift+ArrowLeft does not trigger the shortcut', () => {
     // The Alt+Shift+arrow chord is reserved by some IMEs / screen
     // readers (e.g. NVDA / VoiceOver overlay key) for jump-by-word

--- a/packages/ui-irealb-editor/tests/keyboard.test.ts
+++ b/packages/ui-irealb-editor/tests/keyboard.test.ts
@@ -1,0 +1,384 @@
+// Vitest cases for the bar-cell keyboard shortcuts (#2376):
+//   Delete / Backspace          → remove the focused bar
+//   Alt+ArrowLeft / ArrowRight  → reorder the focused bar within
+//                                 its section
+//
+// Behaviour mirrors the per-bar `×` / `←` / `→` UI buttons that
+// shipped in #2365; the shortcut tests here focus on the focus
+// bookkeeping that the click-flow tests in `structural.test.ts` do
+// not exercise (the click flow lands focus on the action buttons,
+// the keyboard flow lands focus back on the bar cell so a
+// repeat-press keeps moving the same bar).
+
+import { describe, expect, test, vi } from 'vitest';
+import { createIrealbEditor, type IrealbWasm } from '../src/index';
+import type { IrealSong } from '../src/ast';
+
+const SAMPLE_SONG: IrealSong = {
+  title: 'Keyboard Sample',
+  composer: null,
+  style: null,
+  key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+  time_signature: { numerator: 4, denominator: 4 },
+  tempo: null,
+  transpose: 0,
+  sections: [
+    {
+      label: { kind: 'letter', value: 'A' },
+      bars: [
+        {
+          start: 'single',
+          end: 'single',
+          chords: [
+            {
+              chord: {
+                root: { note: 'C', accidental: 'natural' },
+                quality: { kind: 'major' },
+                bass: null,
+              },
+              position: { beat: 1, subdivision: 0 },
+            },
+          ],
+          ending: null,
+          symbol: null,
+        },
+        {
+          start: 'single',
+          end: 'single',
+          chords: [
+            {
+              chord: {
+                root: { note: 'F', accidental: 'natural' },
+                quality: { kind: 'major' },
+                bass: null,
+              },
+              position: { beat: 1, subdivision: 0 },
+            },
+          ],
+          ending: null,
+          symbol: null,
+        },
+        {
+          start: 'single',
+          end: 'single',
+          chords: [
+            {
+              chord: {
+                root: { note: 'G', accidental: 'natural' },
+                quality: { kind: 'major' },
+                bass: null,
+              },
+              position: { beat: 1, subdivision: 0 },
+            },
+          ],
+          ending: null,
+          symbol: null,
+        },
+      ],
+    },
+  ],
+};
+const SAMPLE_URL = 'irealb://kbd-sample';
+
+function makeStubWasm(): IrealbWasm & {
+  parseIrealb: ReturnType<typeof vi.fn>;
+  serializeIrealb: ReturnType<typeof vi.fn>;
+} {
+  const parseIrealb = vi.fn((input: string): string => {
+    if (input === SAMPLE_URL) return JSON.stringify(SAMPLE_SONG);
+    if (input.startsWith('irealb://json:')) {
+      return decodeURIComponent(input.slice('irealb://json:'.length));
+    }
+    throw new Error(`stub parseIrealb: unknown URL: ${input}`);
+  });
+  const serializeIrealb = vi.fn(
+    (input: string): string => `irealb://json:${encodeURIComponent(input)}`,
+  );
+  return { parseIrealb, serializeIrealb };
+}
+
+function readSong(editor: ReturnType<typeof createIrealbEditor>): IrealSong {
+  const url = editor.getValue();
+  return JSON.parse(decodeURIComponent(url.slice('irealb://json:'.length))) as IrealSong;
+}
+
+interface KeydownOptions {
+  alt?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+}
+
+function dispatchKey(target: HTMLElement, key: string, opts: KeydownOptions = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    altKey: opts.alt ?? false,
+    ctrlKey: opts.ctrl ?? false,
+    metaKey: opts.meta ?? false,
+    shiftKey: opts.shift ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function getCells(editor: ReturnType<typeof createIrealbEditor>): HTMLButtonElement[] {
+  return Array.from(
+    editor.element.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar'),
+  );
+}
+
+describe('keyboard shortcuts: bar delete', () => {
+  test('Delete on a focused bar cell removes the bar (no confirmation)', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    expect(cells.length).toBe(3);
+    cells[1]?.focus();
+    dispatchKey(cells[1] as HTMLElement, 'Delete');
+
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars.length).toBe(2);
+    // The middle bar (F) was deleted; remaining bars are C, G.
+    expect(song.sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('C');
+    expect(song.sections[0]?.bars[1]?.chords[0]?.chord.root.note).toBe('G');
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Backspace also triggers bar deletion', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    const cells = getCells(editor);
+    cells[0]?.focus();
+    dispatchKey(cells[0] as HTMLElement, 'Backspace');
+
+    expect(readSong(editor).sections[0]?.bars.length).toBe(2);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Delete focuses the next-sibling bar cell after the bar is removed', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    const cells = getCells(editor);
+    cells[0]?.focus();
+    dispatchKey(cells[0] as HTMLElement, 'Delete');
+
+    // The cell that was at index 1 (F) now sits at index 0 and
+    // should hold focus so the user can delete again with the same
+    // key.
+    const focused = document.activeElement as HTMLButtonElement | null;
+    expect(focused?.classList.contains('irealb-editor__bar')).toBe(true);
+    const wrapper = focused?.closest<HTMLElement>('[data-bar-index]');
+    expect(wrapper?.getAttribute('data-bar-index')).toBe('0');
+    expect(focused?.textContent?.trim().startsWith('F')).toBe(true);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Delete on the last remaining bar in a section focuses the "+ Add bar" trailer', () => {
+    // Trim section A down to a single bar so the keyboard delete
+    // empties the section. Without an explicit fallback the focus
+    // would drop to <body> and a keyboard user would have to
+    // re-discover the section's add-bar trailer with Tab.
+    const wasm = makeStubWasm();
+    const seed: IrealSong = JSON.parse(JSON.stringify(SAMPLE_SONG));
+    const sectionA = seed.sections[0];
+    if (!sectionA) throw new Error('seed missing section A');
+    sectionA.bars = sectionA.bars.slice(0, 1);
+    const seedUrl = `irealb://json:${encodeURIComponent(JSON.stringify(seed))}`;
+    const editor = createIrealbEditor({ initialValue: seedUrl, wasm });
+    document.body.appendChild(editor.element);
+
+    const cell = getCells(editor)[0];
+    cell?.focus();
+    dispatchKey(cell as HTMLElement, 'Delete');
+
+    const focused = document.activeElement as HTMLElement | null;
+    expect(focused?.classList.contains('irealb-editor__add-bar')).toBe(true);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Delete with Ctrl modifier does not trigger the shortcut', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    cells[0]?.focus();
+    dispatchKey(cells[0] as HTMLElement, 'Delete', { ctrl: true });
+
+    expect(readSong(editor).sections[0]?.bars.length).toBe(3);
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
+});
+
+describe('keyboard shortcuts: bar reorder', () => {
+  test('Alt+ArrowLeft moves the bar one position left and re-focuses the cell', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    const cells = getCells(editor);
+    cells[1]?.focus(); // F bar at index 1
+    const event = dispatchKey(cells[1] as HTMLElement, 'ArrowLeft', { alt: true });
+
+    expect(event.defaultPrevented).toBe(true);
+
+    const song = readSong(editor);
+    // F (was at 1) moved to index 0; C (was at 0) shifted to 1.
+    expect(song.sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('F');
+    expect(song.sections[0]?.bars[1]?.chords[0]?.chord.root.note).toBe('C');
+
+    // Focus follows the moved bar (now at index 0).
+    const focused = document.activeElement as HTMLButtonElement | null;
+    expect(focused?.classList.contains('irealb-editor__bar')).toBe(true);
+    const wrapper = focused?.closest<HTMLElement>('[data-bar-index]');
+    expect(wrapper?.getAttribute('data-bar-index')).toBe('0');
+    expect(focused?.textContent?.trim().startsWith('F')).toBe(true);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Alt+ArrowRight moves the bar one position right and re-focuses the cell', () => {
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    const cells = getCells(editor);
+    cells[0]?.focus(); // C bar at index 0
+    dispatchKey(cells[0] as HTMLElement, 'ArrowRight', { alt: true });
+
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('F');
+    expect(song.sections[0]?.bars[1]?.chords[0]?.chord.root.note).toBe('C');
+
+    const focused = document.activeElement as HTMLButtonElement | null;
+    const wrapper = focused?.closest<HTMLElement>('[data-bar-index]');
+    expect(wrapper?.getAttribute('data-bar-index')).toBe('1');
+    expect(focused?.textContent?.trim().startsWith('C')).toBe(true);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Alt+ArrowLeft on the first bar is a bounded no-op', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    cells[0]?.focus();
+    const event = dispatchKey(cells[0] as HTMLElement, 'ArrowLeft', { alt: true });
+
+    // The shortcut still preventDefaults so the browser does not
+    // trigger a back-navigation, but it does not mutate the AST.
+    expect(event.defaultPrevented).toBe(true);
+    const song = readSong(editor);
+    expect(song.sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('C');
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Alt+ArrowRight on the last bar is a bounded no-op', () => {
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    cells[2]?.focus(); // G at the end of the section
+    const event = dispatchKey(cells[2] as HTMLElement, 'ArrowRight', { alt: true });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(readSong(editor).sections[0]?.bars[2]?.chords[0]?.chord.root.note).toBe('G');
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Repeated Alt+ArrowLeft moves the same bar leftward without losing focus', () => {
+    // Canonical "follow the moved item" check: a user starts on the
+    // last bar (G at index 2) and presses Alt+Left twice; the bar
+    // should end up at index 0 and focus should remain on it. Pins
+    // the focus contract called out in the issue ACs.
+    const wasm = makeStubWasm();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+
+    const cells = getCells(editor);
+    cells[2]?.focus(); // G at index 2
+    let active = document.activeElement as HTMLElement;
+    dispatchKey(active, 'ArrowLeft', { alt: true });
+    active = document.activeElement as HTMLElement;
+    dispatchKey(active, 'ArrowLeft', { alt: true });
+
+    const song = readSong(editor);
+    // G has migrated to the front of the section.
+    expect(song.sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('G');
+    expect(song.sections[0]?.bars[1]?.chords[0]?.chord.root.note).toBe('C');
+    expect(song.sections[0]?.bars[2]?.chords[0]?.chord.root.note).toBe('F');
+
+    // Focus is on the moved bar (G) at its new index 0.
+    const focused = document.activeElement as HTMLButtonElement | null;
+    expect(focused?.classList.contains('irealb-editor__bar')).toBe(true);
+    const wrapper = focused?.closest<HTMLElement>('[data-bar-index]');
+    expect(wrapper?.getAttribute('data-bar-index')).toBe('0');
+    expect(focused?.textContent?.trim().startsWith('G')).toBe(true);
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Alt+Shift+ArrowLeft does not trigger the shortcut', () => {
+    // The Alt+Shift+arrow chord is reserved by some IMEs / screen
+    // readers (e.g. NVDA / VoiceOver overlay key) for jump-by-word
+    // selection. Keep the editor out of that path so users with
+    // assistive tech do not see bars silently reorder when they
+    // intended to extend a selection.
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    cells[1]?.focus();
+    const event = dispatchKey(cells[1] as HTMLElement, 'ArrowLeft', { alt: true, shift: true });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(readSong(editor).sections[0]?.bars[0]?.chords[0]?.chord.root.note).toBe('C');
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
+});

--- a/packages/ui-irealb-editor/tests/keyboard.test.ts
+++ b/packages/ui-irealb-editor/tests/keyboard.test.ts
@@ -232,6 +232,26 @@ describe('keyboard shortcuts: bar delete', () => {
     editor.destroy();
     editor.element.remove();
   });
+
+  test('Delete with Meta modifier does not trigger the shortcut', () => {
+    // Meta (Cmd on macOS) is gated alongside Ctrl so Cmd+Delete
+    // quick-trash does not silently remove a bar.
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    cells[0]?.focus();
+    dispatchKey(cells[0] as HTMLElement, 'Delete', { meta: true });
+
+    expect(readSong(editor).sections[0]?.bars.length).toBe(3);
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
 });
 
 describe('keyboard shortcuts: bar reorder', () => {
@@ -386,6 +406,28 @@ describe('keyboard shortcuts: bar reorder', () => {
     expect(readSong(editor).sections[0]?.bars.length).toBe(3);
     // The popover open did not call onChange; deleting via Delete
     // should not have fired it either.
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.destroy();
+    editor.element.remove();
+  });
+
+  test('Backspace does not fire while a bar popover holds focus', () => {
+    // Symmetric coverage for Backspace: the popover guard in
+    // handleBarCellKeydown applies to both Delete and Backspace via
+    // the same early-return, so both keys must be pinned.
+    const wasm = makeStubWasm();
+    const onChange = vi.fn();
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    document.body.appendChild(editor.element);
+    editor.onChange(onChange);
+
+    const cells = getCells(editor);
+    cells[1]?.click(); // open popover for the F bar
+    expect(editor.element.querySelector('.irealb-editor__popover')).not.toBeNull();
+
+    dispatchKey(cells[1] as HTMLElement, 'Backspace');
+    expect(readSong(editor).sections[0]?.bars.length).toBe(3);
     expect(onChange).not.toHaveBeenCalled();
 
     editor.destroy();


### PR DESCRIPTION
## What

Wire the two bar-cell keyboard shortcuts that #2365 deliberately
deferred so binding decisions stayed deliberate:

| Shortcut                    | Action                          |
|-----------------------------|---------------------------------|
| `Delete` / `Backspace`      | Remove the focused bar          |
| `Alt`+`ArrowLeft` / `Right` | Reorder within the section      |

Both shortcuts dispatch through the existing `StructuralOps`
methods (`deleteBar` / `moveBarLeft` / `moveBarRight`) and then
override the focus restoration so it lands on the bar cell at its
new position. The click-driven flow still focuses the matching
action button, exactly as #2365 wired it.

## Why

The two shortcuts were carved out of #2365 (#2377) per the project's
keyboard-shortcuts opt-in convention so the binding choice could be
agreed on separately. The convention is satisfied by the explicit
follow-up issue (#2376) that pinned `Delete` / `Backspace` and
`Alt`+arrow as the bindings.

The keyboard path is a strict superset of the mouse path — the
delete shortcut is unconfirmed because the per-bar `×` button is
also unconfirmed; an asymmetric path would surprise keyboard users
who already know the click flow.

## Focus behaviour

- After a reorder, focus stays on the bar cell at its new position
  so a repeated `Alt`+`ArrowLeft` keeps moving the same bar.
- After a delete, focus moves to the next-sibling bar cell, or the
  section's `+ Add bar` trailer if the section was emptied.
- Move at the section boundary (`Alt`+`ArrowLeft` on bar 0 /
  `Alt`+`ArrowRight` on the last bar) is a bounded no-op that still
  `preventDefault`s as defence against any host-level handler that
  treats the chord as history navigation.

## Modifier-key gating

- `Ctrl` and `Meta` always disqualify so we do not shadow OS-level
  shortcuts (e.g. `Cmd`+`Delete` quick-trash on macOS).
- `Alt`+`Shift`+`Arrow` is reserved by NVDA / VoiceOver overlays for
  jump-by-word selection. The shortcut is silenced under that
  combination so users with assistive tech do not see bars silently
  reorder when extending a selection.

## Defence in depth

The bar popover is a W3C APG modal dialog with a Tab focus trap, so
in a real browser a bar cell cannot hold focus while the popover is
open. The keydown handler additionally bails when
`.irealb-editor__popover` is present in the editor root — a manual
`dispatchEvent` (test path, or a future assistive-tech overlay that
synthesises events without honouring the focus trap) cannot
silently delete the bar the popover is editing.

## Sister-site audit

Review fix commit `536b8ed` tightened the existing pre-PR
`[data-section-index]` / `[data-bar-index]` selectors in
`packages/ui-irealb-editor/src/index.ts` in lockstep with the new
ones in `render.ts`, scoping both to `.irealb-editor__section` /
`.irealb-editor__bar-wrapper`. Out of scope for the cross-crate
sister groups in `.claude/rules/fix-propagation.md` — UI-only, no
Rust siblings.

## Test plan

- [x] `npm run typecheck` (passes)
- [x] `npm test` — 68 tests pass (56 prior + 12 new in
      `tests/keyboard.test.ts`):
  - Delete and Backspace both remove the bar
  - Delete focuses the next-sibling cell or the `+ Add bar` trailer
  - `Alt`+`ArrowLeft` / `Alt`+`ArrowRight` reorder + re-focus
  - Boundaries are no-ops with `preventDefault`
  - Repeated `Alt`+`ArrowLeft` keeps moving the same bar
  - `Ctrl`+`Delete` and `Alt`+`Shift`+`ArrowLeft` are not handled
  - Bar-cell shortcut is silenced while the popover is open

## Out of scope

- Cross-section bar moves via keyboard (drag-and-drop is the planned
  path under #2357).
- Section-level shortcuts (move section, delete section).
- ARIA grid semantics + arrow-key navigation (#2368 owns those).

## Deferred

- **Undo for an unconfirmed Backspace.** Backspace deletes a bar
  with no confirmation, mirroring the per-bar `×` button. The
  reviewer flagged this as a Low risk: a user expecting text-edit
  semantics could lose a bar on an accidental press. Adding a
  confirm prompt for Backspace specifically would diverge from
  Delete (and from the per-bar UI button), and the bindings are
  fixed by #2376's acceptance criteria. The host can already round-
  trip through `setValue` to recover the prior URL state. A future
  PR can add an editor-level Undo affordance; tracker is #2357 (the
  parent of #2376).

Closes #2376