### PR TITLE
feat(ui-irealb-editor): keyboard navigation, ARIA grid semantics, live region

### DIFF
--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -20,9 +20,14 @@
 // keyboard navigation + ARIA in #2368.
 
 import type { Bar, IrealSong, Section, SectionLabel } from './ast.js';
-import { clearChildren } from './dom.js';
+import { clearChildren, el } from './dom.js';
 import { openBarPopover, type BarPopoverHandle } from './popover.js';
-import { render, type RenderHandle, type StructuralOps } from './render.js';
+import {
+  render,
+  type ActiveBarRef,
+  type RenderHandle,
+  type StructuralOps,
+} from './render.js';
 import { IrealbEditorState, type IrealbWasm, makeStateFromUrl } from './state.js';
 
 export type { IrealSong, SectionLabel } from './ast.js';
@@ -89,6 +94,36 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
   const element = document.createElement('div');
   element.classList.add('irealb-editor');
 
+  // ARIA live region for structural-edit announcements (#2368). Held
+  // outside the grid so a re-render of `.irealb-editor__grid` does
+  // not detach it — `aria-live` regions whose nodes are removed and
+  // re-added in the same task can fail to announce on some screen
+  // readers (NVDA in particular). The region carries a visually-
+  // hidden class via `style.css` so it stays in the accessibility
+  // tree without occupying layout.
+  const liveRegion = el('div', {
+    class: 'irealb-editor__sr-only irealb-editor__live',
+    attrs: { 'aria-live': 'polite', 'aria-atomic': 'true' },
+  });
+  element.appendChild(liveRegion);
+
+  /** Push a single sentence into the live region. Read by polite
+   * screen readers after the next idle tick. We blank the region
+   * first so two consecutive identical messages still announce —
+   * `aria-live="polite"` only fires when the text content changes,
+   * so the no-op assignment of the same string would otherwise be
+   * silent. */
+  const announce = (message: string): void => {
+    if (destroyed) return;
+    liveRegion.textContent = '';
+    // Defer the actual text by a microtask so the screen reader
+    // observes the empty-then-populated transition as a change.
+    queueMicrotask(() => {
+      if (destroyed) return;
+      liveRegion.textContent = message;
+    });
+  };
+
   const state = initialValue.length > 0
     ? makeStateFromUrl(wasm, initialValue)
     : new IrealbEditorState(wasm, makeEmptySong());
@@ -97,6 +132,62 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
   let renderHandle: RenderHandle | null = null;
   let popoverHandle: BarPopoverHandle | null = null;
   let destroyed = false;
+  // Roving-tabindex active bar (#2368). `null` when the chart has no
+  // bars (an empty section or a song with no sections at all). The
+  // adapter is the source of truth — `render()` reads this to mark
+  // exactly one cell with `tabindex="0"` and updates it via the
+  // `setActiveBar` callback when the user focuses a different cell.
+  let activeBar: ActiveBarRef | null = null;
+  const setActiveBar = (ref: ActiveBarRef): void => {
+    activeBar = ref;
+  };
+  /** Clamp `activeBar` to the current `state.song` shape. Called at
+   * the top of every render pass so a structural edit (delete bar /
+   * delete section) does not leave the active ref pointing at a
+   * non-existent cell — the would-be focused button would silently
+   * lose its `tabindex="0"` slot and the grid would have zero Tab
+   * stops. Empty grids set `activeBar` to `null`. */
+  const reconcileActiveBar = (): void => {
+    const sections = state.song.sections;
+    if (sections.length === 0) {
+      activeBar = null;
+      return;
+    }
+    if (activeBar === null) {
+      // Default to the first bar of the first section that has any
+      // bars; fall back to (0, 0) so the grid still has one Tab
+      // stop even when every section is empty.
+      for (let s = 0; s < sections.length; s += 1) {
+        const section = sections[s];
+        if (section && section.bars.length > 0) {
+          activeBar = { secIndex: s, barIndex: 0 };
+          return;
+        }
+      }
+      activeBar = { secIndex: 0, barIndex: 0 };
+      return;
+    }
+    const sec = sections[activeBar.secIndex];
+    if (!sec || sec.bars.length === 0) {
+      // The active section was deleted or emptied. Re-anchor on the
+      // first non-empty section, or at (0, 0) if every section is
+      // empty.
+      for (let s = 0; s < sections.length; s += 1) {
+        const section = sections[s];
+        if (section && section.bars.length > 0) {
+          activeBar = { secIndex: s, barIndex: 0 };
+          return;
+        }
+      }
+      activeBar = { secIndex: 0, barIndex: 0 };
+      return;
+    }
+    if (activeBar.barIndex >= sec.bars.length) {
+      // The active bar was beyond the (possibly truncated) section's
+      // tail; clamp to the new last bar.
+      activeBar = { secIndex: activeBar.secIndex, barIndex: sec.bars.length - 1 };
+    }
+  };
 
   const fireUserEdit = (): void => {
     if (destroyed) return;
@@ -249,6 +340,7 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       state.song.sections.push(makeDefaultSection(label));
       renderNow();
       fireUserEdit();
+      announce(`Section ${formatSectionLabelForPrompt(label)} added`);
       // Focus the new section's "Move section up" button — the
       // closest analogue to the just-clicked "+ Add section"
       // trailer (which does not exist on a per-section basis).
@@ -271,6 +363,10 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       section.label = next;
       renderNow();
       fireUserEdit();
+      announce(
+        `Section renamed from ${formatSectionLabelForPrompt(current)} ` +
+          `to ${formatSectionLabelForPrompt(next)}`,
+      );
       focusAfterRender([sectionActionSelector(secIndex, 'Rename section')]);
     },
     deleteSection: (secIndex) => {
@@ -278,10 +374,12 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       const section = state.song.sections[secIndex];
       if (!section) return;
       if (!confirmDeleteSection(section.label)) return;
+      const removedLabel = section.label;
       dismissPopover();
       state.song.sections.splice(secIndex, 1);
       renderNow();
       fireUserEdit();
+      announce(`Section ${formatSectionLabelForPrompt(removedLabel)} deleted`);
       // Focus the next-sibling section's "Delete section" button
       // (the same kind that was just activated). If the deleted
       // section was the last one, focus the new last section's
@@ -305,6 +403,9 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       state.song.sections[secIndex] = prev;
       renderNow();
       fireUserEdit();
+      announce(
+        `Section ${formatSectionLabelForPrompt(cur.label)} moved up`,
+      );
       // The moved section is now at secIndex - 1. Focus its
       // "Move section up" button so a repeat-press keeps moving
       // the same section upward.
@@ -324,6 +425,9 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       state.song.sections[secIndex] = next;
       renderNow();
       fireUserEdit();
+      announce(
+        `Section ${formatSectionLabelForPrompt(cur.label)} moved down`,
+      );
       focusAfterRender([
         sectionActionSelector(secIndex + 1, 'Move section down'),
         sectionActionSelector(secIndex + 1, 'Move section up'),
@@ -339,6 +443,9 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       section.bars.push(makeDefaultBar());
       renderNow();
       fireUserEdit();
+      announce(
+        `Bar ${newBarIndex + 1} added to section ${formatSectionLabelForPrompt(section.label)}`,
+      );
       // Focus the new bar's edit button (its <button class="bar">).
       focusAfterRender([
         `.irealb-editor__section[data-section-index="${secIndex}"] ` +
@@ -351,10 +458,15 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       const section = state.song.sections[secIndex];
       if (!section) return;
       if (barIndex < 0 || barIndex >= section.bars.length) return;
+      const removedBarNumber = barIndex + 1;
+      const sectionLabel = section.label;
       dismissPopover();
       section.bars.splice(barIndex, 1);
       renderNow();
       fireUserEdit();
+      announce(
+        `Bar ${removedBarNumber} deleted from section ${formatSectionLabelForPrompt(sectionLabel)}`,
+      );
       // Focus the next-sibling bar's Delete button (or the new
       // last bar's, or the section's "+ Add bar" trailer).
       const remaining = section.bars.length;
@@ -379,6 +491,7 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       section.bars[barIndex] = prev;
       renderNow();
       fireUserEdit();
+      announce(`Bar ${barIndex + 1} moved left`);
       focusAfterRender([
         barActionSelector(secIndex, barIndex - 1, 'Move bar left'),
         barActionSelector(secIndex, barIndex - 1, 'Move bar right'),
@@ -399,6 +512,7 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       section.bars[barIndex] = next;
       renderNow();
       fireUserEdit();
+      announce(`Bar ${barIndex + 1} moved right`);
       focusAfterRender([
         barActionSelector(secIndex, barIndex + 1, 'Move bar right'),
         barActionSelector(secIndex, barIndex + 1, 'Move bar left'),
@@ -409,12 +523,28 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
     },
   };
 
+  // Rebuild target element for the form + grid (separate from
+  // `element` so the live region survives across re-renders). The
+  // grid container is created once and only its children are
+  // rebuilt, matching how `render()` already works on its own root.
+  const gridRoot = el('div', { class: 'irealb-editor__root' });
+  element.appendChild(gridRoot);
+
   const renderNow = (): void => {
     if (renderHandle !== null) {
       renderHandle.dispose();
       renderHandle = null;
     }
-    renderHandle = render(element, state, fireUserEdit, handleOpenPopover, ops);
+    reconcileActiveBar();
+    renderHandle = render(
+      gridRoot,
+      state,
+      fireUserEdit,
+      handleOpenPopover,
+      ops,
+      activeBar,
+      setActiveBar,
+    );
   };
 
   renderNow();

--- a/packages/ui-irealb-editor/src/index.ts
+++ b/packages/ui-irealb-editor/src/index.ts
@@ -401,6 +401,19 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       const prev = state.song.sections[secIndex - 1] as Section;
       state.song.sections[secIndex - 1] = cur;
       state.song.sections[secIndex] = prev;
+      // Re-anchor the roving-tabindex active bar against the moved
+      // sections so the user's "I was on this bar" position follows
+      // the section content rather than the numeric index. Without
+      // this, swapping sections would leave `activeBar.secIndex`
+      // pointing at the same number — which now references a
+      // different section's content. (#2389 review L2.)
+      if (activeBar !== null) {
+        if (activeBar.secIndex === secIndex) {
+          activeBar = { secIndex: secIndex - 1, barIndex: activeBar.barIndex };
+        } else if (activeBar.secIndex === secIndex - 1) {
+          activeBar = { secIndex, barIndex: activeBar.barIndex };
+        }
+      }
       renderNow();
       fireUserEdit();
       announce(
@@ -423,6 +436,15 @@ export function createIrealbEditor(options: CreateIrealbEditorOptions): EditorAd
       const next = state.song.sections[secIndex + 1] as Section;
       state.song.sections[secIndex + 1] = cur;
       state.song.sections[secIndex] = next;
+      // Re-anchor the roving-tabindex active bar — see moveSectionUp
+      // for the rationale. (#2389 review L2.)
+      if (activeBar !== null) {
+        if (activeBar.secIndex === secIndex) {
+          activeBar = { secIndex: secIndex + 1, barIndex: activeBar.barIndex };
+        } else if (activeBar.secIndex === secIndex + 1) {
+          activeBar = { secIndex, barIndex: activeBar.barIndex };
+        }
+      }
       renderNow();
       fireUserEdit();
       announce(

--- a/packages/ui-irealb-editor/src/render.ts
+++ b/packages/ui-irealb-editor/src/render.ts
@@ -384,24 +384,26 @@ function renderSection(
   // down to each row (`.irealb-editor__row`) so empty trailing
   // cells in the last row do not stretch the row's last bar.
   const barsCount = section.bars.length;
-  const rowCount = Math.max(1, Math.ceil(barsCount / BARS_PER_ROW));
+  // `rowCount` matches the number of `role="row"` children we
+  // actually render — including 0 for an empty section. Reporting
+  // a higher row count would diverge from the accessibility tree
+  // (ARIA 1.2: `aria-rowcount` SHOULD agree with the rendered row
+  // descendants). Screen-reader verbalisation of "0 rows" is
+  // strictly correct for an empty grid; the user opens the
+  // structural "+ Add bar" trailer (which is sibling to the grid)
+  // to populate the first row.
+  const rowCount = Math.ceil(barsCount / BARS_PER_ROW);
   const grid = el('div', {
     class: 'irealb-editor__bars',
     attrs: {
       role: 'grid',
-      // `aria-rowcount` is at least 1 even for an empty section so
-      // assistive tech announces a stable shape ("1 row, 4 columns")
-      // rather than "0 rows" — which screen readers vary in how they
-      // verbalise. The grid is still empty visually; the count refers
-      // to the implicit row that the next "+ Add bar" insertion will
-      // populate.
       'aria-rowcount': String(rowCount),
       'aria-colcount': String(BARS_PER_ROW),
       'aria-label': `Bars in section ${formatSectionLabel(section.label)}`,
     },
   });
 
-  for (let rowIdx = 0; rowIdx < Math.ceil(barsCount / BARS_PER_ROW); rowIdx += 1) {
+  for (let rowIdx = 0; rowIdx < rowCount; rowIdx += 1) {
     const rowEl = el('div', {
       class: 'irealb-editor__row',
       attrs: {

--- a/packages/ui-irealb-editor/src/render.ts
+++ b/packages/ui-irealb-editor/src/render.ts
@@ -82,20 +82,42 @@ export interface RenderHandle {
   dispose(): void;
 }
 
+/** Identifies a bar cell by its (sectionIndex, barIndex) pair. Used
+ * by the roving-tabindex bookkeeping and the focus-restoration
+ * helpers in `index.ts`. */
+export interface ActiveBarRef {
+  secIndex: number;
+  barIndex: number;
+}
+
+/** Number of bar cells per visual row in the bar grid. The CSS layout
+ * uses `grid-template-columns: repeat(4, ...)`, and the ARIA `role="grid"`
+ * semantics added in #2368 reflect the same wrap so `aria-rowindex` /
+ * `aria-colindex` agree with what a sighted user sees. Changing this
+ * value MUST update `style.css` `.irealb-editor__row` in lockstep. */
+export const BARS_PER_ROW = 4;
+
 /** Build the form + bar grid into `root` from `state`. `onUserEdit`
  * fires after every successful user-initiated mutation;
  * `openBarPopover` fires when a user clicks a bar cell (the
  * adapter opens the bar-edit popover, #2364); `ops` exposes the
  * structural mutations the per-section / per-bar UI buttons drive
- * (#2365). The adapter owns the popover container, structural
- * confirm dialogs, and the post-mutation re-render + onUserEdit
- * dispatch. */
+ * (#2365); `activeBar` controls which cell holds `tabindex="0"`
+ * after this render pass — every other cell receives `tabindex="-1"`
+ * per the W3C APG roving-tabindex pattern (#2368), so the entire
+ * grid contributes one Tab stop instead of one per bar; `setActiveBar`
+ * is invoked when the user focuses a different cell so the adapter
+ * can persist the new active bar across re-renders. The adapter
+ * owns the popover container, structural confirm dialogs, and the
+ * post-mutation re-render + onUserEdit dispatch. */
 export function render(
   root: HTMLElement,
   state: IrealbEditorState,
   onUserEdit: () => void,
   openBarPopover: OpenBarPopover,
   ops: StructuralOps,
+  activeBar: ActiveBarRef | null,
+  setActiveBar: (ref: ActiveBarRef) => void,
 ): RenderHandle {
   clearChildren(root);
   const cleanups: Array<() => void> = [];
@@ -240,7 +262,17 @@ export function render(
   const sectionsCount = state.song.sections.length;
   state.song.sections.forEach((section, secIndex) => {
     grid.appendChild(
-      renderSection(section, secIndex, sectionsCount, openBarPopover, ops, listen, root),
+      renderSection(
+        section,
+        secIndex,
+        sectionsCount,
+        openBarPopover,
+        ops,
+        listen,
+        root,
+        activeBar,
+        setActiveBar,
+      ),
     );
   });
 
@@ -282,6 +314,8 @@ function renderSection(
     handler: (ev: HTMLElementEventMap[K]) => void,
   ) => void,
   root: HTMLElement,
+  activeBar: ActiveBarRef | null,
+  setActiveBar: (ref: ActiveBarRef) => void,
 ): HTMLElement {
   const wrapper = el('div', {
     class: 'irealb-editor__section',
@@ -342,17 +376,63 @@ function renderSection(
 
   wrapper.appendChild(headerRow);
 
-  // 4-bars-per-line CSS grid. Emits a flat list of bar wrappers
-  // (each wrapper holds the bar `<button>` plus its delete /
-  // reorder controls). ARIA grid semantics arrive in #2368.
-  const row = el('div', { class: 'irealb-editor__bars' });
+  // 4-bars-per-line layout. Bars are grouped into `role="row"`
+  // containers so the grid's ARIA semantics (`role="grid"` /
+  // `aria-rowcount` / `aria-colcount` / `aria-rowindex` /
+  // `aria-colindex`) match the visual wrap a sighted user sees.
+  // The CSS layout moves from the parent (`.irealb-editor__bars`)
+  // down to each row (`.irealb-editor__row`) so empty trailing
+  // cells in the last row do not stretch the row's last bar.
   const barsCount = section.bars.length;
-  section.bars.forEach((bar, barIndex) => {
-    row.appendChild(
-      renderBar(bar, secIndex, barIndex, barsCount, openBarPopover, ops, listen, root),
-    );
+  const rowCount = Math.max(1, Math.ceil(barsCount / BARS_PER_ROW));
+  const grid = el('div', {
+    class: 'irealb-editor__bars',
+    attrs: {
+      role: 'grid',
+      // `aria-rowcount` is at least 1 even for an empty section so
+      // assistive tech announces a stable shape ("1 row, 4 columns")
+      // rather than "0 rows" — which screen readers vary in how they
+      // verbalise. The grid is still empty visually; the count refers
+      // to the implicit row that the next "+ Add bar" insertion will
+      // populate.
+      'aria-rowcount': String(rowCount),
+      'aria-colcount': String(BARS_PER_ROW),
+      'aria-label': `Bars in section ${formatSectionLabel(section.label)}`,
+    },
   });
-  wrapper.appendChild(row);
+
+  for (let rowIdx = 0; rowIdx < Math.ceil(barsCount / BARS_PER_ROW); rowIdx += 1) {
+    const rowEl = el('div', {
+      class: 'irealb-editor__row',
+      attrs: {
+        role: 'row',
+        // 1-based per ARIA spec.
+        'aria-rowindex': String(rowIdx + 1),
+      },
+    });
+    const startBar = rowIdx * BARS_PER_ROW;
+    const endBar = Math.min(startBar + BARS_PER_ROW, barsCount);
+    for (let barIndex = startBar; barIndex < endBar; barIndex += 1) {
+      const bar = section.bars[barIndex];
+      if (!bar) continue;
+      rowEl.appendChild(
+        renderBar(
+          bar,
+          secIndex,
+          barIndex,
+          barsCount,
+          openBarPopover,
+          ops,
+          listen,
+          root,
+          activeBar,
+          setActiveBar,
+        ),
+      );
+    }
+    grid.appendChild(rowEl);
+  }
+  wrapper.appendChild(grid);
 
   // Append-bar trailer.
   const addBarBtn = el('button', {
@@ -381,31 +461,60 @@ function renderBar(
     handler: (ev: HTMLElementEventMap[K]) => void,
   ) => void,
   root: HTMLElement,
+  activeBar: ActiveBarRef | null,
+  setActiveBar: (ref: ActiveBarRef) => void,
 ): HTMLElement {
+  const colIndex = barIndex % BARS_PER_ROW;
   const wrapper = el('div', {
     class: 'irealb-editor__bar-wrapper',
-    attrs: { 'data-bar-index': String(barIndex) },
+    attrs: {
+      'data-bar-index': String(barIndex),
+      role: 'gridcell',
+      // 1-based per ARIA spec, matches the row's `aria-rowindex`
+      // shape so a screen reader announces consistent indices.
+      'aria-colindex': String(colIndex + 1),
+    },
   });
 
   const text = bar.chords.map((c) => formatChord(c.chord)).join(' ');
+  // Roving tabindex (#2368) — only the active bar receives
+  // `tabindex="0"`; every other cell is `tabindex="-1"` so the
+  // entire grid contributes a single Tab stop. Per the W3C APG
+  // grid pattern, Arrow / Home / End cycle focus inside the grid;
+  // Tab moves to the next interactive element after the grid.
+  const isActiveBar =
+    activeBar !== null &&
+    activeBar.secIndex === secIndex &&
+    activeBar.barIndex === barIndex;
   // `<button type="button">` so the cell announces as a button to
   // screen readers and so Enter / Space activation works without
-  // explicit keyboard handlers. ARIA grid semantics on the wrapping
-  // grid (`role="grid"` / `gridcell`) are deferred to #2368.
+  // explicit keyboard handlers.
   const cell = el('button', {
     class: 'irealb-editor__bar',
     attrs: {
       type: 'button',
       'aria-label': `Edit bar ${barIndex + 1}`,
+      tabindex: isActiveBar ? '0' : '-1',
     },
     text: text || ' ', // U+00A0 keeps empty cells height-stable.
   });
   listen(cell, 'click', () => {
     openBarPopover(bar, cell, secIndex, barIndex);
   });
-  // Keyboard shortcuts (#2376) for the focused bar cell:
-  //   Delete / Backspace          → remove the bar
-  //   Alt+ArrowLeft / ArrowRight  → reorder within the section
+  // Track focus to keep the roving-tabindex active ref in sync.
+  // Persisting via the adapter (rather than mutating sibling
+  // `tabindex` attributes here) means a re-render driven by a
+  // structural op keeps the right cell focusable, even though the
+  // DOM nodes themselves are rebuilt.
+  listen(cell, 'focus', () => {
+    setActiveBar({ secIndex, barIndex });
+  });
+  // Keyboard shortcuts for the focused bar cell:
+  //   Arrow{Left,Right,Up,Down}    → roving navigation within section (#2368)
+  //   Home / End                   → first / last bar of the section (#2368)
+  //   Enter / Space                → open popover (default <button> activation)
+  //   Delete / Backspace           → remove the bar (#2376)
+  //   Alt+ArrowLeft / ArrowRight   → reorder within the section (#2376)
   // Behaviour mirrors the per-bar `×` / `←` / `→` UI buttons. The
   // delete shortcut intentionally has no confirmation prompt — the
   // UI `×` button is also unconfirmed, and an asymmetric path would
@@ -489,7 +598,13 @@ function handleBarCellKeydown(
   // honouring the focus trap) can bypass the trap; bailing on an
   // active popover keeps destructive shortcuts off the cell while a
   // modal owns the user's input.
-  if (root.querySelector('.irealb-editor__popover') !== null) return;
+  //
+  // Walk up to the editor root because the popover is mounted under
+  // the editor's `element` (one level above `root`, which is a
+  // dedicated grid sub-container as of #2368) — querying within
+  // `root` alone would miss the popover.
+  const editorRoot = root.closest<HTMLElement>('.irealb-editor') ?? root;
+  if (editorRoot.querySelector('.irealb-editor__popover') !== null) return;
 
   // Reject any modifier combination outside the two we recognise.
   // `ctrlKey` / `metaKey` are always disqualifying; `shiftKey` is
@@ -512,6 +627,43 @@ function handleBarCellKeydown(
       return;
     }
     return;
+  }
+
+  // Roving navigation (#2368). All four arrows + Home + End move
+  // focus *within the current section's grid*; navigation does not
+  // cross section boundaries. The W3C APG grid pattern says Up /
+  // Down should move by row — with `BARS_PER_ROW` cells per row,
+  // Up subtracts 4 from `barIndex` and Down adds 4. Home jumps to
+  // the first bar of the section, End to the last.
+  if (!ev.altKey && !ev.shiftKey) {
+    let nextBarIndex: number | null = null;
+    switch (ev.key) {
+      case 'ArrowLeft':
+        if (barIndex > 0) nextBarIndex = barIndex - 1;
+        break;
+      case 'ArrowRight':
+        if (barIndex < barsCount - 1) nextBarIndex = barIndex + 1;
+        break;
+      case 'ArrowUp':
+        if (barIndex - BARS_PER_ROW >= 0) nextBarIndex = barIndex - BARS_PER_ROW;
+        break;
+      case 'ArrowDown':
+        if (barIndex + BARS_PER_ROW < barsCount) {
+          nextBarIndex = barIndex + BARS_PER_ROW;
+        }
+        break;
+      case 'Home':
+        if (barIndex !== 0) nextBarIndex = 0;
+        break;
+      case 'End':
+        if (barIndex !== barsCount - 1) nextBarIndex = barsCount - 1;
+        break;
+    }
+    if (nextBarIndex !== null) {
+      ev.preventDefault();
+      focusBarCell(root, secIndex, nextBarIndex);
+      return;
+    }
   }
 
   if (!ev.altKey && !ev.shiftKey && (ev.key === 'Delete' || ev.key === 'Backspace')) {

--- a/packages/ui-irealb-editor/src/style.css
+++ b/packages/ui-irealb-editor/src/style.css
@@ -17,6 +17,23 @@
   overflow: auto;
 }
 
+/* Visually-hidden but reachable by screen readers — used by the
+ * announce() helper in `index.ts` (#2368) to surface structural
+ * edits ("Bar 5 deleted", "Section B added") in an ARIA live
+ * region without occupying visual layout. The classic clip-rect
+ * pattern keeps the node in the accessibility tree. */
+.irealb-editor__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .irealb-editor__header {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -148,9 +165,19 @@
   background: #e4ebf1;
 }
 
-/* 4 bars per line. The grid wraps when the section has more than
- * 4 bars; sections with <4 bars right-pad with empty grid cells. */
+/* 4 bars per line. Bars are grouped into `.irealb-editor__row`
+ * children so the ARIA grid semantics added in #2368
+ * (`role="row"` per row, `role="gridcell"` per bar wrapper)
+ * line up with the visual wrap. The CSS layout moves to each
+ * row so a partial last row does not stretch its bars across
+ * the full grid width. */
 .irealb-editor__bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.irealb-editor__row {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.25rem;

--- a/packages/ui-irealb-editor/src/style.css
+++ b/packages/ui-irealb-editor/src/style.css
@@ -30,6 +30,10 @@
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
+  /* clip-path is the modern replacement for the deprecated clip
+   * property. Both are present so the element is hidden on all
+   * supported browser versions. */
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/packages/ui-irealb-editor/tests/aria-grid.test.ts
+++ b/packages/ui-irealb-editor/tests/aria-grid.test.ts
@@ -161,7 +161,10 @@ describe('ARIA grid semantics', () => {
     }
   });
 
-  test('empty section still carries role="grid" with aria-rowcount=1', () => {
+  test('empty section reports aria-rowcount=0 matching the empty accessibility tree', () => {
+    // ARIA 1.2: `aria-rowcount` SHOULD agree with the rendered
+    // `role="row"` descendant count. An empty section has zero
+    // rows and zero cells — both the attribute and the DOM agree.
     const wasm = makeStubWasm({
       title: 't',
       composer: null,
@@ -177,7 +180,10 @@ describe('ARIA grid semantics', () => {
       const grid = editor.element.querySelector('.irealb-editor__bars');
       expect(grid).not.toBeNull();
       expect((grid as HTMLElement).getAttribute('role')).toBe('grid');
-      expect((grid as HTMLElement).getAttribute('aria-rowcount')).toBe('1');
+      expect((grid as HTMLElement).getAttribute('aria-rowcount')).toBe('0');
+      // No `role="row"` children either — keeps the rendered tree
+      // consistent with the announced rowcount.
+      expect(editor.element.querySelectorAll('.irealb-editor__row').length).toBe(0);
       expect(getCells(editor).length).toBe(0);
     } finally {
       editor.destroy();
@@ -231,20 +237,125 @@ describe('roving tabindex', () => {
       titleInput.dispatchEvent(new Event('input', { bubbles: true }));
       // Title edit doesn't trigger renderNow (form-only), so cells
       // remain. The roving state was updated by the focus listener
-      // (fired by `cell2.focus()`). Trigger a renderNow via deleteBar
-      // on a different bar so the new cells reflect activeBar.
+      // (fired by `cell2.focus()`). Trigger a renderNow via
+      // deleteBar so the post-render cells reflect activeBar.
+      // Note: this assertion verifies the "exactly one cell remains
+      // tabbable after a structural rerender" invariant, not the
+      // identity of the surviving cell — the active bar may shift
+      // when an earlier sibling is removed.
       const deleteBtns = Array.from(
         editor.element.querySelectorAll<HTMLButtonElement>(
           'button[aria-label="Delete bar"]',
         ),
       );
-      // Delete the first bar so the active bar (index 2) re-anchors
-      // — index 2 of the post-delete grid is the same logical cell,
-      // and its tabindex should be 0.
       deleteBtns[0]?.click();
       const cellsAfter = getCells(editor);
       const tabbable = cellsAfter.filter((c) => c.tabIndex === 0);
       expect(tabbable.length).toBe(1);
+    });
+    editor.destroy();
+  });
+
+  test('moving a section preserves the active bar against the moved section, not the index', () => {
+    // Two sections (A, B), each with 2 bars. Focus a bar in section
+    // A (the upper one), then move section A down. The active bar
+    // should follow section A to its new position rather than stay
+    // at the old numeric secIndex (which now references section B).
+    const wasm = makeStubWasm({
+      title: 'Move test',
+      composer: null,
+      style: null,
+      key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+      time_signature: { numerator: 4, denominator: 4 },
+      tempo: null,
+      transpose: 0,
+      sections: [
+        {
+          label: { kind: 'letter', value: 'A' },
+          bars: [
+            {
+              start: 'single', end: 'single', chords: [
+                {
+                  chord: {
+                    root: { note: 'C', accidental: 'natural' },
+                    quality: { kind: 'major' },
+                    bass: null,
+                  },
+                  position: { beat: 1, subdivision: 0 },
+                },
+              ], ending: null, symbol: null,
+            },
+            {
+              start: 'single', end: 'single', chords: [
+                {
+                  chord: {
+                    root: { note: 'F', accidental: 'natural' },
+                    quality: { kind: 'major' },
+                    bass: null,
+                  },
+                  position: { beat: 1, subdivision: 0 },
+                },
+              ], ending: null, symbol: null,
+            },
+          ],
+        },
+        {
+          label: { kind: 'letter', value: 'B' },
+          bars: [
+            {
+              start: 'single', end: 'single', chords: [
+                {
+                  chord: {
+                    root: { note: 'G', accidental: 'natural' },
+                    quality: { kind: 'major' },
+                    bass: null,
+                  },
+                  position: { beat: 1, subdivision: 0 },
+                },
+              ], ending: null, symbol: null,
+            },
+            {
+              start: 'single', end: 'single', chords: [
+                {
+                  chord: {
+                    root: { note: 'A', accidental: 'natural' },
+                    quality: { kind: 'major' },
+                    bass: null,
+                  },
+                  position: { beat: 1, subdivision: 0 },
+                },
+              ], ending: null, symbol: null,
+            },
+          ],
+        },
+      ],
+    });
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      // Focus the second bar of section A (the F chord, index 1
+      // within section index 0).
+      const sectionA = editor.element.querySelector<HTMLElement>(
+        '.irealb-editor__section[data-section-index="0"]',
+      );
+      const sectionACells = sectionA?.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar');
+      sectionACells?.[1]?.focus();
+      expect(sectionACells?.[1]?.textContent).toContain('F');
+
+      // Move section A down. Section A now sits at secIndex=1, B at 0.
+      const sectionADownBtn = sectionA?.querySelector<HTMLButtonElement>(
+        'button[aria-label="Move section down"]',
+      );
+      sectionADownBtn?.click();
+
+      // The tabbable cell should be in the new section A position
+      // (now secIndex=1), at the same barIndex (1, the F chord).
+      const newSectionA = editor.element.querySelector<HTMLElement>(
+        '.irealb-editor__section[data-section-index="1"]',
+      );
+      const newCells = newSectionA?.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar');
+      const tabbable = Array.from(newCells ?? []).filter((c) => c.tabIndex === 0);
+      expect(tabbable.length).toBe(1);
+      expect(tabbable[0]?.textContent).toContain('F');
     });
     editor.destroy();
   });

--- a/packages/ui-irealb-editor/tests/aria-grid.test.ts
+++ b/packages/ui-irealb-editor/tests/aria-grid.test.ts
@@ -1,0 +1,561 @@
+// Vitest cases for the ARIA grid semantics, roving tabindex, arrow-
+// key navigation, and live-region announcements added in #2368.
+//
+// These complement `keyboard.test.ts` (Delete / Backspace / Alt+Arrow
+// from #2376) — that suite covers structural shortcuts, this suite
+// covers the W3C APG roving-tabindex grid pattern + assistive-tech
+// surface.
+
+import { describe, expect, test, vi } from 'vitest';
+import { createIrealbEditor, type IrealbWasm } from '../src/index';
+import type { IrealSong } from '../src/ast';
+
+/** Build a song with `barsCount` bars in a single section. Only the
+ * barIndex matters for the grid-shape tests, so the chord values are
+ * stub C major across the board. */
+function makeSongWithBars(barsCount: number): IrealSong {
+  const bars = [];
+  for (let i = 0; i < barsCount; i += 1) {
+    bars.push({
+      start: 'single' as const,
+      end: 'single' as const,
+      chords: [
+        {
+          chord: {
+            root: { note: 'C' as const, accidental: 'natural' as const },
+            quality: { kind: 'major' as const },
+            bass: null,
+          },
+          position: { beat: 1, subdivision: 0 },
+        },
+      ],
+      ending: null,
+      symbol: null,
+    });
+  }
+  return {
+    title: 'Aria Grid Sample',
+    composer: null,
+    style: null,
+    key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+    time_signature: { numerator: 4, denominator: 4 },
+    tempo: null,
+    transpose: 0,
+    sections: [
+      {
+        label: { kind: 'letter', value: 'A' },
+        bars,
+      },
+    ],
+  };
+}
+
+const SAMPLE_URL = 'irealb://aria-sample';
+
+function makeStubWasm(song: IrealSong): IrealbWasm & {
+  parseIrealb: ReturnType<typeof vi.fn>;
+  serializeIrealb: ReturnType<typeof vi.fn>;
+} {
+  const parseIrealb = vi.fn((input: string): string => {
+    if (input === SAMPLE_URL) return JSON.stringify(song);
+    if (input.startsWith('irealb://json:')) {
+      return decodeURIComponent(input.slice('irealb://json:'.length));
+    }
+    throw new Error(`stub parseIrealb: unknown URL: ${input}`);
+  });
+  const serializeIrealb = vi.fn(
+    (input: string): string => `irealb://json:${encodeURIComponent(input)}`,
+  );
+  return { parseIrealb, serializeIrealb };
+}
+
+interface KeydownOptions {
+  alt?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+}
+
+function dispatchKey(target: HTMLElement, key: string, opts: KeydownOptions = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    altKey: opts.alt ?? false,
+    ctrlKey: opts.ctrl ?? false,
+    metaKey: opts.meta ?? false,
+    shiftKey: opts.shift ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function getCells(editor: ReturnType<typeof createIrealbEditor>): HTMLButtonElement[] {
+  return Array.from(
+    editor.element.querySelectorAll<HTMLButtonElement>('.irealb-editor__bar'),
+  );
+}
+
+function withMounted<T>(
+  editor: ReturnType<typeof createIrealbEditor>,
+  fn: () => T,
+): T {
+  document.body.appendChild(editor.element);
+  try {
+    return fn();
+  } finally {
+    editor.element.remove();
+  }
+}
+
+describe('ARIA grid semantics', () => {
+  test('grid carries role="grid" with aria-rowcount and aria-colcount', () => {
+    const wasm = makeStubWasm(makeSongWithBars(7));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const grids = editor.element.querySelectorAll('.irealb-editor__bars');
+      expect(grids.length).toBe(1);
+      const grid = grids[0] as HTMLElement;
+      expect(grid.getAttribute('role')).toBe('grid');
+      // 7 bars / 4 per row → 2 rows (4 + 3).
+      expect(grid.getAttribute('aria-rowcount')).toBe('2');
+      expect(grid.getAttribute('aria-colcount')).toBe('4');
+      // The grid label includes the section label so an assistive
+      // tech traversing multiple sections distinguishes them.
+      expect(grid.getAttribute('aria-label')).toContain('section A');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('rows carry role="row" with 1-based aria-rowindex', () => {
+    const wasm = makeStubWasm(makeSongWithBars(7));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const rows = editor.element.querySelectorAll('.irealb-editor__row');
+      expect(rows.length).toBe(2);
+      expect((rows[0] as HTMLElement).getAttribute('role')).toBe('row');
+      expect((rows[0] as HTMLElement).getAttribute('aria-rowindex')).toBe('1');
+      expect((rows[1] as HTMLElement).getAttribute('aria-rowindex')).toBe('2');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('bar wrappers carry role="gridcell" with 1-based aria-colindex', () => {
+    const wasm = makeStubWasm(makeSongWithBars(6));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const wrappers = editor.element.querySelectorAll('.irealb-editor__bar-wrapper');
+      expect(wrappers.length).toBe(6);
+      // First row: bars 0-3, colindex 1-4.
+      expect((wrappers[0] as HTMLElement).getAttribute('role')).toBe('gridcell');
+      expect((wrappers[0] as HTMLElement).getAttribute('aria-colindex')).toBe('1');
+      expect((wrappers[3] as HTMLElement).getAttribute('aria-colindex')).toBe('4');
+      // Second row: bars 4-5, colindex 1-2 (the row counter wraps;
+      // colindex restarts from 1 in each row per the wrap layout).
+      expect((wrappers[4] as HTMLElement).getAttribute('aria-colindex')).toBe('1');
+      expect((wrappers[5] as HTMLElement).getAttribute('aria-colindex')).toBe('2');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('empty section still carries role="grid" with aria-rowcount=1', () => {
+    const wasm = makeStubWasm({
+      title: 't',
+      composer: null,
+      style: null,
+      key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+      time_signature: { numerator: 4, denominator: 4 },
+      tempo: null,
+      transpose: 0,
+      sections: [{ label: { kind: 'letter', value: 'A' }, bars: [] }],
+    });
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const grid = editor.element.querySelector('.irealb-editor__bars');
+      expect(grid).not.toBeNull();
+      expect((grid as HTMLElement).getAttribute('role')).toBe('grid');
+      expect((grid as HTMLElement).getAttribute('aria-rowcount')).toBe('1');
+      expect(getCells(editor).length).toBe(0);
+    } finally {
+      editor.destroy();
+    }
+  });
+});
+
+describe('roving tabindex', () => {
+  test('exactly one bar cell has tabindex="0" on initial render', () => {
+    const wasm = makeStubWasm(makeSongWithBars(5));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const cells = getCells(editor);
+      const tabbable = cells.filter((c) => c.tabIndex === 0);
+      expect(tabbable.length).toBe(1);
+      // First bar is the default active cell.
+      expect(cells[0]?.tabIndex).toBe(0);
+      expect(cells[1]?.tabIndex).toBe(-1);
+      expect(cells[4]?.tabIndex).toBe(-1);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('focusing a different cell makes it the tabbable one after the next render', () => {
+    const wasm = makeStubWasm(makeSongWithBars(5));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      const cell2 = cells[2];
+      if (!cell2) throw new Error('cell2 missing');
+      cell2.focus();
+      expect(document.activeElement).toBe(cell2);
+      // The DOM does not yet reflect the new tabindex (we only
+      // restamp on render). After we trigger a re-render via a
+      // structural op (e.g. add bar), the new active cell should
+      // be cell index 2 — which after a no-op no-mutation render
+      // means the carry-over via setActiveBar persisted.
+      // Easier: directly trigger setValue('') then the original
+      // URL to force a renderNow() and check the post-render
+      // tabindex distribution.
+      const onChange = vi.fn();
+      editor.onChange(onChange);
+      // Force a re-render by updating a metadata field: changing the
+      // title via the rendered <input>.
+      const titleInput = editor.element.querySelector<HTMLInputElement>(
+        '.irealb-editor__input',
+      );
+      if (!titleInput) throw new Error('title input missing');
+      titleInput.value = 'updated';
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+      // Title edit doesn't trigger renderNow (form-only), so cells
+      // remain. The roving state was updated by the focus listener
+      // (fired by `cell2.focus()`). Trigger a renderNow via deleteBar
+      // on a different bar so the new cells reflect activeBar.
+      const deleteBtns = Array.from(
+        editor.element.querySelectorAll<HTMLButtonElement>(
+          'button[aria-label="Delete bar"]',
+        ),
+      );
+      // Delete the first bar so the active bar (index 2) re-anchors
+      // — index 2 of the post-delete grid is the same logical cell,
+      // and its tabindex should be 0.
+      deleteBtns[0]?.click();
+      const cellsAfter = getCells(editor);
+      const tabbable = cellsAfter.filter((c) => c.tabIndex === 0);
+      expect(tabbable.length).toBe(1);
+    });
+    editor.destroy();
+  });
+
+  test('after deleting the active bar, a sibling becomes the tabbable cell', () => {
+    const wasm = makeStubWasm(makeSongWithBars(5));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[4]?.focus(); // active bar = last
+      const deleteBtns = Array.from(
+        editor.element.querySelectorAll<HTMLButtonElement>(
+          'button[aria-label="Delete bar"]',
+        ),
+      );
+      deleteBtns[4]?.click(); // delete the last bar
+      const cellsAfter = getCells(editor);
+      expect(cellsAfter.length).toBe(4);
+      const tabbable = cellsAfter.filter((c) => c.tabIndex === 0);
+      // The active ref was clamped to barIndex - 1 (== last
+      // remaining bar, index 3). One cell tabbable.
+      expect(tabbable.length).toBe(1);
+      expect(cellsAfter[3]?.tabIndex).toBe(0);
+    });
+    editor.destroy();
+  });
+});
+
+describe('arrow-key roving navigation', () => {
+  test('ArrowRight moves focus to the next bar', () => {
+    const wasm = makeStubWasm(makeSongWithBars(8));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[0]?.focus();
+      dispatchKey(cells[0] as HTMLElement, 'ArrowRight');
+      expect(document.activeElement).toBe(cells[1]);
+    });
+    editor.destroy();
+  });
+
+  test('ArrowLeft moves focus to the previous bar', () => {
+    const wasm = makeStubWasm(makeSongWithBars(8));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[3]?.focus();
+      dispatchKey(cells[3] as HTMLElement, 'ArrowLeft');
+      expect(document.activeElement).toBe(cells[2]);
+    });
+    editor.destroy();
+  });
+
+  test('ArrowDown moves focus by one row (4 bars)', () => {
+    const wasm = makeStubWasm(makeSongWithBars(8));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[1]?.focus();
+      dispatchKey(cells[1] as HTMLElement, 'ArrowDown');
+      expect(document.activeElement).toBe(cells[5]);
+    });
+    editor.destroy();
+  });
+
+  test('ArrowUp moves focus by one row (4 bars)', () => {
+    const wasm = makeStubWasm(makeSongWithBars(8));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[6]?.focus();
+      dispatchKey(cells[6] as HTMLElement, 'ArrowUp');
+      expect(document.activeElement).toBe(cells[2]);
+    });
+    editor.destroy();
+  });
+
+  test('Home jumps focus to the first bar of the section', () => {
+    const wasm = makeStubWasm(makeSongWithBars(7));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[5]?.focus();
+      dispatchKey(cells[5] as HTMLElement, 'Home');
+      expect(document.activeElement).toBe(cells[0]);
+    });
+    editor.destroy();
+  });
+
+  test('End jumps focus to the last bar of the section', () => {
+    const wasm = makeStubWasm(makeSongWithBars(7));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[2]?.focus();
+      dispatchKey(cells[2] as HTMLElement, 'End');
+      expect(document.activeElement).toBe(cells[6]);
+    });
+    editor.destroy();
+  });
+
+  test('arrow keys are bounded — ArrowLeft on first bar is a no-op', () => {
+    const wasm = makeStubWasm(makeSongWithBars(4));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[0]?.focus();
+      const ev = dispatchKey(cells[0] as HTMLElement, 'ArrowLeft');
+      // Bounded no-op: focus stays, default not prevented.
+      expect(document.activeElement).toBe(cells[0]);
+      expect(ev.defaultPrevented).toBe(false);
+    });
+    editor.destroy();
+  });
+
+  test('ArrowDown without enough rows is a bounded no-op', () => {
+    const wasm = makeStubWasm(makeSongWithBars(3)); // single row
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[1]?.focus();
+      dispatchKey(cells[1] as HTMLElement, 'ArrowDown');
+      expect(document.activeElement).toBe(cells[1]);
+    });
+    editor.destroy();
+  });
+
+  test('arrow keys with Ctrl/Meta do not roving-navigate (passes through to OS)', () => {
+    const wasm = makeStubWasm(makeSongWithBars(8));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      cells[0]?.focus();
+      dispatchKey(cells[0] as HTMLElement, 'ArrowRight', { ctrl: true });
+      expect(document.activeElement).toBe(cells[0]);
+      dispatchKey(cells[0] as HTMLElement, 'ArrowRight', { meta: true });
+      expect(document.activeElement).toBe(cells[0]);
+    });
+    editor.destroy();
+  });
+});
+
+describe('Enter / Space activation opens the popover', () => {
+  test('Enter on a bar cell opens the bar-edit popover', () => {
+    const wasm = makeStubWasm(makeSongWithBars(2));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    withMounted(editor, () => {
+      const cells = getCells(editor);
+      // <button type="button"> activates on Enter via the synthetic
+      // click the browser dispatches; jsdom mirrors that. The
+      // resulting click handler opens the popover.
+      cells[0]?.click();
+      const popover = editor.element.querySelector('.irealb-editor__popover');
+      expect(popover).not.toBeNull();
+      expect((popover as HTMLElement).getAttribute('role')).toBe('dialog');
+      expect((popover as HTMLElement).getAttribute('aria-modal')).toBe('true');
+    });
+    editor.destroy();
+  });
+});
+
+describe('live region announces structural edits', () => {
+  function getLive(editor: ReturnType<typeof createIrealbEditor>): HTMLElement {
+    const live = editor.element.querySelector('.irealb-editor__live');
+    if (!(live instanceof HTMLElement)) {
+      throw new Error('live region not mounted');
+    }
+    return live;
+  }
+
+  test('live region exists with aria-live="polite" and aria-atomic="true"', () => {
+    const wasm = makeStubWasm(makeSongWithBars(2));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const live = getLive(editor);
+      expect(live.getAttribute('aria-live')).toBe('polite');
+      expect(live.getAttribute('aria-atomic')).toBe('true');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('deleting a bar announces "Bar N deleted from section L"', async () => {
+    const wasm = makeStubWasm(makeSongWithBars(3));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const live = getLive(editor);
+      const deleteBtns = Array.from(
+        editor.element.querySelectorAll<HTMLButtonElement>(
+          'button[aria-label="Delete bar"]',
+        ),
+      );
+      deleteBtns[1]?.click();
+      // Announcement is queued via queueMicrotask — flush.
+      await Promise.resolve();
+      expect(live.textContent).toContain('Bar 2 deleted');
+      expect(live.textContent).toContain('section A');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('adding a bar announces "Bar N added to section L"', async () => {
+    const wasm = makeStubWasm(makeSongWithBars(2));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const live = getLive(editor);
+      const addBarBtn = editor.element.querySelector<HTMLButtonElement>(
+        '.irealb-editor__add-bar',
+      );
+      addBarBtn?.click();
+      await Promise.resolve();
+      expect(live.textContent).toContain('Bar 3 added');
+      expect(live.textContent).toContain('section A');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('adding a section announces "Section L added"', async () => {
+    const wasm = makeStubWasm(makeSongWithBars(1));
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      promptSectionLabel: () => ({ kind: 'letter', value: 'B' }),
+    });
+    try {
+      const live = getLive(editor);
+      const addSectionBtn = editor.element.querySelector<HTMLButtonElement>(
+        '.irealb-editor__add-section',
+      );
+      addSectionBtn?.click();
+      await Promise.resolve();
+      expect(live.textContent).toContain('Section B added');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('deleting a section announces "Section L deleted"', async () => {
+    const wasm = makeStubWasm(makeSongWithBars(1));
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      confirmDeleteSection: () => true,
+    });
+    try {
+      const live = getLive(editor);
+      const deleteSectionBtn = editor.element.querySelector<HTMLButtonElement>(
+        'button[aria-label="Delete section"]',
+      );
+      deleteSectionBtn?.click();
+      await Promise.resolve();
+      expect(live.textContent).toContain('Section A deleted');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('moving a bar announces "Bar N moved left/right"', async () => {
+    const wasm = makeStubWasm(makeSongWithBars(3));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const live = getLive(editor);
+      const rightBtns = Array.from(
+        editor.element.querySelectorAll<HTMLButtonElement>(
+          'button[aria-label="Move bar right"]',
+        ),
+      );
+      rightBtns[0]?.click();
+      await Promise.resolve();
+      expect(live.textContent).toContain('Bar 1 moved right');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('two consecutive identical announcements both populate the region (empty-then-set)', async () => {
+    // Polite live regions only fire when text content changes. The
+    // announce() implementation blanks the region first via
+    // queueMicrotask so two consecutive identical messages still
+    // trigger an announcement. Verify the empty-then-set transition
+    // is observable by inspecting the region between flushes.
+    const wasm = makeStubWasm(makeSongWithBars(3));
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const live = getLive(editor);
+      const rightBtns = (): HTMLButtonElement[] =>
+        Array.from(
+          editor.element.querySelectorAll<HTMLButtonElement>(
+            'button[aria-label="Move bar right"]',
+          ),
+        );
+
+      // First click: synchronous side effect blanks the region;
+      // microtask populates it.
+      rightBtns()[0]?.click();
+      expect(live.textContent).toBe('');
+      await Promise.resolve();
+      expect(live.textContent).toContain('moved right');
+
+      // Second click on what is now bar 2 (post-move): same blank-
+      // then-set transition; the region empties and re-populates so
+      // the screen reader observes a change even though the message
+      // is identical.
+      rightBtns()[1]?.click();
+      expect(live.textContent).toBe('');
+      await Promise.resolve();
+      expect(live.textContent).toContain('moved right');
+    } finally {
+      editor.destroy();
+    }
+  });
+});

--- a/packages/ui-irealb-editor/tests/aria-grid.test.ts
+++ b/packages/ui-irealb-editor/tests/aria-grid.test.ts
@@ -669,4 +669,107 @@ describe('live region announces structural edits', () => {
       editor.destroy();
     }
   });
+
+  test('renaming a section announces "Section renamed from L to L2"', async () => {
+    const wasm = makeStubWasm(makeSongWithBars(1));
+    const editor = createIrealbEditor({
+      initialValue: SAMPLE_URL,
+      wasm,
+      // Stub that always renames to section B, regardless of current label.
+      promptSectionLabel: () => ({ kind: 'letter', value: 'B' }),
+    });
+    try {
+      const live = getLive(editor);
+      const renameBtn = editor.element.querySelector<HTMLButtonElement>(
+        'button[aria-label="Rename section"]',
+      );
+      renameBtn?.click();
+      await Promise.resolve();
+      expect(live.textContent).toContain('renamed');
+      expect(live.textContent).toContain('A');
+      expect(live.textContent).toContain('B');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('moving a section up announces "Section L moved up"', async () => {
+    // Two-section song so section B (index 1) can move up.
+    const song: IrealSong = {
+      title: 'Move-section announce test',
+      composer: null,
+      style: null,
+      key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+      time_signature: { numerator: 4, denominator: 4 },
+      tempo: null,
+      transpose: 0,
+      sections: [
+        {
+          label: { kind: 'letter', value: 'A' },
+          bars: [{ start: 'single', end: 'single', chords: [], ending: null, symbol: null }],
+        },
+        {
+          label: { kind: 'letter', value: 'B' },
+          bars: [{ start: 'single', end: 'single', chords: [], ending: null, symbol: null }],
+        },
+      ],
+    };
+    const wasm = makeStubWasm(song);
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const live = getLive(editor);
+      // Section B is at index 1; click its "Move section up" button.
+      const sectionEls = editor.element.querySelectorAll<HTMLElement>(
+        '.irealb-editor__section',
+      );
+      const upBtn = sectionEls[1]?.querySelector<HTMLButtonElement>(
+        'button[aria-label="Move section up"]',
+      );
+      upBtn?.click();
+      await Promise.resolve();
+      expect(live.textContent).toContain('Section B moved up');
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test('moving a section down announces "Section L moved down"', async () => {
+    // Two-section song so section A (index 0) can move down.
+    const song: IrealSong = {
+      title: 'Move-section announce test',
+      composer: null,
+      style: null,
+      key_signature: { root: { note: 'C', accidental: 'natural' }, mode: 'major' },
+      time_signature: { numerator: 4, denominator: 4 },
+      tempo: null,
+      transpose: 0,
+      sections: [
+        {
+          label: { kind: 'letter', value: 'A' },
+          bars: [{ start: 'single', end: 'single', chords: [], ending: null, symbol: null }],
+        },
+        {
+          label: { kind: 'letter', value: 'B' },
+          bars: [{ start: 'single', end: 'single', chords: [], ending: null, symbol: null }],
+        },
+      ],
+    };
+    const wasm = makeStubWasm(song);
+    const editor = createIrealbEditor({ initialValue: SAMPLE_URL, wasm });
+    try {
+      const live = getLive(editor);
+      // Section A is at index 0; click its "Move section down" button.
+      const sectionEls = editor.element.querySelectorAll<HTMLElement>(
+        '.irealb-editor__section',
+      );
+      const downBtn = sectionEls[0]?.querySelector<HTMLButtonElement>(
+        'button[aria-label="Move section down"]',
+      );
+      downBtn?.click();
+      await Promise.resolve();
+      expect(live.textContent).toContain('Section A moved down');
+    } finally {
+      editor.destroy();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes #2368. Final sub-issue of #2357 bar-grid GUI editor (sub-issue [7]).

- **Roving tabindex** (W3C APG grid pattern): each section's bar grid contributes
  one Tab stop. Active bar carries \`tabindex=\"0\"\`; the rest \`-1\`. Focus
  follows the user; the active ref reconciles after every render so a
  delete / truncate cannot leave the grid with zero Tab stops.
- **Arrow / Home / End navigation** within a section. Up / Down step by row
  (4 bars). Modifier-gated: Ctrl / Meta arrows pass through to the OS;
  Alt+Arrow continues to drive bar reordering (#2376).
- **Enter / Space** activates the cell (existing default \`<button>\` behaviour),
  opening the bar-edit popover.
- **ARIA grid semantics**: \`.irealb-editor__bars\` is \`role=\"grid\"\` with
  \`aria-rowcount\` / \`aria-colcount\`. New \`.irealb-editor__row\` wrappers
  carry \`role=\"row\"\` / \`aria-rowindex\`; bar wrappers carry
  \`role=\"gridcell\"\` / \`aria-colindex\`.
- **Live region**: a single \`aria-live=\"polite\" aria-atomic=\"true\"\`
  region announces structural edits (\"Bar 5 deleted from section A\",
  \"Section B added\", \"Section A moved up\", \"Bar 3 moved right\").
  Mounted as a sibling of the rebuilt grid so it survives re-renders.

## Why

#2368 is the accessibility gate for the iRealb bar-grid GUI editor (#2357
tracker). The popover's APG dialog pattern (focus trap + Escape + return
focus) was already in place; this PR closes the grid side: keyboard-only
operability, screen-reader-correct grid semantics, and structural-edit
announcements that a non-sighted user would otherwise miss.

## Test plan

- [x] \`packages/ui-irealb-editor\` vitest — 94 tests pass (70 existing + 24 new)
- [x] \`packages/ui-irealb-editor\` \`tsc --noEmit\` — clean
- [ ] Manual smoke: drive the bar grid with keyboard only, verify NVDA / VoiceOver
      announces grid semantics and structural changes

## Sister-site audit

- Live-region pattern matches \`@chordsketch/ui-web\`'s transpose live region
  (the \`<span class=\"sr-only\" aria-live=\"polite\" aria-atomic=\"true\">\`
  in \`packages/ui-web/src/index.ts\`). Both use the same \`aria-live\` /
  \`aria-atomic\` shape and the same visually-hidden CSS pattern.
- Roving tabindex matches the \`Transpose\` button trio's role=group pattern
  in spirit: one logical control cluster, single Tab stop. The grid uses
  \`role=\"grid\"\` instead of \`role=\"group\"\` because of the 2D navigation.
- Existing \`Alt+ArrowLeft / ArrowRight\` shortcuts (#2376) are preserved
  byte-equal — the new plain-Arrow handler is gated on \`!ev.altKey\` so
  the two paths do not interfere.

## Deferred

None.

Closes #2368