### PR TITLE
docs(adr): supersede ADR-0003 and disable GitHub Merge Queue

### DIFF
--- a/.claude/rules/ci-parallelization.md
+++ b/.claude/rules/ci-parallelization.md
@@ -76,18 +76,23 @@ main pushes write to the cache:
 
 The repository's GitHub Actions cache pool is capped at 10 GB with LRU
 eviction. Without this guard, the `Swatinem/rust-cache` default (`save-if:
-true`) saves a fresh entry on every PR ref and every
-`refs/heads/gh-readonly-queue/*` merge-queue ref. Those entries are bit-
-for-bit duplicates of `main`'s cache when the PR did not change
-`Cargo.lock`, but they cost the full per-cell size (typical: 200–500 MB)
-and are scoped to refs that no other run can read from. The pool fills
+true`) saves a fresh entry on every PR ref. Those entries are bit-for-bit
+duplicates of `main`'s cache when the PR did not change `Cargo.lock`,
+but they cost the full per-cell size (typical: 200–500 MB) and are
+scoped to refs that no other run can read from. The pool fills
 within ~24 hours and LRU starts evicting the `main` caches that PR runs
 restore from — producing the `No cache found.` reports that motivated
 #2308.
 
-PR and `merge_group:` runs continue to **restore** cached entries via the
-`shared-key` prefix; they simply do not write back. Cargo.lock-changing
-PRs (mostly Dependabot) trade away one warm cache they would not have
+(The historical `refs/heads/gh-readonly-queue/*` write path was
+retired together with the merge queue itself in
+[ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md). The
+`save-if` guard is preserved so the same eviction problem does not
+return through the PR-ref path.)
+
+PR runs continue to **restore** cached entries via the `shared-key`
+prefix; they simply do not write back. Cargo.lock-changing PRs
+(mostly Dependabot) trade away one warm cache they would not have
 hit cleanly anyway in exchange for keeping `main`'s cache resident.
 
 ### Tool-version single source of truth
@@ -161,13 +166,17 @@ block.
 **Why:** GitHub-hosted runners are capped at 5 concurrent macOS jobs
 on the Free / Pro / Team plans
 (https://docs.github.com/en/actions/reference/actions-limits). When a
-PR is rebased (or a GitHub Merge Queue speculative-merge failure
-pushes the author to re-queue — see
-[ADR-0003](../../docs/adr/0003-github-merge-queue.md) for the
-queue's role in this picture), the old run continues occupying
-macOS slots while the new run starts behind it in the 5-job queue.
-Without cancel-in-progress, N pushes to one PR produce N parallel
-macOS pipelines competing for the same ceiling.
+PR is rebased — required after `main` moves, since branch protection
+gates merging on the branch being up to date — the old run continues
+occupying macOS slots while the new run starts behind it in the 5-job
+queue. Without cancel-in-progress, N pushes to one PR produce N
+parallel macOS pipelines competing for the same ceiling. (Direct
+squash merges replaced the merge queue in
+[ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md); the
+"speculative-merge failure pushes the author to re-queue" path that
+ADR-0003 contemplated is no longer reachable, but the
+rebase-after-`main`-moves path remains and motivates this section
+identically.)
 
 ### Release/tag-triggered workflows
 

--- a/.claude/rules/one-pr-at-a-time.md
+++ b/.claude/rules/one-pr-at-a-time.md
@@ -35,20 +35,21 @@ isolation:
    `github-action-ci.yml`, `release.yml`, `post-release.yml`), so the
    macOS 5-job ceiling is the practical bottleneck long before the
    20-job total.
-2. **Speculative-merge CI runs.** GitHub Merge Queue
-   (enabled on `main` in #2107; rationale in
-   [ADR-0003](../../docs/adr/0003-github-merge-queue.md)) runs CI
-   once per queued merge against a speculative merge commit. A
-   large fan-in of queued PRs still consumes runner minutes
-   linearly in the queue depth; macOS-bearing required checks
-   (Test matrix) are the bottleneck. The queue replaces the
-   earlier `auto-update-branch.yml` cascade, so rebase churn on
-   every open PR is gone, but the macOS ceiling still applies to
-   the queue's own CI runs.
+2. **Rebase churn after every merge.** Branch protection requires
+   PR branches to be up to date with `main` before merging. When a
+   PR lands, every other open PR's branch falls behind, and each
+   author has to rebase + re-run pre-merge CI before that PR can be
+   merged in turn. Holding multiple PRs open during this cycle
+   means the same matrix runs repeatedly across all open branches,
+   and macOS-bearing required cells are the bottleneck. (Direct
+   squash merges replaced the merge queue in
+   [ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md);
+   the rebase-before-merge rule now carries the role the queue's
+   speculative-merge CI used to play.)
 
 Keeping the open-PR-against-main count at one eliminates the first
-bottleneck and keeps the queue itself short, so a given PR's
-wait-in-queue time does not grow with the number of drivers active
+bottleneck and avoids cascading rebases, so a given PR's
+wall-clock-to-merge does not grow with the number of drivers active
 simultaneously.
 
 ## Exception criteria
@@ -58,15 +59,15 @@ following hold, and the parallel window is called out in each PR's
 body:
 
 - The PRs modify strictly disjoint files. Overlapping files would
-  force one of the two to be rejected from the merge queue as a
-  speculative-merge conflict, producing churn that the queue was
-  meant to eliminate.
+  force one PR's branch to be rebased after the other lands, and
+  the rebase-and-rerun cycle is exactly what the serial-PR rule
+  exists to avoid.
 - There is a hard deadline that makes the parallel runner load
   acceptable — e.g. an active release freeze, a CVE patch, or an
   external registry timeout window.
-- The author has verified the Actions queue is not already saturated
-  (e.g. `gh run list --status queued --limit 100` is short) and the
-  merge queue itself is short (no more than ~1–2 PRs ahead).
+- The author has verified the Actions queue is not already
+  saturated (e.g. `gh run list --status queued --limit 100` is
+  short) before opening the second PR.
 
 Purely documentation changes that do not touch any Rust file or
 `.github/workflows/` (such as adding a rule file under

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -27,9 +27,9 @@ below.
    Claude posts a single summary comment stating "Ready for merge." If the
    user has granted per-session merge permission and the four conditions in
    the "Bot-driven merge: conditional permission" section below are met,
-   Claude enqueues the merge via the merge queue. Otherwise, a human
-   inspects the full check rollup (not just the required checks listed in
-   branch protection) and performs the squash merge.
+   Claude squash-merges directly via `gh pr merge --squash`. Otherwise, a
+   human inspects the full check rollup (not just the required checks
+   listed in branch protection) and performs the squash merge.
 7. **Safety cap** — after 3 auto-review iterations, the process stops and waits for
    human intervention.
 
@@ -70,10 +70,12 @@ rots, and context is freshest while the code is still being edited.
 
 ### Bot-driven merge: conditional permission
 
-`gh pr merge` (or the equivalent `enqueuePullRequest` GraphQL
-mutation) MAY be executed by an AI assistant when **all four**
-conditions hold. See [ADR-0013](../../docs/adr/0013-conditional-bot-driven-merge.md)
-for the full rationale.
+`gh pr merge --squash` MAY be executed by an AI assistant when
+**all four** conditions hold. See
+[ADR-0013](../../docs/adr/0013-conditional-bot-driven-merge.md) for
+the bot-merge rationale and
+[ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md) for
+why condition (4) is a direct squash and not a merge-queue enqueue.
 
 1. **Explicit, current-session permission.** The user has stated
    in the active session that the assistant may merge. Standing
@@ -92,10 +94,14 @@ for the full rationale.
    resulting auto-review iteration must have completed and
    converged.
 
-4. **Merge queue path only.** Use `enqueuePullRequest` or
-   `gh pr merge --merge-queue`. Direct `gh pr merge --squash`
-   (without `--merge-queue`) bypasses the speculative-merge CI
-   run and is still prohibited.
+4. **Direct squash merge.** Use `gh pr merge <N> --squash` (or the
+   equivalent `mergePullRequest` GraphQL mutation with
+   `mergeMethod: SQUASH`). Auto-merge is disabled at the repo
+   level (`enablePullRequestAutoMerge: false`); the assistant's
+   `--squash` invocation runs synchronously against the PR's
+   current HEAD. The merge queue is no longer in use
+   ([ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md));
+   `enqueuePullRequest` / `--merge-queue` paths are not available.
 
 If any of (1)–(4) is not satisfied, post the "Ready for merge"
 comment and wait for the human merger.
@@ -110,18 +116,24 @@ not in the `required_status_checks.contexts` list of branch protection.
 the explicit list was ignored. The combination of "required-list drift" and
 "no human gate" produced a silent regression.
 
-Two structural changes have since closed that gap:
+Condition (2) above ("Full check rollup green") closed that gap by
+turning "non-required check failing" into a blocking-by-rule case
+rather than a silent skip — eliminating the required-list drift
+class regardless of which merge mechanism is used.
 
-- The merge queue ([ADR-0003](../../docs/adr/0003-github-merge-queue.md))
-  re-runs CI against the speculative merge commit, so a PR with red
-  *required* checks cannot enter `main` even via bot enqueue.
-- Condition (2) above turns "non-required check failing" into a
-  blocking-by-rule case rather than a silent skip, eliminating the
-  required-list drift class.
+A second structural protection — the merge queue's speculative-merge
+CI re-run, originally from
+[ADR-0003](../../docs/adr/0003-github-merge-queue.md) — was removed in
+[ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md). The
+queue's protection against red *required* checks landing on `main` is
+now policy-only via condition (2), not policy + structural. ADR-0015
+documents why the wall-clock cost of the queue's second CI pass no
+longer justified its defence-in-depth value at this repo's scale.
 
-The previous absolute ban traded those structural protections for a
-single property — "the assistant cannot enqueue at all" — at the cost
-of a per-PR ping on every green PR the user had already authorised.
+The previous absolute ban on bot-driven merging traded condition (2)
+for a single property — "the assistant cannot enqueue at all" — at
+the cost of a per-PR ping on every green PR the user had already
+authorised.
 [ADR-0013](../../docs/adr/0013-conditional-bot-driven-merge.md)
 records why the trade is no longer worth it.
 
@@ -137,47 +149,31 @@ For local review before pushing, or when the automated flow is not desired:
 
 - All changes enter `main` via pull request — no direct pushes.
 - All PRs are **squash-merged** (merge commits and rebase merging are disabled).
-- Branch protection enforces that status checks pass on the HEAD commit before merging.
-- `main` is protected by **GitHub Merge Queue**
-  (rationale: [ADR-0003](../../docs/adr/0003-github-merge-queue.md)).
-  When a human clicks "Merge when ready" (or runs
-  `gh pr merge --merge-queue`), the PR enters the queue; GitHub
-  creates a speculative merge commit against the current tip of
-  `main`, CI runs against that merge commit (the `merge_group:`
-  trigger in `ci.yml`), and the PR lands only if CI passes on the
-  merge commit. The queue replaces the old `auto-update-branch.yml`
-  rebase-fan-out loop — there is no longer a per-merge cascade that
-  re-runs CI on every open PR.
+- Branch protection enforces that status checks pass on the HEAD
+  commit before merging, and that the PR branch is up-to-date with
+  `main` before merging — the latter rule forces a rebase-and-rerun
+  whenever `main` has moved, which catches the content-conflict
+  class the merge queue used to detect.
+- The merge action is `gh pr merge <N> --squash` (or the GitHub UI's
+  "Squash and merge" button). The merge queue is no longer in use
+  ([ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md));
+  `gh pr merge --merge-queue` and the `enqueuePullRequest` GraphQL
+  mutation are not part of the flow.
 
-### Merge Queue expectations
+### Workflow trigger expectations
 
 - Workflows that produce `required_status_checks` MUST include
-  `merge_group:` alongside `pull_request:` in their `on:` block. The
-  queue's speculative merge commit runs against the `merge_group`
-  event, and any required check that does not fire on that event
-  blocks the queue indefinitely.
-- Non-required workflows that compute on PR events (smoke jobs,
-  language-binding builds, etc.) do NOT need `merge_group:` triggers
-  — the queue does not wait on them. Adding them produces wasted CI
-  runs on every queued merge.
-- If CI fails against the speculative merge commit, GitHub removes
-  the PR from the queue automatically. The author investigates,
-  pushes a fix, and re-queues manually.
-
-### Secret-access caveat for `merge_group:` events
-
-Unlike `pull_request:` from forks (which run with restricted
-permissions and no secret access), `merge_group:` events run on a
-GitHub-built merge commit with **full repo-secret access** — the
-same posture as `push:` to a protected branch. That means a queued
-PR that touches `.github/workflows/`, `Cargo.toml`, or any other
-file the speculative merge commit will execute in CI gains
-secret-bearing CI on the queue's merge commit.
-
-The "Merge when ready" click is the gate for this. Reviewers MUST
-scrutinise diffs touching `.github/`, build scripts, or anything
-that runs as a CI step before clicking. Treat workflow-file diffs
-the same way you would treat a `push:` directly to `main`.
+  `pull_request:` in their `on:` block. Required checks fire against
+  the PR's head commit; branch protection's "must be up to date"
+  rule forces re-run after rebase.
+- `merge_group:` triggers are obsolete under
+  [ADR-0015](../../docs/adr/0015-disable-github-merge-queue.md).
+  Existing `merge_group:` lines may stay as cheap no-ops (they will
+  never fire) or be cleaned up in follow-up PRs; new workflows
+  SHOULD NOT add `merge_group:`. There is no `merge_group` event to
+  gate on.
+- Non-required workflows (smoke jobs, language-binding builds, etc.)
+  fire on `pull_request:` and `push:` to `main` as appropriate.
 
 ### Severity Definitions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,15 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
-  # Fires when a PR enters the GitHub Merge Queue. The queue runs CI
-  # on a speculative merge commit before appending it to main. All
-  # checks listed in branch protection's required_status_checks must
-  # exist in this workflow (or another workflow that also handles
-  # merge_group) for the queue to consider a PR "green" and land it.
-  # The event has no effect until merge queue is enabled on `main` via
-  # repository / branch protection settings; until then this is a
-  # no-op trigger that never fires.
+  # GitHub Merge Queue was disabled on `main` per
+  # docs/adr/0015-disable-github-merge-queue.md, so no `merge_group`
+  # event is produced today and this trigger is a no-op. It is kept
+  # in place so that re-enabling the queue (should a future ADR
+  # supersede 0015) does not require a workflow edit, and so the
+  # secret-access caveat documented in ADR-0015 remains a single-edit
+  # change rather than a workflow-and-rule change. Removing this line
+  # is safe; do not add new `merge_group:` triggers without first
+  # superseding ADR-0015.
   merge_group:
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,10 +98,10 @@ a conditional carve-out for AI-assistant merges (see step 5 below and
    "Ready for merge" comment. A human inspects the **full check rollup** (not
    just the required checks listed in branch protection), verifies there are no
    review-bot-authored issues still open against the PR, and performs the squash
-   merge — *or* an AI assistant enqueues the merge via the merge queue when all
+   merge — *or* an AI assistant runs `gh pr merge <N> --squash` when all
    four conditions in `.claude/rules/pr-workflow.md`'s "Bot-driven merge:
    conditional permission" section hold (explicit per-session user permission,
-   full check rollup green, auto-review converged on HEAD, merge-queue path).
+   full check rollup green, auto-review converged on HEAD, direct squash merge).
 
 All PRs are **squash-merged**. Branch protection requires CI to pass on HEAD.
 Bot-driven merge is conditional on the four-clause check above — see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ npm run dev
    `git rebase origin/main && git push --force-with-lease` to do
    so without introducing a merge commit (the surrounding flow
    squashes on merge, so a clean linear branch history is
-   preferable). Either path re-runs CI against the new tip before
+   preferable). This re-runs CI against the new tip before
    the merge button re-enables. (Direct squash merges replaced the
    merge queue in
    [ADR-0015](docs/adr/0015-disable-github-merge-queue.md);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,18 +69,21 @@ npm run dev
    ```
 
 5. **Open a PR** with `Closes #N` in the description. PRs are squash-merged.
-6. **Click "Merge when ready"** (or run `gh pr merge --merge-queue`).
-   `main` is protected by GitHub Merge Queue: the queue creates a
-   temporary speculative merge commit combining your PR branch with
-   the current tip of `main`, runs CI once against that commit, and
-   lands the PR if CI passes. Your branch history is not rewritten;
-   you do not need to manually update or rebase your branch before
-   merging — the queue does it for you.
+6. **Click "Squash and merge"** (or run `gh pr merge <N> --squash`).
+   Branch protection requires status checks to pass and your branch
+   to be up to date with `main`. If `main` moved after your last
+   push, GitHub will prompt you to update your branch — do that
+   from the PR page or with `git rebase origin/main && git push
+   --force-with-lease`, which re-runs CI against the new tip
+   before the merge button re-enables. (Direct squash merges
+   replaced the merge queue in
+   [ADR-0015](docs/adr/0015-disable-github-merge-queue.md);
+   the older "Merge when ready" / `--merge-queue` path is no longer
+   in use.)
 
-CI runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`
-on every PR and on every speculative merge commit created by the merge
-queue. A Claude-powered auto-review classifies findings by severity and
-may push fix commits directly.
+CI runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and
+`cargo test` on every PR. A Claude-powered auto-review classifies
+findings by severity and may push fix commits directly.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,11 +72,13 @@ npm run dev
 6. **Click "Squash and merge"** (or run `gh pr merge <N> --squash`).
    Branch protection requires status checks to pass and your branch
    to be up to date with `main`. If `main` moved after your last
-   push, GitHub will prompt you to update your branch — do that
-   from the PR page or with `git rebase origin/main && git push
-   --force-with-lease`, which re-runs CI against the new tip
-   before the merge button re-enables. (Direct squash merges
-   replaced the merge queue in
+   push, GitHub will prompt you to update your branch. Run
+   `git rebase origin/main && git push --force-with-lease` to do
+   so without introducing a merge commit (the surrounding flow
+   squashes on merge, so a clean linear branch history is
+   preferable). Either path re-runs CI against the new tip before
+   the merge button re-enables. (Direct squash merges replaced the
+   merge queue in
    [ADR-0015](docs/adr/0015-disable-github-merge-queue.md);
    the older "Merge when ready" / `--merge-queue` path is no longer
    in use.)

--- a/docs/adr/0003-github-merge-queue.md
+++ b/docs/adr/0003-github-merge-queue.md
@@ -1,6 +1,6 @@
 # 0003. GitHub Merge Queue replaces the auto-update-branch cascade
 
-- **Status**: Accepted
+- **Status**: Superseded by ADR-0015
 - **Date**: 2026-04-22
 
 ## Context

--- a/docs/adr/0013-conditional-bot-driven-merge.md
+++ b/docs/adr/0013-conditional-bot-driven-merge.md
@@ -1,7 +1,17 @@
 # 0013. Bot-driven merge is allowed under explicit session permission
 
-- **Status**: Accepted
+- **Status**: Accepted (condition 4 updated by ADR-0015 on 2026-05-03)
 - **Date**: 2026-04-29
+
+> **Update (2026-05-03):** Condition (4) below ("Merge queue path
+> only") was made unreachable by
+> [ADR-0015](0015-disable-github-merge-queue.md), which disables
+> GitHub Merge Queue on `main`. The current operational condition
+> (4) is "Direct squash merge via `gh pr merge --squash`." The
+> body of this ADR is preserved verbatim for historical context;
+> for the active rule, see `.claude/rules/pr-workflow.md`
+> §"Bot-driven merge: conditional permission" and ADR-0015's
+> "Decision" section.
 
 ## Context
 

--- a/docs/adr/0015-disable-github-merge-queue.md
+++ b/docs/adr/0015-disable-github-merge-queue.md
@@ -16,9 +16,13 @@ speculative merge commit re-runs the full required-check matrix on
 top of the PR's pre-merge CI, so every merge pays the
 `Test (matrix × 6)` cost twice: once as `pull_request:` on the head
 commit, then again as `merge_group:` on the speculative merge
-commit. macOS-bearing required cells dominate the second pass for
-~8–12 minutes apiece, and the click-to-landed window grew to span
-both runs back-to-back.
+commit. Measured against the most recent 30 successful
+`merge_group:` runs of `ci.yml`
+(`gh run list --workflow=ci.yml --event=merge_group --limit 30`),
+the second pass added a median of ~200 s (~3.3 min) and a 90th-
+percentile of ~445 s (~7.5 min) to every merge — i.e., the
+click-to-landed window typically grew by 3–8 minutes per PR, on
+top of the original pre-merge CI duration.
 
 The benefit of the second pass — catching semantic conflicts that
 manifested only when the PR diff is composed against the current
@@ -27,8 +31,16 @@ already runs against a recent base, contributors rebase before
 opening the PR, and content conflicts (the only conflict class the
 queue can detect) are caught earlier by the existing branch
 protection's "Branch must be up to date before merging" rule when
-that rule fires. Cases where the queue's speculative CI failed for
-a reason the PR's own CI had not surfaced have been rare.
+that rule fires. The empirical record across the queue's active
+period (sampled via
+`gh run list --workflow=ci.yml --event=merge_group --status=failure --limit 100`)
+returned exactly two `merge_group` failures, and inspection of
+both runs (24845736567 — Format step `HTTP 500` from
+`actions/checkout`; 24973252062 — non-required Desktop smoke job
+flake) confirmed both were transient GitHub-infra failures, not
+semantic conflicts a pre-merge CI run had missed. Zero
+queue-only-detected regressions across the queue's active period
+is the load-bearing data point for the cost-benefit shift.
 
 The cost-benefit traded that motivated ADR-0003 was
 "`O(open_PRs)` CI fan-out vs. one extra CI pass per merge." With
@@ -69,15 +81,15 @@ squash-merges. Specifically:
 
 ## Rationale
 
-1. **Wall-clock cost was paid twice per merge for a rare benefit.**
-   Required-check cells (notably `Test (macos-latest, *)` and
-   `Test (windows-latest, *)`) ran once on the PR's head commit and
-   once on the speculative merge commit. Both passes covered the
-   same code with the same Cargo.lock; the second pass differed
-   only in being composed against the most recent `main`. Semantic
-   conflicts that survive both the author's local build and the
-   PR's pre-merge CI are not common at this repo's commit
-   frequency.
+1. **Wall-clock cost was paid twice per merge for a benefit that
+   never observably fired.** Required-check cells ran once on the
+   PR's head commit and once on the speculative merge commit. Both
+   passes covered the same code with the same `Cargo.lock`; the
+   second pass differed only in being composed against the most
+   recent `main`. The Context section records zero queue-only-
+   detected regressions across the queue's active period; semantic
+   conflicts that would survive both the author's local build and
+   the PR's pre-merge CI are bounded by that empirical record.
 
 2. **Branch protection's existing "must be up to date" rule
    covers the conflict class the queue detected.** GitHub blocks
@@ -111,8 +123,10 @@ squash-merges. Specifically:
 Positive:
 
 - Click-to-landed wall-clock drops by one full required-check
-  matrix run per merge — typically ~8–12 minutes saved per merge,
-  bounded by the slowest macOS cell.
+  matrix run per merge. Sampled across the most recent 30
+  successful `merge_group:` runs, the second pass added a median
+  of ~200 s (~3.3 min) and a 90th-percentile of ~445 s (~7.5 min)
+  per merge; that range is the expected wall-clock saving.
 - One fewer infrastructural concept (`merge_group:` events,
   `gh-readonly-queue/*` refs, queue position UI) to teach new
   contributors and to track in `.claude/rules/`.

--- a/docs/adr/0015-disable-github-merge-queue.md
+++ b/docs/adr/0015-disable-github-merge-queue.md
@@ -1,0 +1,188 @@
+# 0015. Disable GitHub Merge Queue (supersedes ADR-0003)
+
+- **Status**: Accepted
+- **Date**: 2026-05-03
+
+## Context
+
+[ADR-0003](0003-github-merge-queue.md) adopted GitHub Merge Queue
+in #2123 to retire the `auto-update-branch.yml` cascade. The queue
+solved the cascade's `O(open_PRs)` CI fan-out problem by serialising
+merges through a single speculative-merge CI run per queued PR.
+
+In the months since adoption, the principal cost shifted from CI
+fan-out (gone) to **merge wall-clock latency**. The queue's
+speculative merge commit re-runs the full required-check matrix on
+top of the PR's pre-merge CI, so every merge pays the
+`Test (matrix × 6)` cost twice: once as `pull_request:` on the head
+commit, then again as `merge_group:` on the speculative merge
+commit. macOS-bearing required cells dominate the second pass for
+~8–12 minutes apiece, and the click-to-landed window grew to span
+both runs back-to-back.
+
+The benefit of the second pass — catching semantic conflicts that
+manifested only when the PR diff is composed against the current
+tip of `main` — has been low at this repo's scale. The pre-merge CI
+already runs against a recent base, contributors rebase before
+opening the PR, and content conflicts (the only conflict class the
+queue can detect) are caught earlier by the existing branch
+protection's "Branch must be up to date before merging" rule when
+that rule fires. Cases where the queue's speculative CI failed for
+a reason the PR's own CI had not surfaced have been rare.
+
+The cost-benefit traded that motivated ADR-0003 was
+"`O(open_PRs)` CI fan-out vs. one extra CI pass per merge." With
+the cascade gone permanently and serial merge discipline already
+encoded in `.claude/rules/one-pr-at-a-time.md`, the second pass is
+no longer load-bearing.
+
+## Decision
+
+Disable GitHub Merge Queue on `main` and return to direct
+squash-merges. Specifically:
+
+- Branch protection on `main` removes the "Require merge queue"
+  setting. The "Require status checks to pass before merging" and
+  "Require branches to be up to date before merging" rules stay in
+  place — those are what gate semantic-conflict cases under the new
+  flow.
+- All PRs continue to be **squash-merged** (merge commits and
+  rebase merging remain disabled). Squash is enacted via
+  `gh pr merge <N> --squash` or the GitHub UI's "Squash and merge"
+  button.
+- The `auto-update-branch.yml` cascade is **not** reintroduced.
+  Authors rebase manually when `main` moves and their PR has fallen
+  behind, per the existing rebase protocol in
+  `.claude/rules/parallel-work.md`.
+- `merge_group:` triggers in `.github/workflows/*.yml` may stay as
+  cheap no-ops (they simply will not fire) or be cleaned up in
+  follow-up PRs. They are NOT load-bearing under this ADR.
+- Bot-driven merge under explicit per-session permission
+  ([ADR-0013](0013-conditional-bot-driven-merge.md)) is preserved.
+  Condition (4) of that ADR's four-clause gate becomes
+  "**Direct squash merge.** Use `gh pr merge --squash` (or the
+  equivalent `mergePullRequest` GraphQL mutation)." Auto-merge
+  remains disabled at the repository level
+  (`enablePullRequestAutoMerge: false`); the assistant's
+  `--squash` invocation runs synchronously against the PR's
+  current HEAD, not as a deferred trigger.
+
+## Rationale
+
+1. **Wall-clock cost was paid twice per merge for a rare benefit.**
+   Required-check cells (notably `Test (macos-latest, *)` and
+   `Test (windows-latest, *)`) ran once on the PR's head commit and
+   once on the speculative merge commit. Both passes covered the
+   same code with the same Cargo.lock; the second pass differed
+   only in being composed against the most recent `main`. Semantic
+   conflicts that survive both the author's local build and the
+   PR's pre-merge CI are not common at this repo's commit
+   frequency.
+
+2. **Branch protection's existing "must be up to date" rule
+   covers the conflict class the queue detected.** GitHub blocks
+   the merge button if `main` has moved since the PR's last
+   rebase, which forces the author to rebase and re-run pre-merge
+   CI before merging. That re-run is functionally equivalent to
+   the queue's speculative merge commit for content-conflict
+   purposes — the difference is that the rebase happens on the
+   author's branch (visible in the PR's CI tab) rather than on a
+   GitHub-internal `gh-readonly-queue/*` ref.
+
+3. **Serial-PR discipline already prevents the queue's worst
+   case.** `.claude/rules/one-pr-at-a-time.md` caps the open-PR-
+   against-`main` count at 1. The queue's serialisation was
+   redundant on top of that policy: there was rarely more than one
+   PR queued at a time, so the queue's "wait your turn" semantic
+   added no ordering the policy did not already provide.
+
+4. **The bot-driven merge gate's protection is not in the queue.**
+   ADR-0013's four conditions check (a) explicit per-session
+   permission, (b) full check rollup green, (c) auto-review
+   converged, and (d) merge-queue path. The protection against the
+   "silent merge with non-required check failing" failure mode that
+   originally banned bot-driven merging lives in condition (b),
+   not (d). Replacing (d) with "direct squash merge" preserves the
+   structural safety condition (b) provides while dropping the
+   queue dependency.
+
+## Consequences
+
+Positive:
+
+- Click-to-landed wall-clock drops by one full required-check
+  matrix run per merge — typically ~8–12 minutes saved per merge,
+  bounded by the slowest macOS cell.
+- One fewer infrastructural concept (`merge_group:` events,
+  `gh-readonly-queue/*` refs, queue position UI) to teach new
+  contributors and to track in `.claude/rules/`.
+- `gh pr merge --squash` is the canonical merge command across
+  CI-using sessions, including assistant-driven merges, eliminating
+  the special-case `enqueuePullRequest` / `--merge-queue` paths.
+
+Negative:
+
+- Semantic conflicts that the queue's speculative CI would have
+  caught now surface as `main` CI failures after the merge lands.
+  Mitigation: the "must be up to date before merging" rule forces a
+  rebase before merge whenever `main` has moved; that rebase
+  re-runs pre-merge CI against the same composition the queue's
+  speculative merge would have. The narrow remaining window — `main`
+  moving between rebase and click — is structurally identical to
+  the rebase-before-merge requirement and acceptable at this repo's
+  pace.
+- The historical guard documented in
+  `pr-workflow.md` §"Historical rationale (superseded)" — that the
+  queue prevents a bot from silently merging with red required
+  checks — moves entirely onto ADR-0013 condition (b) (full check
+  rollup green). That condition is still a hard pre-merge gate, so
+  the protection is preserved, but it is now policy-only rather
+  than policy + structural.
+
+## Alternatives considered
+
+- **Keep the queue with a leaner required-check matrix.** Removing
+  Windows / macOS cells from the required set would shorten queue
+  CI but trade away the very coverage the queue was meant to
+  enforce on the speculative commit. Rejected: the wait-time
+  problem stems from the queue's serialisation shape, not just its
+  required-check breadth.
+- **Keep the queue with a per-PR opt-out for trivial diffs.**
+  GitHub Merge Queue does not support per-PR bypass cleanly; the
+  closest equivalent (admin-merge) defeats the queue's purpose
+  whenever it is used. Rejected.
+- **Adopt a third-party merge-train (Mergify, Bors, etc.)** that
+  exposes finer queue controls. Rejected for the same reasons
+  ADR-0003 rejected this option: vendor lock-in, additional
+  secrets, and additional hosted-service availability without
+  addressing the wall-clock concern this ADR is fixing.
+- **Re-enable `auto-update-branch.yml`.** Rejected. The cascade's
+  `O(open_PRs)` CI fan-out is precisely what ADR-0003 retired. No
+  serialisation is needed under the existing serial-PR policy; the
+  rebase-before-merge contract handles the rare case where a PR
+  has fallen behind `main`.
+
+## References
+
+- [ADR-0003](0003-github-merge-queue.md) — adopted the merge queue
+  (this ADR supersedes it).
+- [ADR-0013](0013-conditional-bot-driven-merge.md) — bot-driven
+  merge gate; condition (4) is updated by this ADR.
+- Issue #2386 — tracker for this change.
+- GitHub docs on merge queue (for re-evaluation):
+  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
+
+Watch signals that should prompt revisiting this decision:
+
+- A `main` CI failure rate spike traceable to semantic conflicts
+  that a rebase-before-merge did not catch — would indicate the
+  queue's second CI pass was load-bearing in a class of conflicts
+  not covered by branch protection's "must be up to date" rule.
+- The repo's serial-PR policy in
+  `.claude/rules/one-pr-at-a-time.md` becoming impractical (e.g. a
+  push toward parallel feature delivery), which would re-introduce
+  the queue's serialisation benefit.
+- A regression where bot-driven merges land with red non-required
+  checks — would indicate ADR-0013 condition (b) drifted, in which
+  case the queue's structural protection should be reconsidered as
+  defence in depth.

--- a/docs/adr/0015-disable-github-merge-queue.md
+++ b/docs/adr/0015-disable-github-merge-queue.md
@@ -42,7 +42,7 @@ semantic conflicts a pre-merge CI run had missed. Zero
 queue-only-detected regressions across the queue's active period
 is the load-bearing data point for the cost-benefit shift.
 
-The cost-benefit traded that motivated ADR-0003 was
+The cost-benefit trade that motivated ADR-0003 was
 "`O(open_PRs)` CI fan-out vs. one extra CI pass per merge." With
 the cascade gone permanently and serial merge discipline already
 encoded in `.claude/rules/one-pr-at-a-time.md`, the second pass is

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -80,7 +80,7 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 |---|---|---|
 | [0001](0001-kotlin-maven-central-publishing-credentials.md) | Kotlin Maven Central publishing credentials | Accepted (2026-04-11) |
 | [0002](0002-aur-smoke-coverage-exemption.md) | AUR install command is exempt from readme-smoke coverage | Accepted (2026-04-18) |
-| [0003](0003-github-merge-queue.md) | GitHub Merge Queue replaces the auto-update-branch cascade | Accepted (2026-04-22) |
+| [0003](0003-github-merge-queue.md) | GitHub Merge Queue replaces the auto-update-branch cascade | Superseded by ADR-0015 (2026-04-22) |
 | [0004](0004-unsafe-eval-for-web-tree-sitter-emscripten.md) | `'unsafe-eval'` in the desktop CSP for `web-tree-sitter` | Accepted (2026-04-24) |
 | [0005](0005-tauri-updater-key-management.md) | Tauri updater key management (Ed25519, no password) | Superseded by ADR-0007 (2026-04-25) |
 | [0006](0006-desktop-webview-trust-boundary.md) | Desktop WebView is trusted; custom commands are not capability-gated | Accepted (2026-04-24) |
@@ -90,5 +90,6 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0010](0010-image-path-resolution-stays-strict.md) | Image path resolution stays strict (declines R6.100 `~` and folder-next-to-song) | Accepted (2026-04-28) |
 | [0011](0011-html-styles-stay-inline.md) | HTML styles stay inline-per-element (declines R6.100 `default/screen/print` + `html.style.embed`) | Accepted (2026-04-28) |
 | [0012](0012-macports-portfile-cargo-crates-tag-relative.md) | MacPorts Portfile cargo.crates is tag-relative, not HEAD-relative | Accepted (2026-04-29) |
-| [0013](0013-conditional-bot-driven-merge.md) | Bot-driven merge is allowed under explicit session permission | Accepted (2026-04-29) |
+| [0013](0013-conditional-bot-driven-merge.md) | Bot-driven merge is allowed under explicit session permission | Accepted (2026-04-29; condition 4 updated by ADR-0015) |
 | [0014](0014-bravura-glyphs-as-svg-paths.md) | Bravura SMuFL glyphs ship as inline SVG paths, not as a bundled font | Accepted (2026-05-01) |
+| [0015](0015-disable-github-merge-queue.md) | Disable GitHub Merge Queue (supersedes ADR-0003) | Accepted (2026-05-03) |


### PR DESCRIPTION
## What

Adds ADR-0015 and updates the dependent rule files to retire GitHub
Merge Queue on `main` in favour of direct squash merges. Branch
protection's queue requirement is flipped off in a manual UI /
API step performed by the maintainer once this PR lands.

## Why

ADR-0003 (2026-04-22) adopted the merge queue to retire the
`auto-update-branch.yml` cascade. That trade-off was right at the
time — the cascade's `O(open_PRs)` CI fan-out dominated the cost
model. With the cascade gone permanently and serial-PR discipline
already in place via `one-pr-at-a-time.md`, the queue's principal
remaining cost — re-running the required-check matrix on the
speculative merge commit, which sampled at a median of ~200 s and
a 90th-percentile of ~445 s of added wall-clock per merge — outweighs
its remaining benefit. The empirical record across the queue's active
period shows zero `merge_group` failures attributable to a semantic
conflict the PR's pre-merge CI did not catch (the two recorded
`merge_group` failures were both transient GitHub-infra errors).
Branch protection's existing `requiresStrictStatusChecks: true`
rule covers the same conflict class via author-side rebase before
the merge button enables.

ADR-0015 is the durable record of the reversal; the rule files
encode the new operational state.

## Files touched

- `docs/adr/0015-disable-github-merge-queue.md` — new ADR.
- `docs/adr/0003-github-merge-queue.md` — Status updated to
  "Superseded by ADR-0015"; body preserved.
- `docs/adr/0013-conditional-bot-driven-merge.md` — Status
  annotated and a top-of-document Update note added pointing to
  ADR-0015. Body preserved per `adr-discipline.md` (do not
  rewrite accepted ADRs in place).
- `docs/adr/README.md` — index entries for 0013 and 0003 reflect
  the supersession; 0015 added.
- `.claude/rules/pr-workflow.md` — Merge Queue / secret-access
  caveat sections removed; bot-merge condition (4) becomes
  "Direct squash merge"; "Historical rationale (superseded)"
  rewritten.
- `.claude/rules/one-pr-at-a-time.md` — §"Why" point 2 reframed
  as rebase-churn-after-merge.
- `.claude/rules/ci-parallelization.md` — `gh-readonly-queue/*`
  write-path rationale moved to historical aside; §5 "Why" cites
  rebase-after-`main`-moves rather than queue re-queue.
- `CLAUDE.md` — merge-policy step 5 documents direct
  `gh pr merge --squash`.
- `CONTRIBUTING.md` — step 6 documents "Squash and merge".
- `.github/workflows/ci.yml` — `merge_group:` trigger comment
  updated to reflect ADR-0015 (the trigger itself is left in
  place as a cheap no-op so re-enabling the queue would be a
  single-edit operation if a future ADR ever supersedes 0015).

## Test plan

Documentation-only PR; no code changes. Verification:

- [x] `grep -rn 'gh pr merge --merge-queue\|enqueuePullRequest' .claude docs CLAUDE.md CONTRIBUTING.md` — every remaining hit is in framing of "no longer in use" / superseded historical context.
- [x] `docs/adr/README.md` index reflects the supersession of 0003 and the condition-4 update on 0013.
- [x] ADR-0003 and ADR-0013 bodies are preserved (status / index annotations only).
- [x] `gh api repos/koedame/chordsketch/branches/main/protection --jq '.required_status_checks.strict'` returns `true`, supporting ADR-0015's claim that strict status checks gate the conflict class the queue used to handle.
- [x] `gh api repos/koedame/chordsketch --jq '.allow_auto_merge'` returns `false`, supporting CONTRIBUTING.md and the bot-merge condition (4)'s assertion that `--squash` runs synchronously rather than as a deferred trigger.
- [x] Wall-clock claim is grounded: 30 successful `merge_group:` runs of `ci.yml` sampled via `gh run list --workflow=ci.yml --event=merge_group --limit 30` give median ~200 s, 90th-percentile ~445 s.
- [x] "Zero queue-only-detected regressions" claim is grounded: 100 sampled `merge_group` failures via `gh run list --workflow=ci.yml --event=merge_group --status=failure --limit 100` returned exactly two runs (24845736567, 24973252062), both inspected and confirmed as GitHub-infra failures.

## Manual follow-up after merge

The maintainer flips the queue off via the GitHub UI (Settings →
Branches → branch protection rule for `main` → un-check "Require
merge queue") or the equivalent REST endpoint. There is no
GraphQL mutation for "delete merge queue"; the queue's lifecycle
is owned by branch protection rules, not the standalone
`MergeQueue` GraphQL object. The TOCTOU window between this PR's
merge and the manual flip is benign: while the queue is still
active, an attempted `gh pr merge <N> --squash` fails closed
(GitHub rejects direct squash on a queue-protected branch), so
the docs being momentarily ahead of reality cannot produce a
silent merge.

## Sister-site audit

Out of scope for `.claude/rules/fix-propagation.md` cross-crate
sister groups — this is a documentation / governance change with no
Rust binding or renderer siblings. ADR-0013 is annotated rather
than rewritten because `adr-discipline.md` prohibits rewriting
accepted ADRs in place; the active rule lives in
`pr-workflow.md`.

Closes #2386