### PR TITLE
docs(wasm): add iReal Pro API subsection to crates/wasm/README.md

### DIFF
--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -58,29 +58,65 @@ a dual-package layout).
 
 ## API
 
-The exported wasm-bindgen functions are:
+The exported wasm-bindgen functions are grouped below. The
+`### iReal Pro` subsection mirrors the structure of the
+[`### iReal Pro conversion` table in `packages/npm/README.md`](https://github.com/koedame/chordsketch/blob/main/packages/npm/README.md#ireal-pro-conversion)
+and stays in lockstep with the `*_ireal*` / `*_irealb*` /
+`convert_*irealb*` exports in
+[`crates/wasm/src/lib.rs`](src/lib.rs).
+
+### Basic rendering
 
 | Function | Description | Return type |
 |---|---|---|
 | `render_text(input)` | Render ChordPro to plain text | `string` |
 | `render_html(input)` | Render ChordPro to HTML5 | `string` |
 | `render_pdf(input)` | Render ChordPro to a PDF byte array | `Uint8Array` |
-| `render_text_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `string` |
-| `render_html_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `string` |
-| `render_pdf_with_options(input, opts)` | Same, with `{ transpose?, config? }` | `Uint8Array` |
+
+### Rendering with options
+
+| Function | Description | Return type |
+|---|---|---|
+| `render_text_with_options(input, opts)` | Same as `render_text`, with `{ transpose?, config? }` | `string` |
+| `render_html_with_options(input, opts)` | Same as `render_html`, with `{ transpose?, config? }` | `string` |
+| `render_pdf_with_options(input, opts)` | Same as `render_pdf`, with `{ transpose?, config? }` | `Uint8Array` |
+
+### Captured warnings
+
+| Function | Description | Return type |
+|---|---|---|
 | `renderTextWithWarnings(input)` | Plain-text render that captures warnings instead of forwarding to `console.warn` | `{ output: string, warnings: string[] }` |
 | `renderHtmlWithWarnings(input)` | HTML render with captured warnings | `{ output: string, warnings: string[] }` |
 | `renderPdfWithWarnings(input)` | PDF render with captured warnings | `{ output: Uint8Array, warnings: string[] }` |
 | `renderTextWithWarningsAndOptions(input, opts)` | `renderTextWithWarnings` + `{ transpose?, config? }` options | `{ output: string, warnings: string[] }` |
 | `renderHtmlWithWarningsAndOptions(input, opts)` | `renderHtmlWithWarnings` + `{ transpose?, config? }` options | `{ output: string, warnings: string[] }` |
 | `renderPdfWithWarningsAndOptions(input, opts)` | `renderPdfWithWarnings` + `{ transpose?, config? }` options | `{ output: Uint8Array, warnings: string[] }` |
+
+### iReal Pro
+
+| Function | Description | Return type |
+|---|---|---|
 | `convertChordproToIrealb(input)` | Convert ChordPro source to an `irealb://` URL (lossy — drops lyrics, fonts, capo) | `{ output: string, warnings: string[] }` |
 | `convertIrealbToChordproText(input)` | Convert an `irealb://` URL to rendered ChordPro text | `{ output: string, warnings: string[] }` |
 | `renderIrealSvg(input)` | Render an `irealb://` URL as an iReal Pro-style SVG chart | `string` (SVG document) |
-| `renderIrealPng(input)` | Render an `irealb://` URL as a PNG image (300 DPI default) | `Uint8Array` (PNG bytes) |
+| `renderIrealPng(input)` | Render an `irealb://` URL as a PNG image (300 DPI default, A4-equivalent canvas) | `Uint8Array` (PNG bytes) |
 | `renderIrealPdf(input)` | Render an `irealb://` URL as a single-page A4 PDF | `Uint8Array` (PDF bytes) |
 | `parseIrealb(input)` | Parse an `irealb://` URL into AST-shaped JSON (mirrors `IrealSong`) | `string` (JSON) |
 | `serializeIrealb(input)` | Serialize an AST-shaped JSON string back into an `irealb://` URL (round-trip with `parseIrealb`) | `string` (URL) |
+
+`convertChordproToIrealb` is lossy: lyrics, fonts / colours, and capo
+are dropped because iReal has no surface for them. Each drop appears in
+`warnings` as a `"<kind>: <message>"` string (`kind` is `lossy-drop`,
+`approximated`, or `unsupported`).
+
+`convertIrealbToChordproText` returns the `chordsketch-render-text`
+rendering of the converted song, not raw ChordPro source — there is no
+source emitter yet.
+
+### Utility
+
+| Function | Description | Return type |
+|---|---|---|
 | `version()` | Library version string | `string` |
 
 Each element of `warnings` is a plain UTF-8 string containing a


### PR DESCRIPTION
## What

Restructures the flat `## API` table in `crates/wasm/README.md` into
five `###` subsections — Basic rendering, Rendering with options,
Captured warnings, iReal Pro, and Utility — and adds explanatory notes
about the iReal Pro converter's lossy categories and the rendered-text
caveat for `convertIrealbToChordproText`.

The new `### iReal Pro` subsection lists all seven iReal Pro exports
declared in `crates/wasm/src/lib.rs:931-1093`:

- `convertChordproToIrealb`
- `convertIrealbToChordproText`
- `renderIrealSvg`
- `renderIrealPng`
- `renderIrealPdf`
- `parseIrealb`
- `serializeIrealb`

## Why

`packages/npm/README.md` already exposes these as a discrete
`### iReal Pro conversion` subsection. The Rust-side
`crates/wasm/README.md` listed them in a single 20-row flat table, so
the iReal Pro surface was not discoverable as its own group. The
restructure keeps the two READMEs in lockstep per
`.claude/rules/release-doc-sync.md` §5.

## Test plan

- [x] `grep -E '#\[wasm_bindgen\(js_name\s*=\s*[a-zA-Z]*[Ii]real' crates/wasm/src/lib.rs` returns exactly the seven js_name overrides listed in the new `### iReal Pro` subsection — no drift.
- [x] No source files changed; CI's `cargo doc` and `cargo build` paths are unaffected.
- [x] Markdown anchor `#ireal-pro-conversion` resolves against the `### iReal Pro conversion` heading in `packages/npm/README.md`.

## Sister-site audit

`.claude/rules/fix-propagation.md` group: bindings READMEs
(`crates/{wasm,napi,ffi}/README.md`). The PR #2402 audit landed iReal
coverage in NAPI (`crates/napi/README.md`) and FFI
(`crates/ffi/README.md`) at L2 already; this PR closes the remaining
WASM-side drift surfaced during that PR's auto-review. No equivalent
gap remains in NAPI or FFI READMEs (verified via their current
`## API` sections).

## Out of scope

Body usage examples (the `## JavaScript/TypeScript usage (npm)`
section and surrounding prose) were intentionally not extended to
include iReal Pro — that is tracked under the broader
`release-doc-sync.md` §5 audit and is out of scope per the issue.

## Deferred

`crates/wasm/README.md` `## API` still omits eight non-iReal
`#[wasm_bindgen]` exports (`render_html_body`,
`render_html_body_with_options`, `render_html_css`,
`render_html_css_with_options`, `renderHtmlBodyWithWarnings`,
`renderHtmlBodyWithWarningsAndOptions`, `chord_diagram_svg`,
`validate`). This is pre-existing release-doc-sync §5 drift, outside
the iReal-only scope of #2404. Tracked in #2406 for the next
documentation pass.

Closes #2404