### PR TITLE
Update Swift Package.swift to v0.4.0

### DIFF
--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "chordsketchFFI",
-            url: "https://github.com/koedame/chordsketch/releases/download/v0.3.0/chordsketch-xcframework.zip",
-            checksum: "6d0bbc9bb9f98987b16b3dc28d27578b5163384c886ca7dfcd97bdb06ddc82f2"
+            url: "https://github.com/koedame/chordsketch/releases/download/v0.4.0/chordsketch-xcframework.zip",
+            checksum: "4aeebeee2bd5e067e6a4417e7eb7080f1f26a7e9d49c8686c92d00616d45d90c"
         ),
         .target(
             name: "ChordSketch",


### PR DESCRIPTION
## What

Updates `packages/swift/Package.swift`'s `.binaryTarget` to point to
the `v0.4.0` xcframework asset and pin its SHA256.

- **Tag**: `v0.4.0`
- **Asset**: `chordsketch-xcframework.zip`
- **SHA256**: `4aeebeee2bd5e067e6a4417e7eb7080f1f26a7e9d49c8686c92d00616d45d90c`

## Why

Auto-generated by `post-release.yml`'s `update-swift-package` job
after the Swift workflow uploaded the xcframework to the release.
Without this update, `swift package add https://github.com/koedame/chordsketch.git`
against the new tag would fail with an invalid checksum error.

See #1062.