### PR TITLE
chore(release): refresh vscode-extension lockfile for @chordsketch/wasm@0.4.0

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -247,9 +247,9 @@
       "license": "MIT"
     },
     "node_modules/@chordsketch/wasm": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@chordsketch/wasm/-/wasm-0.3.0.tgz",
-      "integrity": "sha512-tZ8jY/KwBdNGu4p5w1YGOYfIQO2scL4UGlO4MuUZ3QIVKBhyGPw403ILTTGHSmEolv1jJmC5/NwaMouoDrbKxg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@chordsketch/wasm/-/wasm-0.4.0.tgz",
+      "integrity": "sha512-Ub6Rje9xkyhyT+gNKc0O9npAZICEQorMEwNcWYorhMvgW6sLek+zvRXnDjE4nN+z2kUNIuHALXqvdc5B/tSFXw==",
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {


### PR DESCRIPTION
## Summary

Regenerate `packages/vscode-extension/package-lock.json` so the
resolved `node_modules/@chordsketch/wasm` entry tracks the
`@chordsketch/wasm@0.4.0` tarball published manually after PR #2412
merged. Three-line lockfile diff (version / resolved URL / integrity
hash); no `package.json` change.

## Why

The release-event run of `vscode-extension.yml` (run id 25432590627)
failed at `npm ci`:

```
Invalid: lock file's @chordsketch/wasm@0.3.0 does not satisfy
@chordsketch/wasm@0.4.0
```

PR #2412 intentionally left the lockfile pointing at 0.3.0 because
the 0.4.0 tarball did not yet exist on the npm registry — see PR
#2412's "Post-merge actions" §5. Now that 0.4.0 is published
(`npm view @chordsketch/wasm version` → `0.4.0`), this PR closes
the gap.

## Test plan

- [x] `cd packages/vscode-extension && rm -rf node_modules && npm ci`
  → succeeds (was the originally failing command).
- [ ] Re-trigger `vscode-extension.yml` against `v0.4.0` after
  merge (`gh workflow run vscode-extension.yml -f tag=v0.4.0`).
  Both `vscode-marketplace` and `open-vsx` channels should publish
  the v0.4.0 VSIX bundles, and the next `release-verify.yml` run
  will turn the corresponding rows green in the GitHub Release body.

Closes #2415

🤖 Generated with [Claude Code](https://claude.com/claude-code)