### PR TITLE
fix(ui-web,vscode-extension): cache-bust iframe srcdoc to force fresh navigation on format toggle

### DIFF
--- a/packages/playground/tests-e2e/render-format-toggle.spec.ts
+++ b/packages/playground/tests-e2e/render-format-toggle.spec.ts
@@ -1,0 +1,67 @@
+// Pins the contract that the HTML preview survives a round-trip
+// through the Text or PDF format selector. #2321 / PR #2322 left a
+// residual blank-preview symptom on the HTML → Text → HTML toggle
+// in real Chrome that headless Chromium does not reproduce; #2421
+// hardens the host with a monotonic cache-bust marker so the iframe
+// `srcdoc` attribute is byte-different on every render. This smoke
+// asserts the marker is present and increments — a regression that
+// drops the cache-bust would collapse it to a constant string and
+// fail this test loudly.
+
+import { expect, test } from '@playwright/test';
+
+test.describe('playground render-format toggle', () => {
+  test('html → text → html keeps the preview rendering and bumps the cache-bust marker', async ({
+    page,
+  }) => {
+    await page.goto('./');
+    const iframe = page.locator('iframe#preview');
+    await expect(iframe).toBeVisible();
+
+    const initialSrcdoc = await iframe.getAttribute('srcdoc');
+    expect(initialSrcdoc, 'mount-time srcdoc should be populated').toBeTruthy();
+    expect(initialSrcdoc).toMatch(/<!--\s*r:\d+\s*-->/);
+
+    const formatSelect = page.locator('select#format');
+    await formatSelect.selectOption('text');
+    // The text pane is now visible; the iframe still carries its
+    // previous `srcdoc` value but is hidden via `display: none`.
+    const textPane = page.locator('pre#text-output');
+    await expect(textPane).toBeVisible();
+
+    await formatSelect.selectOption('html');
+    await expect(iframe).toBeVisible();
+
+    const finalSrcdoc = await iframe.getAttribute('srcdoc');
+    expect(finalSrcdoc, 'post-toggle srcdoc should be populated').toBeTruthy();
+    // The iframe must still carry the rendered body; a regression
+    // that wipes the document on hide/show would leave srcdoc empty.
+    expect(finalSrcdoc).toContain('<div class="song"');
+    // Most important assertion: the cache-bust marker increments
+    // monotonically, which guarantees Chromium cannot elide the
+    // navigation as a same-value no-op (#2421).
+    expect(finalSrcdoc).not.toBe(initialSrcdoc);
+    expect(finalSrcdoc).toMatch(/<!--\s*r:\d+\s*-->/);
+  });
+
+  test('repeated html ↔ text toggles produce strictly distinct srcdoc values', async ({
+    page,
+  }) => {
+    await page.goto('./');
+    const iframe = page.locator('iframe#preview');
+    const formatSelect = page.locator('select#format');
+    await expect(iframe).toBeVisible();
+
+    const seen = new Set<string>();
+    seen.add((await iframe.getAttribute('srcdoc')) ?? '');
+    for (let i = 0; i < 4; i++) {
+      await formatSelect.selectOption('text');
+      await formatSelect.selectOption('html');
+      seen.add((await iframe.getAttribute('srcdoc')) ?? '');
+    }
+    // 1 mount-time + 4 post-toggle writes = 5 distinct strings if
+    // the cache-bust marker is increment-on-render. A regression
+    // that drops the marker collapses this set to size 1.
+    expect(seen.size).toBe(5);
+  });
+});

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -310,10 +310,20 @@ const RENDER_DEBOUNCE_MS = 300;
 // user-reported "Blocked script execution in 'about:blank'" warning
 // and the format-toggle blank-preview symptom on certain Chrome
 // configurations.
-const HTML_FRAME_TEMPLATE = (body: string): string => `<!DOCTYPE html>
+//
+// `cacheBust` is a monotonic per-mount counter rendered as an HTML
+// comment inside `<head>`. It guarantees the resulting `srcdoc`
+// string is byte-different on every render so the iframe's
+// navigation hook cannot elide the assignment as a no-op when the
+// produced body would otherwise be byte-equal to the previous
+// render — the residual format-toggle blank-preview symptom #2421
+// reported after the #2321 / PR #2322 fix landed. The comment is
+// ignored by HTML rendering and adds ~12 bytes per srcdoc.
+const HTML_FRAME_TEMPLATE = (body: string, cacheBust: number): string => `<!DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8">
+<!-- r:${cacheBust} -->
 </head>
 <body>${body}</body>
 </html>`;
@@ -905,6 +915,13 @@ export async function mountChordSketchUi(
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Monotonic per-mount counter feeding the `HTML_FRAME_TEMPLATE`
+  // cache-bust comment. Incremented before every iframe `srcdoc`
+  // assignment so the produced string is byte-different on every
+  // render, defeating the same-string-skip-navigation quirk that
+  // surfaced after the #2321 fix (#2421).
+  let srcdocCounter = 0;
+
   const getTranspose = (): number => {
     const val = parseInt(transposeInput.value, 10);
     // Clamp to `TRANSPOSE_MIN..=TRANSPOSE_MAX`. Empty/non-numeric
@@ -990,11 +1007,9 @@ export async function mountChordSketchUi(
         const svg = renderOpts
           ? renderers.renderSvg(input, renderOpts)
           : renderers.renderSvg(input);
-        // Mirror the same empty-then-set assignment used on the
-        // ChordPro html branch below — see #2321 for the structural
-        // cause of the blank-preview symptom on `srcdoc` reuse.
-        preview.srcdoc = '';
-        preview.srcdoc = HTML_FRAME_TEMPLATE(svg);
+        // Cache-busting `srcdoc` write — see the matching ChordPro
+        // html branch below for the rationale (#2421).
+        preview.srcdoc = HTML_FRAME_TEMPLATE(svg, ++srcdocCounter);
         hideError();
       } catch (e) {
         showError(formatError(e));
@@ -1010,20 +1025,22 @@ export async function mountChordSketchUi(
         const html = renderOpts
           ? renderers.renderHtml(input, renderOpts)
           : renderers.renderHtml(input);
-        // Defense in depth, paired with the double-wrap fix above.
-        // The user reported a blank-preview symptom on HTML → other →
-        // HTML toggle (#2321) that we could not reproduce in headless
-        // Chromium. The structural cause — `srcdoc` containing two
-        // `<!DOCTYPE>` / `<head>` / `<body>` pairs that survived only
-        // via HTML5 nested-document recovery — is fixed by the
-        // body-fragment + minimal-frame switch. If a separate
-        // same-string-assignment skip-navigation quirk also
-        // contributes, clearing `srcdoc` to '' before assigning the
-        // new content forces a navigation cycle at near-zero cost.
-        // Drop this empty-then-set if the symptom turns out to be
-        // fully covered by the double-wrap fix.
-        preview.srcdoc = '';
-        preview.srcdoc = HTML_FRAME_TEMPLATE(html);
+        // Force a fresh iframe navigation on every render. The
+        // empty-then-set sequence introduced by #2321 / PR #2322
+        // turned out to leave the format-toggle blank-preview
+        // symptom on the HTML → Text → HTML path reachable in
+        // some Chrome configurations: two synchronous writes to
+        // the same IDL property in a single task can be coalesced
+        // by the browser, and when the resulting attribute value
+        // is byte-equal to the previous render the navigation
+        // hook treats it as a no-op — leaving the iframe blank
+        // when its document had been discarded while hidden via
+        // `display: none`. `HTML_FRAME_TEMPLATE` now emits a
+        // monotonically-increasing cache-bust comment in `<head>`
+        // so the assigned string is guaranteed to be different on
+        // every render, which forces the navigation regardless of
+        // attribute coalescing or document discard. (#2421)
+        preview.srcdoc = HTML_FRAME_TEMPLATE(html, ++srcdocCounter);
         hideError();
       } else if (format === 'text') {
         showPane('text');

--- a/packages/ui-web/tests/srcdoc-cachebust.test.ts
+++ b/packages/ui-web/tests/srcdoc-cachebust.test.ts
@@ -1,0 +1,110 @@
+// Verifies the format-toggle blank-preview defence introduced in
+// #2421: every iframe `srcdoc` write must produce a byte-different
+// string from the previous write, so Chromium's same-value
+// skip-navigation quirk cannot leave the iframe blank when the user
+// toggles HTML → Text → HTML on unchanged input. The previous defence
+// (empty-then-set in #2321 / PR #2322) relied on two synchronous
+// writes that the browser could coalesce; this test pins the
+// stronger contract that the FINAL value differs every time.
+
+import { describe, expect, test, vi } from 'vitest';
+import { mountChordSketchUi, type Renderers } from '../src/index';
+
+const HTML_BODY = '<style>body{}</style><div class="song">SAMPLE</div>';
+
+function makeRenderers(): Renderers {
+  return {
+    init: vi.fn(() => Promise.resolve()),
+    // Returning a constant here is the point: even when the rendered
+    // body is byte-equal across renders, the host wrapper MUST emit a
+    // different `srcdoc` string every time.
+    renderHtml: vi.fn(() => HTML_BODY),
+    renderText: vi.fn(() => 'SAMPLE_TEXT'),
+    renderPdf: vi.fn(() => new Uint8Array([0x25, 0x50, 0x44, 0x46])),
+  };
+}
+
+function getPreviewIframe(root: HTMLElement): HTMLIFrameElement {
+  const iframe = root.querySelector('iframe');
+  if (!(iframe instanceof HTMLIFrameElement)) {
+    throw new Error('preview iframe not mounted');
+  }
+  return iframe;
+}
+
+function getFormatSelect(root: HTMLElement): HTMLSelectElement {
+  const select = root.querySelector<HTMLSelectElement>('select#format');
+  if (select === null) {
+    throw new Error('format select not mounted');
+  }
+  return select;
+}
+
+describe('srcdoc cache-bust (#2421)', () => {
+  test('html → text → html toggle produces a byte-different srcdoc', async () => {
+    const renderers = makeRenderers();
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const handle = await mountChordSketchUi(root, {
+      renderers,
+      initialChordPro: '{title: Sample}\n[C]hello',
+    });
+
+    const iframe = getPreviewIframe(root);
+    const select = getFormatSelect(root);
+
+    // Mount-time render is HTML by default.
+    const initialSrcdoc = iframe.srcdoc;
+    expect(initialSrcdoc).toContain(HTML_BODY);
+
+    // Toggle to text — iframe is hidden, srcdoc retains its value.
+    select.value = 'text';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(iframe.srcdoc).toBe(initialSrcdoc);
+
+    // Toggle back to html. Even though `renderHtml` returns a
+    // byte-equal body, the iframe srcdoc MUST differ from the
+    // previous write so Chromium cannot elide the navigation.
+    select.value = 'html';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(iframe.srcdoc).not.toBe(initialSrcdoc);
+    // Body is still embedded — the change is a marker, not a payload
+    // shape change.
+    expect(iframe.srcdoc).toContain(HTML_BODY);
+
+    handle.destroy();
+    root.remove();
+  });
+
+  test('every render with constant input still increments the marker', async () => {
+    const renderers = makeRenderers();
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const handle = await mountChordSketchUi(root, {
+      renderers,
+      initialChordPro: '{title: Sample}\n[C]hello',
+    });
+
+    const iframe = getPreviewIframe(root);
+    const select = getFormatSelect(root);
+
+    const seen = new Set<string>();
+    seen.add(iframe.srcdoc);
+    for (let i = 0; i < 5; i++) {
+      select.value = 'text';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      select.value = 'html';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      seen.add(iframe.srcdoc);
+    }
+    // 1 mount-time + 5 toggle-back-to-html writes = 6 distinct
+    // srcdoc strings. A regression that drops the cache-bust would
+    // collapse this set down to 1.
+    expect(seen.size).toBe(6);
+
+    handle.destroy();
+    root.remove();
+  });
+});

--- a/packages/vscode-extension/webview/preview.ts
+++ b/packages/vscode-extension/webview/preview.ts
@@ -154,6 +154,19 @@ function formatError(e: unknown): string {
 let CHORDSKETCH_CSS = '';
 
 /**
+ * Monotonic per-WebView counter feeding the `wrapHtml` cache-bust
+ * comment. Incremented before each iframe `srcdoc` assignment so the
+ * produced string is byte-different on every render — required
+ * because the iframe is hidden via `style.display = 'none'` while
+ * the user is in Plain text mode and Chromium can elide the
+ * same-value re-assignment navigation when toggling back to HTML,
+ * leaving the iframe blank even though the attribute is present.
+ * Mirrors the `srcdocCounter` in `packages/ui-web/src/index.ts` per
+ * `.claude/rules/fix-propagation.md` (#2421).
+ */
+let srcdocCounter = 0;
+
+/**
  * Wraps a body-only HTML fragment from `render_html_body_with_options`
  * inside a complete document for the preview iframe.
  *
@@ -181,12 +194,17 @@ let CHORDSKETCH_CSS = '';
  * is intentional — the canonical CSS already covers it; the previous
  * override was load-bearing only because of the double-wrap and is
  * not worth preserving.
+ *
+ * `cacheBust` is rendered as an HTML comment in `<head>` so the
+ * resulting string is byte-different on every render — see the
+ * `srcdocCounter` doc comment above for why this matters (#2421).
  */
-function wrapHtml(body: string): string {
+function wrapHtml(body: string, cacheBust: number): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<!-- r:${cacheBust} -->
 <style>
 ${CHORDSKETCH_CSS}
 /* VS Code preview theme overrides — applied after the canonical
@@ -288,9 +306,17 @@ function renderPreview(text: string): void {
     if (viewMode === 'html') {
       const body = render_html_body_with_options(text, options);
       hideError();
-      previewFrame.srcdoc = wrapHtml(body);
-      previewFrame.style.display = 'block';
+      // Reveal the iframe BEFORE assigning `srcdoc` so the navigation
+      // happens against an attached frame. Chromium can defer
+      // navigation on a `display: none` iframe and, paired with the
+      // same-value coalescing covered by `srcdocCounter`, that path
+      // produced the format-toggle blank-preview symptom (#2421).
+      // `wrapHtml` cache-busts the produced string monotonically so
+      // the IDL-property write is guaranteed to differ from the
+      // previous render.
       textFrame.style.display = 'none';
+      previewFrame.style.display = 'block';
+      previewFrame.srcdoc = wrapHtml(body, ++srcdocCounter);
     } else {
       const plain = render_text_with_options(text, options);
       hideError();


### PR DESCRIPTION
## Summary

- Replace the empty-then-set `srcdoc` defence in `packages/ui-web/src/index.ts` (added by #2321 / PR #2322) with a monotonic per-mount cache-bust counter rendered as an HTML comment in `<head>`. The produced `srcdoc` string is now byte-different on every render, which forces a fresh iframe navigation regardless of whether the rendered body is byte-equal to the previous render or whether Chromium has discarded the inner document while the iframe was hidden via `display: none`.
- Apply the same fix to `packages/vscode-extension/webview/preview.ts`, which had no empty-then-set defence at all, and reorder the assignments so `previewFrame.style.display = 'block'` precedes the `srcdoc` write — the playground had this ordering already and the VS Code path did not.
- Add a vitest in `packages/ui-web/tests/srcdoc-cachebust.test.ts` and a Playwright smoke in `packages/playground/tests-e2e/render-format-toggle.spec.ts` that pin the byte-difference contract: 5 successive HTML ↔ Text round-trips must produce 5 strictly distinct `srcdoc` values, asserting the cache-bust marker increments. A regression that drops the marker collapses the set to size 1 and fails loudly.

## Why

The user reports the format-toggle blank-preview symptom is reachable in real Chrome on the deployed playground and in the VS Code preview after the #2321 fix landed. Headless Chromium does not reproduce — verified by driving HTML→Text→HTML, HTML→PDF→HTML, and 5× rapid toggle through Playwright before this change — same outcome as the original PR #2322 author noted in #2321 §Background. The structural weakness is real regardless: the empty-then-set is two synchronous IDL-property writes in one task that Chromium can coalesce into a single mutation, and the navigation hook treats a same-value end-state as a no-op. Combined with `display: none` on the iframe potentially discarding the inner document, the blank-preview symptom persists.

The cache-bust marker forces the assigned attribute string to be unique on every render, which removes the same-value-skip-navigation path from the equation entirely and is strictly stronger than the empty-then-set.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`:

- `packages/ui-web/src/index.ts` — both ChordPro HTML branch and iReal SVG branch now route through `HTML_FRAME_TEMPLATE(body, ++srcdocCounter)`. The empty-input branch (`preview.srcdoc = ''`) is intentionally unchanged because `''` is structurally distinct from any rendered HTML.
- `packages/vscode-extension/webview/preview.ts` — `wrapHtml` takes the same `cacheBust` arg, the `srcdocCounter` is module-scoped (one WebView per module instance), and the `previewFrame.style.display = 'block'` ordering now mirrors ui-web. The empty-input branch (`previewFrame.srcdoc = ''`) is similarly unchanged.
- `apps/desktop/src-tauri/` — desktop reuses ui-web's mount path, so it receives the fix transitively. No additional change needed.

## Test plan

- [x] `cd packages/ui-web && npx vitest run` — 24 passed, including 2 new cache-bust assertions.
- [x] `cd packages/ui-web && npx tsc --noEmit` — clean.
- [x] `cd packages/vscode-extension && npm run lint && npm run build && npm test` — typecheck clean, esbuild clean, 56 unit tests passed.
- [x] `cd packages/playground && npm run build && npx playwright test` — 7 specs passed (3 prior `format-toggle.spec.ts` + 2 prior `irealb-deep-link.spec.ts` + 2 new `render-format-toggle.spec.ts`).
- [x] `cd packages/playground && npm test && npm run typecheck` — vitest 11 passed, tsc clean.

## Out of scope

- Switching the iframe-hide mechanism from `display: none` to a `visibility`/`position`-based overlay (the (b) follow-up). If cache-busting alone is not sufficient in user reports, that is the next layer of defence.
- Changing the iframe sandbox flags.

Closes #2421