### PR TITLE
docs(napi): document remaining NAPI exports in crates/napi/README.md

### DIFF
--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -50,22 +50,46 @@ console.log(`ChordSketch ${version()}`);
 
 ## API
 
-### Rendering
+The tables below cover every `#[napi]`-exported `pub fn` in
+[`crates/napi/src/lib.rs`](src/lib.rs).
+
+### Basic rendering
 
 | Function | Returns | Description |
 |----------|---------|-------------|
 | `renderText(source)` | `string` | Plain text: chord names above lyric lines |
 | `renderHtml(source)` | `string` | Full HTML document |
 | `renderPdf(source)` | `Buffer` | Raw PDF bytes |
+
+### Rendering with options
+
+| Function | Returns | Description |
+|----------|---------|-------------|
 | `renderTextWithOptions(source, options)` | `string` | Text with transposition / config |
 | `renderHtmlWithOptions(source, options)` | `string` | HTML with transposition / config |
 | `renderPdfWithOptions(source, options)` | `Buffer` | PDF with transposition / config |
+
+### Body-only HTML and stylesheet
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `renderHtmlBody(source)` | `string` | Body-only `<div class="song">…</div>` HTML fragment with no `<!DOCTYPE>` / `<html>` / `<head>` / `<title>` / embedded `<style>` — pair with `renderHtmlCss` when the host supplies its own document envelope |
+| `renderHtmlBodyWithOptions(source, options)` | `string` | Same as `renderHtmlBody`, with transposition / config |
+| `renderHtmlCss()` | `string` | Canonical chord-over-lyrics CSS that `renderHtml` embeds inside `<style>` (byte-stable; safe to hash for cache-busting) |
+| `renderHtmlCssWithOptions(options)` | `string` | Variant of `renderHtmlCss` that honours `settings.wraplines` from the supplied options (when `wraplines` is false, `.line` emits `flex-wrap: nowrap`) |
+
+### Captured warnings
+
+| Function | Returns | Description |
+|----------|---------|-------------|
 | `renderTextWithWarnings(source)` | `{ output: string, warnings: string[] }` | Text render that captures warnings as structured data |
 | `renderHtmlWithWarnings(source)` | `{ output: string, warnings: string[] }` | HTML render with captured warnings |
 | `renderPdfWithWarnings(source)` | `{ output: Buffer, warnings: string[] }` | PDF render with captured warnings |
+| `renderHtmlBodyWithWarnings(source)` | `{ output: string, warnings: string[] }` | Body-only HTML fragment with captured warnings (body counterpart to `renderHtmlWithWarnings`) |
 | `renderTextWithWarningsAndOptions(source, options)` | `{ output: string, warnings: string[] }` | `renderTextWithWarnings` + transposition / config |
 | `renderHtmlWithWarningsAndOptions(source, options)` | `{ output: string, warnings: string[] }` | `renderHtmlWithWarnings` + transposition / config |
 | `renderPdfWithWarningsAndOptions(source, options)` | `{ output: Buffer, warnings: string[] }` | `renderPdfWithWarnings` + transposition / config |
+| `renderHtmlBodyWithWarningsAndOptions(source, options)` | `{ output: string, warnings: string[] }` | `renderHtmlBodyWithWarnings` + transposition / config |
 
 ### iReal Pro conversion
 
@@ -108,14 +132,24 @@ console.log(text);
 
 ### Validation
 
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `validate(source)` | `ValidationError[]` (`{ line: number, column: number, message: string }`, line / column one-based) | Validate ChordPro input and return any parse errors as structured records (empty array if clean). Mirrors the WASM `validate` shape and the FFI `ValidationError` dictionary. |
+
 ```js
 import { validate } from '@chordsketch/node';
 
-const errors = validate(source); // string[] — empty array if clean
-for (const msg of errors) {
-  console.warn(msg);
+const errors = validate(source); // ValidationError[] — empty array if clean
+for (const { line, column, message } of errors) {
+  console.warn(`line ${line}, column ${column}: ${message}`);
 }
 ```
+
+### Chord diagrams
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `chordDiagramSvg(chord, instrument)` | `string \| null` (SVG markup) | Render a chord diagram as inline SVG. `instrument` is `"guitar"`, `"ukulele"` (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`). Returns `null` when the chord is not in the built-in voicing database; throws on unknown instrument. |
 
 ### Utility
 

--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -149,7 +149,7 @@ for (const { line, column, message } of errors) {
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `chordDiagramSvg(chord, instrument)` | `string \| null` (SVG markup) | Render a chord diagram as inline SVG. `instrument` is `"guitar"`, `"ukulele"` (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`). Returns `null` when the chord is not in the built-in voicing database; throws on unknown instrument. |
+| `chordDiagramSvg(chord, instrument)` | `string \| null` (SVG markup) | Render a chord diagram as inline SVG. `instrument` is case-insensitive: `"guitar"`, `"ukulele"` (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`). Returns `null` when the chord is not in the built-in voicing database; throws on unknown instrument. |
 
 ### Utility
 
@@ -162,7 +162,8 @@ for (const { line, column, message } of errors) {
 ```ts
 interface RenderOptions {
   /** Semitone transposition offset. Default: 0.
-   *  Values outside the i8 range (-128..127) are clamped, then reduced mod 12. */
+   *  Values outside -128..=127 cause the function to throw with an `InvalidArg`
+   *  error (matches CLI / UniFFI / WASM binding semantics — no silent clamping). */
   transpose?: number;
 
   /** Preset name ("guitar", "ukulele") or inline RRJSON configuration string. */

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -113,7 +113,7 @@ the
 
 | Function | Description | Return type |
 |---|---|---|
-| `chord_diagram_svg(chord, instrument)` | Render a chord diagram as inline SVG. `instrument` is `"guitar"`, `"ukulele"` (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`). Returns `null` when the chord is not in the built-in voicing database; throws on unknown instrument | `string \| null` (SVG markup) |
+| `chord_diagram_svg(chord, instrument)` | Render a chord diagram as inline SVG. `instrument` is case-insensitive: `"guitar"`, `"ukulele"` (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`). Returns `null` when the chord is not in the built-in voicing database; throws on unknown instrument | `string \| null` (SVG markup) |
 
 ### iReal Pro
 


### PR DESCRIPTION
## What

Restructures `## API` in `crates/napi/README.md` into the same
subsection layout as `crates/wasm/README.md` and adds the eight
`#[napi]`-exported `pub fn`s that were missing from the API tables
after PR #2407:

- `### Body-only HTML and stylesheet` (new) — `renderHtmlBody`,
  `renderHtmlBodyWithOptions`, `renderHtmlCss`,
  `renderHtmlCssWithOptions`.
- `### Captured warnings` (existing — extended) —
  `renderHtmlBodyWithWarnings`,
  `renderHtmlBodyWithWarningsAndOptions`.
- `### Chord diagrams` (new) — `chordDiagramSvg`, documenting the
  `guitar` / `ukulele` (alias `uke`) / `piano` (aliases `keyboard`,
  `keys`) instrument set, the `null` return for unknown chords, and
  the throw-on-unknown-instrument error path.

`### Validation` gains a tabular API row alongside the existing
code example. The previous example claimed the return shape was
`string[]` (`for (const msg of errors) console.warn(msg)`), but
napi-rs marshals `Vec<ValidationError>` (`{ line, column, message }`)
per `crates/napi/src/lib.rs:570-587`. The example now destructures
the structured shape.

The `## API` intro paragraph is updated to state explicitly that the
tables cover every `#[napi]`-exported `pub fn`.

## Why

`.claude/rules/release-doc-sync.md` §5 + `.claude/rules/fix-propagation.md`
Bindings group: every binding crate's README must keep its API list
matching the actual exported functions and stay in lockstep across
the WASM / NAPI / FFI sister sites. PR #2407 closed the WASM half;
this PR closes the NAPI half. The FFI half is tracked under #2409.

## Test plan

- [x] `awk '/^#[napi]$/{getline; print}' crates/napi/src/lib.rs | grep '^pub fn'` enumerates 28 `#[napi]` exports; every one appears in the README API tables (3 + 3 + 4 + 8 + 7 + 1 + 1 + 1 = 28). No drift remains.
- [x] Each new row's description matches the doc-comment in `crates/napi/src/lib.rs`:
  - `renderHtmlBody` body-only fragment contract (lines 434-444), including the explicit `<title>` exclusion that PR #2407's first iteration missed.
  - `renderHtmlCss` byte-stable contract (lines 510-515).
  - `renderHtmlCssWithOptions` `settings.wraplines` honouring (lines 530-535).
  - `chordDiagramSvg` instrument aliases and null-on-unknown-chord vs throw-on-unknown-instrument contract match `crates/napi/src/lib.rs:622-644`.
  - `validate` returns `Vec<ValidationError>` per `crates/napi/src/lib.rs:572`; the README's TS shape `{ line, column, message }` (one-based) matches the `#[napi(object)]` definition at lines 552-560.
- [x] No source files changed; CI's `cargo doc` and `cargo build` paths are unaffected.
- [x] The pre-existing `for (const msg of errors) console.warn(msg)` example would have printed `[object Object]` against the actual `ValidationError[]` shape — fixed in this PR.

## Sister-site audit

`.claude/rules/fix-propagation.md` Bindings group:
- WASM (`crates/wasm/README.md`): closed by PR #2407.
- NAPI (`crates/napi/README.md`): this PR.
- FFI (`crates/ffi/README.md`): tracked in #2409 — UDL surface
  needs a separate audit before that PR can land, see issue body.

Closes #2408