### PR TITLE
docs(ffi): document remaining FFI exports in crates/ffi/README.md

### DIFF
--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -40,24 +40,45 @@ print(chordsketch.version())
 
 ## API
 
-### Rendering
+The tables below cover every function in
+[`crates/ffi/src/chordsketch.udl`](src/chordsketch.udl) (UniFFI's
+`namespace chordsketch { ... }` block is the authoritative export
+surface for all language bindings).
 
-All render functions accept the same three arguments:
+### Render-function parameters
+
+`parse_and_render_*` functions all accept the same three arguments:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `input` | `str` | ChordPro source text |
 | `config_json` | `str \| None` | Preset name (`"guitar"`, `"ukulele"`) or inline RRJSON; `None` for defaults |
-| `transpose` | `int \| None` | Semitone offset (-128..127); `None` defaults to 0 |
+| `transpose` | `int \| None` | Semitone offset; must fit in `i8` (`-128..=127`). Out-of-range values raise `ChordSketchError.InvalidConfig`. `None` defaults to 0. |
+
+### Basic rendering
 
 | Function | Returns | Description |
 |----------|---------|-------------|
 | `parse_and_render_text(input, config_json, transpose)` | `str` | Plain text output |
 | `parse_and_render_html(input, config_json, transpose)` | `str` | Full HTML document |
 | `parse_and_render_pdf(input, config_json, transpose)` | `bytes` | Raw PDF bytes |
+
+### Body-only HTML and stylesheet
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `parse_and_render_html_body(input, config_json, transpose)` | `str` | Body-only `<div class="song">…</div>` HTML fragment with no `<!DOCTYPE>` / `<html>` / `<head>` / `<title>` / embedded `<style>` — pair with `render_html_css` when the host supplies its own document envelope |
+| `render_html_css()` | `str` | Canonical chord-over-lyrics CSS that `parse_and_render_html` embeds inside `<style>` (byte-stable; safe to hash for cache-busting) |
+| `render_html_css_with_config_json(config_json)` | `str` | Variant of `render_html_css` that honours `settings.wraplines` from the supplied config (when `wraplines` is false, `.line` emits `flex-wrap: nowrap`) |
+
+### Captured warnings
+
+| Function | Returns | Description |
+|----------|---------|-------------|
 | `parse_and_render_text_with_warnings(input, config_json, transpose)` | `TextRenderWithWarnings { output: str, warnings: list[str] }` | Plain text + captured warnings |
 | `parse_and_render_html_with_warnings(input, config_json, transpose)` | `TextRenderWithWarnings { output: str, warnings: list[str] }` | HTML + captured warnings |
 | `parse_and_render_pdf_with_warnings(input, config_json, transpose)` | `PdfRenderWithWarnings { output: bytes, warnings: list[str] }` | PDF + captured warnings |
+| `parse_and_render_html_body_with_warnings(input, config_json, transpose)` | `TextRenderWithWarnings { output: str, warnings: list[str] }` | Body-only HTML fragment + captured warnings (body counterpart to `parse_and_render_html_with_warnings`) |
 
 ### iReal Pro conversion
 
@@ -95,16 +116,30 @@ See #1827.
 
 ### Validation
 
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `validate(input)` | `list[ValidationError]` (`{ line: int, column: int, message: str }`, line / column one-based) | Validate ChordPro input and return any parse errors as structured records (empty list if clean). Mirrors the WASM `validate` shape and the NAPI `ValidationError[]` interface. |
+
 ```python
 errors = chordsketch.validate(source)  # list[ValidationError] — empty if clean
 for e in errors:
     print(f"line {e.line}, column {e.column}: {e.message}")
 ```
 
+### Chord diagrams
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `chord_diagram_svg(chord, instrument)` | `str \| None` (SVG markup) | Render a chord diagram as inline SVG. `instrument` is case-insensitive: `"guitar"`, `"ukulele"` (alias `"uke"`), or `"piano"` (aliases `"keyboard"`, `"keys"`). Returns `None` when the chord is not in the built-in voicing database; raises `ChordSketchError.InvalidConfig` on unknown instrument. |
+
 ### Utility
 
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `version()` | `str` | Library version string |
+
 ```python
-print(chordsketch.version())  # e.g. "0.2.0"
+print(chordsketch.version())  # e.g. "0.3.0"
 ```
 
 ## Options
@@ -132,9 +167,10 @@ except chordsketch.ChordSketchError as e:
     print(e)
 ```
 
-`ChordSketchError` has two variants:
+`ChordSketchError` has three variants:
 - `NoSongsFound` — the input produced no parseable songs (rare with lenient parsing)
-- `InvalidConfig` — the `config_json` argument is not a known preset and not valid RRJSON
+- `InvalidConfig(reason)` — the `config_json` argument is not a known preset and not valid RRJSON, or `transpose` is outside the `i8` range, or `chord_diagram_svg` was called with an unsupported instrument
+- `ConversionFailed(reason)` — a ChordPro ↔ iReal Pro conversion failed (`convert_chordpro_to_irealb`, `convert_irealb_to_chordpro_text`, `render_ireal_*`, `parse_irealb`, `serialize_irealb`)
 
 Parse errors in the ChordPro input are **not** raised — the renderer is lenient
 and produces a best-effort result. Call `validate()` to surface diagnostics.


### PR DESCRIPTION
## What

Restructures `## API` in `crates/ffi/README.md` to mirror the
`crates/wasm/README.md` and `crates/napi/README.md` subsection
layout, and adds the six functions declared in
`crates/ffi/src/chordsketch.udl` that were missing from the API
tables after PR #2410:

- `### Body-only HTML and stylesheet` (new) — `parse_and_render_html_body`,
  `render_html_css`, `render_html_css_with_config_json`.
- `### Captured warnings` (existing — extended) —
  `parse_and_render_html_body_with_warnings`.
- `### Validation` gains a tabular API row alongside the existing
  code example.
- `### Chord diagrams` (new) — `chord_diagram_svg`, documenting the
  case-insensitive `guitar` / `ukulele` (alias `uke`) / `piano`
  (aliases `keyboard`, `keys`) instrument set, the `None` return
  for unknown chords, and the `InvalidConfig` raise on unknown
  instrument.

Also fixes two pre-existing accuracy bugs:

- Render-function `transpose` row claimed `Semitone offset (-128..127)` using Python range notation (exclusive upper bound), but the UDL signature is `i8?` (inclusive `-128..=127`). Updated to inclusive range and the `InvalidConfig` raise behavior, matching the same fix the auto-review applied to NAPI in #2410.
- `## Error handling` listed only `NoSongsFound` and `InvalidConfig` variants. The UDL declares `ConversionFailed` too — used by every ChordPro ↔ iReal Pro conversion and render function. Added it to the variant list with its scope description.

The `## API` intro paragraph now states explicitly that the UDL
(`crates/ffi/src/chordsketch.udl`) is the authoritative export
surface for all UniFFI bindings.

## Why

`.claude/rules/release-doc-sync.md` §5 +
`.claude/rules/fix-propagation.md` Bindings group: every binding
crate's README must keep its API list matching the actual exported
functions and stay in lockstep across the WASM / NAPI / FFI sister
sites. PR #2407 closed WASM, PR #2410 closed NAPI; this PR closes
FFI.

## Test plan

- [x] `grep -oE '^\s+(string\??|bytes|sequence<[A-Za-z]+>|[A-Z][A-Za-z]+) [a-z_]+\(' crates/ffi/src/chordsketch.udl` enumerates 20 UDL functions; every one appears in the README API tables (3 + 3 + 4 + 7 + 1 + 1 + 1 = 20). No drift remains.
- [x] Each new row's description matches the UDL doc-comment in `crates/ffi/src/chordsketch.udl`:
  - `parse_and_render_html_body` body-only fragment contract (lines 51-60), including the explicit `<title>` exclusion.
  - `render_html_css` byte-stable contract (lines 71-77).
  - `render_html_css_with_config_json` `settings.wraplines` honouring (lines 80-83).
  - `chord_diagram_svg` instrument aliases, case-insensitivity, and None-on-unknown-chord vs throw-on-unknown-instrument contract (lines 95-114).
  - `validate` returns `sequence<ValidationError>` (line 91) with `{ line, column, message }` (one-based).
- [x] No source files changed; CI's `cargo doc` and `cargo build` paths are unaffected.

## Sister-site audit

`.claude/rules/fix-propagation.md` Bindings group:
- WASM (`crates/wasm/README.md`): closed by PR #2407.
- NAPI (`crates/napi/README.md`): closed by PR #2410.
- FFI (`crates/ffi/README.md`): this PR.

The transpose-range / `InvalidConfig` fix is the same accuracy
bug class the auto-review caught for NAPI in PR #2410 — applying
it here keeps the three binding READMEs in lockstep.

Closes #2409