### PR TITLE
docs(wasm): document remaining wasm exports in crates/wasm/README.md

### DIFF
--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -85,7 +85,7 @@ the
 
 | Function | Description | Return type |
 |---|---|---|
-| `render_html_body(input)` | Render ChordPro to a body-only `<div class="song">…</div>` HTML fragment with no `<!DOCTYPE>` / `<html>` / `<head>` / embedded `<style>` — pair with `render_html_css` when the host supplies its own document envelope | `string` |
+| `render_html_body(input)` | Render ChordPro to a body-only `<div class="song">…</div>` HTML fragment with no `<!DOCTYPE>` / `<html>` / `<head>` / `<title>` / embedded `<style>` — pair with `render_html_css` when the host supplies its own document envelope | `string` |
 | `render_html_body_with_options(input, opts)` | Same as `render_html_body`, with `{ transpose?, config? }` | `string` |
 | `render_html_css()` | Return the canonical chord-over-lyrics CSS that `render_html` embeds inside `<style>` (byte-stable; safe to hash for cache-busting) | `string` |
 | `render_html_css_with_options(opts)` | Variant of `render_html_css` that honours `settings.wraplines` from `{ transpose?, config? }` (when `wraplines` is false, `.line` emits `flex-wrap: nowrap`) | `string` |

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -58,12 +58,12 @@ a dual-package layout).
 
 ## API
 
-The exported wasm-bindgen functions are grouped below. The
-`### iReal Pro` subsection mirrors the structure of the
-[`### iReal Pro conversion` table in `packages/npm/README.md`](https://github.com/koedame/chordsketch/blob/main/packages/npm/README.md#ireal-pro-conversion)
-and stays in lockstep with the `*_ireal*` / `*_irealb*` /
-`convert_*irealb*` exports in
-[`crates/wasm/src/lib.rs`](src/lib.rs).
+The tables below cover every `#[wasm_bindgen]`-exported `pub fn`
+in [`crates/wasm/src/lib.rs`](src/lib.rs) (the `start` lifecycle
+hook and the `console` `extern "C"` shim are intentionally
+omitted). The `### iReal Pro` subsection mirrors the structure of
+the
+[`### iReal Pro conversion` table in `packages/npm/README.md`](https://github.com/koedame/chordsketch/blob/main/packages/npm/README.md#ireal-pro-conversion).
 
 ### Basic rendering
 
@@ -81,6 +81,15 @@ and stays in lockstep with the `*_ireal*` / `*_irealb*` /
 | `render_html_with_options(input, opts)` | Same as `render_html`, with `{ transpose?, config? }` | `string` |
 | `render_pdf_with_options(input, opts)` | Same as `render_pdf`, with `{ transpose?, config? }` | `Uint8Array` |
 
+### Body-only HTML and stylesheet
+
+| Function | Description | Return type |
+|---|---|---|
+| `render_html_body(input)` | Render ChordPro to a body-only `<div class="song">…</div>` HTML fragment with no `<!DOCTYPE>` / `<html>` / `<head>` / embedded `<style>` — pair with `render_html_css` when the host supplies its own document envelope | `string` |
+| `render_html_body_with_options(input, opts)` | Same as `render_html_body`, with `{ transpose?, config? }` | `string` |
+| `render_html_css()` | Return the canonical chord-over-lyrics CSS that `render_html` embeds inside `<style>` (byte-stable; safe to hash for cache-busting) | `string` |
+| `render_html_css_with_options(opts)` | Variant of `render_html_css` that honours `settings.wraplines` from `{ transpose?, config? }` (when `wraplines` is false, `.line` emits `flex-wrap: nowrap`) | `string` |
+
 ### Captured warnings
 
 | Function | Description | Return type |
@@ -88,9 +97,23 @@ and stays in lockstep with the `*_ireal*` / `*_irealb*` /
 | `renderTextWithWarnings(input)` | Plain-text render that captures warnings instead of forwarding to `console.warn` | `{ output: string, warnings: string[] }` |
 | `renderHtmlWithWarnings(input)` | HTML render with captured warnings | `{ output: string, warnings: string[] }` |
 | `renderPdfWithWarnings(input)` | PDF render with captured warnings | `{ output: Uint8Array, warnings: string[] }` |
+| `renderHtmlBodyWithWarnings(input)` | Body-only HTML fragment with captured warnings (body counterpart to `renderHtmlWithWarnings`) | `{ output: string, warnings: string[] }` |
 | `renderTextWithWarningsAndOptions(input, opts)` | `renderTextWithWarnings` + `{ transpose?, config? }` options | `{ output: string, warnings: string[] }` |
 | `renderHtmlWithWarningsAndOptions(input, opts)` | `renderHtmlWithWarnings` + `{ transpose?, config? }` options | `{ output: string, warnings: string[] }` |
 | `renderPdfWithWarningsAndOptions(input, opts)` | `renderPdfWithWarnings` + `{ transpose?, config? }` options | `{ output: Uint8Array, warnings: string[] }` |
+| `renderHtmlBodyWithWarningsAndOptions(input, opts)` | `renderHtmlBodyWithWarnings` + `{ transpose?, config? }` options | `{ output: string, warnings: string[] }` |
+
+### Validation
+
+| Function | Description | Return type |
+|---|---|---|
+| `validate(input)` | Validate ChordPro input and return any parse errors as structured records (empty array if valid). Matches the NAPI `ValidationError[]` shape and the FFI `ValidationError` dictionary | `ValidationError[]` (`{ line: number, column: number, message: string }`, line / column one-based) |
+
+### Chord diagrams
+
+| Function | Description | Return type |
+|---|---|---|
+| `chord_diagram_svg(chord, instrument)` | Render a chord diagram as inline SVG. `instrument` is `"guitar"`, `"ukulele"` (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`). Returns `null` when the chord is not in the built-in voicing database; throws on unknown instrument | `string \| null` (SVG markup) |
 
 ### iReal Pro
 


### PR DESCRIPTION
## What

Adds the eight remaining `#[wasm_bindgen]`-exported `pub fn`s to the
`## API` table in `crates/wasm/README.md` and slots them into new
subsections matching their semantics:

- `### Body-only HTML and stylesheet` (new) — `render_html_body`,
  `render_html_body_with_options`, `render_html_css`,
  `render_html_css_with_options`.
- `### Captured warnings` (existing — extended) —
  `renderHtmlBodyWithWarnings`,
  `renderHtmlBodyWithWarningsAndOptions`.
- `### Validation` (new) — `validate`, with the full
  `ValidationError` `{ line, column, message }` shape that matches
  the NAPI / FFI bindings.
- `### Chord diagrams` (new) — `chord_diagram_svg`, documenting the
  `guitar` / `ukulele` (alias `uke`) / `piano` (aliases `keyboard`,
  `keys`) instrument set, the `null` return for unknown chords, and
  the throw-on-unknown-instrument error path.

The `## API` intro paragraph is updated to state explicitly that the
tables cover every `#[wasm_bindgen]`-exported `pub fn` (excluding
the `start` lifecycle hook and the `console` `extern "C"` shim).

## Why

`.claude/rules/release-doc-sync.md` §5 requires every binding crate
README's API list to match the actual exported functions. PR #2405
restructured the table and added the `### iReal Pro` subsection
scoped to issue #2404, leaving these eight non-iReal exports
undocumented. This PR closes that wider drift on the WASM side.

## Test plan

- [x] `grep -nE '^pub fn ' crates/wasm/src/lib.rs` enumerates 29 `pub fn`s; subtracting the `start` lifecycle hook leaves 28 documented entries — every one appears in the new README API tables (3 + 3 + 4 + 8 + 1 + 1 + 7 + 1 = 28). No drift remains.
- [x] Each new row's description matches the doc-comment in `crates/wasm/src/lib.rs`:
  - `render_html_body` body-only fragment contract (lines 321-330).
  - `render_html_css` byte-stable contract (lines 365-373).
  - `render_html_css_with_options` `settings.wraplines` honouring (lines 380-385).
  - `validate` `ValidationError` shape matches the `typescript_custom_section` block at `crates/wasm/src/lib.rs:819-842`.
  - `chord_diagram_svg` instrument aliases and null-on-unknown-chord contract match `crates/wasm/src/lib.rs:711-737`.
- [x] No source files changed; CI's `cargo doc` and `cargo build` paths are unaffected.

## Sister-site audit

`.claude/rules/fix-propagation.md` group: bindings READMEs
(`crates/{wasm,napi,ffi}/README.md`). The same drift class exists
on the NAPI and FFI sides — `crates/napi/README.md` and
`crates/ffi/README.md` both list the basic / with-options /
with-warnings / iReal Pro families but omit the body-only, CSS,
chord-diagram, and `validate`-as-table entries. This PR is scoped
to WASM per its issue's `Out of scope` note, which explicitly
asked for separate sibling issues for the NAPI and FFI halves.
Trackers filed:

- #2408 — NAPI sister-site drift.
- #2409 — FFI sister-site drift.

## Deferred

- NAPI README sister-site drift (same eight-function class) →
  #2408.
- FFI README sister-site drift (same eight-function class plus
  `_with_options` variants pending UDL audit) → #2409.

Closes #2406