### PR TITLE
fix(scripts): release-verify probes for ghcr/docker-hub/maven-central

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -216,7 +216,7 @@ jobs:
     continue-on-error: true
     environment:
       name: maven-central
-      url: https://repo1.maven.org/maven2/io/github/koedame/chordsketch/
+      url: https://repo1.maven.org/maven2/me/koeda/chordsketch/
     # Enforce `bash -euo pipefail` in `run:` blocks. Scoped to this job
     # rather than workflow-level because kotlin.yml has a Windows matrix
     # cell (build-jni-others) whose `run:` blocks must keep pwsh defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `scripts/check-release-channels.py`: the `ghcr`, `docker-hub`,
+  and `maven-central` probes returned `<error>` on every release in
+  the rollup table, even though the underlying publishes succeeded.
+  Three independent bugs:
+  - **Docker Hub / GHCR**: the probe URLs prepended a `v` to the
+    version (`tags/v0.4.0/`, `manifests/v0.4.0`), but `docker.yml`
+    uses `metadata-action` with `pattern={{version}}` which strips
+    the `v` and pushes images as `0.4.0`, `0.4`, `latest`. The
+    probe URLs now match the bare semver.
+  - **GHCR auth**: anonymous GET against the v2 manifest endpoint
+    always returned 401 because the Docker Registry v2 protocol
+    requires `Authorization: Bearer <token>` even for public
+    packages. The probe now fetches a pull token from
+    `https://ghcr.io/token?…&scope=repository:<repo>:pull` first.
+    Token availability is itself the visibility check for public
+    packages.
+  - **GHCR Accept header**: the manifest endpoint returns 404
+    unless the request advertises a manifest media type via
+    `Accept`. Multi-arch images come back as either OCI
+    image-index or Docker manifest-list, so the probe now sends
+    both content types in the negotiation list.
+  - **Maven Central**: `ci/release-channels.toml` declared the
+    package as `io.github.koedame:chordsketch`, but the actual
+    publish coordinates are `me.koeda:chordsketch` (reverse-DNS
+    of the `koeda.me` domain registered on Sonatype Central
+    Portal). The probe is also rebuilt to read the authoritative
+    `repo1.maven.org/maven2/<group>/<artifact>/maven-metadata.xml`
+    rather than `search.maven.org/solrsearch`, which was
+    empirically not indexing this artifact at all. Sister
+    references in `.github/workflows/kotlin.yml` deployment URL
+    and `docs/releasing.md` Distribution Channels table are
+    corrected. (#2418)
+
 ### Changed
 
 - `scripts/macports-regen-cargo-crates.py --check`: when the tag

--- a/ci/release-channels.toml
+++ b/ci/release-channels.toml
@@ -263,9 +263,9 @@ notes = "Publishes via .github/workflows/ruby.yml."
 
 [[channels]]
 id = "maven-central"
-display = "Maven Central — io.github.koedame:chordsketch"
+display = "Maven Central — me.koeda:chordsketch"
 kind = "maven-central"
-package = "io.github.koedame:chordsketch"
+package = "me.koeda:chordsketch"
 expected_version = "tag"
 required_secrets = [
     "CENTRAL_PORTAL_USERNAME",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -284,7 +284,7 @@ When adding a new channel, update both.
 | VS Code Marketplace | `koedame.chordsketch` (1 universal + 7 platform-specific VSIXes, #1789) | `vscode-extension.yml` on `release: published` | `VSCE_PAT` (PAT, Marketplace Publish scope) | `vscode-marketplace` rollup entry |
 | PyPI | `chordsketch` | `python.yml` on tag push | none (OIDC trusted publisher) | `pypi` rollup entry |
 | RubyGems | `chordsketch` | `ruby.yml` on tag push | none (OIDC trusted publisher) | `rubygems` rollup entry |
-| Maven Central | `io.github.koedame:chordsketch` | `kotlin.yml` on tag push | `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD` | `maven-central` rollup entry |
+| Maven Central | `me.koeda:chordsketch` | `kotlin.yml` on tag push | `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD` | `maven-central` rollup entry |
 | CocoaPods | `ChordSketch` | `post-release.yml` on `release: published` | `COCOAPODS_TRUNK_TOKEN` | `cocoapods` rollup entry |
 | JetBrains Marketplace | `me.koeda.chordsketch` | manual `./gradlew publishPlugin` | `JETBRAINS_MARKETPLACE_TOKEN` | not yet automated |
 | from source | `git clone` + `cargo install --path crates/cli` | always available | none | `source-build` job |

--- a/scripts/check-release-channels.py
+++ b/scripts/check-release-channels.py
@@ -73,19 +73,36 @@ def _http_get_text(url: str) -> str:
         return resp.read().decode("utf-8")
 
 
-def _http_head_ok(url: str) -> bool:
-    """Return True if the URL responds 200 to an unauthenticated GET.
+def _http_head_ok(
+    url: str,
+    *,
+    bearer_token: str | None = None,
+    accept: str | None = None,
+) -> bool:
+    """Return True if the URL responds 200/206 to a GET request.
 
     HEAD is technically what we want, but several container registries (GHCR
     in particular) return 401 on HEAD for public images while responding 200
     to GET. Using GET with `Range: bytes=0-0` avoids downloading the manifest
     body while still matching what the public visibility contract actually
     guarantees.
+
+    Pass `bearer_token` when the registry requires an OAuth bearer (GHCR
+    enforces this even for public packages — anonymous GET always returns
+    401, so the caller must obtain a pull token first via
+    `_ghcr_pull_token`).
+
+    Pass `accept` to override the Accept header. GHCR's manifest endpoint
+    returns 404 unless the request explicitly negotiates a manifest media
+    type (OCI / Docker v2); without an Accept header, the registry cannot
+    resolve which manifest representation to serve.
     """
-    req = urllib.request.Request(
-        url,
-        headers={"User-Agent": USER_AGENT, "Range": "bytes=0-0"},
-    )
+    headers = {"User-Agent": USER_AGENT, "Range": "bytes=0-0"}
+    if bearer_token is not None:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    if accept is not None:
+        headers["Accept"] = accept
+    req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
             return resp.status in (200, 206)
@@ -97,6 +114,33 @@ def _http_head_ok(url: str) -> bool:
         return False
     except urllib.error.URLError:
         return False
+
+
+def _ghcr_pull_token(repo: str) -> str | None:
+    """Fetch an anonymous GHCR pull token for `<repo>` (e.g. `koedame/chordsketch`).
+
+    GHCR follows the Docker Registry v2 token-handshake: even for public
+    packages, manifest GETs require an `Authorization: Bearer <token>`
+    header. The token endpoint serves it without credentials when the
+    package's visibility is `public`.
+
+    Returns the token string on success, or `None` if the token endpoint
+    is unreachable / returns a malformed payload (which indicates the
+    package is private or the registry is misbehaving — both surface as
+    `_check_ghcr` failures, which is the right outcome).
+    """
+    url = (
+        "https://ghcr.io/token?service=ghcr.io"
+        f"&scope=repository:{repo}:pull"
+    )
+    try:
+        payload = _http_get_json(url)
+    except Exception:  # noqa: BLE001
+        return None
+    token = payload.get("token")
+    if isinstance(token, str) and token:
+        return token
+    return None
 
 
 def _normalize_tag(tag: str) -> str:
@@ -131,37 +175,70 @@ def _check_npm(channel: Channel, version: str) -> CheckResult:
 
 
 def _check_ghcr(channel: Channel, version: str) -> CheckResult:
-    # Two assertions: (1) the tag exists, (2) public anonymous GET returns 200.
-    # Both are satisfied by the same request.
-    url = f"https://ghcr.io/v2/{channel.package}/manifests/v{version}"
-    if _http_head_ok(url):
+    # Two assertions: (1) the tag exists, (2) the package is public
+    # (anonymous Bearer-token GET returns 200).
+    #
+    # GHCR follows the Docker Registry v2 token-handshake: the
+    # manifest endpoint requires `Authorization: Bearer <token>` even
+    # for public packages, and anonymous GET returns 401. The probe
+    # therefore acquires a pull token first via
+    # `https://ghcr.io/token?…&scope=repository:<repo>:pull`, then
+    # GETs the manifest with that token. Token acquisition itself
+    # succeeds anonymously only when the package is public — which
+    # is exactly the visibility contract this check is asserting.
+    #
+    # The image tag is the bare `X.Y.Z` (no `v` prefix) — `docker.yml`
+    # uses `docker/metadata-action` with `pattern={{version}}`, which
+    # strips the `v` from the source git tag. The previous probe
+    # targeted `manifests/v<version>` and 404'd on every release (#2418).
+    token = _ghcr_pull_token(channel.package)
+    if token is None:
+        return _error(
+            channel, version,
+            "GHCR pull token unavailable (package private or token endpoint unreachable)",
+        )
+    url = f"https://ghcr.io/v2/{channel.package}/manifests/{version}"
+    # GHCR's manifest endpoint returns 404 unless the request explicitly
+    # negotiates a manifest media type. Both OCI and Docker v2 formats
+    # are listed because `docker.yml` builds multi-arch images that
+    # surface as either an OCI image-index or a Docker manifest-list,
+    # depending on the registry's content negotiation.
+    manifest_accept = ",".join([
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ])
+    if _http_head_ok(url, bearer_token=token, accept=manifest_accept):
         return CheckResult(
             channel_id=channel.id,
             ok=True,
-            observed=f"v{version}",
-            expected=f"v{version}",
+            observed=version,
+            expected=version,
             detail="GHCR manifest is publicly reachable",
         )
     return _error(channel, version, "GHCR manifest not publicly reachable (visibility or missing tag)")
 
 
 def _check_docker_hub(channel: Channel, version: str) -> CheckResult:
-    url = f"https://hub.docker.com/v2/repositories/{channel.package}/tags/v{version}/"
+    # Docker Hub tag matches the published image's bare semver
+    # (`0.4.0`, `0.4`, `latest`) — `docker.yml` uses
+    # `docker/metadata-action` with `pattern={{version}}` which
+    # strips the `v` from the git tag. The previous probe targeted
+    # `tags/v<version>/` and 404'd on every release (#2418).
+    url = f"https://hub.docker.com/v2/repositories/{channel.package}/tags/{version}/"
     try:
         payload = _http_get_json(url)
     except Exception as exc:  # noqa: BLE001
         return _error(channel, version, f"Docker Hub API error: {exc}")
-    # Docker Hub's tag API returns `"name": "v0.2.0"` — the value already
-    # carries the `v` prefix, so `observed` must use it as-is. A previous
-    # f"v{name}" produced `vv0.2.0` in the display table. See #1512.
     name = str(payload.get("name") or "<missing>")
     observed = name
-    if name == f"v{version}":
+    if name == version:
         return CheckResult(
             channel_id=channel.id,
             ok=True,
             observed=observed,
-            expected=f"v{version}",
+            expected=version,
             detail="Docker Hub tag present",
         )
     return _error(channel, version, f"Docker Hub tag mismatch: got {observed}")
@@ -253,21 +330,37 @@ def _check_rubygems(channel: Channel, version: str) -> CheckResult:
 
 
 def _check_maven_central(channel: Channel, version: str) -> CheckResult:
-    # channel.package is "io.github.koedame:chordsketch"; split into g and a.
+    # channel.package is "me.koeda:chordsketch"; split into g and a.
     try:
         group_id, artifact_id = channel.package.split(":", 1)
     except ValueError:
         return _error(channel, version, f"maven package must be 'group:artifact', got {channel.package!r}")
-    query = f"g:{group_id} AND a:{artifact_id}"
-    url = f"https://search.maven.org/solrsearch/select?q={urllib.parse.quote(query)}&wt=json&rows=1"
+    # Read the authoritative maven-metadata.xml from the canonical Maven
+    # Central repository (`repo1.maven.org/maven2`) rather than the
+    # `search.maven.org` solrsearch index. The solrsearch index lags
+    # publication arbitrarily — empirically, `me.koeda:chordsketch`
+    # was unreachable via solrsearch even after multiple releases were
+    # accepted by `repo1.maven.org`, producing a perpetual `<error>` in
+    # the rollup table (#2418). The metadata.xml endpoint serves the
+    # same data the cargo portgroup / Maven clients consume to resolve
+    # versions, so it is the publication source of truth.
+    group_path = group_id.replace(".", "/")
+    url = (
+        f"https://repo1.maven.org/maven2/{group_path}/{artifact_id}"
+        "/maven-metadata.xml"
+    )
     try:
-        payload = _http_get_json(url)
+        text = _http_get_text(url)
     except Exception as exc:  # noqa: BLE001
-        return _error(channel, version, f"Maven Central search error: {exc}")
-    docs = payload.get("response", {}).get("docs", [])
-    if not docs:
-        return _error(channel, version, "artifact not found on Maven Central")
-    observed = str(docs[0].get("latestVersion") or "<missing>")
+        return _error(channel, version, f"Maven Central metadata error: {exc}")
+    # Extract `<release>` from `<versioning><release>X.Y.Z</release>`.
+    # Use a narrow regex rather than full XML parsing because the file
+    # is a small, well-known, attacker-uncontrolled document and the
+    # regex avoids any XXE surface.
+    m = re.search(r"<release>([^<]+)</release>", text)
+    if not m:
+        return _error(channel, version, "Maven Central metadata missing <release>")
+    observed = m.group(1).strip()
     return _compare(channel, version, observed)
 
 

--- a/scripts/test_check_release_channels.py
+++ b/scripts/test_check_release_channels.py
@@ -227,12 +227,14 @@ class VerifyChannelTests(unittest.TestCase):
         with patch(
             "check_release_channels._ghcr_pull_token",
             return_value="fake-bearer-token",
-        ), patch(
+        ) as mock_token, patch(
             "check_release_channels._http_head_ok",
             return_value=True,
         ) as mock_head:
             result = check_release_channels.verify_channel(channel, "v0.2.0", force_stale=False)
         self.assertTrue(result.ok)
+        # Token must be fetched for the exact package being probed.
+        mock_token.assert_called_once_with("koedame/chordsketch")
         # The image tag is the bare semver (`0.2.0`, not `v0.2.0`) —
         # `docker.yml` uses `metadata-action` with
         # `pattern={{version}}` which strips the `v` from the git tag.

--- a/scripts/test_check_release_channels.py
+++ b/scripts/test_check_release_channels.py
@@ -225,22 +225,70 @@ class VerifyChannelTests(unittest.TestCase):
     def test_ghcr_head_ok_path(self) -> None:
         channel = _fake_channel(kind="ghcr", package="koedame/chordsketch")
         with patch(
+            "check_release_channels._ghcr_pull_token",
+            return_value="fake-bearer-token",
+        ), patch(
             "check_release_channels._http_head_ok",
             return_value=True,
         ) as mock_head:
             result = check_release_channels.verify_channel(channel, "v0.2.0", force_stale=False)
         self.assertTrue(result.ok)
-        # The URL must include the v-prefixed tag, matching the Docker
-        # Registry v2 manifest path contract.
-        called_url = mock_head.call_args.args[0]
-        self.assertEqual(called_url, "https://ghcr.io/v2/koedame/chordsketch/manifests/v0.2.0")
+        # The image tag is the bare semver (`0.2.0`, not `v0.2.0`) —
+        # `docker.yml` uses `metadata-action` with
+        # `pattern={{version}}` which strips the `v` from the git tag.
+        # Probing with `manifests/v0.2.0` 404'd on every release before
+        # this fix (#2418). The probe must also pass a Bearer token
+        # because GHCR requires auth even for public packages.
+        called = mock_head.call_args
+        self.assertEqual(
+            called.args[0],
+            "https://ghcr.io/v2/koedame/chordsketch/manifests/0.2.0",
+        )
+        self.assertEqual(called.kwargs.get("bearer_token"), "fake-bearer-token")
+        # GHCR's manifest endpoint returns 404 without an Accept header
+        # negotiating a manifest media type. Both OCI and Docker v2
+        # formats must be advertised — `docker.yml` produces multi-arch
+        # images that come back as either an OCI image-index or a
+        # Docker manifest-list.
+        accept = called.kwargs.get("accept", "")
+        self.assertIn("application/vnd.oci.image.index.v1+json", accept)
+        self.assertIn(
+            "application/vnd.docker.distribution.manifest.list.v2+json",
+            accept,
+        )
+        self.assertEqual(result.observed, "0.2.0")
+        self.assertEqual(result.expected, "0.2.0")
 
     def test_ghcr_head_fail_path(self) -> None:
         channel = _fake_channel(kind="ghcr", package="koedame/chordsketch")
-        with patch("check_release_channels._http_head_ok", return_value=False):
+        with patch(
+            "check_release_channels._ghcr_pull_token",
+            return_value="fake-bearer-token",
+        ), patch(
+            "check_release_channels._http_head_ok",
+            return_value=False,
+        ):
             result = check_release_channels.verify_channel(channel, "v0.2.0", force_stale=False)
         self.assertFalse(result.ok)
         self.assertIn("not publicly reachable", result.detail)
+
+    def test_ghcr_token_unavailable_reports_distinct_error(self) -> None:
+        # When `_ghcr_pull_token` returns None (token endpoint
+        # unreachable, or package is private), the manifest GET is
+        # never attempted — the failure is attributed to the visibility
+        # / token layer specifically so on-call can act on it directly
+        # without inspecting the manifest URL.
+        channel = _fake_channel(kind="ghcr", package="koedame/chordsketch")
+        with patch(
+            "check_release_channels._ghcr_pull_token",
+            return_value=None,
+        ), patch(
+            "check_release_channels._http_head_ok",
+        ) as mock_head:
+            result = check_release_channels.verify_channel(channel, "v0.2.0", force_stale=False)
+        self.assertFalse(result.ok)
+        self.assertIn("pull token unavailable", result.detail)
+        mock_head.assert_not_called()
 
     def test_pypi_mismatch(self) -> None:
         channel = _fake_channel(kind="pypi", package="chordsketch")
@@ -264,27 +312,33 @@ class VerifyChannelTests(unittest.TestCase):
     # response-parsing breaks. See #1516.
     # ----------------------------------------------------------------
 
-    def test_docker_hub_match_no_double_v_prefix(self) -> None:
-        """Regression test for #1512: Docker Hub returns `name: v0.2.0` (with
-        the `v` already), so `observed` must not add another `v`."""
+    def test_docker_hub_match_bare_semver_tag(self) -> None:
+        """Regression test for #2418: Docker Hub tags are bare semver
+        (`0.2.0`, `0.2`, `latest`) — `docker.yml` uses metadata-action
+        with `pattern={{version}}` which strips the `v` prefix from the
+        git tag. The probe URL must therefore target `tags/0.2.0/`,
+        and the API's `name` field comes back as `0.2.0` (without `v`).
+        Earlier the probe targeted `tags/v0.2.0/` and 404'd on every
+        release."""
         channel = _fake_channel(kind="docker-hub", package="koedame/chordsketch")
         with patch(
             "check_release_channels._http_get_json",
-            return_value={"name": "v0.2.0"},
+            return_value={"name": "0.2.0"},
         ) as mock_http:
             result = check_release_channels.verify_channel(channel, "v0.2.0", force_stale=False)
         self.assertTrue(result.ok, f"expected OK, got {result}")
-        self.assertEqual(result.observed, "v0.2.0")  # NOT "vv0.2.0"
+        self.assertEqual(result.observed, "0.2.0")
+        self.assertEqual(result.expected, "0.2.0")
         self.assertEqual(
             mock_http.call_args.args[0],
-            "https://hub.docker.com/v2/repositories/koedame/chordsketch/tags/v0.2.0/",
+            "https://hub.docker.com/v2/repositories/koedame/chordsketch/tags/0.2.0/",
         )
 
     def test_docker_hub_mismatch(self) -> None:
         channel = _fake_channel(kind="docker-hub", package="koedame/chordsketch")
         with patch(
             "check_release_channels._http_get_json",
-            return_value={"name": "v0.1.9"},
+            return_value={"name": "0.1.9"},
         ):
             result = check_release_channels.verify_channel(channel, "v0.2.0", force_stale=False)
         self.assertFalse(result.ok)
@@ -430,18 +484,35 @@ end
         )
 
     def test_maven_central_match(self) -> None:
+        # Maven groupId is `me.koeda` (reverse-DNS of the koeda.me
+        # domain registered on Sonatype Central Portal), NOT
+        # `io.github.koedame`. The probe also reads the canonical
+        # `repo1.maven.org/maven2/<group>/<artifact>/maven-metadata.xml`
+        # rather than `search.maven.org/solrsearch` because the latter
+        # was empirically not indexing this artifact, surfacing as
+        # `<error>` in the rollup table for every release until #2418.
         channel = _fake_channel(
-            kind="maven-central", package="io.github.koedame:chordsketch"
+            kind="maven-central", package="me.koeda:chordsketch"
+        )
+        fake_metadata = (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            "<metadata>\n"
+            "  <groupId>me.koeda</groupId>\n"
+            "  <artifactId>chordsketch</artifactId>\n"
+            "  <versioning>\n"
+            "    <latest>0.2.0</latest>\n"
+            "    <release>0.2.0</release>\n"
+            "    <versions>\n"
+            "      <version>0.1.0</version>\n"
+            "      <version>0.2.0</version>\n"
+            "    </versions>\n"
+            "    <lastUpdated>20260506110000</lastUpdated>\n"
+            "  </versioning>\n"
+            "</metadata>\n"
         )
         with patch(
-            "check_release_channels._http_get_json",
-            return_value={
-                "response": {
-                    "docs": [
-                        {"latestVersion": "0.2.0"},
-                    ]
-                }
-            },
+            "check_release_channels._http_get_text",
+            return_value=fake_metadata,
         ) as mock_http:
             result = check_release_channels.verify_channel(
                 channel, "v0.2.0", force_stale=False
@@ -449,27 +520,54 @@ end
         self.assertTrue(result.ok, f"expected OK, got {result}")
         self.assertEqual(result.observed, "0.2.0")
         called_url = mock_http.call_args.args[0]
-        # The solrsearch query must URL-encode the AND+group+artifact
-        # expression correctly so ":" and spaces round-trip through
-        # maven's search index.
-        self.assertIn(
-            "q=g%3Aio.github.koedame%20AND%20a%3Achordsketch",
+        # The group's dots must be converted to slashes in the
+        # repository path: `me.koeda` → `me/koeda/`.
+        self.assertEqual(
             called_url,
+            "https://repo1.maven.org/maven2/me/koeda/chordsketch/maven-metadata.xml",
         )
 
-    def test_maven_central_not_found(self) -> None:
+    def test_maven_central_metadata_missing_release(self) -> None:
+        # If the metadata.xml is reachable but lacks a <release> element,
+        # treat as error rather than silently passing on `<missing>`.
         channel = _fake_channel(
-            kind="maven-central", package="io.github.koedame:chordsketch"
+            kind="maven-central", package="me.koeda:chordsketch"
+        )
+        bad_metadata = (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            "<metadata>\n"
+            "  <groupId>me.koeda</groupId>\n"
+            "  <artifactId>chordsketch</artifactId>\n"
+            "  <versioning>\n"
+            "    <versions/>\n"
+            "  </versioning>\n"
+            "</metadata>\n"
         )
         with patch(
-            "check_release_channels._http_get_json",
-            return_value={"response": {"docs": []}},
+            "check_release_channels._http_get_text",
+            return_value=bad_metadata,
         ):
             result = check_release_channels.verify_channel(
                 channel, "v0.2.0", force_stale=False
             )
         self.assertFalse(result.ok)
-        self.assertIn("not found on Maven Central", result.detail)
+        self.assertIn("missing <release>", result.detail)
+
+    def test_maven_central_metadata_unreachable(self) -> None:
+        # Network / 404 / other transport failure must surface as a
+        # _error result rather than crashing the whole rollup.
+        channel = _fake_channel(
+            kind="maven-central", package="me.koeda:chordsketch"
+        )
+        with patch(
+            "check_release_channels._http_get_text",
+            side_effect=RuntimeError("HTTP 404"),
+        ):
+            result = check_release_channels.verify_channel(
+                channel, "v0.2.0", force_stale=False
+            )
+        self.assertFalse(result.ok)
+        self.assertIn("Maven Central metadata error", result.detail)
 
 
 class CliOutputOrderingTests(unittest.TestCase):


### PR DESCRIPTION
Closes #2418 — see commit message and CHANGELOG entry for full rationale.

Four fixes against `scripts/check-release-channels.py`:
1. Docker Hub / GHCR URL: drop the `v` prefix (metadata-action's `pattern={{version}}` strips it on push)
2. GHCR auth: fetch Bearer pull token before manifest GET (Docker Registry v2 requires it even for public packages)
3. GHCR Accept header: send OCI + Docker v2 manifest media types (manifest endpoint 404s without negotiation)
4. Maven Central: switch package coords to `me.koeda:chordsketch` (was `io.github.koedame`) AND switch from `search.maven.org/solrsearch` (not indexing this artifact) to `repo1.maven.org/maven2/.../maven-metadata.xml` (authoritative).

Sister-site fixes per fix-propagation.md: kotlin.yml deployment URL + docs/releasing.md Distribution Channels table.

Tests: 28 pass (+2). All 3 probes verified against live production endpoints.

Post-merge: dispatch release-verify.yml against v0.4.0 to flip the table green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)