### PR TITLE
fix(scripts): graceful tag fallback in macports cargo.crates --check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `scripts/macports-regen-cargo-crates.py --check`: when the tag
+  auto-resolved from `packaging/macports/Portfile`'s `github.setup`
+  line does not yet exist (release-cut PR window), gracefully fall
+  back to comparing the `cargo.crates` block against
+  `HEAD:Cargo.lock` with an advisory note on stderr instead of
+  failing. Explicit `--from-ref REF` invocations still fail
+  loudly when `REF` is missing — preserves user intent. The
+  next normal CI run, after the tag is pushed, validates against
+  the real tagged `Cargo.lock` per the original tag-relative
+  invariant (ADR-0012). Removes the workaround that forced the
+  v0.4.0 release-cut PR to revert its Portfile bump and ship a
+  separate post-release Portfile refresh PR. (#2413)
+
 ## [0.4.0] - 2026-05-06
 
 ### Added

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -399,10 +399,21 @@ After the release workflow completes and the GitHub Release is published:
         python3 scripts/macports-regen-cargo-crates.py --apply
         ```
         Use `--from-ref HEAD` instead when the new tag does not yet
-        exist (release rehearsal against unreleased commits). The
-        bare `--check` form is what the `macports-portfile-sync` CI
-        guard runs on every PR, so running it locally before pushing
-        catches drift before CI.
+        exist (release rehearsal against unreleased commits, or the
+        release-cut PR itself bumping the Portfile inline before the
+        merge → tag-push sequence). The bare `--check` form is what
+        the `macports-portfile-sync` CI guard runs on every PR, so
+        running it locally before pushing catches drift before CI.
+
+        The CI guard also tolerates the **release-cut window** —
+        when the auto-resolved tag does not yet exist, `--check`
+        falls back to comparing against `HEAD:Cargo.lock` with a
+        clear advisory note on stderr, instead of failing. This
+        means a release-cut PR can bump `github.setup` and
+        regenerate `cargo.crates` (against HEAD via `--apply
+        --from-ref HEAD`) inline; the next normal CI run, after
+        the tag is pushed, validates against the real tagged
+        `Cargo.lock`. See #2413 / ADR-0012 for the rationale.
       - On a Mac with MacPorts installed, run `cargo2port.py` from a
         local MacPorts install **after** checking out the tag (so
         `Cargo.lock` in the working tree is the tagged one). The output

--- a/scripts/macports-regen-cargo-crates.py
+++ b/scripts/macports-regen-cargo-crates.py
@@ -29,6 +29,25 @@ portfile-cargo-crates-tag-relative.md` for the full rationale.
 Override with `--from-ref REF` (any git revision, e.g. `HEAD`) when
 preparing a Portfile bump for a release that has not been tagged yet.
 
+`--check` carries one graceful behaviour the other commands do not:
+when the tag is auto-resolved from the Portfile and that tag does
+not yet exist (i.e. a release-cut PR has bumped `github.setup` to
+the new version but the corresponding `vX.Y.Z` tag is created only
+post-merge), the check **falls back to comparing against
+`HEAD:Cargo.lock`** with a clear advisory note on stderr. This
+keeps the in-PR signal useful (the `cargo.crates` block must still
+match SOMETHING coherent — HEAD if the tag is unavailable) without
+forcing the maintainer to revert their Portfile bump out of the
+release-cut PR. After the tag is pushed, the next normal CI run
+validates against the real tagged `Cargo.lock` per the original
+invariant. See ADR-0012 §"Release-cut window" and #2413 for the
+rationale.
+
+The fallback is intentionally scoped to `--check` with an
+auto-resolved tag. If the caller explicitly passes `--from-ref REF`
+and `REF` does not exist, the script still fails — explicit
+user intent is preserved.
+
 Usage:
     # Print the cargo.crates block we would generate from the
     # Portfile's tagged Cargo.lock
@@ -41,7 +60,8 @@ Usage:
 
     # Verify the Portfile matches the tagged Cargo.lock; exits
     # non-zero on drift. The `macports-portfile-sync` CI guard runs
-    # this on every PR.
+    # this on every PR. Falls back to HEAD when the auto-resolved
+    # tag does not yet exist (release-cut window).
     python3 scripts/macports-regen-cargo-crates.py --check
 
     # Pre-tag refresh: regenerate from a not-yet-tagged ref.
@@ -80,8 +100,28 @@ def portfile_tag() -> str:
     return f"v{m.group(1)}"
 
 
+class GitRefMissingError(Exception):
+    """Raised when `git show <ref>:<path>` fails because `<ref>` does not exist.
+
+    Distinct from generic `git show` failures so callers can choose to
+    handle "tag not yet created" specifically (see `cmd_check`'s
+    release-cut fallback) without swallowing other git errors.
+    """
+
+    def __init__(self, ref: str, stderr: str) -> None:
+        super().__init__(f"git ref does not exist: {ref!r} ({stderr})")
+        self.ref = ref
+        self.stderr = stderr
+
+
 def read_cargo_lock(from_ref: str) -> str:
-    """Return the contents of `Cargo.lock` at the given git revision."""
+    """Return the contents of `Cargo.lock` at the given git revision.
+
+    Raises `GitRefMissingError` if `from_ref` does not resolve to any
+    object reachable from the local repository. Other failure modes
+    (git not installed, permission errors, missing `Cargo.lock` at
+    the resolved ref) raise `SystemExit` with a descriptive message.
+    """
     # Defense-in-depth: refuse refs that could be mis-parsed by `git
     # show` as a flag. `git show` does not provide a `--` separator
     # for revisions, so the only safe form is to validate the
@@ -102,9 +142,24 @@ def read_cargo_lock(from_ref: str) -> str:
     except FileNotFoundError as exc:
         raise SystemExit(f"git is required but not on PATH: {exc}") from exc
     except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip()
+        # `git show <missing-ref>:<path>` emits one of:
+        #   fatal: invalid object name '<ref>'.
+        #   fatal: bad revision '<ref>'.
+        # depending on what kind of name was passed. Both indicate the
+        # ref itself is unreachable, which is the case the release-cut
+        # fallback in `cmd_check` wants to detect specifically. Any
+        # other CalledProcessError (e.g. ref exists but lacks a
+        # `Cargo.lock` at that revision) stays a hard error.
+        marker_invalid_ref = (
+            "invalid object name" in stderr.lower()
+            or "bad revision" in stderr.lower()
+        )
+        if marker_invalid_ref:
+            raise GitRefMissingError(from_ref, stderr) from exc
         raise SystemExit(
             f"git show {from_ref}:Cargo.lock failed (exit {exc.returncode}): "
-            f"{exc.stderr.strip()}"
+            f"{stderr}"
         ) from exc
     return result.stdout
 
@@ -192,8 +247,35 @@ def cmd_apply(from_ref: str) -> int:
     return 0
 
 
-def cmd_check(from_ref: str) -> int:
-    crates = parse_cargo_lock(read_cargo_lock(from_ref))
+def cmd_check(from_ref: str, *, allow_tag_fallback: bool) -> int:
+    """Verify the Portfile matches `Cargo.lock@from_ref`.
+
+    When `allow_tag_fallback=True` and the auto-resolved tag does not
+    yet exist (release-cut window), fall back to comparing against
+    `HEAD:Cargo.lock` with an advisory note on stderr instead of
+    failing. `--check` invocations without an explicit `--from-ref`
+    pass `allow_tag_fallback=True`; explicit refs do not, so user
+    intent is preserved.
+    """
+    effective_ref = from_ref
+    try:
+        text = read_cargo_lock(from_ref)
+    except GitRefMissingError as exc:
+        if not allow_tag_fallback:
+            sys.stderr.write(
+                f"git ref '{exc.ref}' does not exist: {exc.stderr}\n"
+            )
+            return 1
+        sys.stderr.write(
+            f"NOTE: tag '{exc.ref}' does not yet exist — assuming this is "
+            f"a release-cut PR window (see #2413).\n"
+            f"      Falling back to HEAD:Cargo.lock for advisory check; "
+            f"the next normal CI run after the tag is pushed will validate "
+            f"against the real tagged Cargo.lock.\n"
+        )
+        effective_ref = "HEAD"
+        text = read_cargo_lock(effective_ref)
+    crates = parse_cargo_lock(text)
     new_block = render_block(crates)
     portfile = PORTFILE.read_text(encoding="utf-8")
     expected = replace_block_in_portfile(portfile, new_block)
@@ -201,10 +283,10 @@ def cmd_check(from_ref: str) -> int:
         return 0
     sys.stderr.write(
         f"{PORTFILE.relative_to(REPO_ROOT)} cargo.crates block drifted from "
-        f"Cargo.lock@{from_ref}.\n"
+        f"Cargo.lock@{effective_ref}.\n"
         "\n"
         f"Refresh with: python3 scripts/macports-regen-cargo-crates.py "
-        f"--apply --from-ref {from_ref}\n"
+        f"--apply --from-ref {effective_ref}\n"
     )
     return 1
 
@@ -227,12 +309,15 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    from_ref = args.from_ref if args.from_ref is not None else portfile_tag()
+    auto_resolved = args.from_ref is None
+    from_ref = args.from_ref if not auto_resolved else portfile_tag()
 
     if args.apply:
         return cmd_apply(from_ref)
     if args.check:
-        return cmd_check(from_ref)
+        # Auto-resolved tag may not yet exist in a release-cut PR; allow
+        # graceful fallback to HEAD in that one case (see #2413).
+        return cmd_check(from_ref, allow_tag_fallback=auto_resolved)
     return cmd_print(from_ref)
 
 

--- a/scripts/test_macports_regen_cargo_crates.py
+++ b/scripts/test_macports_regen_cargo_crates.py
@@ -6,18 +6,24 @@ The pure functions (`portfile_tag`, `parse_cargo_lock`, `render_block`,
 `read_cargo_lock`) are unit-tested against synthetic fixtures so the
 suite is independent of the real Portfile / Cargo.lock.
 
-Tests intentionally do NOT exercise the `git show` subprocess path —
-that would couple the suite to the host's git history. The `from_ref`
-validation guard (refuses values starting with `-`) IS covered because
-it short-circuits before any subprocess call.
+Tests intentionally do NOT exercise the `git show` subprocess path
+end-to-end — that would couple the suite to the host's git history.
+The `from_ref` validation guard (refuses values starting with `-`)
+IS covered because it short-circuits before any subprocess call. The
+`GitRefMissingError` classification path is covered by patching
+`subprocess.run` to return a synthesised CalledProcessError, and
+`cmd_check`'s release-cut fallback is covered by patching
+`read_cargo_lock` itself.
 """
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
@@ -205,6 +211,147 @@ class ReadCargoLockGuardTests(unittest.TestCase):
     def test_rejects_simple_dash_prefix(self) -> None:
         with self.assertRaises(SystemExit):
             mod.read_cargo_lock("-foo")
+
+
+def _make_called_process_error(stderr: str) -> subprocess.CalledProcessError:
+    err = subprocess.CalledProcessError(returncode=128, cmd=["git", "show"])
+    err.stderr = stderr
+    return err
+
+
+class ReadCargoLockGitRefMissingTests(unittest.TestCase):
+    """Verify the `GitRefMissingError` classification."""
+
+    def test_invalid_object_name_raises_GitRefMissingError(self) -> None:
+        # The exact stderr `git show` emits when a ref does not exist.
+        err = _make_called_process_error(
+            "fatal: invalid object name 'v9.9.9'."
+        )
+        with patch.object(mod.subprocess, "run", side_effect=err):
+            with self.assertRaises(mod.GitRefMissingError) as cm:
+                mod.read_cargo_lock("v9.9.9")
+        self.assertEqual(cm.exception.ref, "v9.9.9")
+        self.assertIn("invalid object name", cm.exception.stderr)
+
+    def test_bad_revision_also_classified_as_GitRefMissingError(self) -> None:
+        # Some git versions emit "bad revision" instead. Both indicate
+        # the ref is unreachable.
+        err = _make_called_process_error("fatal: bad revision 'vNOPE'.")
+        with patch.object(mod.subprocess, "run", side_effect=err):
+            with self.assertRaises(mod.GitRefMissingError):
+                mod.read_cargo_lock("vNOPE")
+
+    def test_unrelated_git_error_still_raises_SystemExit(self) -> None:
+        # E.g., the ref exists but has no `Cargo.lock` at that revision.
+        err = _make_called_process_error(
+            "fatal: path 'Cargo.lock' does not exist in 'v0.0.1'"
+        )
+        with patch.object(mod.subprocess, "run", side_effect=err):
+            with self.assertRaises(SystemExit) as cm:
+                mod.read_cargo_lock("v0.0.1")
+        # Must NOT degrade to GitRefMissingError — that would silently
+        # mask a real "Cargo.lock missing" defect on a tagged release.
+        self.assertNotIsInstance(cm.exception, mod.GitRefMissingError)
+
+
+def _matching_portfile() -> str:
+    """Portfile whose cargo.crates block matches CARGO_LOCK_FIXTURE exactly."""
+    return (
+        "PortSystem 1.0\n"
+        "PortGroup github 1.0\n"
+        "PortGroup cargo 1.0\n"
+        "\n"
+        "github.setup        koedame chordsketch 0.5.0 v\n"
+        "revision            0\n"
+        "categories          textproc music\n"
+        "license             MIT\n"
+        "\n"
+        + mod.render_block(mod.parse_cargo_lock(CARGO_LOCK_FIXTURE))
+        + "\n"
+        "build.dir ${worksrcpath}\n"
+    )
+
+
+class CmdCheckFallbackTests(unittest.TestCase):
+    """`cmd_check` graceful fallback during the release-cut window (#2413)."""
+
+    def _setup_portfile(self, tmp: str, body: str) -> Path:
+        root = Path(tmp)
+        portfile = root / "packaging" / "macports" / "Portfile"
+        portfile.parent.mkdir(parents=True)
+        portfile.write_text(body, encoding="utf-8")
+        mod.REPO_ROOT = root
+        mod.PORTFILE = portfile
+        return portfile
+
+    def test_fallback_passes_when_block_matches_HEAD(self) -> None:
+        # Simulate a release-cut PR: Portfile points at v0.5.0 (not yet
+        # tagged) but the cargo.crates block was regenerated against
+        # HEAD's Cargo.lock, so the fallback comparison succeeds.
+        with TemporaryDirectory() as tmp:
+            self._setup_portfile(tmp, _matching_portfile())
+
+            def _fake_read(ref: str) -> str:
+                if ref == "v0.5.0":
+                    raise mod.GitRefMissingError(
+                        "v0.5.0", "fatal: invalid object name 'v0.5.0'."
+                    )
+                if ref == "HEAD":
+                    return CARGO_LOCK_FIXTURE
+                self.fail(f"unexpected ref: {ref}")
+
+            with patch.object(mod, "read_cargo_lock", side_effect=_fake_read):
+                rc = mod.cmd_check("v0.5.0", allow_tag_fallback=True)
+            self.assertEqual(rc, 0)
+
+    def test_fallback_disabled_returns_1_on_missing_ref(self) -> None:
+        # An explicit `--from-ref` that does not exist must NOT silently
+        # fall back to HEAD — explicit user intent is preserved.
+        with TemporaryDirectory() as tmp:
+            self._setup_portfile(tmp, _matching_portfile())
+
+            def _fake_read(ref: str) -> str:
+                raise mod.GitRefMissingError(
+                    ref, f"fatal: invalid object name '{ref}'."
+                )
+
+            with patch.object(mod, "read_cargo_lock", side_effect=_fake_read):
+                rc = mod.cmd_check("vNOPE", allow_tag_fallback=False)
+            self.assertEqual(rc, 1)
+
+    def test_fallback_still_reports_drift(self) -> None:
+        # When the fallback comparison surfaces actual drift between
+        # Portfile and HEAD, cmd_check must still report it (return 1)
+        # — the fallback is a venue change, not a free pass.
+        with TemporaryDirectory() as tmp:
+            # Portfile has a cargo.crates block that does NOT match HEAD's
+            # Cargo.lock contents.
+            stale_portfile = (
+                "PortSystem 1.0\n"
+                "PortGroup github 1.0\n"
+                "PortGroup cargo 1.0\n"
+                "\n"
+                "github.setup        koedame chordsketch 0.5.0 v\n"
+                "revision            0\n"
+                "license             MIT\n"
+                "\n"
+                "cargo.crates \\\n"
+                "    stale 0.0.0 stalestalestalestalestalestalestalestalestalestalestalestale\n"
+                "\n"
+                "build.dir ${worksrcpath}\n"
+            )
+            self._setup_portfile(tmp, stale_portfile)
+
+            def _fake_read(ref: str) -> str:
+                if ref == "v0.5.0":
+                    raise mod.GitRefMissingError(
+                        "v0.5.0", "fatal: invalid object name 'v0.5.0'."
+                    )
+                return CARGO_LOCK_FIXTURE
+
+            with patch.object(mod, "read_cargo_lock", side_effect=_fake_read):
+                rc = mod.cmd_check("v0.5.0", allow_tag_fallback=True)
+            self.assertEqual(rc, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`scripts/macports-regen-cargo-crates.py --check` now gracefully
falls back to `HEAD:Cargo.lock` when the tag auto-resolved from
`packaging/macports/Portfile`'s `github.setup` line does not yet
exist. This unblocks **release-cut PRs from bumping the Portfile
inline** instead of having to revert the bump and ship a separate
post-release Portfile PR.

## Why

Release-cut PRs need to bump `github.setup` to the new version
(`0.4.0`, `0.5.0`, …) before the corresponding tag exists — the
tag is created at merge time. The previous CI guard implementation
ran `git show v<TAG>:Cargo.lock` against the auto-resolved tag and
failed with `fatal: invalid object name 'v<TAG>'`, blocking every
release-cut PR. The v0.4.0 cut worked around this by:

1. Reverting the Portfile bump out of the release-cut PR (#2412).
2. Adding an `[[allowed_skews]]` entry in
   `ci/version-skew-allowlist.toml` so `check-version-consistency.py`
   tolerated the resulting drift.
3. Shipping a separate post-release Portfile refresh PR (#2417)
   that bumped Portfile + checksums + cargo.crates together once
   the tag existed.

That two-step is exactly what ADR-0012's Rationale section
anticipated needing to avoid — *"A release-prep PR legitimately
needs to regenerate `cargo.crates` against an unreleased commit,
and that commit becomes the tag at merge time"* — but the CI
guard's `--check` path didn't honour it.

## What changed

- `read_cargo_lock` classifies the `git show` `fatal: invalid object
  name` / `fatal: bad revision` stderr signatures into a new
  `GitRefMissingError`. Other failure modes (git missing on PATH,
  `Cargo.lock` missing at a tagged revision, etc.) still raise
  `SystemExit` so a real defect cannot silently degrade.
- `cmd_check(from_ref, *, allow_tag_fallback)` catches
  `GitRefMissingError` when `allow_tag_fallback=True` and falls back
  to `HEAD:Cargo.lock` with a clear advisory note on stderr.
- `main()` passes `allow_tag_fallback=True` only for the auto-resolved
  case (no explicit `--from-ref`). Explicit `--from-ref REF` against a
  missing ref still fails with exit 1 — user intent preserved.
- `--apply` and `--print` are unchanged: the fallback is `--check`-only.
- `docs/releasing.md` §5 documents the new behaviour and points at
  ADR-0012 / this issue.
- `CHANGELOG.md` `[Unreleased]` records it under `### Changed`.

## Tests

20 unit tests pass (14 existing + 6 new):

- `ReadCargoLockGitRefMissingTests` (3): verifies the `invalid object
  name` and `bad revision` stderr signatures both produce
  `GitRefMissingError`, and that an unrelated git error (e.g.
  `Cargo.lock` missing at a real ref) still raises `SystemExit`.
- `CmdCheckFallbackTests` (3): verifies the fallback passes when
  Portfile matches `HEAD:Cargo.lock`, fails (exit 1) when
  `allow_tag_fallback=False`, and still detects drift when the
  fallback comparison surfaces a real mismatch.

## Test plan

- [x] `python3 -m unittest scripts/test_macports_regen_cargo_crates.py` → 20/20 pass.
- [x] `python3 scripts/macports-regen-cargo-crates.py --check` against
  the real tree → exit 0 (auto-resolves to `v0.4.0`, tag exists,
  cargo.crates matches).
- [x] Smoke test with simulated release-cut: temporarily edit Portfile
  to point at `v0.5.0`, run `--check` → emits the advisory NOTE on
  stderr, falls back to HEAD, exit 0 (cargo.crates still matches HEAD).
- [x] Smoke test with explicit nonexistent ref:
  `--check --from-ref vNOPE` → exit 1, stderr explains "git ref
  'vNOPE' does not exist".

## Migration impact

Future release-cut PRs (v0.5.0 onward) can:

1. Bump `github.setup 0.X.Y v` in `packaging/macports/Portfile`.
2. Run `python3 scripts/macports-regen-cargo-crates.py --apply --from-ref HEAD`.
3. Commit. CI's `--check` falls back to HEAD, sees the regenerated
   block matches, and passes.
4. After merge → tag push, the next normal CI run validates against
   the real tagged `Cargo.lock` per the original tag-relative invariant.

The post-release Portfile checksum refresh (the GitHub-auto-generated
tarball's hashes) is still required separately because the tarball
does not exist until the tag is pushed. That is a smaller delta than
the v0.4.0 #2417 PR was.

Closes #2413

🤖 Generated with [Claude Code](https://claude.com/claude-code)