### PR TITLE
Release v0.4.0

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -202,7 +202,7 @@ jobs:
           # 0.1.0 → 0.1.1 fix, in the publish PR itself). The README sync
           # check (.github/workflows/readme-sync.yml) does not catch this
           # automatically because the version string lives only here.
-          npm install '@chordsketch/wasm@0.3.0'
+          npm install '@chordsketch/wasm@0.4.0'
 
       - name: Smoke test text + HTML + PDF render
         run: |
@@ -583,13 +583,13 @@ jobs:
             INCLUDE_IREAL=1
             MODE="workspace path deps (PR, ChordPro + iReal)"
           else
-            # Cargo `^0.3` means `>=0.3.0, <0.4.0` (the caret rules treat
+            # Cargo `^0.4` means `>=0.4.0, <0.5.0` (the caret rules treat
             # the leftmost non-zero as the breaking-change boundary).
-            # Bump policy: when the workspace bumps to 0.4.x, update both
-            # constraints below to `^0.4` in the same release PR.
+            # Bump policy: when the workspace bumps to 0.5.x, update both
+            # constraints below to `^0.5` in the same release PR.
             # Otherwise, daily smoke tests will silently stop resolving.
-            CORE_DEP='chordsketch-chordpro = "^0.3"'
-            RENDER_DEP='chordsketch-render-text = "^0.3"'
+            CORE_DEP='chordsketch-chordpro = "^0.4"'
+            RENDER_DEP='chordsketch-render-text = "^0.4"'
             IREAL_DEP=''
             IREAL_RENDER_DEP=''
             INCLUDE_IREAL=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-06
+
 ### Added
 
 #### iReal Pro support (multi-format track, #2050)
@@ -36,6 +38,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filter group, and `bundle.fileAssociations` registers `.irealb` /
   `.irealbook` as OS-level associations on macOS, Windows, and Linux.
   (#2358)
+- `@chordsketch/ui-web`: routes `irealb://` input through
+  `render_ireal_svg` to render a read-only iReal Pro chart preview
+  alongside the ChordPro pipeline. (#2362)
+- VS Code extension: registers `.irealb` / `.irealbook` as a new
+  language id with TextMate grammar so iReal files highlight
+  separately from ChordPro. (#2359)
+- JetBrains plugin and Zed extension: register `.irealb` /
+  `.irealbook` extensions for the same separate-language treatment.
+  (#2360)
+
+#### iReal Pro bar-grid editor (`@chordsketch/ui-irealb-editor`)
+
+- New private workspace package — pluggable bar-grid GUI editor for
+  iReal Pro charts that slots into `@chordsketch/ui-web`'s
+  `MountOptions.createEditor` via the `EditorAdapter` contract.
+  Scaffolded with header metadata editing (title / composer / style /
+  key / time / tempo / transpose) plus a 4-bars-per-line read-only
+  grid. (#2363)
+- Bar popover for inline editing of chord, barline, ending, and
+  music-symbol fields. (#2364)
+- Structural section / bar add / remove / reorder operations with
+  ChordPro round-trip stability. (#2365)
+- Keyboard shortcuts for bar delete and reorder. (#2376)
+- Roving-tabindex grid navigation, `role="grid"` / `role="row"` /
+  `role="gridcell"` ARIA semantics, and a polite live region for
+  structural-edit announcements. (#2368)
+- Playground / `@chordsketch/ui-web`: runtime editor swap via
+  `ChordSketchUiHandle.replaceEditor` driving a ChordPro / iRealb
+  format toggle in the playground header. (#2366)
+- Desktop (Tauri): Open / Save dispatch routes `.irealb` /
+  `.irealbook` files to the grid editor, with a View → Edit as Grid
+  / Edit as URL Text menu pair to switch between the bar-grid GUI
+  and the raw URL textarea. (#2367)
 
 #### Bindings (multi-format track, #2067)
 
@@ -107,6 +142,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preview pane fills available height. (#2281)
 - Playground / `ui-web`: drop double-wrapped HTML doc, ship favicon,
   add defensive iframe reload. (#2322)
+- `@chordsketch/ui-web`: `mountChordSketchUi` now awaits
+  `Renderers.init()` before invoking the editor factory, so factories
+  may safely use wasm-backed helpers in their constructors.
+  Playground gains a Playwright browser smoke
+  (`packages/playground/tests-e2e/`) so the wasm-init race that
+  motivated this fix cannot recur silently. (#2397)
 
 ## [0.3.0] - 2026-04-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chordsketch"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "chordsketch-chordpro",
@@ -699,14 +699,14 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-chordpro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "chordsketch-convert"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "chordsketch-ireal",
@@ -715,14 +715,14 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-convert-musicxml"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
 ]
 
 [[package]]
 name = "chordsketch-desktop"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "chordsketch-render-html",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-ffi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "chordsketch-convert",
@@ -753,11 +753,11 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-ireal"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "chordsketch-lsp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "serde_json",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-napi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "chordsketch-convert",
@@ -784,14 +784,14 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-render-html"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
 ]
 
 [[package]]
 name = "chordsketch-render-ireal"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-ireal",
  "resvg",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-render-pdf"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "flate2",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-render-text"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "unicode-width",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "chordsketch-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chordsketch-chordpro",
  "chordsketch-convert",

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chordsketch-desktop-frontend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chordsketch-desktop-frontend",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsketch-desktop-frontend",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Vite frontend for the ChordSketch desktop app; mounts @chordsketch/ui-web inside the Tauri WebView.",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "chordsketch-desktop"
 # line together with every `crates/*/Cargo.toml` and the desktop
 # frontend manifests (`apps/desktop/package.json`,
 # `apps/desktop/src-tauri/tauri.conf.json`).
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 # Application-layer license per CLAUDE.md §License Policy ("future Forum,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ChordSketch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "me.koeda.chordsketch.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/ci/version-skew-allowlist.toml
+++ b/ci/version-skew-allowlist.toml
@@ -30,3 +30,20 @@
 #                    human-actionable)
 #   tracking_issue — GitHub issue number, as a string or integer
 
+[[allowed_skews]]
+file = "packaging/macports/Portfile"
+field = "github.setup version"
+current_value = "0.3.0"
+reason = """
+The MacPorts Portfile sync CI guard reads `git show v<TAG>:Cargo.lock`
+where `<TAG>` is taken from this `github.setup` line. Bumping the
+Portfile to 0.4.0 in the release-cut PR causes that guard to fail
+because `v0.4.0` does not yet exist as a tag — the tag is only
+created post-merge. `docs/releasing.md` §5 (Post-Release > MacPorts
+Portfile) is the canonical place to bump the Portfile (version +
+checksums + `cargo.crates` regen, all together, against the tagged
+source tarball).
+"""
+expires_at = "Post-release MacPorts Portfile refresh PR for v0.4.0 (per docs/releasing.md §5)"
+tracking_issue = 2413
+

--- a/crates/chordpro/Cargo.toml
+++ b/crates/chordpro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-chordpro"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -17,13 +17,13 @@ name = "chordsketch"
 path = "src/main.rs"
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
-chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
-chordsketch-render-text = { version = "0.3.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.3.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.3.0", path = "../render-pdf" }
-chordsketch-render-ireal = { version = "0.3.0", path = "../render-ireal" }
-chordsketch-convert-musicxml = { version = "0.3.0", path = "../convert-musicxml" }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
+chordsketch-ireal = { version = "0.4.0", path = "../ireal" }
+chordsketch-render-text = { version = "0.4.0", path = "../render-text" }
+chordsketch-render-html = { version = "0.4.0", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.4.0", path = "../render-pdf" }
+chordsketch-render-ireal = { version = "0.4.0", path = "../render-ireal" }
+chordsketch-convert-musicxml = { version = "0.4.0", path = "../convert-musicxml" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tempfile = "3"

--- a/crates/convert-musicxml/Cargo.toml
+++ b/crates/convert-musicxml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-convert-musicxml"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,4 +13,4 @@ readme = "README.md"
 description = "MusicXML ↔ ChordPro bidirectional converter"
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }

--- a/crates/convert/Cargo.toml
+++ b/crates/convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-convert"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,10 +13,10 @@ description = "ChordPro ↔ iReal Pro format-conversion bridge (trait scaffold)"
 readme = "README.md"
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
-chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
+chordsketch-ireal = { version = "0.4.0", path = "../ireal" }
 
 [dev-dependencies]
 # Integration tests in `tests/from_ireal.rs` round-trip through
 # `render-text` to confirm a converted Song actually renders.
-chordsketch-render-text = { version = "0.3.0", path = "../render-text" }
+chordsketch-render-text = { version = "0.4.0", path = "../render-text" }

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-ffi"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,13 +15,13 @@ description = "UniFFI bindings for ChordPro parsing and rendering"
 crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
-chordsketch-render-text = { version = "0.3.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.3.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.3.0", path = "../render-pdf" }
-chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
-chordsketch-convert = { version = "0.3.0", path = "../convert" }
-chordsketch-render-ireal = { version = "0.3.0", path = "../render-ireal", features = ["png", "pdf"] }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
+chordsketch-render-text = { version = "0.4.0", path = "../render-text" }
+chordsketch-render-html = { version = "0.4.0", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.4.0", path = "../render-pdf" }
+chordsketch-ireal = { version = "0.4.0", path = "../ireal" }
+chordsketch-convert = { version = "0.4.0", path = "../convert" }
+chordsketch-render-ireal = { version = "0.4.0", path = "../render-ireal", features = ["png", "pdf"] }
 # `uniffi` is pinned to an exact patch version because the .udl + scaffolding
 # generated layout is part of the FFI surface — Python/Swift/Kotlin/Ruby
 # bindings depend on the binary being byte-compatible with the bindgen output.

--- a/crates/ireal/Cargo.toml
+++ b/crates/ireal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-ireal"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-lsp"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ name = "chordsketch-lsp"
 path = "src/main.rs"
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["rt", "macros", "io-std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-napi"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,13 +15,13 @@ description = "Native Node.js addon for ChordPro parsing and rendering via napi-
 crate-type = ["cdylib"]
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
-chordsketch-render-text = { version = "0.3.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.3.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.3.0", path = "../render-pdf" }
-chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
-chordsketch-convert = { version = "0.3.0", path = "../convert" }
-chordsketch-render-ireal = { version = "0.3.0", path = "../render-ireal", features = ["png", "pdf"] }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
+chordsketch-render-text = { version = "0.4.0", path = "../render-text" }
+chordsketch-render-html = { version = "0.4.0", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.4.0", path = "../render-pdf" }
+chordsketch-ireal = { version = "0.4.0", path = "../ireal" }
+chordsketch-convert = { version = "0.4.0", path = "../convert" }
+chordsketch-render-ireal = { version = "0.4.0", path = "../render-ireal", features = ["png", "pdf"] }
 # `napi` and `napi-derive` are pinned to exact patch versions because the
 # `#[napi]` macro emits ABI-sensitive C glue against the Node-API ABI.
 # Caret ranges (`"3"`) would let a 3.5 release land via a casual `cargo

--- a/crates/napi/npm/darwin-arm64/package.json
+++ b/crates/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-darwin-arm64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Prebuilt @chordsketch/node binary for macOS aarch64 (Apple Silicon).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/darwin-x64/package.json
+++ b/crates/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-darwin-x64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Prebuilt @chordsketch/node binary for macOS x86_64.",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/crates/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-linux-arm64-gnu",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Prebuilt @chordsketch/node binary for Linux aarch64 (glibc).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/linux-x64-gnu/package.json
+++ b/crates/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-linux-x64-gnu",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Prebuilt @chordsketch/node binary for Linux x86_64 (glibc).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/npm/win32-x64-msvc/package.json
+++ b/crates/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node-win32-x64-msvc",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Prebuilt @chordsketch/node binary for Windows x86_64 (MSVC).",
   "license": "MIT",
   "repository": {

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Native Node.js addon for ChordPro parsing and rendering via napi-rs.",
   "license": "MIT",
   "repository": {

--- a/crates/render-html/Cargo.toml
+++ b/crates/render-html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-html"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,4 +13,4 @@ description = "HTML renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }

--- a/crates/render-ireal/Cargo.toml
+++ b/crates/render-ireal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-ireal"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 # Override the workspace's plain `MIT` because the crate ships
@@ -18,7 +18,7 @@ description = "iReal Pro chart renderer (SVG skeleton)"
 readme = "README.md"
 
 [dependencies]
-chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
+chordsketch-ireal = { version = "0.4.0", path = "../ireal" }
 
 # `resvg` / `tiny-skia` (PNG rasteriser, #2064) and `svg2pdf` (PDF
 # converter, #2063) are pulled in only when the corresponding

--- a/crates/render-pdf/Cargo.toml
+++ b/crates/render-pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-pdf"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ description = "PDF renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
 ttf-parser = { version = "0.25", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/render-text/Cargo.toml
+++ b/crates/render-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-render-text"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,5 +13,5 @@ description = "Plain text renderer for ChordPro documents"
 readme = "README.md"
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
 unicode-width = "0.2.2"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordsketch-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -16,13 +16,13 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-chordsketch-chordpro = { version = "0.3.0", path = "../chordpro" }
-chordsketch-render-text = { version = "0.3.0", path = "../render-text" }
-chordsketch-render-html = { version = "0.3.0", path = "../render-html" }
-chordsketch-render-pdf = { version = "0.3.0", path = "../render-pdf" }
-chordsketch-ireal = { version = "0.3.0", path = "../ireal" }
-chordsketch-convert = { version = "0.3.0", path = "../convert" }
-chordsketch-render-ireal = { version = "0.3.0", path = "../render-ireal", features = ["png", "pdf"] }
+chordsketch-chordpro = { version = "0.4.0", path = "../chordpro" }
+chordsketch-render-text = { version = "0.4.0", path = "../render-text" }
+chordsketch-render-html = { version = "0.4.0", path = "../render-html" }
+chordsketch-render-pdf = { version = "0.4.0", path = "../render-pdf" }
+chordsketch-ireal = { version = "0.4.0", path = "../ireal" }
+chordsketch-convert = { version = "0.4.0", path = "../convert" }
+chordsketch-render-ireal = { version = "0.4.0", path = "../render-ireal", features = ["png", "pdf"] }
 wasm-bindgen = "0.2"
 # `render_pdf_with_warnings` (#1893) builds its JS return value via
 # `js_sys::Object` + `js_sys::Reflect` and converts the byte payload

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chordsketch/wasm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "ChordPro parser and renderer compiled to WebAssembly",
   "license": "MIT",
   "type": "module",

--- a/packages/tree-sitter-chordpro/package.json
+++ b/packages/tree-sitter-chordpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-chordpro",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Tree-sitter grammar for ChordPro music notation files",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "chordsketch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chordsketch",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@chordsketch/wasm": "^0.3.0",
+        "@chordsketch/wasm": "^0.4.0",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "chordsketch",
   "displayName": "ChordSketch",
   "description": "ChordPro language support with syntax highlighting, diagnostics, completions, and a live HTML preview panel.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "koedame",
   "icon": "icon.png",
   "license": "MIT",
@@ -163,7 +163,7 @@
     "prepackage": "npm run build"
   },
   "dependencies": {
-    "@chordsketch/wasm": "^0.3.0",
+    "@chordsketch/wasm": "^0.4.0",
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {

--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -26,7 +26,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        koedame chordsketch 0.4.0 v
+github.setup        koedame chordsketch 0.3.0 v
 revision            0
 categories          textproc music
 license             MIT
@@ -37,13 +37,13 @@ long_description    ChordSketch is a Rust implementation of the ChordPro file \
                     HTML, or PDF output. Full compatibility with the ChordPro \
                     specification.
 
-# Source-tarball checksums for v0.4.0. Regenerate on each release —
+# Source-tarball checksums for v0.3.0. Regenerate on each release —
 # the canonical procedure lives in `docs/releasing.md` §MacPorts.
 checksums           rmd160  7a9e7d7548ac8eb07673403361e7da436bdca9d8 \
                     sha256  b0d2f8bf9ef6f2601811d05c1d7d17ad11533b38e0f4dfaed364f98be5f10ba6 \
                     size    6692315
 
-# Cargo crate manifest auto-generated from `git show v0.4.0:Cargo.lock`.
+# Cargo crate manifest auto-generated from `git show v0.3.0:Cargo.lock`.
 # Do not edit by hand — regenerate per docs/releasing.md §MacPorts.
 cargo.crates \
     adler2 2.0.1 320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \

--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -26,7 +26,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        koedame chordsketch 0.3.0 v
+github.setup        koedame chordsketch 0.4.0 v
 revision            0
 categories          textproc music
 license             MIT
@@ -37,13 +37,13 @@ long_description    ChordSketch is a Rust implementation of the ChordPro file \
                     HTML, or PDF output. Full compatibility with the ChordPro \
                     specification.
 
-# Source-tarball checksums for v0.3.0. Regenerate on each release —
+# Source-tarball checksums for v0.4.0. Regenerate on each release —
 # the canonical procedure lives in `docs/releasing.md` §MacPorts.
 checksums           rmd160  7a9e7d7548ac8eb07673403361e7da436bdca9d8 \
                     sha256  b0d2f8bf9ef6f2601811d05c1d7d17ad11533b38e0f4dfaed364f98be5f10ba6 \
                     size    6692315
 
-# Cargo crate manifest auto-generated from `git show v0.3.0:Cargo.lock`.
+# Cargo crate manifest auto-generated from `git show v0.4.0:Cargo.lock`.
 # Do not edit by hand — regenerate per docs/releasing.md §MacPorts.
 cargo.crates \
     adler2 2.0.1 320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -5,9 +5,9 @@
 # checkout and submit a PR.
 #
 # Last verified build: v0.2.0 on x86_64-linux with nixpkgs unstable.
-# v0.3.0 hashes are intentionally blank (see `hash` / `cargoHash`
-# below) — the release PR #1897 bumped `version` but leaves the
-# derivation in its "awaiting-build" state per the workflow below.
+# v0.4.0 hashes are intentionally blank (see `hash` / `cargoHash`
+# below) — the release PR bumps `version` but leaves the derivation
+# in its "awaiting-build" state per the workflow below.
 #
 # When bumping to a new release, update `version` and recompute `hash`
 # and `cargoHash` by setting both to "" and building once — nix will
@@ -22,7 +22,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "chordsketch";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "koedame";

--- a/packaging/winget/koedame.chordsketch.installer.yaml
+++ b/packaging/winget/koedame.chordsketch.installer.yaml
@@ -1,10 +1,10 @@
 PackageIdentifier: koedame.chordsketch
-PackageVersion: 0.3.0
+PackageVersion: 0.4.0
 InstallerType: zip
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/koedame/chordsketch/releases/download/v0.3.0/chordsketch-v0.3.0-x86_64-pc-windows-msvc.zip
-    # SHA256 must be recomputed after the v0.3.0 release artifact is published.
+    InstallerUrl: https://github.com/koedame/chordsketch/releases/download/v0.4.0/chordsketch-v0.4.0-x86_64-pc-windows-msvc.zip
+    # SHA256 must be recomputed after the v0.4.0 release artifact is published.
     # Run: curl -L <InstallerUrl> | sha256sum  (uppercase the hex output)
     # This value is the v0.2.2 hash and is intentionally stale — do not
     # submit this manifest to winget-pkgs until the hash is refreshed.

--- a/packaging/winget/koedame.chordsketch.locale.en-US.yaml
+++ b/packaging/winget/koedame.chordsketch.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: koedame.chordsketch
-PackageVersion: 0.3.0
+PackageVersion: 0.4.0
 PackageLocale: en-US
 Publisher: koedame
 PackageName: ChordSketch

--- a/packaging/winget/koedame.chordsketch.yaml
+++ b/packaging/winget/koedame.chordsketch.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: koedame.chordsketch
-PackageVersion: 0.3.0
+PackageVersion: 0.4.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Lockstep bump `0.3.0` → `0.4.0` across every tracked version site
(32 sources, enforced by `scripts/check-version-consistency.py`).
CLI and GUI share the single `0.4.0` version per the established
lockstep policy.

## Sites bumped

- **Workspace** — all 13 SDK + bin `Cargo.toml` plus 26 inter-crate
  `version =` pins.
- **Desktop (lockstep)** — `apps/desktop/src-tauri/Cargo.toml`,
  `apps/desktop/src-tauri/tauri.conf.json`,
  `apps/desktop/package.json`, `apps/desktop/package-lock.json`.
- **npm / node** — `packages/npm`, `packages/vscode-extension`
  (top-level + `@chordsketch/wasm` dep range),
  `crates/napi` + 5 per-platform prebuilt manifests,
  `packages/tree-sitter-chordpro`.
- **Packaging** — `packaging/nix/package.nix`, 3 winget manifests.
  `packaging/macports/Portfile` is intentionally NOT bumped here:
  the MacPorts Portfile sync CI guard (#2317) reads
  `git show v<TAG>:Cargo.lock`, which fails for the not-yet-tagged
  release. Per `docs/releasing.md` §5, the full Portfile update
  (version + checksums + `cargo.crates` regen) is a post-release
  step. Tracker for the CI-guard structural bug: #2413. Allowlist
  entry in `ci/version-skew-allowlist.toml` covers the consequent
  Portfile drift; it retires when the post-release MacPorts
  refresh PR for v0.4.0 lands.
- **CI pins** — `readme-smoke.yml`: `@chordsketch/wasm@0.4.0` exact
  pin and caret constraints (`chordsketch-chordpro = "^0.4"`,
  `chordsketch-render-text = "^0.4"`).
- **`Cargo.lock`** — regenerated by `cargo check --workspace`.

## CHANGELOG

`[Unreleased]` contents graduate to `[0.4.0] - 2026-05-06`; a fresh
empty `[Unreleased]` sits above. Headline themes:

- **iReal Pro support (multi-format track, #2050)** — three new
  crates (`chordsketch-ireal`, `chordsketch-render-ireal`,
  `chordsketch-convert`) plus `irealb://` URL parse / serialize,
  bidirectional ChordPro ↔ iReal Pro conversion, `.irealb` /
  `.irealbook` extension dispatch across CLI, desktop, VS Code,
  JetBrains, and Zed.
- **Bar-grid GUI editor** — new private package
  `@chordsketch/ui-irealb-editor` with header metadata editing,
  per-bar popovers, structural section / bar reordering, keyboard
  shortcuts, and ARIA grid semantics. Wires into
  `@chordsketch/ui-web` via the `EditorAdapter` contract; runtime
  swap drives the playground's ChordPro / iRealb format toggle and
  the desktop Open / Save dispatch.
- **Bindings (#2067)** — WASM / NAPI / FFI all expose the iReal
  Pro surface (conversion, SVG / PNG / PDF render, AST parse /
  serialize) across four phases.
- **ChordPro parser** — `settings.strict` + missing-`{key}`
  warning, `keys.force-common` / `keys.flats` canonicalizer,
  transposable `{chord: [X]}` / `{define: [X]}`, Charango
  voicings.
- **Renderers** — `render-html` body-only export +
  `render_html_css()`, `settings.wraplines`; `render-pdf` `/Info`
  `/Title` for single-song output.
- **Desktop app** — full native menu, file I/O / focus-toggle /
  transpose keyboard shortcuts.
- **Linux** — standalone GNOME thumbnailer for `.cho`.

## Release-doc-sync verification

`release-doc-sync.md §§1-6` verified against `42ac308`:

- §1 CHANGELOG completeness — fix-ups for missing entries
  (`@chordsketch/ui-irealb-editor`, editor-extension `.irealb`
  registrations, playground browser smoke / wasm init race) folded
  into this PR; remaining 52 `feat`/`fix` commits since v0.3.0 all
  have bullets or are covered by umbrella entries.
- §2 `docs/releasing.md` — 13 crates, Step 6 publish list
  topologically valid (verified per crate's `[dependencies]` block,
  `[dev-dependencies]` excluded).
- §3 `CLAUDE.md` Architecture table — every row's Dependencies
  column matches the corresponding `Cargo.toml` `[dependencies]`
  block exactly.
- §4 README Features section — covers ChordPro and iReal Pro
  surfaces shipped this release.
- §5 Binding READMEs — `crates/{wasm,napi,ffi}/README.md` all
  document the iReal Pro API surface (#2405, #2407, #2410, #2411).
- §6 Security ADRs — ADR-0007 / ADR-0008 / ADR-0009 still align
  with `desktop-release.yml` updater wiring, `.github/workflows/`
  has no actual `npm publish` invocations, and both
  `release.yml` + `desktop-release.yml` use
  `secrets.RELEASE_DISPATCH_TOKEN` on every `gh release create`.

## Test plan

- [x] `python3 scripts/check-version-consistency.py` →
  `canonical version: 0.4.0`, `sources checked: 32`,
  `allowlist entries: 1` (Portfile entry retiring at the
  post-release MacPorts refresh PR), exit 0.
- [x] `cargo check --workspace` — clean, `Cargo.lock` regenerated.
- [x] `python3 scripts/macports-regen-cargo-crates.py --check` →
  exit 0 (Portfile still pins `0.3.0` so the tag-relative check
  resolves cleanly).

## Expected pre-publish failures

The following two checks fail and are **expected to remain red
until `@chordsketch/wasm@0.4.0` is published to npm**, mirroring
the v0.3.0 release-cut PR (#2255) which merged with the same
`npm (@chordsketch/wasm)` failure:

- `README Install Smoke Tests / npm (@chordsketch/wasm)` —
  `npm install '@chordsketch/wasm@0.4.0'` fails with `ETARGET`
  because the registry does not yet have 0.4.0. The pin in
  `readme-smoke.yml` is bumped per the in-file comment
  ("Update this pin in the same PR that bumps the workspace
  version"); the smoke run that proves the install path will
  pass on the next scheduled run after the manual `npm publish`.
- `VS Code Extension / Build & Package Extension` —
  `packages/vscode-extension`'s `@chordsketch/wasm` dep range is
  bumped to `^0.4.0`, so `npm install` resolves to ETARGET until
  0.4.0 is on the registry.

These two failures will resolve on the next workflow run after
the maintainer's local `npm publish @chordsketch/wasm@0.4.0`
(per `docs/releasing.md` §7a / ADR-0008).

## Deferred

- **MacPorts Portfile bump** — full update (version + checksums +
  `cargo.crates` regen) is a post-release step per
  `docs/releasing.md` §5. The CI-guard structural bug that
  prevents bumping the version line in the release-cut PR is
  tracked separately as #2413.

## Post-merge actions

1. `git tag v0.4.0 && git push origin v0.4.0` →
   triggers `release.yml`.
2. `git tag desktop-v0.4.0 && git push origin desktop-v0.4.0` →
   triggers `desktop-release.yml`.
3. `cargo publish` cascade per `docs/releasing.md` §6.
4. Manual `npm publish` for `@chordsketch/wasm`,
   `@chordsketch/node` (via local script), and
   `tree-sitter-chordpro` per ADR-0008 / `docs/releasing.md` §7.
5. `npm install` in `packages/vscode-extension` and
   `apps/desktop` after `@chordsketch/wasm@0.4.0` is published, so
   the resolved `node_modules/@chordsketch/wasm` lock entries
   refresh to 0.4.0 (these are intentionally left at 0.3.0 in this
   PR because the 0.4.0 tarball does not yet exist on the
   registry).
6. Trigger remaining `release: published` workflows manually per
   `docs/releasing.md` §8.
7. Per `docs/releasing.md` §5, refresh the MacPorts Portfile
   (version + checksums + `cargo.crates` block) and submit the
   PR to `macports/macports-ports`. The same PR removes the
   `[[allowed_skews]]` entry for `packaging/macports/Portfile` /
   `github.setup version` from `ci/version-skew-allowlist.toml`
   and closes #2413 (or its successor, depending on how the
   CI-guard fix lands).

## Review summary

Self-reviewed; no findings. Mechanical version bump with
release-doc-sync drift fixes — no behavioural code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)