### PR TITLE
Add ChordSketch design system: tokens, component previews, and ui_kits demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ packages/playground/test-results/
 # Python (used by scripts/ and CI helpers, not a runtime dep)
 __pycache__/
 *.pyc
+
+# Local scratch / reference assets (screenshots, sample PDFs)
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,16 @@ Additionally, these non-Rust packages exist:
 | ChordPro (Zed extension) | `packages/zed-extension` | Zed editor extension with tree-sitter highlighting and LSP integration (not in workspace; targets wasm32-wasi) |
 | ChordPro (JetBrains plugin) | `packages/jetbrains-plugin` | JetBrains IDE plugin with TextMate syntax highlighting for ChordPro files |
 
+The repository also ships a static design-system reference at the repo root:
+`DESIGN.md` (rationale + token reference), `tokens.css` (single source of
+truth for color / typography / space / radius / elevation / motion),
+`design-system.html` (visual landing page), `preview/` (10 component
+preview pages + index), and `ui_kits/web/` (four product-surface demos:
+editor, viewer, library, iReal Pro chart editor). These are static
+HTML/CSS — no build step. Token decisions in `tokens.css` are the
+authoritative reference for `@chordsketch/ui-web`, `@chordsketch/react`,
+the playground, and the desktop app.
+
 ### Dependency Policy
 
 - `chordsketch-chordpro` must have **zero external dependencies**. All parsing and AST logic

--- a/ChordSketch Design System.html
+++ b/ChordSketch Design System.html
@@ -1,0 +1,378 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ChordSketch — Design System</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&family=Noto+Sans+JP:wght@400;500;700;900&family=Roboto:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="tokens.css">
+<style>
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+body {
+  font-family: var(--font-jp);
+  font-size: var(--fs-16);
+  line-height: 1.6875;
+  color: var(--text-primary);
+  background: var(--canvas);
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; }
+
+.eyebrow {
+  font-family: var(--font-latin);
+  font-weight: 600;
+  font-size: var(--fs-12);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin: 0 0 var(--sp-3);
+}
+
+.container { max-width: var(--maxw-guide); margin: 0 auto; padding: 0 var(--sp-6); }
+
+.hero { padding: var(--sp-24) 0 var(--sp-16); border-bottom: 1px solid var(--border); }
+.hero .display { font-family: var(--font-display); font-weight: 900; font-size: var(--fs-72); line-height: 1.05; letter-spacing: -0.03em; margin: 0; }
+.hero .lead { font-size: var(--fs-18); color: var(--text-secondary); margin: var(--sp-6) 0 0; max-width: 56ch; }
+.hero .badge { display: inline-flex; align-items: center; gap: var(--sp-2); background: var(--ink-0); border: 1px solid var(--border); border-radius: var(--r-full); padding: var(--sp-1) var(--sp-3); font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); margin-top: var(--sp-6); }
+.hero .badge::before { content: ""; width: 6px; height: 6px; background: var(--crimson-500); border-radius: var(--r-full); }
+
+.toc { padding: var(--sp-8) 0; border-bottom: 1px solid var(--border); }
+.toc ol { margin: 0; padding: 0; list-style: none; display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: var(--sp-3); counter-reset: toc; }
+.toc li { counter-increment: toc; }
+.toc a { text-decoration: none; display: flex; gap: var(--sp-3); padding: var(--sp-2) 0; font-size: var(--fs-14); border-top: 1px solid var(--border); }
+.toc a::before { content: counter(toc, decimal-leading-zero); font-family: var(--font-mono); color: var(--text-tertiary); font-size: var(--fs-12); }
+
+.section { padding: var(--sp-16) 0; border-top: 1px solid var(--border); }
+.section:first-of-type { border-top: 0; }
+.section h2 { font-family: var(--font-display); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-2); }
+.section .deck { color: var(--text-secondary); margin: 0 0 var(--sp-8); max-width: 56ch; }
+.section h3 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-10) 0 var(--sp-4); }
+
+.palette { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: var(--sp-4); }
+.swatch { display: flex; flex-direction: column; gap: var(--sp-2); }
+.chip { height: 96px; border-radius: var(--r-3); border: 1px solid var(--border); }
+.swatch .name { font-family: var(--font-mono); font-size: var(--fs-13); margin: 0; }
+.swatch .hex { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); margin: 0; }
+
+.semantic-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: var(--sp-4); }
+.semantic { border-radius: var(--r-3); border: 1px solid var(--border); overflow: hidden; }
+.semantic .surface { padding: var(--sp-4) var(--sp-5); font-size: var(--fs-14); }
+.semantic .meta { display: flex; justify-content: space-between; padding: var(--sp-2) var(--sp-3); background: var(--ink-0); border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); }
+
+.specimen { display: grid; grid-template-columns: 200px 1fr; gap: var(--sp-6); padding: var(--sp-5) 0; border-bottom: 1px solid var(--border); align-items: baseline; }
+.specimen .role { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.specimen .role .meta { display: block; font-family: var(--font-mono); font-size: var(--fs-12); letter-spacing: 0; text-transform: none; color: var(--text-tertiary); margin-top: var(--sp-1); }
+.spec-display { font-family: var(--font-display); font-weight: 900; font-size: var(--fs-60); line-height: 1.05; letter-spacing: -0.03em; margin: 0; }
+.spec-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-48); line-height: 1.1; letter-spacing: -0.02em; margin: 0; }
+.spec-h2 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0; }
+.spec-h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-30); line-height: 1.2; letter-spacing: -0.02em; margin: 0; }
+.spec-h4 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-24); line-height: 1.333; letter-spacing: -0.01em; margin: 0; }
+.spec-h5 { font-family: var(--font-jp); font-weight: 600; font-size: var(--fs-18); line-height: 1.444; margin: 0; }
+.spec-body { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-16); line-height: 1.6875; margin: 0; max-width: 56ch; }
+.spec-small { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-13); line-height: 1.692; margin: 0; color: var(--text-secondary); }
+.spec-eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0; }
+.spec-mono { font-family: var(--font-mono); font-weight: 600; font-size: var(--fs-14); line-height: 1.857; margin: 0; }
+.spec-meta { font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-13); line-height: 1.692; font-variant-numeric: tabular-nums; margin: 0; color: var(--text-secondary); }
+
+.chord-sheet-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8) var(--sp-10); }
+.chord-sheet-meta { display: flex; gap: var(--sp-6); flex-wrap: wrap; margin-bottom: var(--sp-6); }
+.chord-sheet-meta dt { display: inline; font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.chord-sheet-meta dd { display: inline; margin: 0 var(--sp-3) 0 var(--sp-2); font-family: var(--font-mono); font-size: var(--fs-13); }
+.section-label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); border-top: 1px solid var(--border); padding-top: var(--sp-3); margin: var(--sp-6) 0 var(--sp-3); }
+.line { font-size: 0; margin-bottom: var(--sp-3); }
+.pair { display: inline-flex; flex-direction: column; align-items: flex-start; vertical-align: bottom; }
+.pair .chord { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
+.pair .lyric { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-18); line-height: 1.5; white-space: pre; }
+
+.scale-grid { display: grid; grid-template-columns: 80px 80px 1fr; gap: var(--sp-4); align-items: center; padding: var(--sp-2) 0; border-bottom: 1px solid var(--border); }
+.scale-grid .token { font-family: var(--font-mono); font-size: var(--fs-13); }
+.scale-grid .px { font-family: var(--font-mono); font-size: var(--fs-13); color: var(--text-secondary); }
+.scale-grid .bar { height: 8px; background: var(--crimson-500); border-radius: var(--r-1); }
+
+.radius-row { display: flex; gap: var(--sp-6); flex-wrap: wrap; }
+.radius-tile { width: 96px; height: 96px; background: var(--ink-100); border: 1px solid var(--border); display: flex; align-items: end; justify-content: center; padding: var(--sp-2); font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); }
+
+.motion-row { display: flex; gap: var(--sp-6); flex-wrap: wrap; }
+.motion-card { flex: 1 1 200px; border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5); background: var(--surface); }
+.motion-card h4 { margin: 0 0 var(--sp-1); font-family: var(--font-mono); font-size: var(--fs-13); font-weight: 600; }
+.motion-card p { margin: 0 0 var(--sp-4); font-size: var(--fs-13); color: var(--text-secondary); }
+.motion-bar { display: block; width: 100%; height: 6px; background: var(--ink-200); border-radius: var(--r-full); overflow: hidden; }
+.motion-bar > i { display: block; height: 100%; width: 0; background: var(--crimson-500); animation: pulse 2.4s var(--ease-out) infinite; }
+.motion-card[data-dur="1"] .motion-bar > i { animation-duration: calc(var(--dur-1) * 12); }
+.motion-card[data-dur="2"] .motion-bar > i { animation-duration: calc(var(--dur-2) * 12); }
+.motion-card[data-dur="3"] .motion-bar > i { animation-duration: calc(var(--dur-3) * 12); }
+.motion-card[data-dur="4"] .motion-bar > i { animation-duration: calc(var(--dur-4) * 12); }
+@keyframes pulse { 0%, 100% { width: 0; } 50% { width: 100%; } }
+
+table.voice { width: 100%; border-collapse: collapse; }
+table.voice thead th { text-align: left; font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); padding: var(--sp-3) 0; border-bottom: 1px solid var(--border-strong); }
+table.voice td { padding: var(--sp-4) var(--sp-6) var(--sp-4) 0; border-bottom: 1px solid var(--border); vertical-align: top; width: 50%; }
+table.voice td.avoid { color: var(--text-tertiary); text-decoration: line-through; text-decoration-color: var(--ink-300); }
+
+.site-footer { padding: var(--sp-12) 0 var(--sp-16); color: var(--text-tertiary); border-top: 1px solid var(--border); margin-top: var(--sp-16); font-size: var(--fs-13); }
+.site-footer a { color: var(--text-secondary); text-decoration: none; }
+.site-footer a:hover { color: var(--text-primary); }
+.site-footer .row { display: flex; justify-content: space-between; gap: var(--sp-8); flex-wrap: wrap; }
+.site-footer .links { display: flex; gap: var(--sp-6); }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="container">
+    <p class="eyebrow">ChordSketch · Design System · v1.0</p>
+    <h1 class="display">A library<br>for chord sheets.</h1>
+    <p class="lead">ChordSketch is a tool for ChordPro and iReal Pro. This guide is the visual contract between every surface — playground, ui-web, desktop, and the VS Code extension — and the brand.</p>
+    <span class="badge">tokens.css · v1.0</span>
+  </div>
+</header>
+
+<nav class="toc" aria-label="Sections">
+  <div class="container">
+    <ol>
+      <li><a href="#brand">Brand</a></li>
+      <li><a href="#color">Color</a></li>
+      <li><a href="#typography">Typography</a></li>
+      <li><a href="#chord-sheet">Chord sheet</a></li>
+      <li><a href="#space">Space</a></li>
+      <li><a href="#radius">Radius</a></li>
+      <li><a href="#motion">Motion</a></li>
+      <li><a href="#voice">Voice &amp; Tone</a></li>
+    </ol>
+  </div>
+</nav>
+
+<main class="container">
+
+  <section class="section" id="brand">
+    <h2>Brand</h2>
+    <p class="deck">A white quill on a crimson field. Writing and notation.</p>
+    <div style="display: flex; align-items: center; gap: var(--sp-8); flex-wrap: wrap;">
+      <img src="assets/logo.svg" alt="ChordSketch logo" width="180" height="180" style="border-radius: var(--r-3); box-shadow: var(--e-2); display: block;">
+      <div>
+        <p class="eyebrow">Wordmark · Noto Sans JP 700</p>
+        <p style="font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-48); letter-spacing: -0.02em; margin: 0;">ChordSketch</p>
+      </div>
+    </div>
+    <p class="spec-small" style="margin-top: var(--sp-6); max-width: 56ch;">Crimson appears as a large color field <em>only inside the mark itself</em>. Clearspace ≥ ¼ of mark height, or ≥ 24px next to the wordmark. Minimum 24px (mobile) / 32px (print). The mark sits on white or <code style="font-family: var(--font-mono);">--ink-50</code>; never on crimson.</p>
+  </section>
+
+  <section class="section" id="color">
+    <h2>Color</h2>
+    <p class="deck">Crimson is the only accent. Ink — warm, slightly red — carries everything else.</p>
+
+    <h3>Crimson</h3>
+    <div class="palette">
+      <div class="swatch"><div class="chip" style="background:#FDF2F5"></div><p class="name">--crimson-50</p><p class="hex">#FDF2F5</p></div>
+      <div class="swatch"><div class="chip" style="background:#FBE1E8"></div><p class="name">--crimson-100</p><p class="hex">#FBE1E8</p></div>
+      <div class="swatch"><div class="chip" style="background:#EC8AA3"></div><p class="name">--crimson-300</p><p class="hex">#EC8AA3</p></div>
+      <div class="swatch"><div class="chip" style="background:#BD1642"></div><p class="name">--crimson-500 ★</p><p class="hex">#BD1642</p></div>
+      <div class="swatch"><div class="chip" style="background:#A30F37"></div><p class="name">--crimson-600</p><p class="hex">#A30F37</p></div>
+      <div class="swatch"><div class="chip" style="background:#87092C"></div><p class="name">--crimson-700</p><p class="hex">#87092C</p></div>
+      <div class="swatch"><div class="chip" style="background:#480418"></div><p class="name">--crimson-900</p><p class="hex">#480418</p></div>
+    </div>
+
+    <h3>Ink</h3>
+    <div class="palette">
+      <div class="swatch"><div class="chip" style="background:#FFFFFF"></div><p class="name">--ink-0</p><p class="hex">#FFFFFF</p></div>
+      <div class="swatch"><div class="chip" style="background:#FAFAF7"></div><p class="name">--ink-50</p><p class="hex">#FAFAF7</p></div>
+      <div class="swatch"><div class="chip" style="background:#F6F4F7"></div><p class="name">--ink-100</p><p class="hex">#F6F4F7</p></div>
+      <div class="swatch"><div class="chip" style="background:#E8E6EA"></div><p class="name">--ink-200</p><p class="hex">#E8E6EA</p></div>
+      <div class="swatch"><div class="chip" style="background:#D4D1D6"></div><p class="name">--ink-300</p><p class="hex">#D4D1D6</p></div>
+      <div class="swatch"><div class="chip" style="background:#8A8790"></div><p class="name">--ink-500</p><p class="hex">#8A8790</p></div>
+      <div class="swatch"><div class="chip" style="background:#67646D"></div><p class="name">--ink-600</p><p class="hex">#67646D</p></div>
+      <div class="swatch"><div class="chip" style="background:#44424A"></div><p class="name">--ink-700</p><p class="hex">#44424A</p></div>
+      <div class="swatch"><div class="chip" style="background:#0A0A0B"></div><p class="name">--ink-1000</p><p class="hex">#0A0A0B</p></div>
+    </div>
+
+    <h3>Semantic</h3>
+    <div class="semantic-grid">
+      <div class="semantic">
+        <div class="surface" style="background: var(--success-surface); color: var(--success-fg);">Saved · 12:04</div>
+        <div class="meta"><span>success</span><span>#E8F3EC / #1A6B3A</span></div>
+      </div>
+      <div class="semantic">
+        <div class="surface" style="background: var(--warning-surface); color: var(--warning-fg);">Unsaved changes</div>
+        <div class="meta"><span>warning</span><span>#FBF1D9 / #8A5A07</span></div>
+      </div>
+      <div class="semantic">
+        <div class="surface" style="background: var(--danger-surface); color: var(--danger-fg);">Save failed. Check connection.</div>
+        <div class="meta"><span>danger</span><span>#FBE1E8 / #A30F37</span></div>
+      </div>
+      <div class="semantic">
+        <div class="surface" style="background: var(--info-surface); color: var(--info-fg);">Tip · ⌘K to search</div>
+        <div class="meta"><span>info</span><span>#E6EEF7 / #1F4F8A</span></div>
+      </div>
+    </div>
+
+    <h3>Contrast</h3>
+    <ul class="spec-small" style="margin: 0; padding-left: var(--sp-6);">
+      <li><code style="font-family: var(--font-mono);">--ink-1000</code> on <code style="font-family: var(--font-mono);">--ink-50</code> — 18.7:1 ✓</li>
+      <li><code style="font-family: var(--font-mono);">#fff</code> on <code style="font-family: var(--font-mono);">--crimson-500</code> — 6.2:1 ✓</li>
+      <li><code style="font-family: var(--font-mono);">--ink-500</code> is for supporting copy only.</li>
+    </ul>
+  </section>
+
+  <section class="section" id="typography">
+    <h2>Typography</h2>
+    <p class="deck">Noto Sans JP for body and display. Inter for Latin metadata and eyebrow labels. JetBrains Mono for chord glyphs and source.</p>
+
+    <div class="specimen">
+      <div class="role">Display<span class="meta">Noto Sans JP 900 · 60–72 / 1.05 · -0.03em</span></div>
+      <p class="spec-display">A library<br>for chord sheets.</p>
+    </div>
+    <div class="specimen">
+      <div class="role">H1<span class="meta">Noto Sans JP 700 · 48 / 53 · -0.02em</span></div>
+      <p class="spec-h1">Chapter 1 — Introduction</p>
+    </div>
+    <div class="specimen">
+      <div class="role">H2<span class="meta">Noto Sans JP 700 · 36 / 40 · -0.02em</span></div>
+      <p class="spec-h2">Section heading</p>
+    </div>
+    <div class="specimen">
+      <div class="role">H3<span class="meta">Noto Sans JP 700 · 30 / 36 · -0.02em</span></div>
+      <p class="spec-h3">Subsection heading</p>
+    </div>
+    <div class="specimen">
+      <div class="role">H4<span class="meta">Noto Sans JP 700 · 24 / 32 · -0.01em</span></div>
+      <p class="spec-h4">Small heading</p>
+    </div>
+    <div class="specimen">
+      <div class="role">H5<span class="meta">Noto Sans JP 600 · 18 / 26</span></div>
+      <p class="spec-h5">Helper heading</p>
+    </div>
+    <div class="specimen">
+      <div class="role">Body<span class="meta">Noto Sans JP 400 · 16 / 27</span></div>
+      <p class="spec-body">ChordSketch is a tool for searching, editing, and sharing chord sheets with lyrics for ChordPro and iReal Pro. From amateurs through professionals, every step of working with charts becomes smoother.</p>
+    </div>
+    <div class="specimen">
+      <div class="role">Small<span class="meta">Noto Sans JP 400 · 13 / 22</span></div>
+      <p class="spec-small">Last updated 2026-05-08 · 14 songs in this setlist</p>
+    </div>
+    <div class="specimen">
+      <div class="role">Eyebrow<span class="meta">Inter 600 · 12 / 16 · +0.12em UPPER</span></div>
+      <p class="spec-eyebrow">Verse · Section A</p>
+    </div>
+    <div class="specimen">
+      <div class="role">Mono<span class="meta">JetBrains Mono 600 · 14 / 26</span></div>
+      <p class="spec-mono">{title: Country Roads}<br>{key: G}<br>[G]Almost heaven, [Em]West Virginia</p>
+    </div>
+    <div class="specimen">
+      <div class="role">Meta<span class="meta">Inter 500 · 13 / 22 · tabular-nums</span></div>
+      <p class="spec-meta">BPM 82 · Key G · Capo 0 · 4/4</p>
+    </div>
+  </section>
+
+  <section class="section" id="chord-sheet">
+    <h2>Chord-sheet typesetting</h2>
+    <p class="deck">The heart of the product. Chord above, lyric below, both vertically stacked inside <code style="font-family: var(--font-mono);">.pair</code> — pairs flow as <code style="font-family: var(--font-mono);">inline-flex</code>.</p>
+
+    <article class="chord-sheet-card">
+      <header style="margin-bottom: var(--sp-6);">
+        <p class="eyebrow" style="margin: 0 0 var(--sp-1);">Verse 1 · Country Roads</p>
+        <p style="font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-30); margin: 0; letter-spacing: -0.02em;">Country Roads</p>
+        <dl class="chord-sheet-meta" style="margin-top: var(--sp-4);">
+          <dt>Key</dt><dd>G</dd>
+          <dt>Capo</dt><dd>0</dd>
+          <dt>BPM</dt><dd>82</dd>
+          <dt>Time</dt><dd>4/4</dd>
+        </dl>
+      </header>
+
+      <p class="section-label">Verse 1</p>
+      <div class="line">
+        <span class="pair"><span class="chord">G</span><span class="lyric">Almost heaven, </span></span><span class="pair"><span class="chord">Em</span><span class="lyric">West Virginia</span></span>
+      </div>
+      <div class="line">
+        <span class="pair"><span class="chord">D</span><span class="lyric">Blue Ridge Mountains, </span></span><span class="pair"><span class="chord">C</span><span class="lyric">Shenandoah </span></span><span class="pair"><span class="chord">G</span><span class="lyric">River</span></span>
+      </div>
+
+      <p class="section-label">Chorus</p>
+      <div class="line">
+        <span class="pair"><span class="chord">G</span><span class="lyric">Country roads, </span></span><span class="pair"><span class="chord">D</span><span class="lyric">take me home</span></span>
+      </div>
+      <div class="line">
+        <span class="pair"><span class="chord">Em</span><span class="lyric">To the place </span></span><span class="pair"><span class="chord">C</span><span class="lyric">I belong, </span></span><span class="pair"><span class="chord">G</span><span class="lyric">West Virginia</span></span>
+      </div>
+    </article>
+  </section>
+
+  <section class="section" id="space">
+    <h2>Space</h2>
+    <p class="deck">4pt baseline. Tokens scale from <code style="font-family: var(--font-mono);">--sp-1</code> to <code style="font-family: var(--font-mono);">--sp-32</code>.</p>
+    <div>
+      <div class="scale-grid"><span class="token">--sp-1</span><span class="px">4 px</span><span class="bar" style="width: 4px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-2</span><span class="px">8 px</span><span class="bar" style="width: 8px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-3</span><span class="px">12 px</span><span class="bar" style="width: 12px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-4</span><span class="px">16 px</span><span class="bar" style="width: 16px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-5</span><span class="px">20 px</span><span class="bar" style="width: 20px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-6</span><span class="px">24 px</span><span class="bar" style="width: 24px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-8</span><span class="px">32 px</span><span class="bar" style="width: 32px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-10</span><span class="px">40 px</span><span class="bar" style="width: 40px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-12</span><span class="px">48 px</span><span class="bar" style="width: 48px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-16</span><span class="px">64 px</span><span class="bar" style="width: 64px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-20</span><span class="px">80 px</span><span class="bar" style="width: 80px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-24</span><span class="px">96 px</span><span class="bar" style="width: 96px;"></span></div>
+      <div class="scale-grid"><span class="token">--sp-32</span><span class="px">128 px</span><span class="bar" style="width: 128px;"></span></div>
+    </div>
+  </section>
+
+  <section class="section" id="radius">
+    <h2>Radius</h2>
+    <p class="deck">Restrained. Buttons 4px, cards 8px, modals 12px.</p>
+    <div class="radius-row">
+      <div class="radius-tile" style="border-radius: 2px;">--r-1 · 2px</div>
+      <div class="radius-tile" style="border-radius: var(--r-2);">--r-2 · 4px</div>
+      <div class="radius-tile" style="border-radius: var(--r-3);">--r-3 · 8px</div>
+      <div class="radius-tile" style="border-radius: var(--r-4);">--r-4 · 12px</div>
+      <div class="radius-tile" style="border-radius: var(--r-full);">--r-full</div>
+    </div>
+  </section>
+
+  <section class="section" id="motion">
+    <h2>Motion</h2>
+    <p class="deck">A single curve, four durations. <code style="font-family: var(--font-mono);">prefers-reduced-motion</code> collapses durations to 0ms.</p>
+    <div class="motion-row">
+      <div class="motion-card" data-dur="1"><h4>--dur-1</h4><p>120ms · hover / focus</p><span class="motion-bar"><i></i></span></div>
+      <div class="motion-card" data-dur="2"><h4>--dur-2</h4><p>200ms · state</p><span class="motion-bar"><i></i></span></div>
+      <div class="motion-card" data-dur="3"><h4>--dur-3</h4><p>280ms · dialog</p><span class="motion-bar"><i></i></span></div>
+      <div class="motion-card" data-dur="4"><h4>--dur-4</h4><p>400ms · page</p><span class="motion-bar"><i></i></span></div>
+    </div>
+    <p class="spec-small" style="margin-top: var(--sp-4);">Easing — <code style="font-family: var(--font-mono);">cubic-bezier(.2, .8, .2, 1)</code> · <code style="font-family: var(--font-mono);">--ease-out</code>. No bounce.</p>
+  </section>
+
+  <section class="section" id="voice">
+    <h2>Voice &amp; Tone</h2>
+    <p class="deck">Capable musicians. Strip ornament; be precise. No emoji. No exclamation marks.</p>
+    <table class="voice">
+      <thead><tr><th>Avoid</th><th>Use</th></tr></thead>
+      <tbody>
+        <tr><td class="avoid">Oops! Couldn't save your song… 🥲</td><td>Save failed. Check your connection.</td></tr>
+        <tr><td class="avoid">Let's create a new song!</td><td>New song</td></tr>
+        <tr><td class="avoid">Try adding your very first song now!</td><td>Add your first song</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container">
+    <div class="row">
+      <span>ChordSketch · Design System · v1.0</span>
+      <span class="links">
+        <a href="ui_kits/web/library.html">Library</a>
+        <a href="ui_kits/web/viewer.html">Viewer</a>
+        <a href="ui_kits/web/editor.html">Editor · ChordPro</a>
+        <a href="ui_kits/web/editor-irealb.html">Editor · iReal Pro</a>
+        <a href="preview/index.html">Components</a>
+      </span>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -85,21 +85,32 @@ Not pure gray. A faint red tint keeps it in harmony with crimson.
 - `#fff` on `--crimson-500` = 6.2:1 ✓
 - `--ink-500` is for supporting copy only; never use it for body text.
 
+Ratios verified with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+Re-measure when a token's hex value changes.
+
 ---
 
 ## 3. Typography
 
-**No mincho / serif.** Sans-serif and monospace only.
+UI text is sans-serif and monospace. The chart-rendering surface is
+the one place a serif is allowed: iReal Pro charts use Source Serif 4
+italic for `D.C.` / `D.S.` / `Fine` text marks and the chart header,
+matching the engraved-feel of iReal Pro's own charts. Outside the
+chart surface, no serifs.
 
 | Family | Role | Weights |
 |---|---|---|
 | **Noto Sans JP**   | Japanese UI throughout, display | 400 / 500 / 700 / **900** |
 | **Inter**          | Latin, numerals, eyebrow labels | 400 / 500 / 600 / 700 / 800 |
-| **JetBrains Mono** | Code, chord progressions (`[G]`), ChordPro source | 400 / 600 / **700** |
+| **JetBrains Mono** | Code, ChordPro source, monospaced UI elements | 400 / 600 / **700** |
+| **Roboto**         | Chord glyphs (`[G]`, `Am7`) and section letters in chart-rendering surfaces. Chosen for its stable Latin-numeric balance at small sizes. | 400 / 500 / 700 / 900 |
+| **Source Serif 4** | iReal Pro chart text marks (`D.C.`, `D.S.`, `Fine`) and chart header. Italic-leaning, evokes engraved sheet music. *Chart surfaces only.* | 400 / 700 / 900 (italic 400) |
 | **Bravura Text**   | SMuFL music glyphs — accidentals (♯ ♭), barlines, segno / coda, repeat dots. Used by `chordsketch-render-ireal` and the iReal Pro editor surface. | 400 |
 
+Token aliases in `tokens.css`:
 `--font-jp` = body, `--font-display` = display (Noto Sans JP 900),
 `--font-latin` = Inter, `--font-mono` = JetBrains Mono,
+`--font-chord` = Roboto, `--font-chart-serif` = Source Serif 4,
 `--font-music` = Bravura Text (see [ADR-0014](docs/adr/0014-bravura-glyphs-as-svg-paths.md)).
 
 ### 3.1 Scale
@@ -120,7 +131,7 @@ Not pure gray. A faint red tint keeps it in harmony with crimson.
 
 ### 3.2 Chord-sheet typesetting (the heart of the product)
 
-- Chord (`[G]`) = `--crimson-500` + JetBrains Mono 700 / 16px.
+- Chord (`[G]`) = `--crimson-500` + Roboto 700 / 16px (`--font-chord`).
 - Lyric = Noto Sans JP 400 / 16–18px.
 - Chord and lyric are **stacked vertically** (`flex-direction: column`)
   inside a `.pair`, and `.pair` elements flow as `inline-flex`.
@@ -164,7 +175,7 @@ Not pure gray. A faint red tint keeps it in harmony with crimson.
 
 Every component depends on tokens in `tokens.css`. Only the minimum
 requirements are listed here; visual detail will live in
-`ChordSketch Design System.html` and `preview/components-*.html` once
+`design-system.html` and `preview/components-*.html` once
 those artifacts are produced.
 
 | Category   | Variants |
@@ -227,7 +238,7 @@ those artifacts are produced.
 | File | Contents |
 |---|---|
 | `tokens.css` | Source of truth for every design token |
-| `ChordSketch Design System.html` | Long-form visual guide (single page) |
+| `design-system.html` | Long-form visual guide (single page) |
 | `ui_kits/web/library.html` | Full-screen sample — library |
 | `ui_kits/web/viewer.html` | Full-screen sample — chord sheet viewer |
 | `ui_kits/web/editor.html` | Full-screen sample — ChordPro split editor (source + live preview) |
@@ -252,4 +263,6 @@ those artifacts are produced.
 ## 10. Changelog
 
 - **v1.0** — Initial. Crimson + Warm Ink + Noto Sans JP / Inter /
-  JetBrains Mono. Mincho / serif typefaces are explicitly out of scope.
+  JetBrains Mono / Roboto / Source Serif 4 / Bravura Text. Source
+  Serif 4 is restricted to chart-rendering surfaces (iReal Pro); UI
+  text remains sans-serif and monospace.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,9 +20,9 @@ components, and tone. Implementation references the tokens defined in
   background); raster derivatives ship as `assets/logo-128.png` (VS Code
   extension icon) and `assets/logo-256.png` (high-DPI / Marketplace
   README headers).
-- **Wordmark** — "ChordSketch" set in Noto Sans JP 700. Japanese
-  reading コードスケッチ is documented for ja-JP localization but
-  does not appear in default UI surfaces.
+- **Wordmark** — "ChordSketch" set in Noto Sans JP 700. The ja-JP
+  localization name (romanized: "Koodo Suketchi") is documented in the
+  locale resource file; it does not appear in default English UI surfaces.
 - **Clearspace** — At least ¼ of the mark's height on every side. When
   paired with the wordmark, leave ≥ 24px between the two.
 - **Minimum size** — 24px (mobile UI) / 32px (print).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,255 @@
+# ChordSketch — Design System
+
+**Version 1.0** · English-primary UI · Light theme · Editorial / Professional
+
+ChordSketch is a library of chord sheets with lyrics for **ChordPro** and
+**iReal Pro**. A tool for amateurs through professionals to search, edit,
+and share music smoothly.
+
+This document is the source of truth for color, typography, space, motion,
+components, and tone. Implementation references the tokens defined in
+`tokens.css`.
+
+---
+
+## 1. Brand
+
+- **Mark** — A white quill on a crimson color field. It signifies the act
+  of writing / inscribing and the symbolism of musical notation. The
+  canonical asset is `assets/logo.svg` (vector, 180×180, `#BD1642`
+  background); raster derivatives ship as `assets/logo-128.png` (VS Code
+  extension icon) and `assets/logo-256.png` (high-DPI / Marketplace
+  README headers).
+- **Wordmark** — "ChordSketch" set in Noto Sans JP 700. Japanese
+  reading コードスケッチ is documented for ja-JP localization but
+  does not appear in default UI surfaces.
+- **Clearspace** — At least ¼ of the mark's height on every side. When
+  paired with the wordmark, leave ≥ 24px between the two.
+- **Minimum size** — 24px (mobile UI) / 32px (print).
+- **Background** — Place the mark on white or `--ink-50` only. Never
+  overlay it on crimson.
+
+Crimson appears as a large color field **only inside the mark itself**.
+Using crimson on large surfaces elsewhere in the product is prohibited.
+
+---
+
+## 2. Color
+
+### 2.1 Crimson — the only accent
+
+A deep red-violet crimson sampled from the logo. Reserved for primary
+action, active state, chord symbols, and key signatures.
+
+| Token | Hex | Use |
+|---|---|---|
+| `--crimson-50`  | `#FDF2F5` | Tint background, error-form wash |
+| `--crimson-100` | `#FBE1E8` | Banner wash |
+| `--crimson-300` | `#EC8AA3` | Hover accent |
+| `--crimson-500` ★ | `#BD1642` | **Brand primary** |
+| `--crimson-600` | `#A30F37` | Hover / pressed |
+| `--crimson-700` | `#87092C` | Text on tint |
+| `--crimson-900` | `#480418` | Dark mode accent |
+
+★ = default (aliased as `--crimson`).
+
+### 2.2 Ink — warm neutrals
+
+Not pure gray. A faint red tint keeps it in harmony with crimson.
+
+| Token | Hex | Role |
+|---|---|---|
+| `--ink-0`    | `#FFFFFF` | Surface |
+| `--ink-50`   | `#FAFAF7` | Canvas (page background) |
+| `--ink-100`  | `#F6F4F7` | Hover surface |
+| `--ink-200`  | `#E8E6EA` | Hairline / subtle border |
+| `--ink-300`  | `#D4D1D6` | Border |
+| `--ink-500`  | `#8A8790` | Text-tertiary |
+| `--ink-600`  | `#67646D` | Text-secondary |
+| `--ink-700`  | `#44424A` | Text-strong (sub) |
+| `--ink-1000` | `#0A0A0B` | Text-primary |
+
+### 2.3 Semantic
+
+| Token   | Surface   | Foreground | Use |
+|---|---|---|---|
+| success | `#E8F3EC` | `#1A6B3A`  | Save / sync complete |
+| warning | `#FBF1D9` | `#8A5A07`  | Unsaved / caution |
+| danger  | `#FBE1E8` | `#A30F37`  | Error / delete |
+| info    | `#E6EEF7` | `#1F4F8A`  | Hint / notification |
+
+### 2.4 Contrast
+
+- Body text on background must meet WCAG AA (≥ 4.5:1).
+- `--ink-1000` on `--ink-50` = 18.7:1 ✓
+- `#fff` on `--crimson-500` = 6.2:1 ✓
+- `--ink-500` is for supporting copy only; never use it for body text.
+
+---
+
+## 3. Typography
+
+**No mincho / serif.** Sans-serif and monospace only.
+
+| Family | Role | Weights |
+|---|---|---|
+| **Noto Sans JP**   | Japanese UI throughout, display | 400 / 500 / 700 / **900** |
+| **Inter**          | Latin, numerals, eyebrow labels | 400 / 500 / 600 / 700 / 800 |
+| **JetBrains Mono** | Code, chord progressions (`[G]`), ChordPro source | 400 / 600 / **700** |
+| **Bravura Text**   | SMuFL music glyphs — accidentals (♯ ♭), barlines, segno / coda, repeat dots. Used by `chordsketch-render-ireal` and the iReal Pro editor surface. | 400 |
+
+`--font-jp` = body, `--font-display` = display (Noto Sans JP 900),
+`--font-latin` = Inter, `--font-mono` = JetBrains Mono,
+`--font-music` = Bravura Text (see [ADR-0014](docs/adr/0014-bravura-glyphs-as-svg-paths.md)).
+
+### 3.1 Scale
+
+| Role    | Family         | Weight | Size / Line | Tracking |
+|---|---|---|---|---|
+| Display | Noto Sans JP   | 900 | 60–72 / 1.05 | `-0.03em` |
+| H1      | Noto Sans JP   | 700 | 48 / 53      | `-0.02em` |
+| H2      | Noto Sans JP   | 700 | 36 / 40      | `-0.02em` |
+| H3      | Noto Sans JP   | 700 | 30 / 36      | `-0.02em` |
+| H4      | Noto Sans JP   | 700 | 24 / 32      | `-0.01em` |
+| H5      | Noto Sans JP   | 600 | 18 / 26      | `0`       |
+| Body    | Noto Sans JP   | 400 | 16 / 27      | `0`       |
+| Small   | Noto Sans JP   | 400 | 13 / 22      | `0`       |
+| Eyebrow | Inter          | 600 | 12 / 16      | `+0.12em` UPPER |
+| Mono    | JetBrains Mono | 600 | 14 / 26      | `0`       |
+| Meta    | Inter          | 500 | 13 / 22      | `0` tabular-nums |
+
+### 3.2 Chord-sheet typesetting (the heart of the product)
+
+- Chord (`[G]`) = `--crimson-500` + JetBrains Mono 700 / 16px.
+- Lyric = Noto Sans JP 400 / 16–18px.
+- Chord and lyric are **stacked vertically** (`flex-direction: column`)
+  inside a `.pair`, and `.pair` elements flow as `inline-flex`.
+- Section labels (Verse / Chorus / Bridge) use the eyebrow style with a
+  horizontal rule.
+
+---
+
+## 4. Space
+
+- **Baseline** — 4pt. Tokens: `--sp-1` (4) → `--sp-32` (128).
+- **Radius** — Restrained. `--r-2` (4px / button) and `--r-3`
+  (8px / card) carry most of the load. `--r-4` (12px) is reserved for
+  modals.
+- **Elevation** — Lines first (`--border` = `--ink-200`). Shadows are
+  reserved for popovers (e2), modals (e3), and the command-palette
+  overlay.
+- **Borders are uniform.** A container's border is the same width on
+  all four sides. Asymmetric thick borders (e.g., a 3 px crimson top
+  border) are not used as an accent device. To call attention, swap
+  the border color (e.g., `--crimson-500`) or reposition hierarchy —
+  never one thick edge.
+- **Container max-widths** — 1280px (app) / 720px (reading) /
+  1080px (guides).
+- **Grid** — 12 columns, 24px gutter.
+
+---
+
+## 5. Motion
+
+- **Easing** — A single curve, `cubic-bezier(.2, .8, .2, 1)`
+  (`--ease-out`). No bounce.
+- **Duration** — `--dur-1` 120ms (hover/focus) / `--dur-2` 200ms
+  (state) / `--dur-3` 280ms (dialog) / `--dur-4` 400ms (page).
+- **`prefers-reduced-motion`** is honored — durations collapse to 0ms
+  when set.
+
+---
+
+## 6. Components
+
+Every component depends on tokens in `tokens.css`. Only the minimum
+requirements are listed here; visual detail will live in
+`ChordSketch Design System.html` and `preview/components-*.html` once
+those artifacts are produced.
+
+| Category   | Variants |
+|---|---|
+| Buttons    | primary / secondary / ghost / danger × sm / md / lg, icon-only, disabled |
+| Forms      | input / select / textarea / segmented / checkbox / radio, focus = `--focus-ring` |
+| Cards      | song / setlist / featured (uniform 1px `--crimson-500` border; surface, type, and other tokens unchanged) |
+| Badges     | status (4 semantic + crimson + muted) / key (mono on ink-1000 or crimson) / genre (pill) |
+| Avatars    | 24 / 28 / 36 / 48 px, stacked +N |
+| Navigation | top nav 56px, tabs (underline + count) |
+| Modal      | 12px radius, e3 elevation, footer `--ink-50` wash to demarcate |
+| Table      | eyebrow header, tabular-nums, hover row = `--ink-50` |
+| Toast      | `--ink-1000` base / success / danger / warning, action button uses inherited foreground + underline (no color shift) so contrast holds on every variant |
+| Progress   | 6px bar / spinner / skeleton |
+
+---
+
+## 7. Voice & Tone
+
+- **Audience** = capable musicians. Strip ornament; be precise.
+- UI labels and headings are short noun phrases. System messages are
+  declarative sentences. No filler words.
+- Domain terms (Capo, Verse, Chorus, Bridge, ChordPro, iReal Pro) are
+  **not translated**.
+- Quotation marks: straight `"…"` only. Curly `“…”` and Japanese
+  `「…」` appear only inside localized ja-JP strings, never in source.
+- **No emoji.** Icons are line icons (1.5px stroke).
+- Avoid exclamation marks. State errors plainly: what happened, and
+  the next step.
+
+| Avoid | Use |
+|---|---|
+| Oops! Couldn't save your song… 🥲 | Save failed. Check your connection. |
+| Let's create a new song! | New song |
+| Try adding your very first song now! | Add your first song |
+
+---
+
+## 8. Implementation
+
+```html
+<link rel="stylesheet" href="tokens.css">
+```
+
+```css
+.btn-primary {
+  background: var(--crimson);
+  color: var(--fg-on-crimson);
+  border-radius: var(--r-2);
+  padding: var(--sp-2) var(--sp-4);
+  font: 500 var(--fs-14)/1 var(--font-sans);
+  transition: background var(--dur-1) var(--ease-out);
+}
+```
+
+---
+
+## 9. Related files
+
+| File | Contents |
+|---|---|
+| `tokens.css` | Source of truth for every design token |
+| `ChordSketch Design System.html` | Long-form visual guide (single page) |
+| `ui_kits/web/library.html` | Full-screen sample — library |
+| `ui_kits/web/viewer.html` | Full-screen sample — chord sheet viewer |
+| `ui_kits/web/editor.html` | Full-screen sample — ChordPro split editor (source + live preview) |
+| `ui_kits/web/editor-irealb.html` | Full-screen sample — iReal Pro bar-grid editor with metadata header and bar inspector |
+| `preview/index.html` | Component preview index |
+| `preview/components-buttons.html` | Buttons — variants, sizes, icon-only, disabled, loading |
+| `preview/components-forms.html` | Inputs, textarea, select, segmented, check, radio, switch |
+| `preview/components-cards.html` | Song / setlist / accent cards |
+| `preview/components-badges.html` | Status, key, format, genre badges |
+| `preview/components-avatars.html` | Avatars at 24 / 28 / 36 / 48 px, stacked +N |
+| `preview/components-navigation.html` | Top nav, tabs, breadcrumbs, sidebar |
+| `preview/components-modal.html` | Confirm dialog, form modal, command palette |
+| `preview/components-table.html` | Library table, stats table |
+| `preview/components-toast.html` | Default, success, danger, warning, stack |
+| `preview/components-progress.html` | Linear bar, spinner, skeleton |
+| `assets/logo.svg` | Brand mark (vector, 180×180, `#BD1642` field) |
+| `assets/logo-128.png` | Raster derivative — VS Code extension icon |
+| `assets/logo-256.png` | Raster derivative — Marketplace README header / high-DPI contexts |
+
+---
+
+## 10. Changelog
+
+- **v1.0** — Initial. Crimson + Warm Ink + Noto Sans JP / Inter /
+  JetBrains Mono. Mincho / serif typefaces are explicitly out of scope.

--- a/design-system.html
+++ b/design-system.html
@@ -84,7 +84,7 @@ a { color: inherit; }
 .section-label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); border-top: 1px solid var(--border); padding-top: var(--sp-3); margin: var(--sp-6) 0 var(--sp-3); }
 .line { font-size: 0; margin-bottom: var(--sp-3); }
 .pair { display: inline-flex; flex-direction: column; align-items: flex-start; vertical-align: bottom; }
-.pair .chord { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
+.pair .chord { font-family: var(--font-chord); font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
 .pair .lyric { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-18); line-height: 1.5; white-space: pre; }
 
 .scale-grid { display: grid; grid-template-columns: 80px 80px 1fr; gap: var(--sp-4); align-items: center; padding: var(--sp-2) 0; border-bottom: 1px solid var(--border); }

--- a/preview/components-avatars.html
+++ b/preview/components-avatars.html
@@ -23,16 +23,13 @@ a { color: inherit; }
 .frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8); display: flex; flex-wrap: wrap; gap: var(--sp-6); align-items: center; }
 
 .avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: var(--r-full); font-family: var(--font-latin); font-weight: 600; color: var(--ink-0); }
-.avatar.s24 { width: 24px; height: 24px; font-size: 10px; }
-.avatar.s28 { width: 28px; height: 28px; font-size: 11px; }
-.avatar.s36 { width: 36px; height: 36px; font-size: 13px; }
-.avatar.s48 { width: 48px; height: 48px; font-size: 16px; }
+.avatar.s24 { width: 24px; height: 24px; font-size: var(--fs-10); }
+.avatar.s28 { width: 28px; height: 28px; font-size: var(--fs-10); }
+.avatar.s36 { width: 36px; height: 36px; font-size: var(--fs-13); }
+.avatar.s48 { width: 48px; height: 48px; font-size: var(--fs-16); }
 
 .avatar.crimson { background: var(--crimson-500); }
 .avatar.ink     { background: var(--ink-700); }
-.avatar.warm    { background: #C97A4F; }
-.avatar.olive   { background: #6E7E4A; }
-.avatar.steel   { background: #4A6E7E; }
 .avatar.muted   { background: var(--ink-300); color: var(--text-strong); }
 
 .avatars { display: inline-flex; }
@@ -60,8 +57,8 @@ a { color: inherit; }
     <div class="frame">
       <span class="avatar s24 crimson">SL</span>
       <span class="avatar s28 ink">MC</span>
-      <span class="avatar s36 warm">AT</span>
-      <span class="avatar s48 olive">RH</span>
+      <span class="avatar s36 ink">AT</span>
+      <span class="avatar s48 muted">RH</span>
     </div>
   </section>
 
@@ -71,19 +68,19 @@ a { color: inherit; }
       <span class="avatars">
         <span class="avatar s28 crimson">SL</span>
         <span class="avatar s28 ink">MC</span>
-        <span class="avatar s28 warm">AT</span>
+        <span class="avatar s28 ink">AT</span>
       </span>
       <span class="avatars">
         <span class="avatar s28 crimson">SL</span>
         <span class="avatar s28 ink">MC</span>
-        <span class="avatar s28 warm">AT</span>
-        <span class="avatar s28 olive">RH</span>
+        <span class="avatar s28 ink">AT</span>
+        <span class="avatar s28 muted">RH</span>
         <span class="avatar s28 muted">+3</span>
       </span>
       <span class="avatars lg">
         <span class="avatar s48 crimson">SL</span>
         <span class="avatar s48 ink">MC</span>
-        <span class="avatar s48 warm">AT</span>
+        <span class="avatar s48 ink">AT</span>
         <span class="avatar s48 muted">+5</span>
       </span>
     </div>
@@ -107,7 +104,7 @@ a { color: inherit; }
         </div>
       </div>
       <div class="with-meta">
-        <span class="avatar s36 warm">AT</span>
+        <span class="avatar s36 ink">AT</span>
         <div>
           <div class="name">Alex Tanaka</div>
           <div class="role">viewer</div>

--- a/preview/components-avatars.html
+++ b/preview/components-avatars.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Avatars — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); text-decoration: none; }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8); display: flex; flex-wrap: wrap; gap: var(--sp-6); align-items: center; }
+
+.avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: var(--r-full); font-family: var(--font-latin); font-weight: 600; color: var(--ink-0); }
+.avatar.s24 { width: 24px; height: 24px; font-size: 10px; }
+.avatar.s28 { width: 28px; height: 28px; font-size: 11px; }
+.avatar.s36 { width: 36px; height: 36px; font-size: 13px; }
+.avatar.s48 { width: 48px; height: 48px; font-size: 16px; }
+
+.avatar.crimson { background: var(--crimson-500); }
+.avatar.ink     { background: var(--ink-700); }
+.avatar.warm    { background: #C97A4F; }
+.avatar.olive   { background: #6E7E4A; }
+.avatar.steel   { background: #4A6E7E; }
+.avatar.muted   { background: var(--ink-300); color: var(--text-strong); }
+
+.avatars { display: inline-flex; }
+.avatars > .avatar { border: 2px solid var(--surface); margin-left: -8px; }
+.avatars > .avatar:first-child { margin-left: 0; }
+.avatars.lg > .avatar { margin-left: -10px; }
+
+.with-meta { display: inline-flex; align-items: center; gap: var(--sp-3); }
+.with-meta .name { font-family: var(--font-jp); font-weight: 600; font-size: var(--fs-14); }
+.with-meta .role { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); }
+
+.presence { position: relative; }
+.presence::after { content: ""; position: absolute; right: -2px; bottom: -2px; width: 10px; height: 10px; border: 2px solid var(--surface); border-radius: var(--r-full); background: var(--success-fg); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Avatars</h1>
+  <p class="preview-deck">Sizes 24 / 28 / 36 / 48 px. Stacked overlap of 8 px (10 px at 48). Initials use Inter 600.</p>
+
+  <section class="group">
+    <h2>Sizes</h2>
+    <div class="frame">
+      <span class="avatar s24 crimson">SL</span>
+      <span class="avatar s28 ink">MC</span>
+      <span class="avatar s36 warm">AT</span>
+      <span class="avatar s48 olive">RH</span>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Stacked +N</h2>
+    <div class="frame">
+      <span class="avatars">
+        <span class="avatar s28 crimson">SL</span>
+        <span class="avatar s28 ink">MC</span>
+        <span class="avatar s28 warm">AT</span>
+      </span>
+      <span class="avatars">
+        <span class="avatar s28 crimson">SL</span>
+        <span class="avatar s28 ink">MC</span>
+        <span class="avatar s28 warm">AT</span>
+        <span class="avatar s28 olive">RH</span>
+        <span class="avatar s28 muted">+3</span>
+      </span>
+      <span class="avatars lg">
+        <span class="avatar s48 crimson">SL</span>
+        <span class="avatar s48 ink">MC</span>
+        <span class="avatar s48 warm">AT</span>
+        <span class="avatar s48 muted">+5</span>
+      </span>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>With metadata</h2>
+    <div class="frame" style="flex-direction: column; align-items: stretch; gap: var(--sp-4);">
+      <div class="with-meta">
+        <span class="avatar s36 crimson presence">SL</span>
+        <div>
+          <div class="name">Sarah Lee</div>
+          <div class="role">koedame · owner</div>
+        </div>
+      </div>
+      <div class="with-meta">
+        <span class="avatar s36 ink">MC</span>
+        <div>
+          <div class="name">Mike Chen</div>
+          <div class="role">editor · added 2 songs</div>
+        </div>
+      </div>
+      <div class="with-meta">
+        <span class="avatar s36 warm">AT</span>
+        <div>
+          <div class="name">Alex Tanaka</div>
+          <div class="role">viewer</div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-badges.html
+++ b/preview/components-badges.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Badges — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); text-decoration: none; }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8); display: flex; flex-wrap: wrap; gap: var(--sp-3); align-items: center; }
+
+.badge { display: inline-flex; align-items: center; gap: var(--sp-1); padding: 2px var(--sp-2); border-radius: var(--r-1); font-family: var(--font-mono); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.02em; }
+.badge.dot::before { content: ""; width: 6px; height: 6px; border-radius: var(--r-full); background: currentColor; }
+
+/* Status (semantic) */
+.badge.success { background: var(--success-surface); color: var(--success-fg); }
+.badge.warning { background: var(--warning-surface); color: var(--warning-fg); }
+.badge.danger { background: var(--danger-surface); color: var(--danger-fg); }
+.badge.info { background: var(--info-surface); color: var(--info-fg); }
+.badge.crimson { background: var(--crimson-50); color: var(--crimson-700); }
+.badge.muted { background: var(--ink-100); color: var(--text-secondary); }
+
+/* Key badges */
+.badge.key { background: var(--ink-1000); color: var(--ink-0); padding: 2px var(--sp-2); }
+.badge.key.crimson-fill { background: var(--crimson-500); color: var(--fg-on-crimson); }
+
+/* Format pill */
+.badge.format { background: var(--ink-100); color: var(--text-strong); border: 1px solid var(--border); }
+
+/* Genre pill */
+.pill { display: inline-flex; align-items: center; padding: var(--sp-1) var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-full); background: var(--surface); font: 500 var(--fs-13)/1 var(--font-jp); color: var(--text-secondary); }
+.pill.solid { background: var(--ink-1000); color: var(--ink-0); border-color: var(--ink-1000); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Badges</h1>
+  <p class="preview-deck">Status, key, format, and genre badges. Mono on dark for keys; semantic surfaces for status; pill for genre.</p>
+
+  <section class="group">
+    <h2>Status — semantic</h2>
+    <div class="frame">
+      <span class="badge success dot">Saved</span>
+      <span class="badge warning dot">Unsaved</span>
+      <span class="badge danger dot">Error</span>
+      <span class="badge info dot">Tip</span>
+      <span class="badge crimson dot">New</span>
+      <span class="badge muted dot">Draft</span>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Key</h2>
+    <div class="frame">
+      <span class="badge key">C</span>
+      <span class="badge key">G</span>
+      <span class="badge key">D</span>
+      <span class="badge key">F#m</span>
+      <span class="badge key">Bb</span>
+      <span class="badge key crimson-fill">G</span>
+      <span class="badge key crimson-fill">Em</span>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Format</h2>
+    <div class="frame">
+      <span class="badge format">ChordPro</span>
+      <span class="badge format">iReal Pro</span>
+      <span class="badge format">PDF</span>
+      <span class="badge format">HTML</span>
+      <span class="badge format">MusicXML</span>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Genre — pill</h2>
+    <div class="frame">
+      <span class="pill solid">All</span>
+      <span class="pill">J-Pop</span>
+      <span class="pill">Jazz Standard</span>
+      <span class="pill">Folk</span>
+      <span class="pill">Acoustic</span>
+      <span class="pill">Bossa</span>
+      <span class="pill">Funk</span>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>In context</h2>
+    <div class="frame" style="display: block;">
+      <p style="margin: 0 0 var(--sp-3); font-size: var(--fs-14); color: var(--text-secondary);">Library row</p>
+      <div style="display: flex; align-items: center; gap: var(--sp-3); padding: var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2);">
+        <strong style="font-family: var(--font-jp); font-weight: 700;">Country Roads</strong>
+        <span class="badge key crimson-fill">G</span>
+        <span class="badge format">ChordPro</span>
+        <span class="badge success dot">Synced</span>
+        <span style="margin-left: auto; font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary);">BPM 82 · Capo 0</span>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-buttons.html
+++ b/preview/components-buttons.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Buttons — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { display: inline-flex; align-items: center; gap: var(--sp-2); font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); text-decoration: none; }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8); display: flex; flex-wrap: wrap; gap: var(--sp-4); align-items: center; }
+
+.btn { display: inline-flex; align-items: center; gap: var(--sp-2); height: 36px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid transparent; font: 500 var(--fs-14)/1 var(--font-jp); cursor: pointer; transition: background var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out); text-decoration: none; }
+.btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.btn:disabled, .btn[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
+.btn-sm { height: 28px; padding: 0 var(--sp-3); font-size: var(--fs-13); }
+.btn-md { height: 36px; }
+.btn-lg { height: 44px; padding: 0 var(--sp-5); font-size: var(--fs-16); }
+.btn-icon { padding: 0; width: 36px; justify-content: center; }
+.btn-sm.btn-icon { width: 28px; }
+.btn-lg.btn-icon { width: 44px; }
+
+.btn-primary { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.btn-primary:hover:not(:disabled) { background: var(--crimson-600); }
+.btn-primary:active { background: var(--crimson-700); }
+
+.btn-secondary { background: var(--surface); color: var(--text-primary); border-color: var(--border-strong); }
+.btn-secondary:hover:not(:disabled) { background: var(--ink-100); }
+
+.btn-ghost { background: transparent; color: var(--text-secondary); }
+.btn-ghost:hover:not(:disabled) { background: var(--ink-100); color: var(--text-primary); }
+
+.btn-danger { background: var(--danger-fg); color: var(--fg-on-crimson); }
+.btn-danger:hover:not(:disabled) { background: var(--crimson-700); }
+
+.btn .spinner { width: 14px; height: 14px; border: 2px solid currentColor; border-right-color: transparent; border-radius: var(--r-full); animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(1turn); } }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Buttons</h1>
+  <p class="preview-deck">primary / secondary / ghost / danger × sm / md / lg, plus icon-only, disabled, and loading states. Focus uses <code style="font-family: var(--font-mono);">--focus-ring</code>.</p>
+
+  <section class="group">
+    <h2>Variants — md</h2>
+    <div class="frame">
+      <button class="btn btn-primary">Save</button>
+      <button class="btn btn-secondary">Cancel</button>
+      <button class="btn btn-ghost">Preview</button>
+      <button class="btn btn-danger">Delete</button>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Sizes — sm / md / lg</h2>
+    <div class="frame">
+      <button class="btn btn-primary btn-sm">Save</button>
+      <button class="btn btn-primary btn-md">Save</button>
+      <button class="btn btn-primary btn-lg">Save</button>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>With icon</h2>
+    <div class="frame">
+      <button class="btn btn-primary"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>New</button>
+      <button class="btn btn-secondary"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12l7-7 7 7"/></svg>Import</button>
+      <button class="btn btn-ghost">Edit<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg></button>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Icon-only</h2>
+    <div class="frame">
+      <button class="btn btn-secondary btn-icon" aria-label="Search"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg></button>
+      <button class="btn btn-ghost btn-icon" aria-label="More"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg></button>
+      <button class="btn btn-secondary btn-icon btn-sm" aria-label="Close"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+      <button class="btn btn-primary btn-icon btn-lg" aria-label="Play"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><polygon points="6 4 20 12 6 20 6 4"/></svg></button>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Disabled</h2>
+    <div class="frame">
+      <button class="btn btn-primary" disabled>Save</button>
+      <button class="btn btn-secondary" disabled>Cancel</button>
+      <button class="btn btn-ghost" disabled>Preview</button>
+      <button class="btn btn-danger" disabled>Delete</button>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Loading</h2>
+    <div class="frame">
+      <button class="btn btn-primary"><span class="spinner" aria-hidden="true"></span>Saving</button>
+      <button class="btn btn-secondary"><span class="spinner" aria-hidden="true"></span>Syncing</button>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-cards.html
+++ b/preview/components-cards.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cards — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); text-decoration: none; }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--sp-6); }
+
+/* Song card */
+.song-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5); transition: border-color var(--dur-2) var(--ease-out), transform var(--dur-2) var(--ease-out), box-shadow var(--dur-2) var(--ease-out); cursor: pointer; }
+.song-card:hover { border-color: var(--border-strong); transform: translateY(-1px); box-shadow: var(--e-1); }
+.song-card.featured { border-color: var(--crimson-500); }
+.song-card .artist { font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-13); color: var(--text-secondary); margin: 0 0 var(--sp-2); }
+.song-card h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-18); line-height: 1.4; letter-spacing: -0.01em; margin: 0 0 var(--sp-4); }
+.song-card .meta { display: flex; gap: var(--sp-3); flex-wrap: wrap; font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); margin-bottom: var(--sp-4); font-variant-numeric: tabular-nums; }
+.song-card .footer { display: flex; align-items: center; justify-content: space-between; padding-top: var(--sp-3); border-top: 1px solid var(--border); }
+.badge { display: inline-flex; align-items: center; padding: 2px var(--sp-2); border-radius: var(--r-1); font-family: var(--font-mono); font-weight: 600; font-size: var(--fs-12); }
+.badge.key { background: var(--ink-1000); color: var(--ink-0); }
+.badge.key.crimson { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.badge.format { background: var(--ink-100); color: var(--text-strong); border: 1px solid var(--border); }
+.song-card time { font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-12); color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
+
+/* Setlist card */
+.setlist { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5); display: flex; flex-direction: column; }
+.setlist h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-18); margin: 0 0 var(--sp-2); letter-spacing: -0.01em; }
+.setlist .desc { color: var(--text-secondary); font-size: var(--fs-14); margin: 0 0 var(--sp-5); }
+.setlist .stats { display: flex; gap: var(--sp-6); padding: var(--sp-3) 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); margin-bottom: var(--sp-4); }
+.setlist .stat { display: flex; flex-direction: column; gap: var(--sp-1); }
+.setlist .stat .num { font-family: var(--font-mono); font-weight: 600; font-size: var(--fs-24); letter-spacing: -0.01em; font-variant-numeric: tabular-nums; }
+.setlist .stat .label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); }
+.setlist time { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); margin-top: auto; }
+
+/* Featured */
+.featured-card { background: var(--surface); border: 1px solid var(--crimson-500); border-radius: var(--r-3); padding: var(--sp-6) var(--sp-5); }
+.featured-card .eyebrow { margin: 0 0 var(--sp-1); color: var(--text-secondary); }
+.featured-card h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-24); margin: 0 0 var(--sp-2); letter-spacing: -0.01em; }
+.featured-card p { color: var(--text-secondary); margin: 0 0 var(--sp-5); font-size: var(--fs-14); }
+.btn { display: inline-flex; align-items: center; gap: var(--sp-2); height: 36px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid transparent; font: 500 var(--fs-14)/1 var(--font-jp); cursor: pointer; transition: background var(--dur-1) var(--ease-out); text-decoration: none; }
+.btn-primary { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.btn-primary:hover { background: var(--crimson-600); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Cards</h1>
+  <p class="preview-deck">Song cards for the library, setlist cards with stats, and featured cards that swap only the border color to <code style="font-family: var(--font-mono);">--crimson-500</code>. Borders stay uniform — no asymmetric thick edges.</p>
+
+  <section class="group">
+    <h2>Song card · default · featured · hover</h2>
+    <div class="grid">
+      <article class="song-card">
+        <p class="artist">John Denver</p>
+        <h3>Country Roads</h3>
+        <div class="meta"><span>Key G</span><span>BPM 82</span><span>Capo 0</span><span>4/4</span></div>
+        <div class="footer">
+          <span class="badge format">ChordPro</span>
+          <span class="badge key">G</span>
+        </div>
+      </article>
+      <article class="song-card featured">
+        <p class="artist">Oasis</p>
+        <h3>Wonderwall</h3>
+        <div class="meta"><span>Key Em</span><span>BPM 87</span><span>Capo 0</span><span>4/4</span></div>
+        <div class="footer">
+          <span class="badge format">ChordPro</span>
+          <span class="badge key crimson">Em</span>
+        </div>
+      </article>
+      <article class="song-card" style="border-color: var(--border-strong); transform: translateY(-1px); box-shadow: var(--e-1);">
+        <p class="artist">Bill Evans Trio · hover</p>
+        <h3>Autumn Leaves</h3>
+        <div class="meta"><span>Key Em</span><span>BPM 124</span><span>Capo 0</span><span>4/4</span></div>
+        <div class="footer">
+          <span class="badge format">iReal Pro</span>
+          <span class="badge key">Em</span>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Setlist card</h2>
+    <div class="grid">
+      <article class="setlist">
+        <h3>Live · 2026-05-12</h3>
+        <p class="desc">The Local · 7:00pm · 4 sets</p>
+        <div class="stats">
+          <div class="stat"><span class="num">14</span><span class="label">Songs</span></div>
+          <div class="stat"><span class="num">52</span><span class="label">Min</span></div>
+          <div class="stat"><span class="num">3</span><span class="label">Keys</span></div>
+        </div>
+        <time datetime="2026-05-12">2026-05-12 · 4 days from now</time>
+      </article>
+      <article class="setlist">
+        <h3>Acoustic standards</h3>
+        <p class="desc">A curated collection of acoustic standards.</p>
+        <div class="stats">
+          <div class="stat"><span class="num">24</span><span class="label">Songs</span></div>
+          <div class="stat"><span class="num">96</span><span class="label">Min</span></div>
+          <div class="stat"><span class="num">5</span><span class="label">Keys</span></div>
+        </div>
+        <time datetime="2026-04-22">Updated 2 weeks ago</time>
+      </article>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Featured card</h2>
+    <div class="grid">
+      <article class="featured-card">
+        <p class="eyebrow">New</p>
+        <h3>Now with iReal Pro</h3>
+        <p>Open iReal Pro charts in ChordSketch and edit the chord progressions in place.</p>
+        <a class="btn btn-primary" href="#">Learn more</a>
+      </article>
+      <article class="featured-card">
+        <p class="eyebrow">Setup</p>
+        <h3>Add your first song</h3>
+        <p>Add one song to the library to start using search and setlist editing.</p>
+        <a class="btn btn-primary" href="#">Add</a>
+      </article>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-forms.html
+++ b/preview/components-forms.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Forms — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); text-decoration: none; }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8); display: grid; gap: var(--sp-6); grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+
+.field { display: flex; flex-direction: column; gap: var(--sp-2); }
+.field > label { font-family: var(--font-jp); font-weight: 500; font-size: var(--fs-14); color: var(--text-primary); }
+.field .help { font-size: var(--fs-13); color: var(--text-secondary); }
+.field .err { font-size: var(--fs-13); color: var(--danger-fg); }
+
+.input, .textarea, .select {
+  width: 100%; padding: 0 var(--sp-3); height: 36px;
+  border: 1px solid var(--border-strong); border-radius: var(--r-2);
+  background: var(--surface); font: 400 var(--fs-14)/1 var(--font-jp); color: var(--text-primary);
+  transition: border-color var(--dur-1) var(--ease-out), box-shadow var(--dur-1) var(--ease-out);
+}
+.textarea { height: auto; padding: var(--sp-3); line-height: 1.6; resize: vertical; min-height: 96px; font-family: var(--font-jp); }
+.input:hover, .textarea:hover, .select:hover { border-color: var(--text-secondary); }
+.input:focus, .textarea:focus, .select:focus { outline: none; border-color: var(--crimson-500); box-shadow: var(--focus-ring); }
+.input.error { border-color: var(--danger-fg); }
+.input:disabled, .textarea:disabled, .select:disabled { background: var(--ink-50); color: var(--text-tertiary); cursor: not-allowed; }
+.input::placeholder { color: var(--text-tertiary); }
+
+/* Segmented */
+.segmented { display: inline-flex; border: 1px solid var(--border-strong); border-radius: var(--r-2); overflow: hidden; }
+.segmented button { background: var(--surface); border: 0; padding: 0 var(--sp-4); height: 36px; font: 500 var(--fs-14)/1 var(--font-jp); color: var(--text-secondary); cursor: pointer; border-right: 1px solid var(--border); }
+.segmented button:last-child { border-right: 0; }
+.segmented button[aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); }
+
+/* Checkbox */
+.check, .radio { display: inline-flex; align-items: center; gap: var(--sp-2); cursor: pointer; user-select: none; font-size: var(--fs-14); }
+.check input, .radio input { position: absolute; opacity: 0; pointer-events: none; }
+.check .box, .radio .box { width: 18px; height: 18px; border: 1px solid var(--border-strong); background: var(--surface); display: inline-flex; align-items: center; justify-content: center; transition: background var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out); }
+.check .box { border-radius: var(--r-1); }
+.radio .box { border-radius: var(--r-full); }
+.check input:checked + .box, .radio input:checked + .box { background: var(--crimson-500); border-color: var(--crimson-500); }
+.check input:checked + .box::before { content: ""; width: 10px; height: 6px; border-left: 2px solid var(--ink-0); border-bottom: 2px solid var(--ink-0); transform: rotate(-45deg) translate(1px, -1px); }
+.radio input:checked + .box::before { content: ""; width: 6px; height: 6px; border-radius: var(--r-full); background: var(--ink-0); }
+.check input:focus-visible + .box, .radio input:focus-visible + .box { box-shadow: var(--focus-ring); outline: none; }
+
+/* Switch */
+.switch { display: inline-flex; align-items: center; gap: var(--sp-3); cursor: pointer; font-size: var(--fs-14); }
+.switch input { position: absolute; opacity: 0; }
+.switch .track { width: 36px; height: 20px; border-radius: var(--r-full); background: var(--ink-300); position: relative; transition: background var(--dur-1) var(--ease-out); }
+.switch .track::before { content: ""; position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: var(--r-full); background: var(--ink-0); transition: transform var(--dur-2) var(--ease-out); box-shadow: var(--e-1); }
+.switch input:checked + .track { background: var(--crimson-500); }
+.switch input:checked + .track::before { transform: translateX(16px); }
+.switch input:focus-visible + .track { box-shadow: var(--focus-ring); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Forms</h1>
+  <p class="preview-deck">Inputs, selects, textareas, segmented controls, checkboxes, radios, switches. All focus rings use <code style="font-family: var(--font-mono);">--focus-ring</code>.</p>
+
+  <section class="group">
+    <h2>Text input</h2>
+    <div class="frame">
+      <div class="field">
+        <label for="title">Title</label>
+        <input id="title" class="input" placeholder="Country Roads" value="Country Roads">
+        <span class="help">Displayed as the song's main title when published.</span>
+      </div>
+      <div class="field">
+        <label for="bpm">BPM</label>
+        <input id="bpm" class="input" type="number" value="82" inputmode="numeric" style="font-family: var(--font-mono); font-variant-numeric: tabular-nums;">
+        <span class="help">Whole number, 1–300.</span>
+      </div>
+      <div class="field">
+        <label for="email">Email</label>
+        <input id="email" class="input error" type="email" value="not-an-email">
+        <span class="err">Enter a valid email address.</span>
+      </div>
+      <div class="field">
+        <label for="readonly">Owner</label>
+        <input id="readonly" class="input" value="koedame" disabled>
+        <span class="help">Read-only.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Textarea</h2>
+    <div class="frame" style="grid-template-columns: 1fr;">
+      <div class="field">
+        <label for="cho">ChordPro source</label>
+        <textarea id="cho" class="textarea" style="font-family: var(--font-mono); font-size: var(--fs-14);">{title: Country Roads}
+{artist: John Denver}
+{key: G}
+{capo: 0}
+
+[G]Almost heaven, [Em]West Virginia
+[D]Blue Ridge Mountains, [C]Shenandoah [G]River</textarea>
+        <span class="help">ChordPro 6.0 directives are supported.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Select</h2>
+    <div class="frame">
+      <div class="field">
+        <label for="key">Key</label>
+        <select id="key" class="select" style="font-family: var(--font-mono);">
+          <option>C</option><option>C#</option><option>D</option><option>D#</option><option>E</option>
+          <option>F</option><option>F#</option><option selected>G</option><option>G#</option>
+          <option>A</option><option>A#</option><option>B</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format" class="select">
+          <option>ChordPro</option>
+          <option>iReal Pro</option>
+        </select>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Segmented</h2>
+    <div class="frame">
+      <div class="segmented" role="tablist" aria-label="Format">
+        <button aria-pressed="true">ChordPro</button>
+        <button aria-pressed="false">iReal Pro</button>
+      </div>
+      <div class="segmented" role="tablist" aria-label="View">
+        <button aria-pressed="true">Split</button>
+        <button aria-pressed="false">Source</button>
+        <button aria-pressed="false">Preview</button>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Checkbox · Radio · Switch</h2>
+    <div class="frame">
+      <div style="display: flex; flex-direction: column; gap: var(--sp-3);">
+        <label class="check"><input type="checkbox" checked><span class="box"></span>Show lyrics</label>
+        <label class="check"><input type="checkbox"><span class="box"></span>Show section labels</label>
+        <label class="check"><input type="checkbox" disabled><span class="box"></span>Show tab notation (disabled)</label>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: var(--sp-3);">
+        <label class="radio"><input type="radio" name="ed" checked><span class="box"></span>Text editor</label>
+        <label class="radio"><input type="radio" name="ed"><span class="box"></span>Bar-grid editor</label>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: var(--sp-3);">
+        <label class="switch"><input type="checkbox" checked><span class="track"></span>Live preview</label>
+        <label class="switch"><input type="checkbox"><span class="track"></span>Dark mode</label>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-forms.html
+++ b/preview/components-forms.html
@@ -141,11 +141,11 @@ a { color: inherit; }
   <section class="group">
     <h2>Segmented</h2>
     <div class="frame">
-      <div class="segmented" role="tablist" aria-label="Format">
+      <div class="segmented" role="group" aria-label="Format">
         <button aria-pressed="true">ChordPro</button>
         <button aria-pressed="false">iReal Pro</button>
       </div>
-      <div class="segmented" role="tablist" aria-label="View">
+      <div class="segmented" role="group" aria-label="View">
         <button aria-pressed="true">Split</button>
         <button aria-pressed="false">Source</button>
         <button aria-pressed="false">Preview</button>

--- a/preview/components-modal.html
+++ b/preview/components-modal.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Modal — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; text-decoration: none; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+
+.stage { position: relative; min-height: 480px; background: var(--canvas); border: 1px solid var(--border); border-radius: var(--r-3); overflow: hidden; }
+.stage::before { content: ""; position: absolute; inset: 0; background: rgba(10, 10, 11, 0.32); }
+
+.dialog { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: min(520px, calc(100% - var(--sp-12))); background: var(--surface); border-radius: var(--r-4); box-shadow: var(--e-3); overflow: hidden; }
+.dialog header { padding: var(--sp-6) var(--sp-6) var(--sp-4); display: flex; align-items: start; gap: var(--sp-4); }
+.dialog .icon { width: 36px; height: 36px; border-radius: var(--r-full); background: var(--danger-surface); color: var(--danger-fg); display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.dialog .icon.crimson { background: var(--crimson-50); color: var(--crimson-700); }
+.dialog .icon.info { background: var(--info-surface); color: var(--info-fg); }
+.dialog h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-18); margin: 0 0 var(--sp-2); letter-spacing: -0.01em; }
+.dialog p { color: var(--text-secondary); font-size: var(--fs-14); margin: 0; }
+.dialog .body { padding: 0 var(--sp-6) var(--sp-6) calc(var(--sp-6) + 36px + var(--sp-4)); }
+.dialog footer { display: flex; gap: var(--sp-3); justify-content: flex-end; padding: var(--sp-4) var(--sp-6); background: var(--ink-50); border-top: 1px solid var(--border); }
+
+.btn { display: inline-flex; align-items: center; gap: var(--sp-2); height: 36px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid transparent; font: 500 var(--fs-14)/1 var(--font-jp); cursor: pointer; transition: background var(--dur-1) var(--ease-out); text-decoration: none; }
+.btn-primary { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.btn-primary:hover { background: var(--crimson-600); }
+.btn-secondary { background: var(--surface); color: var(--text-primary); border-color: var(--border-strong); }
+.btn-secondary:hover { background: var(--ink-100); }
+.btn-danger { background: var(--danger-fg); color: var(--fg-on-crimson); }
+.btn-danger:hover { background: var(--crimson-700); }
+
+/* Command palette */
+.palette { position: absolute; left: 50%; top: 25%; transform: translateX(-50%); width: min(640px, calc(100% - var(--sp-12))); background: var(--surface); border-radius: var(--r-3); box-shadow: var(--e-overlay); overflow: hidden; }
+.palette .input { display: flex; align-items: center; gap: var(--sp-3); padding: var(--sp-4) var(--sp-5); border-bottom: 1px solid var(--border); }
+.palette input { flex: 1; border: 0; outline: 0; font: 400 var(--fs-16)/1 var(--font-jp); background: transparent; color: var(--text-primary); }
+.palette input::placeholder { color: var(--text-tertiary); }
+.palette .hint { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); border: 1px solid var(--border); border-radius: var(--r-1); padding: 1px var(--sp-1); }
+.palette ul { list-style: none; padding: var(--sp-2); margin: 0; max-height: 280px; overflow: auto; }
+.palette li { padding: var(--sp-3) var(--sp-4); border-radius: var(--r-2); display: flex; align-items: center; gap: var(--sp-3); font-size: var(--fs-14); }
+.palette li[aria-selected="true"] { background: var(--ink-1000); color: var(--ink-0); }
+.palette li .meta { margin-left: auto; font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); }
+.palette li[aria-selected="true"] .meta { color: var(--ink-300); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Modal</h1>
+  <p class="preview-deck">12 px radius. <code style="font-family: var(--font-mono);">--e-3</code> elevation. Footer washed with <code style="font-family: var(--font-mono);">--ink-50</code> to demarcate. Command palette uses <code style="font-family: var(--font-mono);">--e-overlay</code>.</p>
+
+  <section class="group">
+    <h2>Confirmation · destructive</h2>
+    <div class="stage" role="presentation">
+      <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="m1-title">
+        <header>
+          <span class="icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+          <div><h3 id="m1-title">Delete this song?</h3><p>Removes "Country Roads" from the Library. This action cannot be undone.</p></div>
+        </header>
+        <div class="body"></div>
+        <footer><button class="btn btn-secondary">Cancel</button><button class="btn btn-danger">Delete</button></footer>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Form modal · save</h2>
+    <div class="stage" role="presentation">
+      <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="m2-title">
+        <header>
+          <span class="icon crimson"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg></span>
+          <div><h3 id="m2-title">Save as setlist</h3><p>Saves the current filter as a new setlist.</p></div>
+        </header>
+        <div class="body">
+          <div style="display: flex; flex-direction: column; gap: var(--sp-3);">
+            <label style="font-size: var(--fs-13); font-weight: 500;">Name
+              <input type="text" value="Live · 2026-05-12" style="width: 100%; margin-top: var(--sp-1); padding: 0 var(--sp-3); height: 36px; border: 1px solid var(--border-strong); border-radius: var(--r-2); font: 400 var(--fs-14)/1 var(--font-jp);">
+            </label>
+            <label style="display: inline-flex; align-items: center; gap: var(--sp-2); font-size: var(--fs-14);">
+              <input type="checkbox" checked> Generate a shareable link
+            </label>
+          </div>
+        </div>
+        <footer><button class="btn btn-secondary">Cancel</button><button class="btn btn-primary">Save</button></footer>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Command palette · ⌘K</h2>
+    <div class="stage" role="presentation">
+      <div class="palette" role="dialog" aria-modal="true" aria-label="Command palette">
+        <div class="input">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color: var(--text-tertiary);"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+          <input type="search" placeholder="Search commands or songs …" autofocus>
+          <span class="hint">ESC</span>
+        </div>
+        <ul role="listbox">
+          <li aria-selected="true" role="option"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>New song<span class="meta">⌘N</span></li>
+          <li role="option"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect width="12" height="8" x="6" y="14"/></svg>Print as PDF<span class="meta">⌘P</span></li>
+          <li role="option"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>Delete<span class="meta">⌘⌫</span></li>
+          <li role="option"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" x2="15.42" y1="13.51" y2="17.49"/><line x1="15.41" x2="8.59" y1="6.51" y2="10.49"/></svg>Share link<span class="meta">⇧⌘S</span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-navigation.html
+++ b/preview/components-navigation.html
@@ -74,7 +74,7 @@ a { color: inherit; text-decoration: none; }
           <a href="#">Editor</a>
           <a href="#">Setlists</a>
         </nav>
-        <div class="right"><span>⌘K</span><span style="width: 28px; height: 28px; border-radius: var(--r-full); background: var(--crimson-500); color: var(--fg-on-crimson); display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: 11px;">YS</span></div>
+        <div class="right"><span>⌘K</span><span style="width: 28px; height: 28px; border-radius: var(--r-full); background: var(--crimson-500); color: var(--fg-on-crimson); display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-10);">YS</span></div>
       </header>
     </div>
   </section>

--- a/preview/components-navigation.html
+++ b/preview/components-navigation.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Navigation — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; text-decoration: none; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); overflow: hidden; }
+
+/* Top nav */
+.topnav { height: 56px; display: flex; align-items: center; padding: 0 var(--sp-6); gap: var(--sp-4); background: var(--surface); border-bottom: 1px solid var(--border); }
+.topnav .brand { display: flex; align-items: center; gap: var(--sp-3); font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-16); letter-spacing: -0.01em; }
+.topnav .brand .mark { width: 24px; height: 24px; border-radius: var(--r-1); display: block; }
+.topnav .nav-links { display: flex; gap: var(--sp-1); margin-left: var(--sp-6); }
+.topnav .nav-links a { font-family: var(--font-jp); font-size: var(--fs-14); padding: var(--sp-1) var(--sp-3); border-radius: var(--r-2); color: var(--text-secondary); }
+.topnav .nav-links a[aria-current="page"] { background: var(--ink-100); color: var(--text-primary); }
+.topnav .nav-links a:hover:not([aria-current="page"]) { color: var(--text-primary); }
+.topnav .right { margin-left: auto; display: flex; gap: var(--sp-3); align-items: center; font-size: var(--fs-13); color: var(--text-secondary); }
+
+/* Tabs */
+.tabs { display: flex; gap: var(--sp-2); padding: 0 var(--sp-6); border-bottom: 1px solid var(--border); }
+.tabs a { display: inline-flex; align-items: center; gap: var(--sp-2); padding: var(--sp-3) var(--sp-3); margin-bottom: -1px; border-bottom: 2px solid transparent; color: var(--text-secondary); font-size: var(--fs-14); font-weight: 500; }
+.tabs a[aria-current="page"] { border-bottom-color: var(--crimson-500); color: var(--text-primary); }
+.tabs a:hover:not([aria-current="page"]) { color: var(--text-primary); }
+.tabs .count { display: inline-flex; align-items: center; justify-content: center; min-width: 22px; height: 18px; padding: 0 6px; border-radius: var(--r-full); background: var(--ink-100); color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--fs-12); font-weight: 600; font-variant-numeric: tabular-nums; }
+.tabs a[aria-current="page"] .count { background: var(--crimson-500); color: var(--fg-on-crimson); }
+
+/* Breadcrumbs */
+.crumbs { display: flex; align-items: center; gap: var(--sp-3); font-size: var(--fs-14); color: var(--text-secondary); padding: var(--sp-4) var(--sp-6); }
+.crumbs .sep { color: var(--text-tertiary); }
+.crumbs .current { color: var(--text-primary); font-weight: 500; }
+
+/* Side nav */
+.sidenav { display: grid; grid-template-columns: 220px 1fr; min-height: 320px; }
+.sidenav nav { background: var(--canvas); border-right: 1px solid var(--border); padding: var(--sp-4); }
+.sidenav nav h3 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-tertiary); margin: var(--sp-4) var(--sp-2) var(--sp-2); }
+.sidenav nav h3:first-child { margin-top: 0; }
+.sidenav nav a { display: flex; align-items: center; gap: var(--sp-2); padding: var(--sp-2) var(--sp-3); border-radius: var(--r-2); font-size: var(--fs-14); color: var(--text-secondary); }
+.sidenav nav a[aria-current="page"] { background: var(--ink-1000); color: var(--ink-0); }
+.sidenav nav a:hover:not([aria-current="page"]) { background: var(--ink-100); color: var(--text-primary); }
+.sidenav .body { padding: var(--sp-6); color: var(--text-secondary); font-size: var(--fs-14); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Navigation</h1>
+  <p class="preview-deck">Top nav (56 px), underline tabs with counts, breadcrumbs, and sidebar nav.</p>
+
+  <section class="group">
+    <h2>Top nav · 56 px</h2>
+    <div class="frame">
+      <header class="topnav">
+        <a class="brand" href="#"><img class="mark" src="../assets/logo.svg" alt="" width="24" height="24">ChordSketch</a>
+        <nav class="nav-links">
+          <a href="#" aria-current="page">Library</a>
+          <a href="#">Viewer</a>
+          <a href="#">Editor</a>
+          <a href="#">Setlists</a>
+        </nav>
+        <div class="right"><span>⌘K</span><span style="width: 28px; height: 28px; border-radius: var(--r-full); background: var(--crimson-500); color: var(--fg-on-crimson); display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: 11px;">YS</span></div>
+      </header>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Tabs · underline + count</h2>
+    <div class="frame">
+      <nav class="tabs" aria-label="Library tabs">
+        <a href="#" aria-current="page">All <span class="count">248</span></a>
+        <a href="#">Drafts <span class="count">12</span></a>
+        <a href="#">Shared <span class="count">8</span></a>
+        <a href="#">Archived <span class="count">31</span></a>
+      </nav>
+      <div style="padding: var(--sp-6); color: var(--text-secondary); font-size: var(--fs-14);">Selected tab's content renders below.</div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Breadcrumbs</h2>
+    <div class="frame">
+      <nav class="crumbs" aria-label="Breadcrumb">
+        <a href="#">Library</a>
+        <span class="sep">›</span>
+        <a href="#">Japanese standards</a>
+        <span class="sep">›</span>
+        <span class="current">Country Roads</span>
+      </nav>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Sidebar navigation</h2>
+    <div class="frame">
+      <div class="sidenav">
+        <nav>
+          <h3>Library</h3>
+          <a href="#" aria-current="page">All songs</a>
+          <a href="#">Recently edited</a>
+          <a href="#">Drafts</a>
+          <h3>Setlists</h3>
+          <a href="#">Live · 2026-05-12</a>
+          <a href="#">Open mic</a>
+          <a href="#">Acoustic standards</a>
+          <h3>Format</h3>
+          <a href="#">ChordPro</a>
+          <a href="#">iReal Pro</a>
+        </nav>
+        <div class="body">The active sidebar item uses the dark <code style="font-family: var(--font-mono);">--ink-1000</code> state to mark the current location. Crimson is reserved for primary actions and key signatures.</div>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-progress.html
+++ b/preview/components-progress.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Progress — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; text-decoration: none; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8); display: flex; flex-direction: column; gap: var(--sp-6); }
+
+/* Bar */
+.bar { width: 100%; height: 6px; background: var(--ink-200); border-radius: var(--r-full); overflow: hidden; }
+.bar > i { display: block; height: 100%; background: var(--crimson-500); border-radius: inherit; transition: width var(--dur-2) var(--ease-out); }
+.bar.indeterminate > i { width: 30%; animation: slide 1.6s var(--ease-out) infinite; }
+@keyframes slide {
+  0%   { transform: translateX(-100%); }
+  60%  { transform: translateX(260%); }
+  100% { transform: translateX(260%); }
+}
+.bar-row { display: grid; grid-template-columns: 1fr auto; gap: var(--sp-4); align-items: center; }
+.bar-row .meta { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+
+/* Spinner */
+.spinner { display: inline-block; width: 24px; height: 24px; border: 2px solid var(--ink-200); border-top-color: var(--crimson-500); border-radius: var(--r-full); animation: spin 0.8s linear infinite; }
+.spinner.sm { width: 14px; height: 14px; border-width: 2px; }
+.spinner.lg { width: 40px; height: 40px; border-width: 3px; }
+@keyframes spin { to { transform: rotate(1turn); } }
+
+/* Skeleton */
+.skel { background: linear-gradient(90deg, var(--ink-100) 0%, var(--ink-200) 50%, var(--ink-100) 100%); background-size: 200% 100%; border-radius: var(--r-2); animation: shimmer 1.6s var(--ease-out) infinite; }
+.skel.line { height: 14px; }
+.skel.line.lg { height: 20px; }
+.skel.line.xl { height: 32px; }
+.skel.circle { width: 36px; height: 36px; border-radius: var(--r-full); }
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.song-card { background: var(--canvas); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5); }
+.song-card .row { display: grid; grid-template-columns: 36px 1fr; gap: var(--sp-4); align-items: center; }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Progress</h1>
+  <p class="preview-deck">6 px linear bar (determinate / indeterminate), spinner, skeleton. Reduced motion is honored via tokens.</p>
+
+  <section class="group">
+    <h2>Bar — determinate</h2>
+    <div class="frame">
+      <div class="bar-row"><span class="bar"><i style="width: 24%;"></i></span><span class="meta">24%</span></div>
+      <div class="bar-row"><span class="bar"><i style="width: 62%;"></i></span><span class="meta">62%</span></div>
+      <div class="bar-row"><span class="bar"><i style="width: 100%;"></i></span><span class="meta">100%</span></div>
+      <div class="bar-row"><span class="meta" style="font-family: var(--font-jp); color: var(--text-primary); font-size: var(--fs-14); font-variant-numeric: normal;">Generating PDF…</span><span class="meta">147 / 248</span></div>
+      <div class="bar"><i style="width: 59%;"></i></div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Bar — indeterminate</h2>
+    <div class="frame">
+      <div class="bar indeterminate"><i></i></div>
+      <p style="margin: 0; font-size: var(--fs-13); color: var(--text-secondary);">Syncing …</p>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Spinner</h2>
+    <div class="frame" style="flex-direction: row; align-items: center; gap: var(--sp-6);">
+      <span class="spinner sm" role="status" aria-label="Loading"></span>
+      <span class="spinner" role="status" aria-label="Loading"></span>
+      <span class="spinner lg" role="status" aria-label="Loading"></span>
+      <span style="display: inline-flex; align-items: center; gap: var(--sp-3); margin-left: var(--sp-6); font-size: var(--fs-14); color: var(--text-secondary);"><span class="spinner sm" aria-hidden="true"></span>Parsing</span>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Skeleton — song card</h2>
+    <div class="frame" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--sp-4);">
+      <article class="song-card">
+        <div class="skel line" style="width: 30%; margin-bottom: var(--sp-3);"></div>
+        <div class="skel line xl" style="width: 80%; margin-bottom: var(--sp-4);"></div>
+        <div class="skel line" style="width: 60%; margin-bottom: var(--sp-2);"></div>
+        <div class="skel line" style="width: 45%;"></div>
+      </article>
+      <article class="song-card">
+        <div class="skel line" style="width: 40%; margin-bottom: var(--sp-3);"></div>
+        <div class="skel line xl" style="width: 70%; margin-bottom: var(--sp-4);"></div>
+        <div class="skel line" style="width: 55%; margin-bottom: var(--sp-2);"></div>
+        <div class="skel line" style="width: 50%;"></div>
+      </article>
+      <article class="song-card">
+        <div class="skel line" style="width: 35%; margin-bottom: var(--sp-3);"></div>
+        <div class="skel line xl" style="width: 90%; margin-bottom: var(--sp-4);"></div>
+        <div class="skel line" style="width: 50%; margin-bottom: var(--sp-2);"></div>
+        <div class="skel line" style="width: 40%;"></div>
+      </article>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Skeleton — list row</h2>
+    <div class="frame">
+      <div class="song-card row" style="display: grid; grid-template-columns: 36px 1fr 80px 80px; gap: var(--sp-4); align-items: center;">
+        <div class="skel circle"></div>
+        <div><div class="skel line" style="width: 60%; margin-bottom: 6px;"></div><div class="skel line" style="width: 40%; height: 10px;"></div></div>
+        <div class="skel line" style="height: 12px;"></div>
+        <div class="skel line" style="height: 12px;"></div>
+      </div>
+      <div class="song-card row" style="display: grid; grid-template-columns: 36px 1fr 80px 80px; gap: var(--sp-4); align-items: center;">
+        <div class="skel circle"></div>
+        <div><div class="skel line" style="width: 75%; margin-bottom: 6px;"></div><div class="skel line" style="width: 50%; height: 10px;"></div></div>
+        <div class="skel line" style="height: 12px;"></div>
+        <div class="skel line" style="height: 12px;"></div>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-table.html
+++ b/preview/components-table.html
@@ -175,22 +175,22 @@ caption { caption-side: top; text-align: left; padding: var(--sp-4) var(--sp-4) 
   <section class="group">
     <h2>Compact · stats</h2>
     <div class="frame">
-      <table class="t" aria-label="Render performance">
-        <caption>Render performance — last 100 main runs</caption>
+      <table class="t" aria-label="Setlist preview">
+        <caption>Setlist preview — illustrative only</caption>
         <thead>
           <tr>
-            <th>Renderer</th>
-            <th>Median</th>
-            <th>p95</th>
-            <th>Max</th>
-            <th>Coverage</th>
+            <th>Song</th>
+            <th>Key</th>
+            <th>Tempo</th>
+            <th>Bars</th>
+            <th>Style</th>
           </tr>
         </thead>
         <tbody>
-          <tr><td>render-text</td><td class="num">8 ms</td><td class="num">14 ms</td><td class="num">21 ms</td><td class="num">88.4%</td></tr>
-          <tr><td>render-html</td><td class="num">12 ms</td><td class="num">22 ms</td><td class="num">36 ms</td><td class="num">85.1%</td></tr>
-          <tr><td>render-pdf</td><td class="num">94 ms</td><td class="num">142 ms</td><td class="num">218 ms</td><td class="num">82.6%</td></tr>
-          <tr><td>render-ireal</td><td class="num">21 ms</td><td class="num">33 ms</td><td class="num">52 ms</td><td class="num">81.0%</td></tr>
+          <tr><td>Autumn Leaves</td><td class="num">Em</td><td class="num">120</td><td class="num">32</td><td class="num">Jazz</td></tr>
+          <tr><td>Blue Bossa</td><td class="num">Cm</td><td class="num">160</td><td class="num">16</td><td class="num">Bossa</td></tr>
+          <tr><td>So What</td><td class="num">Dm</td><td class="num">132</td><td class="num">32</td><td class="num">Modal</td></tr>
+          <tr><td>Take Five</td><td class="num">E♭m</td><td class="num">176</td><td class="num">24</td><td class="num">5/4</td></tr>
         </tbody>
       </table>
     </div>

--- a/preview/components-table.html
+++ b/preview/components-table.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Table — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; text-decoration: none; }
+.container { max-width: 1080px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); overflow: hidden; }
+
+table.t { width: 100%; border-collapse: collapse; font-size: var(--fs-14); }
+table.t thead th {
+  text-align: left;
+  font-family: var(--font-latin);
+  font-weight: 600;
+  font-size: var(--fs-12);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--canvas);
+  white-space: nowrap;
+}
+table.t thead th.sortable { cursor: pointer; user-select: none; }
+table.t thead th.sortable .arrow { display: inline-flex; margin-left: var(--sp-1); color: var(--text-tertiary); }
+table.t thead th[aria-sort="ascending"] .arrow,
+table.t thead th[aria-sort="descending"] .arrow { color: var(--crimson-500); }
+table.t tbody td { padding: var(--sp-3) var(--sp-4); border-bottom: 1px solid var(--border); vertical-align: middle; }
+table.t tbody tr:hover { background: var(--ink-50); }
+table.t tbody tr:last-child td { border-bottom: 0; }
+table.t .num { font-family: var(--font-mono); font-variant-numeric: tabular-nums; color: var(--text-secondary); text-align: right; }
+table.t .title { font-weight: 500; }
+table.t .artist { color: var(--text-secondary); }
+table.t .key { font-family: var(--font-mono); font-weight: 600; }
+table.t .key.crimson { color: var(--crimson-500); }
+table.t .badge { display: inline-flex; align-items: center; padding: 2px var(--sp-2); border-radius: var(--r-1); font-family: var(--font-mono); font-weight: 600; font-size: var(--fs-12); background: var(--ink-100); color: var(--text-strong); border: 1px solid var(--border); }
+table.t .more { color: var(--text-tertiary); }
+
+.toolbar { display: flex; align-items: center; gap: var(--sp-3); padding: var(--sp-3) var(--sp-4); border-bottom: 1px solid var(--border); }
+.toolbar input { height: 32px; padding: 0 var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2); background: var(--ink-50); font: 400 var(--fs-13)/1 var(--font-jp); width: 220px; }
+.toolbar input:focus { outline: none; border-color: var(--crimson-500); box-shadow: var(--focus-ring); }
+.toolbar .count { margin-left: auto; font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); }
+
+caption { caption-side: top; text-align: left; padding: var(--sp-4) var(--sp-4) var(--sp-2); font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-tertiary); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Table</h1>
+  <p class="preview-deck">Eyebrow header (Inter 600, +0.12em UPPER), tabular-nums for numeric columns, hover row tinted with <code style="font-family: var(--font-mono);">--ink-50</code>.</p>
+
+  <section class="group">
+    <h2>Library table</h2>
+    <div class="frame">
+      <div class="toolbar">
+        <input type="search" placeholder="Filter …">
+        <span class="count">8 of 248</span>
+      </div>
+      <table class="t" aria-label="Library">
+        <thead>
+          <tr>
+            <th style="width: 40px;">#</th>
+            <th class="sortable" aria-sort="ascending">Title <span class="arrow">↑</span></th>
+            <th>Artist</th>
+            <th>Key</th>
+            <th>BPM</th>
+            <th>Capo</th>
+            <th>Format</th>
+            <th>Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="num">1</td>
+            <td class="title">Country Roads</td>
+            <td class="artist">John Denver</td>
+            <td class="key crimson">G</td>
+            <td class="num">82</td>
+            <td class="num">0</td>
+            <td><span class="badge">ChordPro</span></td>
+            <td class="num">2 hours ago</td>
+          </tr>
+          <tr>
+            <td class="num">2</td>
+            <td class="title">Wonderwall</td>
+            <td class="artist">Oasis</td>
+            <td class="key">Em</td>
+            <td class="num">87</td>
+            <td class="num">0</td>
+            <td><span class="badge">ChordPro</span></td>
+            <td class="num">1 day ago</td>
+          </tr>
+          <tr>
+            <td class="num">3</td>
+            <td class="title">Yesterday</td>
+            <td class="artist">The Beatles</td>
+            <td class="key">F</td>
+            <td class="num">96</td>
+            <td class="num">0</td>
+            <td><span class="badge">ChordPro</span></td>
+            <td class="num">2 days ago</td>
+          </tr>
+          <tr>
+            <td class="num">4</td>
+            <td class="title">Let It Be</td>
+            <td class="artist">The Beatles</td>
+            <td class="key">C</td>
+            <td class="num">73</td>
+            <td class="num">0</td>
+            <td><span class="badge">ChordPro</span></td>
+            <td class="num">4 days ago</td>
+          </tr>
+          <tr>
+            <td class="num">5</td>
+            <td class="title">Autumn Leaves</td>
+            <td class="artist">Bill Evans Trio</td>
+            <td class="key">Em</td>
+            <td class="num">124</td>
+            <td class="num">0</td>
+            <td><span class="badge">iReal Pro</span></td>
+            <td class="num">6 days ago</td>
+          </tr>
+          <tr>
+            <td class="num">6</td>
+            <td class="title">Stand By Me</td>
+            <td class="artist">Ben E. King</td>
+            <td class="key">A</td>
+            <td class="num">118</td>
+            <td class="num">0</td>
+            <td><span class="badge">ChordPro</span></td>
+            <td class="num">8 days ago</td>
+          </tr>
+          <tr>
+            <td class="num">7</td>
+            <td class="title">Hallelujah</td>
+            <td class="artist">Leonard Cohen</td>
+            <td class="key">C</td>
+            <td class="num">72</td>
+            <td class="num">0</td>
+            <td><span class="badge">ChordPro</span></td>
+            <td class="num">2 weeks ago</td>
+          </tr>
+          <tr>
+            <td class="num">8</td>
+            <td class="title">Hotel California</td>
+            <td class="artist">Eagles</td>
+            <td class="key">Bm</td>
+            <td class="num">75</td>
+            <td class="num">7</td>
+            <td><span class="badge">iReal Pro</span></td>
+            <td class="num">2 weeks ago</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Compact · stats</h2>
+    <div class="frame">
+      <table class="t" aria-label="Render performance">
+        <caption>Render performance — last 100 main runs</caption>
+        <thead>
+          <tr>
+            <th>Renderer</th>
+            <th>Median</th>
+            <th>p95</th>
+            <th>Max</th>
+            <th>Coverage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>render-text</td><td class="num">8 ms</td><td class="num">14 ms</td><td class="num">21 ms</td><td class="num">88.4%</td></tr>
+          <tr><td>render-html</td><td class="num">12 ms</td><td class="num">22 ms</td><td class="num">36 ms</td><td class="num">85.1%</td></tr>
+          <tr><td>render-pdf</td><td class="num">94 ms</td><td class="num">142 ms</td><td class="num">218 ms</td><td class="num">82.6%</td></tr>
+          <tr><td>render-ireal</td><td class="num">21 ms</td><td class="num">33 ms</td><td class="num">52 ms</td><td class="num">81.0%</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-toast.html
+++ b/preview/components-toast.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Toast — ChordSketch Components</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; text-decoration: none; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.frame { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-8); display: flex; flex-direction: column; gap: var(--sp-3); align-items: stretch; }
+
+.toast {
+  display: grid;
+  grid-template-columns: 20px 1fr auto auto;
+  gap: var(--sp-3);
+  align-items: center;
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--r-2);
+  background: var(--ink-1000);
+  color: var(--ink-0);
+  box-shadow: var(--e-2);
+  font-size: var(--fs-14);
+  max-width: 480px;
+}
+.toast.success { background: var(--success-fg); }
+.toast.danger  { background: var(--danger-fg); }
+.toast.warning { background: var(--warning-fg); color: #FFF; }
+.toast .icon { display: inline-flex; }
+.toast .body { display: flex; flex-direction: column; gap: 2px; }
+.toast .body .title { font-weight: 600; }
+.toast .body .desc { color: rgba(255, 255, 255, 0.72); font-size: var(--fs-13); }
+.toast .action { background: transparent; border: 0; color: inherit; font: 600 var(--fs-13)/1 var(--font-jp); cursor: pointer; padding: 0 var(--sp-2); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+.toast .action:hover { text-decoration: none; }
+.toast .action:focus-visible { outline: none; box-shadow: 0 0 0 2px currentColor; border-radius: var(--r-1); }
+.toast .close { background: transparent; border: 0; color: rgba(255,255,255,0.6); cursor: pointer; padding: var(--sp-1); display: inline-flex; }
+.toast .close:hover { color: #FFF; }
+
+.stack { display: flex; flex-direction: column; gap: var(--sp-3); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Component</p>
+  <h1 class="preview-h1">Toast</h1>
+  <p class="preview-deck">Default base is <code style="font-family: var(--font-mono);">--ink-1000</code>; success / danger swap to semantic foreground colors. Action links use <code style="font-family: var(--font-mono);">--crimson-300</code>.</p>
+
+  <section class="group">
+    <h2>Default</h2>
+    <div class="frame">
+      <div class="toast" role="status">
+        <span class="icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
+        <span class="body"><span class="title">Copied to clipboard</span></span>
+        <button class="action">Undo</button>
+        <button class="close" aria-label="Close"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Success</h2>
+    <div class="frame">
+      <div class="toast success" role="status">
+        <span class="icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/></svg></span>
+        <span class="body">
+          <span class="title">Saved</span>
+          <span class="desc">"Country Roads" has been saved to Library.</span>
+        </span>
+        <button class="action">View</button>
+        <button class="close" aria-label="Close"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Danger</h2>
+    <div class="frame">
+      <div class="toast danger" role="alert">
+        <span class="icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></span>
+        <span class="body">
+          <span class="title">Save failed</span>
+          <span class="desc">Check your connection.</span>
+        </span>
+        <button class="action">Retry</button>
+        <button class="close" aria-label="Close"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Stack — bottom-right</h2>
+    <div class="frame">
+      <div class="stack" style="margin-left: auto;">
+        <div class="toast" role="status">
+          <span class="icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+          <span class="body"><span class="title">Synced · 14:32</span></span>
+          <span></span>
+          <button class="close" aria-label="Close"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+        </div>
+        <div class="toast warning" role="status">
+          <span class="icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+          <span class="body"><span class="title">Unsaved changes</span></span>
+          <button class="action">Save</button>
+          <button class="close" aria-label="Close"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/preview/components-toast.html
+++ b/preview/components-toast.html
@@ -56,7 +56,7 @@ a { color: inherit; text-decoration: none; }
   <a href="index.html" class="preview-back">← Components</a>
   <p class="eyebrow">Component</p>
   <h1 class="preview-h1">Toast</h1>
-  <p class="preview-deck">Default base is <code style="font-family: var(--font-mono);">--ink-1000</code>; success / danger swap to semantic foreground colors. Action links use <code style="font-family: var(--font-mono);">--crimson-300</code>.</p>
+  <p class="preview-deck">Default base is <code style="font-family: var(--font-mono);">--ink-1000</code>; success / danger swap to semantic foreground colors. Action buttons inherit the toast foreground and add an underline — no color shift — so contrast holds on every variant.</p>
 
   <section class="group">
     <h2>Default</h2>

--- a/preview/index.html
+++ b/preview/index.html
@@ -30,7 +30,7 @@ h1 { font-family: var(--font-display); font-weight: 900; font-size: var(--fs-60)
 </head>
 <body>
 <main class="container">
-  <a href="../ChordSketch%20Design%20System.html" class="back">← Design System</a>
+  <a href="../design-system.html" class="back">← Design System</a>
   <p class="eyebrow" style="margin-top: var(--sp-8);">ChordSketch · Components</p>
   <h1>Components.</h1>
   <p class="deck">Single-component previews. Each page exercises the variants and states declared in <code style="font-family: var(--font-mono);">DESIGN.md §6</code>, against tokens from <code style="font-family: var(--font-mono);">tokens.css</code>.</p>

--- a/preview/index.html
+++ b/preview/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Components — ChordSketch</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; text-decoration: none; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-16) var(--sp-6); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-3); }
+h1 { font-family: var(--font-display); font-weight: 900; font-size: var(--fs-60); line-height: 1.05; letter-spacing: -0.03em; margin: 0 0 var(--sp-3); }
+.deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; font-size: var(--fs-18); }
+.list { list-style: none; padding: 0; margin: 0; counter-reset: idx; }
+.list li { counter-increment: idx; }
+.list a { display: grid; grid-template-columns: 36px 1fr auto; gap: var(--sp-4); padding: var(--sp-5) 0; border-top: 1px solid var(--border); align-items: baseline; transition: background var(--dur-1) var(--ease-out); }
+.list a:hover { background: var(--ink-100); margin: 0 calc(var(--sp-4) * -1); padding-left: var(--sp-4); padding-right: var(--sp-4); border-radius: var(--r-2); }
+.list a::before { content: counter(idx, decimal-leading-zero); font-family: var(--font-mono); font-size: var(--fs-13); color: var(--text-tertiary); }
+.list .name { font-family: var(--font-jp); font-weight: 600; font-size: var(--fs-18); }
+.list .meta { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); }
+.back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); }
+.back:hover { color: var(--text-primary); }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="../ChordSketch%20Design%20System.html" class="back">← Design System</a>
+  <p class="eyebrow" style="margin-top: var(--sp-8);">ChordSketch · Components</p>
+  <h1>Components.</h1>
+  <p class="deck">Single-component previews. Each page exercises the variants and states declared in <code style="font-family: var(--font-mono);">DESIGN.md §6</code>, against tokens from <code style="font-family: var(--font-mono);">tokens.css</code>.</p>
+
+  <ol class="list">
+    <li><a href="components-buttons.html"><span class="name">Buttons</span><span class="meta">primary · secondary · ghost · danger</span></a></li>
+    <li><a href="components-forms.html"><span class="name">Forms</span><span class="meta">input · select · textarea · segmented · check · radio</span></a></li>
+    <li><a href="components-cards.html"><span class="name">Cards</span><span class="meta">song · setlist · featured</span></a></li>
+    <li><a href="components-badges.html"><span class="name">Badges</span><span class="meta">status · key · genre</span></a></li>
+    <li><a href="components-avatars.html"><span class="name">Avatars</span><span class="meta">24 · 28 · 36 · 48 · stacked</span></a></li>
+    <li><a href="components-navigation.html"><span class="name">Navigation</span><span class="meta">top nav · tabs · breadcrumbs</span></a></li>
+    <li><a href="components-modal.html"><span class="name">Modal</span><span class="meta">e3 · 12px radius · ink-50 footer</span></a></li>
+    <li><a href="components-table.html"><span class="name">Table</span><span class="meta">eyebrow header · tabular-nums</span></a></li>
+    <li><a href="components-toast.html"><span class="name">Toast</span><span class="meta">ink-1000 · success · danger</span></a></li>
+    <li><a href="components-progress.html"><span class="name">Progress</span><span class="meta">bar · spinner · skeleton</span></a></li>
+  </ol>
+</main>
+</body>
+</html>

--- a/tokens.css
+++ b/tokens.css
@@ -1,0 +1,130 @@
+/*
+ * ChordSketch — Design Tokens
+ *
+ * Source of truth for color, typography, space, radius, elevation,
+ * and motion. See DESIGN.md for usage guidance and rationale.
+ */
+
+:root {
+  /* ---------- Color: Crimson (the only accent) ---------- */
+  --crimson-50:  #FDF2F5;
+  --crimson-100: #FBE1E8;
+  --crimson-300: #EC8AA3;
+  --crimson-500: #BD1642;
+  --crimson-600: #A30F37;
+  --crimson-700: #87092C;
+  --crimson-900: #480418;
+  --crimson:        var(--crimson-500);
+  --fg-on-crimson:  #FFFFFF;
+
+  /* ---------- Color: Ink (warm neutrals) ---------- */
+  --ink-0:    #FFFFFF;
+  --ink-50:   #FAFAF7;
+  --ink-100:  #F6F4F7;
+  --ink-200:  #E8E6EA;
+  --ink-300:  #D4D1D6;
+  --ink-500:  #8A8790;
+  --ink-600:  #67646D;
+  --ink-700:  #44424A;
+  --ink-1000: #0A0A0B;
+
+  /* Surface / border aliases */
+  --canvas:        var(--ink-50);
+  --surface:       var(--ink-0);
+  --surface-hover: var(--ink-100);
+  --border:        var(--ink-200);
+  --border-strong: var(--ink-300);
+
+  /* Text aliases */
+  --text-primary:   var(--ink-1000);
+  --text-strong:    var(--ink-700);
+  --text-secondary: var(--ink-600);
+  --text-tertiary:  var(--ink-500);
+
+  /* ---------- Color: Semantic ---------- */
+  --success-surface: #E8F3EC;
+  --success-fg:      #1A6B3A;
+  --warning-surface: #FBF1D9;
+  --warning-fg:      #8A5A07;
+  --danger-surface:  #FBE1E8;
+  --danger-fg:       #A30F37;
+  --info-surface:    #E6EEF7;
+  --info-fg:         #1F4F8A;
+
+  /* ---------- Focus ---------- */
+  --focus-ring: 0 0 0 2px var(--ink-0), 0 0 0 4px var(--crimson-500);
+
+  /* ---------- Typography: families ---------- */
+  --font-jp:      "Noto Sans JP", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  --font-display: "Noto Sans JP", system-ui, sans-serif;
+  --font-latin:   "Inter", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-sans:    var(--font-jp);
+  /* SMuFL music notation (segno, coda, accidentals, barlines, etc.).
+     iReal Pro / render-ireal use Bravura Text. See ADR-0014. */
+  --font-music:   "Bravura Text", "Noto Music", "Symbola", serif;
+
+  /* ---------- Typography: sizes (rem at 16px root) ---------- */
+  --fs-10: 0.625rem;
+  --fs-12: 0.75rem;
+  --fs-13: 0.8125rem;
+  --fs-14: 0.875rem;
+  --fs-15: 0.9375rem;
+  --fs-16: 1rem;
+  --fs-18: 1.125rem;
+  --fs-24: 1.5rem;
+  --fs-30: 1.875rem;
+  --fs-36: 2.25rem;
+  --fs-48: 3rem;
+  --fs-60: 3.75rem;
+  --fs-72: 4.5rem;
+
+  /* ---------- Space: 4pt baseline ---------- */
+  --sp-1:  0.25rem;   /*  4 */
+  --sp-2:  0.5rem;    /*  8 */
+  --sp-3:  0.75rem;   /* 12 */
+  --sp-4:  1rem;      /* 16 */
+  --sp-5:  1.25rem;   /* 20 */
+  --sp-6:  1.5rem;    /* 24 */
+  --sp-8:  2rem;      /* 32 */
+  --sp-10: 2.5rem;    /* 40 */
+  --sp-12: 3rem;      /* 48 */
+  --sp-16: 4rem;      /* 64 */
+  --sp-20: 5rem;      /* 80 */
+  --sp-24: 6rem;      /* 96 */
+  --sp-32: 8rem;      /* 128 */
+
+  /* ---------- Radius ---------- */
+  --r-1:    2px;
+  --r-2:    4px;   /* button */
+  --r-3:    8px;   /* card */
+  --r-4:    12px;  /* modal */
+  --r-full: 9999px;
+
+  /* ---------- Elevation ---------- */
+  --e-1:       0 1px 2px rgba(10, 10, 11, 0.04);
+  --e-2:       0 4px 12px rgba(10, 10, 11, 0.08);   /* popover */
+  --e-3:       0 16px 32px rgba(10, 10, 11, 0.12);  /* modal */
+  --e-overlay: 0 24px 48px rgba(10, 10, 11, 0.18);  /* command palette */
+
+  /* ---------- Motion ---------- */
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dur-1: 120ms;  /* hover / focus */
+  --dur-2: 200ms;  /* state */
+  --dur-3: 280ms;  /* dialog */
+  --dur-4: 400ms;  /* page */
+
+  /* ---------- Container max-widths ---------- */
+  --maxw-app:     1280px;
+  --maxw-reading: 720px;
+  --maxw-guide:   1080px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --dur-1: 0ms;
+    --dur-2: 0ms;
+    --dur-3: 0ms;
+    --dur-4: 0ms;
+  }
+}

--- a/tokens.css
+++ b/tokens.css
@@ -60,6 +60,14 @@
   --font-latin:   "Inter", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
   --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --font-sans:    var(--font-jp);
+  /* Chord glyphs (`[G]`, `Am7`) and section letters in chart-rendering
+     surfaces. Roboto's Latin-numeric balance reads cleanly at small
+     sizes and matches the chord typography in iReal Pro / render-ireal. */
+  --font-chord:   "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  /* iReal Pro chart text marks (D.C., D.S., Fine) and chart header.
+     Italic Source Serif 4 evokes engraved sheet music. CHART SURFACES
+     ONLY — outside the chart, UI text is sans-serif and monospace. */
+  --font-chart-serif: "Source Serif 4", Georgia, "Times New Roman", serif;
   /* SMuFL music notation (segno, coda, accidentals, barlines, etc.).
      iReal Pro / render-ireal use Bravura Text. See ADR-0014. */
   --font-music:   "Bravura Text", "Noto Music", "Symbola", serif;

--- a/ui_kits/web/editor-irealb.html
+++ b/ui_kits/web/editor-irealb.html
@@ -1,0 +1,1054 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Editor · iReal Pro — ChordSketch</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&family=Noto+Sans+JP:wght@400;500;700;900&family=Roboto:wght@400;500;700;900&family=Source+Serif+4:ital,wght@0,400;0,700;0,900;1,400&display=swap">
+<link rel="stylesheet" href="../../tokens.css">
+<style>
+@font-face {
+  font-family: "Bravura Text";
+  src: url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura/redist/woff/BravuraText.woff2") format("woff2"),
+       url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura/redist/woff/BravuraText.woff") format("woff");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+  /* SMuFL Private Use Area glyphs (segno, coda, time-sig digits,
+     barline glyphs, etc.) + the standard music accidentals (♯ ♭ ♮)
+     ONLY. Chord-symbol text — root letter, digits, qualities — uses a
+     regular text font instead of Bravura, with Greek / Latin Unicode
+     stand-ins for the chord qualities (Δ for maj7, ø for half-dim,
+     ° for dim, − for minor). That way the whole chord reads at one
+     consistent weight from a regular text font; Bravura is reserved
+     for symbols that genuinely have no Latin / Greek equivalent. */
+  unicode-range: U+E000-F8FF, U+266D-266F;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; display: flex; flex-direction: column; min-height: 100vh; }
+a { color: inherit; text-decoration: none; }
+
+/* ---------- Top nav ---------- */
+.topnav { height: 56px; background: var(--surface); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 var(--sp-6); gap: var(--sp-4); }
+.topnav .brand { display: flex; align-items: center; gap: var(--sp-3); font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-16); letter-spacing: -0.01em; }
+.topnav .brand .mark { width: 24px; height: 24px; border-radius: var(--r-1); display: block; }
+.topnav .crumbs { display: flex; align-items: center; gap: var(--sp-3); margin-left: var(--sp-6); font-size: var(--fs-14); color: var(--text-secondary); }
+.topnav .crumbs .sep { color: var(--text-tertiary); }
+.topnav .crumbs .current { color: var(--text-primary); font-weight: 500; }
+.topnav .save-state { display: inline-flex; align-items: center; gap: var(--sp-2); font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-13); color: var(--success-fg); margin-left: var(--sp-3); }
+.topnav .save-state .dot { width: 6px; height: 6px; border-radius: var(--r-full); background: currentColor; }
+.topnav .actions { margin-left: auto; display: flex; align-items: center; gap: var(--sp-2); }
+
+.btn { display: inline-flex; align-items: center; gap: var(--sp-2); height: 36px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid transparent; font: 500 var(--fs-14)/1 var(--font-jp); cursor: pointer; transition: background var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out); text-decoration: none; }
+.btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.btn-primary { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.btn-primary:hover { background: var(--crimson-600); }
+.btn-secondary { background: var(--surface); color: var(--text-primary); border-color: var(--border-strong); }
+.btn-secondary:hover { background: var(--ink-100); }
+.btn-ghost { background: transparent; color: var(--text-secondary); }
+.btn-ghost:hover { background: var(--ink-100); color: var(--text-primary); }
+.btn-icon { padding: 0; width: 36px; justify-content: center; }
+.btn-sm { height: 28px; padding: 0 var(--sp-3); font-size: var(--fs-13); }
+
+/* ---------- Toolbar ---------- */
+.toolbar { display: flex; align-items: center; gap: var(--sp-2); padding: var(--sp-2) var(--sp-6); background: var(--surface); border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+.tool-group { display: flex; align-items: center; gap: var(--sp-1); padding: 0 var(--sp-3); border-right: 1px solid var(--border); height: 28px; }
+.tool-group:last-of-type { border-right: 0; }
+.tool-group .label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); margin-right: var(--sp-2); }
+.segmented { display: inline-flex; border: 1px solid var(--border-strong); border-radius: var(--r-2); overflow: hidden; }
+.segmented a, .segmented button { background: var(--surface); border: 0; padding: 0 var(--sp-3); height: 28px; font: 500 var(--fs-13)/1 var(--font-jp); color: var(--text-secondary); cursor: pointer; border-right: 1px solid var(--border); display: inline-flex; align-items: center; text-decoration: none; }
+.segmented a:last-child, .segmented button:last-child { border-right: 0; }
+.segmented [aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); }
+
+/* ---------- Page ---------- */
+.page { flex: 1; max-width: var(--maxw-app); width: 100%; margin: 0 auto; padding: var(--sp-8) var(--sp-6); display: grid; grid-template-columns: 1fr 320px; gap: var(--sp-8); align-items: start; }
+@media (max-width: 1080px) { .page { grid-template-columns: 1fr; } .inspector { order: 2; } }
+
+/* ---------- Metadata card ---------- */
+.meta-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5) var(--sp-6); margin-bottom: var(--sp-6); }
+.meta-card h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-30); line-height: 1.2; letter-spacing: -0.02em; margin: 0 0 var(--sp-1); }
+.meta-card .composer { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-14); color: var(--text-secondary); margin: 0 0 var(--sp-5); }
+.meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: var(--sp-4); }
+.meta-field { display: flex; flex-direction: column; gap: 4px; }
+.meta-field label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); }
+.meta-field input, .meta-field select { height: 32px; padding: 0 var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2); background: var(--ink-50); font: 500 var(--fs-14)/1 var(--font-mono); color: var(--text-primary); transition: border-color var(--dur-1) var(--ease-out), background var(--dur-1) var(--ease-out); font-variant-numeric: tabular-nums; }
+.meta-field input:focus, .meta-field select:focus { outline: none; border-color: var(--crimson-500); background: var(--surface); box-shadow: var(--focus-ring); }
+
+/* ============================================================
+   iReal Pro chart — engraved in black on white, no cell grid.
+   Bars are separated by left border-lines only; section markers
+   are small bordered letters anchored at the top-left of the
+   first bar of a section. Chord typography uses Source Serif
+   (a Garamond/Times-class serif close to iReal's house face) for
+   letters and digits, and Bravura Text for SMuFL accidentals,
+   chord-symbol qualities, barline glyphs, and segno / coda.
+   ============================================================ */
+.chart { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-10) var(--sp-12); color: var(--ink-1000); }
+
+.chart-header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: baseline; gap: var(--sp-4); padding-bottom: var(--sp-6); margin-bottom: var(--sp-6); border-bottom: 1px solid var(--border); font-family: "Source Serif 4", Georgia, "Times New Roman", serif; color: var(--ink-1000); }
+.chart-header .style { font-style: italic; font-size: var(--fs-14); }
+.chart-header .title { font-weight: 700; font-size: var(--fs-18); text-align: center; }
+.chart-header .type { text-align: right; font-size: var(--fs-14); }
+
+/* Lines have an explicit vertical gap. Section markers ([A] [B] [C])
+   are absolutely positioned above the first bar of their section and
+   sit visually inside this gap rather than colliding with the previous
+   line's bars. iReal Pro uses the same convention — section letters
+   live in inter-line whitespace, not on top of music. */
+.chart-body { display: flex; flex-direction: column; gap: 32px; }
+
+/* 4 bars per line in equal-width columns. iReal Pro's printed layouts
+   alternate between equal and content-driven widths depending on the
+   chart, but the equal-grid look is closer to the engraved feel of the
+   Even 8ths 3 / Rock 3 PDFs in /tmp/, and avoids flex auto-width
+   reflowing the chart awkwardly when content density differs. */
+.chart-line { display: grid; grid-template-columns: repeat(4, 1fr); align-items: stretch; }
+/* Coda destination — same column geometry as the main chart so the bars
+   line up vertically with the form above; only an extra margin separates
+   it as an out-of-form block. */
+.chart-line.coda-line { margin-top: var(--sp-8); }
+
+/* Each bar carries its left barline. The chart line's last bar gets a right
+   barline. Bars are sized by content (flex auto), so chord text fills more
+   of the bar's vertical space — matching iReal Pro's printed density. */
+.bar {
+  position: relative;
+  padding: 2px var(--sp-3) 2px var(--sp-3);
+  /* The bar is a metric grid: 4 columns for 4/4, 3 columns for 3/4
+     (override `--beats` per chart or per bar). Each chord lives in the
+     grid column corresponding to its beat — beat 1 by default, or
+     `data-beat="2|3|4"` on the chord — so chord placement is metrically
+     accurate without CSS positioning hacks. */
+  display: grid;
+  grid-template-columns: repeat(var(--beats, 4), 1fr);
+  align-items: center;
+  border-left: 1.5px solid var(--ink-1000);
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease-out);
+}
+.bar > .chord                 { grid-column: 1; justify-self: start; align-self: center; }
+.bar > .chord[data-beat="2"]  { grid-column: 2; }
+.bar > .chord[data-beat="3"]  { grid-column: 3; }
+.bar > .chord[data-beat="4"]  { grid-column: 4; }
+
+/* iReal Pro convention: every line reserves an indent at its left edge.
+   The first barline of every line begins at the same offset from the
+   chart-card content edge — so chord roots stack vertically across
+   lines. The reserved gap holds the time signature (line 1 only,
+   typeset BEFORE the repeat-start barline as in standard music
+   notation), section markers ([A] [B] [C]), or Coda glyphs. */
+.chart-line { position: relative; padding-left: 26px; }
+.chart-line > .time-sig {
+  /* Sits in the reserved indent area, before the first bar's barline,
+     centered both horizontally and vertically against the chord row. */
+  position: absolute;
+  left: 0;
+  width: 22px;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-right: 0;
+}
+.bar:hover { background: rgba(189, 22, 66, 0.05); }
+.bar.active { background: var(--crimson-50); outline: 1.5px solid var(--crimson-500); outline-offset: -1.5px; z-index: 2; }
+
+/* End-of-line single barline. Skipped when the last bar already carries
+   its own glyph-based barline (repeat-end or final), so we never need
+   `!important` to override. */
+.chart-line .bar:last-child:not(.repeat-end):not(.final) { border-right: 1.5px solid var(--ink-1000); }
+
+/* All barlines render at the same vertical extent: single barlines use
+   border-left at the bar's full height, and special barlines use SMuFL
+   glyphs sized to match. The bar's min-height drives both via the
+   shared `--barline-h` token, so changing the bar height keeps the
+   single barline and the engraved glyphs in lockstep. */
+.bar {
+  --barline-h: 58px;
+  min-height: var(--barline-h);
+}
+.bar.repeat-start,
+.bar.repeat-end,
+.bar.final { position: relative; }
+.bar.repeat-start::before,
+.bar.repeat-end::after,
+.bar.final::after {
+  font-family: var(--font-music);
+  font-weight: normal;
+  /* Empirically tuned so the visible Bravura barline strokes occupy the
+     same y-range (1px..57px within a 58px bar = 57px tall) as the 1.5px
+     border-left used on adjacent single barlines. Verified by reading
+     pixel data from a Playwright screenshot of the rendered DOM:
+       single barline:   y=1..57, h=57
+       repeat-start:     y=1..57, h=57
+       repeat-end:       y=1..57, h=57
+       final:            y=1..57, h=57
+     The values below (font-size 71px, top -1px) were the last in a
+     series of probe edits at this `--barline-h: 58px` setting. If the
+     bar height is changed, both numbers must be re-tuned — Bravura's
+     glyph metrics aren't perfectly proportional with font-size. */
+  font-size: 71px;
+  line-height: 1;
+  color: var(--ink-1000);
+  position: absolute;
+  top: -1px;
+  pointer-events: none;
+}
+.bar.repeat-start { border-left: 0; padding-left: calc(var(--sp-4) + 12px); }
+.bar.repeat-start::before { content: "\E040"; left: -2px; }    /* repeatLeft */
+.bar.repeat-end   { border-right: 0; padding-right: calc(var(--sp-3) + 12px); }
+.bar.repeat-end::after   { content: "\E041"; right: -2px; }    /* repeatRight */
+.bar.final        { border-right: 0; padding-right: calc(var(--sp-3) + 10px); }
+.bar.final::after        { content: "\E032"; right: -2px; }    /* barlineFinal */
+
+/* Section marker — small black-filled square with white letter, anchored at
+   the top-left of the first bar of a section. Matches iReal Pro's printed
+   chart convention (see /tmp/Even 8ths 3.pdf, /tmp/Rock 3.pdf). */
+.bar .section-marker {
+  position: absolute;
+  left: -20px;
+  /* Sit centered in the inter-line gap above this bar. */
+  top: -16px;
+  width: 20px;
+  height: 20px;
+  background: var(--ink-1000);
+  color: var(--ink-0);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Roboto", system-ui, sans-serif;
+  font-weight: 900;
+  font-size: var(--fs-15);
+  z-index: 3;
+  letter-spacing: 0;
+}
+
+/* Time signature stacked at the very start of the chart. Uses Bravura's
+   purpose-built timeSig digits (U+E080–E089) which are proportioned for
+   two-line stacked rendering. Stacked total height ≈ chord-root height so
+   the two read as one engraved unit. */
+.time-sig {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  /* Regular text digits (Roboto Bold) instead of Bravura's timeSig
+     glyphs. Bravura's timeSig digits sit close to the baseline by
+     design, which makes a stacked time signature look bottom-heavy
+     in plain CSS line-boxes; standard text digits center naturally. */
+  font-family: "Roboto", system-ui, sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--ink-1000);
+  margin-right: 0;
+  flex-shrink: 0;
+  letter-spacing: 0;
+}
+.time-sig span {
+  display: block;
+  text-align: center;
+  width: 1em;
+  line-height: 1.05;
+}
+.time-sig span:first-child { border-bottom: 1.5px solid currentColor; }
+
+/* Bar text-symbol (italic, e.g. D.C. al Coda) */
+.bar .text-mark {
+  position: absolute;
+  left: var(--sp-5);
+  bottom: -22px;
+  font-family: "Source Serif 4", Georgia, serif;
+  font-style: italic;
+  font-size: var(--fs-13);
+  color: var(--ink-1000);
+  white-space: nowrap;
+}
+
+/* SMuFL glyph anchored above a CHORD (segno / coda). iReal Pro engraves
+   these symbols above the chord they cue, not above the barline — so
+   the glyph is grid-placed into the beat column the chord lives in
+   (`data-beat="1|2|3|4"`), then absolutely lifted above the bar with
+   translateY. Defaults to beat 1 (the first chord of the bar). */
+.bar .glyph-mark {
+  position: absolute;
+  grid-column: 1;
+  justify-self: start;
+  top: -2px;
+  transform: translateY(-100%);
+  font-family: var(--font-music);
+  font-style: normal;
+  font-size: 32px;
+  line-height: 1;
+  color: var(--ink-1000);
+  pointer-events: none;
+}
+.bar .glyph-mark[data-beat="2"] { grid-column: 2; }
+.bar .glyph-mark[data-beat="3"] { grid-column: 3; }
+.bar .glyph-mark[data-beat="4"] { grid-column: 4; }
+
+/* ---------- Volta / repeat-ending brackets ----------
+   Standard music-notation 1st / 2nd ending brackets. The bracket sits
+   above the bar(s) it covers, with a horizontal line, a downward tail
+   at the LEFT end (always), an optional CLOSING tail at the right end
+   (1st ending only — 2nd-ending brackets stay open at the right because
+   the music continues forward), and a small numeric label ("1." / "2.")
+   at the upper-left of the bracket. */
+.bar.ending { position: relative; }
+.bar > .ending-bracket {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -22px;
+  height: 18px;
+  border-top: 1.5px solid var(--ink-1000);
+  border-left: 1.5px solid var(--ink-1000);
+  box-sizing: border-box;
+  padding: 2px 0 0 5px;
+  font-family: "Roboto", system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--ink-1000);
+  line-height: 1;
+}
+/* 1st ending closes at the right (the repeat sends you back from here);
+   2nd ending stays open at the right (music continues into the next
+   section). */
+.bar.ending-1 > .ending-bracket { border-right: 1.5px solid var(--ink-1000); }
+
+/* ---------- Chord typography ----------
+   Root letter — heavy serif (Source Serif Black 900) at chart-symbol
+   size. Accidentals (♯ / ♭) — Bravura SMuFL csym glyphs, raised
+   superscript next to the root. Quality (m, 7, ø7, Δ7, m7♭5) — small
+   subscript that hangs slightly below the baseline. Multiple
+   sub-quality lines stack vertically (e.g. "7♯9" over "♯5").
+   Matches iReal Pro's chart engraving in /tmp/Even 8ths 3.pdf and
+   /tmp/Rock 3.pdf. Implemented with inline-block + vertical-align so
+   the typography flows like text (the PDFs are typeset, not laid out
+   with flexbox). */
+.chord {
+  display: inline-block;
+  white-space: nowrap;
+  /* Chord text (root letter, digits, qualities) all uses one regular
+     text font at one weight. Quality glyphs are rendered with Latin /
+     Greek stand-ins (Δ for maj7, ø for half-dim, − for minor, ° for
+     dim, + for aug) which all live in the regular font's glyph set —
+     this keeps minor signs visible and digits balanced instead of
+     fighting a music-font weight mismatch. Accidentals (♯ ♭) still
+     come from Bravura since Roboto lacks proper music sharp / flat
+     shapes. */
+  font-family: "Roboto", system-ui, -apple-system, sans-serif;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink-1000);
+  line-height: 1;
+  vertical-align: baseline;
+}
+.chord-root {
+  font-size: 44px;
+  display: inline-block;
+  line-height: 1;
+}
+.chord-acc {
+  /* Sharp / flat next to the root letter, raised superscript but kept
+     within the root letter's vertical extent. Accidental glyph from
+     Bravura Text — same weight family as the rest of the chord. */
+  font-family: var(--font-music);
+  font-weight: normal;
+  font-size: 26px;
+  display: inline-block;
+  vertical-align: 0.18em;
+  margin-left: -2px;
+  line-height: 1;
+}
+.chord-qual {
+  /* Inherits chord font (Source Serif at chord weight). Quality glyphs
+     (Δ for maj7, ø for half-dim, − for minor, ° for dim, + for aug)
+     are regular Unicode characters that render in the same font as
+     the digits, so the whole quality reads at one consistent weight. */
+  font-size: 22px;
+  display: inline-block;
+  vertical-align: -0.15em;
+  margin-left: 0;
+  letter-spacing: -0.005em;
+  line-height: 1;
+}
+.chord-qual .smufl { font-family: var(--font-music); font-weight: normal; }
+/* Stacked quality lines (e.g. "7♯9" above "♯5"). */
+.chord-qual.stacked { vertical-align: -0.5em; line-height: 0.95; }
+.chord-qual.stacked > span { display: block; }
+
+/* Slash chord — root chord over bass note separated by a horizontal rule.
+   Used for figures like "D−/A" or "E♭−7/D♭". */
+.chord.slash { display: inline-flex; flex-direction: column; align-items: center; line-height: 0.95; gap: 0; vertical-align: middle; }
+.chord.slash .top, .chord.slash .bot { display: inline-block; line-height: 1; }
+.chord.slash .bot { font-size: 18px; padding-top: 2px; border-top: 1px solid var(--ink-1000); margin-top: 2px; }
+
+/* SMuFL utility — beats more-specific component selectors that use the
+   `font:` shorthand (which would otherwise reset font-family back to mono). */
+.smufl { font-family: var(--font-music) !important; font-style: normal; line-height: 1; }
+
+/* ---------- Bar-content variants beyond the regular chord cell ---------- */
+
+/* No-Chord bar: literal "N.C." rendered in the chord typeface so it sits
+   on the same baseline as a regular chord. */
+.chord.nc { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: 22px; letter-spacing: 0.02em; }
+
+/* Invisible-root: the chord root is intentionally not rendered (the
+   chord is held; only the bass moves). Visually this is a slash chord
+   with the top half blank — a horizontal divider plus a bass note
+   below. The oval icon in the iReal Pro editor toolbar is a button
+   glyph, not a chart rendering. */
+.chord.invisible-root { display: inline-flex; flex-direction: column; align-items: center; line-height: 1; gap: 0; }
+.chord.invisible-root .bass {
+  font-family: "Roboto", system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 22px;
+  border-top: 1.5px solid var(--ink-1000);
+  padding-top: 2px;
+  /* Reserve space ABOVE the divider equal to the chord-root height so
+     the invisible-root cell shares vertical metrics with neighbouring
+     bars. */
+  margin-top: 28px;
+  min-width: 28px;
+  text-align: center;
+  line-height: 1;
+}
+
+/* Repeat-1-bar / repeat-2-bars slash glyphs render as a single SMuFL
+   character occupying the chord cell. */
+.bar > .repeat-bar {
+  font-family: var(--font-music);
+  font-size: 36px;
+  line-height: 1;
+  color: var(--ink-1000);
+  align-self: center;
+  justify-self: center;
+  grid-column: 1 / -1;
+}
+
+/* Alternate chord — a smaller chord rendered ABOVE the primary chord in
+   the same beat column. Sits inline above the primary so it scrolls with
+   the bar. */
+.chord-stack { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 1px; }
+.chord-stack .alt {
+  font-family: "Roboto", system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--text-secondary);
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+
+/* Fermata glyph anchored above its chord. Bravura's fermataAbove visible
+   ink sits in the top ~25% of the rendered font-size box; the element
+   is positioned so the visible arc lands JUST above the chord, not
+   floating in the middle of the inter-line gap. */
+.bar > .fermata {
+  position: absolute;
+  top: -22px;
+  font-family: var(--font-music);
+  font-style: normal;
+  font-size: 56px;
+  line-height: 1;
+  color: var(--ink-1000);
+  pointer-events: none;
+  grid-column: 1;
+  justify-self: center;
+}
+.bar > .fermata[data-beat="2"] { grid-column: 2; }
+.bar > .fermata[data-beat="3"] { grid-column: 3; }
+.bar > .fermata[data-beat="4"] { grid-column: 4; }
+
+/* Last-bar (END) playback marker — small "END" text rendered below the
+   bar's right barline, not on top of any glyph. The right barline is
+   unchanged; "END" is just a label that sits underneath it. */
+.bar.last-bar .end-mark {
+  position: absolute;
+  right: 0;
+  bottom: -2px;
+  transform: translate(50%, 100%);
+  font-family: "Roboto", system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--ink-1000);
+  line-height: 1;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+/* Vertical spacer between chart-line rows. */
+.chart-line-spacer { height: var(--sp-6); }
+.chart-line-spacer.x2 { height: var(--sp-12); }
+.chart-line-spacer.x3 { height: var(--sp-20); }
+
+/* Chord width modes. The chart-wide `.chart.compact` modifier scales
+   chord glyphs horizontally (Normal=1, Small=0.7) without touching
+   vertical metrics — matches iReal Pro's N / S toggle. */
+.chart.compact .chord { transform: scaleX(0.72); transform-origin: left center; }
+
+/* ---------- Player controls strip ----------
+   Sits below the chart body. Mocks the iReal Pro editor's bottom strip:
+   style label / Play / Time / Repeats / Tempo / Key. Non-functional. */
+.player-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  margin-top: var(--sp-8);
+  padding: var(--sp-4) var(--sp-5);
+  background: var(--ink-1000);
+  color: var(--ink-0);
+  border-radius: var(--r-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-13);
+  font-variant-numeric: tabular-nums;
+}
+.player-controls .play-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--r-full);
+  background: var(--crimson-500);
+  color: var(--fg-on-crimson);
+  border: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.player-controls .pc-stat { display: inline-flex; flex-direction: column; gap: 2px; min-width: 56px; }
+.player-controls .pc-stat .label {
+  font-family: var(--font-latin);
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-300);
+}
+.player-controls .pc-stat .value { font-weight: 600; color: var(--ink-0); }
+
+/* ============================================================
+   Inspector
+   ============================================================ */
+.inspector { position: sticky; top: var(--sp-8); background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5); }
+.inspector header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--sp-4); padding-bottom: var(--sp-3); border-bottom: 1px solid var(--border); }
+.inspector header .title { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-16); }
+.inspector header .pos { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); }
+.inspector .row { display: flex; flex-direction: column; gap: var(--sp-2); margin-bottom: var(--sp-4); }
+.inspector .row > .label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); }
+.inspector input.chord-input { width: 100%; height: 36px; padding: 0 var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-2); font: 500 var(--fs-18)/1 "Roboto", system-ui, sans-serif; color: var(--ink-1000); background: var(--ink-50); }
+.inspector input.chord-input:focus { outline: none; border-color: var(--crimson-500); background: var(--surface); box-shadow: var(--focus-ring); }
+.inspector .chips { display: flex; flex-wrap: wrap; gap: var(--sp-1); }
+.inspector .chip { display: inline-flex; align-items: center; padding: var(--sp-1) var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-full); background: var(--surface); font: 500 var(--fs-13)/1 "Roboto", system-ui, sans-serif; color: var(--text-secondary); cursor: pointer; min-height: 28px; }
+/* SMuFL music-symbol chips render their glyph larger than the regular
+   text-chip font-size, since Bravura draws the visible ink at a small
+   fraction of the rendered em-square. */
+.inspector .chip.smufl { font-size: 20px; line-height: 1; padding-top: 0; padding-bottom: 0; }
+/* Fermata's visible-ink ratio is ~28% (vs ~70% for segno/coda), so the
+   chip wraps the glyph in an inner span and scales just the glyph via
+   transform — keeping chip box dimensions identical to its neighbours
+   while the visible ink reads at the same scale. The translateY shifts
+   the visible arc down so its centre lands on the chip's vertical
+   centre (Bravura draws fermataAbove well above the baseline). */
+.inspector .chip.smufl .scale-up {
+  display: inline-block;
+  transform: translateY(35%) scale(1.9);
+  transform-origin: center;
+  line-height: 1;
+}
+.inspector .chip[aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); border-color: var(--ink-1000); }
+.inspector .chip:hover:not([aria-pressed="true"]) { color: var(--text-primary); background: var(--ink-100); }
+.inspector .footer { display: flex; gap: var(--sp-2); padding-top: var(--sp-3); border-top: 1px solid var(--border); }
+
+/* ---------- Status ---------- */
+.status { display: flex; align-items: center; padding: var(--sp-2) var(--sp-6); background: var(--surface); border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); gap: var(--sp-6); }
+.status .item { display: inline-flex; align-items: center; gap: var(--sp-2); }
+.status .spacer { flex: 1; }
+.status .ok { color: var(--success-fg); }
+</style>
+</head>
+<body>
+
+<header class="topnav">
+  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+    <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
+    ChordSketch
+  </a>
+  <div class="crumbs">
+    <a href="library.html">Library</a>
+    <span class="sep">›</span>
+    <span class="current">Autumn Leaves</span>
+  </div>
+  <span class="save-state" aria-live="polite"><span class="dot"></span>Saved · 14:32</span>
+  <div class="actions">
+    <button class="btn btn-ghost btn-sm">⌘K · Commands</button>
+    <button class="btn btn-ghost btn-icon" aria-label="Undo"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-15-6.7L3 13"/></svg></button>
+    <button class="btn btn-ghost btn-icon" aria-label="Redo"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 15-6.7L21 13"/></svg></button>
+    <a href="viewer.html" class="btn btn-secondary">Preview</a>
+    <button class="btn btn-primary">Save</button>
+  </div>
+</header>
+
+<div class="toolbar" role="toolbar" aria-label="Editor tools">
+  <div class="tool-group">
+    <span class="label">Format</span>
+    <div class="segmented" role="tablist">
+      <a href="editor.html" aria-pressed="false">ChordPro</a>
+      <a href="editor-irealb.html" aria-pressed="true">iReal Pro</a>
+    </div>
+  </div>
+  <div class="tool-group">
+    <span class="label">Transpose</span>
+    <button class="btn btn-secondary btn-sm" aria-label="Transpose down">−</button>
+    <span style="font-family: var(--font-mono); font-size: var(--fs-13); padding: 0 var(--sp-2); min-width: 28px; text-align: center;">+0</span>
+    <button class="btn btn-secondary btn-sm" aria-label="Transpose up">+</button>
+  </div>
+  <div class="tool-group">
+    <span class="label">Width</span>
+    <div class="segmented" role="tablist" aria-label="Chord width">
+      <button aria-pressed="true" title="Normal width">N</button>
+      <button aria-pressed="false" title="Small width — compresses chord glyphs horizontally so several chords fit in a tight bar">S</button>
+    </div>
+  </div>
+  <div class="tool-group">
+    <span class="label">Chord</span>
+    <div class="segmented" role="tablist" aria-label="Chord input target">
+      <button aria-pressed="true">Regular</button>
+      <button aria-pressed="false" title="Small alternate chord rendered above the primary chord">Alternate</button>
+    </div>
+  </div>
+  <div class="tool-group">
+    <span class="label">Insert</span>
+    <button class="btn btn-ghost btn-sm">Bar</button>
+    <button class="btn btn-ghost btn-sm">Section</button>
+    <button class="btn btn-ghost btn-sm">Repeat</button>
+    <button class="btn btn-ghost btn-sm">Ending</button>
+    <button class="btn btn-ghost btn-sm">Symbol</button>
+  </div>
+  <div class="tool-group">
+    <span class="label">Layout</span>
+    <span style="font-family: var(--font-mono); font-size: var(--fs-13); color: var(--text-secondary);">4 bars / line</span>
+  </div>
+</div>
+
+<main class="page">
+  <div>
+
+    <section class="meta-card" aria-label="Chart metadata">
+      <h1>Autumn Leaves</h1>
+      <p class="composer">Joseph Kosma · Johnny Mercer · Jacques Prévert</p>
+      <div class="meta-grid">
+        <div class="meta-field"><label for="title">Title</label><input id="title" value="Autumn Leaves"></div>
+        <div class="meta-field"><label for="composer">Composer</label><input id="composer" value="Joseph Kosma"></div>
+        <div class="meta-field"><label for="style">Style</label>
+          <select id="style">
+            <optgroup label="Jazz">
+              <option>Afro 12/8</option>
+              <option>Ballad Double Time Feel</option>
+              <option>Ballad Even</option>
+              <option>Ballad Melodic</option>
+              <option>Ballad Swing</option>
+              <option>Blue Note</option>
+              <option>Bossa Nova</option>
+              <option>Bossa/Swing</option>
+              <option>Doo Doo Cats</option>
+              <option>Even 8ths</option>
+              <option>Even 8ths Open</option>
+              <option>Even 16ths</option>
+              <option>Guitar Trio</option>
+              <option>Gypsy Jazz</option>
+              <option>Latin</option>
+              <option>Latin/Swing</option>
+              <option>Long Notes</option>
+              <option selected>Medium Swing</option>
+              <option>Medium Up Swing</option>
+              <option>Medium Up Swing 2</option>
+              <option>New Orleans Swing</option>
+              <option>Second Line</option>
+              <option>Slow Swing</option>
+              <option>Swing Two/Four</option>
+              <option>Trad Jazz</option>
+              <option>Up Tempo Swing</option>
+              <option>Up Tempo Swing 2</option>
+            </optgroup>
+            <optgroup label="Latin">
+              <option>Argentina: Tango</option>
+              <option>Brazil: Bossa Acoustic</option>
+              <option>Brazil: Bossa Electric</option>
+              <option>Brazil: Samba</option>
+              <option>Cuba: Bolero</option>
+              <option>Cuba: Cha Cha Cha</option>
+              <option>Cuba: Son Montuno 2-3</option>
+              <option>Cuba: Son Montuno 3-2</option>
+            </optgroup>
+            <optgroup label="Pop">
+              <option>Bluegrass</option>
+              <option>Country</option>
+              <option>Disco</option>
+              <option>Funk</option>
+              <option>Glam Funk</option>
+              <option>House</option>
+              <option>Reggae</option>
+              <option>Rock</option>
+              <option>Rock 12/8</option>
+              <option>RnB</option>
+              <option>Shuffle</option>
+              <option>Slow Rock</option>
+              <option>Smooth</option>
+              <option>Soul</option>
+              <option>Virtual Funk</option>
+            </optgroup>
+            <optgroup label="Blues">
+              <option>Chicago Shuffle</option>
+              <option>Flat Tire</option>
+              <option>Funky</option>
+              <option>Gospel</option>
+              <option>Lucille</option>
+              <option>Mo-Slo</option>
+              <option>Muddy</option>
+              <option>Nola</option>
+              <option>Shout</option>
+              <option>Slo-Mo</option>
+              <option>Stax</option>
+              <option>Texas Rock</option>
+            </optgroup>
+            <optgroup label="Brazilian">
+              <option>Afoxe</option>
+              <option>Baiao</option>
+              <option>Bossa Ballad</option>
+              <option>Bossa Cha</option>
+              <option>Bossa Nova</option>
+              <option>Maracatu</option>
+              <option>Partido Alto</option>
+              <option>Samba</option>
+              <option>Samba Brush</option>
+              <option>Samba Fast</option>
+              <option>Samba Percussion</option>
+            </optgroup>
+            <optgroup label="Salsa">
+              <option>Cuba: Afro 6/8</option>
+              <option>Cuba: Bolero</option>
+              <option>Cuba: Cha Cha Cha</option>
+              <option>Cuba: Comparsa</option>
+              <option>Cuba: Danzon</option>
+              <option>Cuba: Guajira</option>
+              <option>Cuba: Guaracha</option>
+              <option>Cuba: Mambo</option>
+              <option>Cuba: Mozambique</option>
+              <option>Cuba: Rumba Guaguanco</option>
+              <option>Cuba: Son Montuno 2-3</option>
+              <option>Cuba: Songo</option>
+              <option>Cuba: Timba</option>
+              <option>Dominican Republic: Merengue</option>
+              <option>Puerto Rico: Bomba</option>
+              <option>Puerto Rico: Plena</option>
+            </optgroup>
+          </select>
+        </div>
+        <div class="meta-field"><label for="key">Key</label>
+          <select id="key" style="color: var(--crimson-500); font-weight: 700;"><option>C</option><option>D</option><option selected>Em</option><option>F</option><option>G</option><option>Am</option></select>
+        </div>
+        <div class="meta-field"><label for="time">Time</label>
+          <select id="time">
+            <option>2/2</option><option>3/2</option>
+            <option>2/4</option><option>3/4</option><option selected>4/4</option><option>5/4</option><option>6/4</option><option>7/4</option>
+            <option>3/8</option><option>5/8</option><option>6/8</option><option>7/8</option><option>9/8</option><option>12/8</option>
+          </select>
+        </div>
+        <div class="meta-field"><label for="tempo">Tempo</label><input id="tempo" type="number" value="124"></div>
+      </div>
+      <div style="display: flex; gap: var(--sp-2); margin-top: var(--sp-4); padding-top: var(--sp-4); border-top: 1px solid var(--border); align-items: center;">
+        <span style="font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); margin-right: var(--sp-2);">Key change</span>
+        <button class="btn btn-secondary btn-sm" title="Update the key signature display only — chord symbols are unchanged">Set</button>
+        <button class="btn btn-secondary btn-sm" title="Change the key and transpose every chord in the chart to match">Set and Transpose</button>
+      </div>
+    </section>
+
+    <section class="chart" aria-label="iReal Pro chart">
+      <header class="chart-header">
+        <span class="style">(Medium Swing)</span>
+        <span class="title">Autumn Leaves</span>
+        <span class="type">Lead Sheet</span>
+      </header>
+
+      <div class="chart-body">
+        <!-- Line 1 — chart begins with time signature, then repeat-start barline -->
+        <div class="chart-line">
+          <span class="time-sig"><span>4</span><span>4</span></span>
+          <div class="bar repeat-start">
+            <span class="section-marker">A</span>
+            <span class="chord">
+              <span class="chord-root">A</span><span class="chord-qual">−7</span>
+            </span>
+          </div>
+          <div class="bar"><span class="chord"><span class="chord-root">D</span><span class="chord-qual">7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">G</span><span class="chord-qual">Δ7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">C</span><span class="chord-qual">Δ7</span></span></div>
+        </div>
+
+        <!-- Line 2 — A section closes with repeat-end. The last two bars
+             demonstrate 1st / 2nd ending brackets: bar 3 ("1.") ends with
+             the repeat-end barline, bar 4 ("2.") is the alternate ending
+             that the second pass takes. E7♯9 demonstrates a tension qual:
+             digit 7 + sharp accidental (Bravura ♯) + digit 9. -->
+        <div class="chart-line">
+          <div class="bar"><span class="chord"><span class="chord-root">F</span><span class="chord-acc">&#x266F;</span><span class="chord-qual">ø7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">B</span><span class="chord-qual">7<span class="smufl">&#x266D;</span>9</span></span></div>
+          <div class="bar active repeat-end ending ending-1" aria-current="true">
+            <span class="ending-bracket">1.</span>
+            <span class="chord"><span class="chord-root">E</span><span class="chord-qual">−7</span></span>
+          </div>
+          <div class="bar ending ending-2">
+            <span class="ending-bracket">2.</span>
+            <span class="chord"><span class="chord-root">E</span><span class="chord-qual">7<span class="smufl">&#x266F;</span>9</span></span>
+          </div>
+        </div>
+
+        <!-- Line 3 — B section -->
+        <div class="chart-line">
+          <div class="bar">
+            <span class="section-marker">B</span>
+            <span class="chord"><span class="chord-root">F</span><span class="chord-acc">&#x266F;</span><span class="chord-qual">ø7</span></span>
+          </div>
+          <div class="bar"><span class="chord"><span class="chord-root">B</span><span class="chord-qual">7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">E</span><span class="chord-qual">−7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">E</span><span class="chord-qual">−7</span></span></div>
+        </div>
+
+        <!-- Line 4 — last bar uses a slash chord (Gmaj7/D, Gmaj7 over D bass)
+             rendered with the .chord.slash component: top chord stacked on
+             a bass note separated by a horizontal divider. -->
+        <div class="chart-line">
+          <div class="bar"><span class="chord"><span class="chord-root">A</span><span class="chord-qual">−7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">D</span><span class="chord-qual">7</span></span></div>
+          <!-- Fermata anchored above the chord on this bar (SMuFL fermataAbove). -->
+          <div class="bar">
+            <span class="fermata" aria-label="Fermata">&#xE4C0;</span>
+            <span class="chord"><span class="chord-root">G</span><span class="chord-qual">Δ7</span></span>
+          </div>
+          <div class="bar">
+            <span class="chord slash">
+              <span class="top"><span class="chord-root">G</span><span class="chord-qual">Δ7</span></span>
+              <span class="bot">D</span>
+            </span>
+            <span class="text-mark">rit.</span>
+          </div>
+        </div>
+
+        <!-- Line 5 — C section. Demonstrates an Em7/B slash chord, an A13
+             tension, and an Alternate-chord (small "A7♭13" above the
+             primary A13). -->
+        <div class="chart-line">
+          <div class="bar">
+            <span class="section-marker">C</span>
+            <span class="chord"><span class="chord-root">F</span><span class="chord-acc">&#x266F;</span><span class="chord-qual">ø7</span></span>
+          </div>
+          <div class="bar"><span class="chord"><span class="chord-root">B</span><span class="chord-qual">7</span></span></div>
+          <div class="bar">
+            <span class="chord slash">
+              <span class="top"><span class="chord-root">E</span><span class="chord-qual">−7</span></span>
+              <span class="bot">B</span>
+            </span>
+          </div>
+          <div class="bar">
+            <span class="chord-stack">
+              <span class="alt">A7<span class="smufl">&#x266D;</span>13</span>
+              <span class="chord"><span class="chord-root">A</span><span class="chord-qual">13</span></span>
+            </span>
+          </div>
+        </div>
+
+        <!-- Line 6 — C section closes. G7♭9♯5 shows the .chord-qual.stacked
+             layout (two qual lines: "7♭9" above "♯5"). Cmaj7♯11 shows a
+             single-line tension. Last bar carries two chords plus the
+             Coda glyph + D.C. al Coda text-mark. -->
+        <div class="chart-line">
+          <div class="bar"><span class="chord"><span class="chord-root">D</span><span class="chord-qual">−7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">G</span><span class="chord-qual stacked"><span>7<span class="smufl">&#x266D;</span>9</span><span><span class="smufl">&#x266F;</span>5</span></span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">C</span><span class="chord-qual">Δ7<span class="smufl">&#x266F;</span>11</span></span></div>
+          <div class="bar final">
+            <span class="chord"><span class="chord-root">B</span><span class="chord-qual">−7</span></span>
+            <span class="chord" data-beat="3"><span class="chord-root">E</span><span class="chord-qual">7<span class="smufl">&#x266D;</span>9</span></span>
+            <span class="glyph-mark" data-beat="3" aria-label="Coda">&#xE048;</span>
+            <span class="text-mark">D.C. al Coda</span>
+          </div>
+        </div>
+
+        <!-- Coda destination — separate single line with Coda glyph at start.
+             Mock [D] section marker added so we can preview how a section
+             label coexists with the Coda glyph in the same indent area. -->
+        <div class="chart-line coda-line">
+          <div class="bar">
+            <span class="section-marker">D</span>
+            <span class="chord"><span class="chord-root">A</span><span class="chord-qual">−7</span></span>
+            <span class="glyph-mark" aria-label="Coda">&#xE048;</span>
+          </div>
+          <div class="bar"><span class="chord"><span class="chord-root">D</span><span class="chord-qual">7</span></span></div>
+          <div class="bar"><span class="chord"><span class="chord-root">G</span><span class="chord-qual">Δ7</span></span></div>
+          <div class="bar final last-bar">
+            <span class="chord"><span class="chord-root">E</span><span class="chord-qual">−7</span></span>
+            <span class="end-mark">END</span>
+          </div>
+        </div>
+
+        <!-- Showcase line — bars demonstrating bar-content variants that
+             aren't part of the Autumn Leaves form: N.C. (no chord),
+             invisible-root chord with a moving bass, repeat-1-bar slash
+             glyph, and repeat-2-bars slash glyph. -->
+        <div class="chart-line" style="margin-top: var(--sp-12);">
+          <div class="bar">
+            <span class="chord nc">N.C.</span>
+            <span class="text-mark">free time</span>
+          </div>
+          <div class="bar">
+            <span class="chord invisible-root" aria-label="Invisible root over D bass">
+              <span class="bass">D</span>
+            </span>
+          </div>
+          <div class="bar">
+            <span class="repeat-bar smufl" aria-label="Repeat 1 bar">&#xE500;</span>
+          </div>
+          <div class="bar final"><span class="repeat-bar smufl" aria-label="Repeat 2 bars">&#xE501;</span></div>
+        </div>
+      </div>
+
+      <!-- Player controls strip — non-functional mock that mirrors iReal
+           Pro's bottom toolbar (style label, play, time, repeats, tempo,
+           key indicator). -->
+      <div class="player-controls" role="toolbar" aria-label="Playback controls">
+        <span class="pc-stat"><span class="label">Style</span><span class="value">Medium Swing</span></span>
+        <button class="play-btn" aria-label="Play">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><polygon points="6 4 20 12 6 20 6 4"/></svg>
+        </button>
+        <span class="pc-stat"><span class="label">Time</span><span class="value">00:00</span></span>
+        <span class="pc-stat"><span class="label">Repeats</span><span class="value">1</span></span>
+        <span class="pc-stat"><span class="label">Tempo</span><span class="value">124</span></span>
+        <span class="pc-stat"><span class="label">Key</span><span class="value" style="color: var(--crimson-300);">Em</span></span>
+      </div>
+    </section>
+  </div>
+
+  <aside class="inspector" aria-label="Selected bar inspector">
+    <header>
+      <span class="title">Bar 7</span>
+      <span class="pos">Section A · beat 1</span>
+    </header>
+    <div class="row">
+      <span class="label">Chord</span>
+      <input class="chord-input" type="text" value="Em7" aria-label="Chord symbol">
+    </div>
+    <div class="row">
+      <span class="label">Quality</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip">M</button>
+        <button class="chip">−</button>
+        <button class="chip">7</button>
+        <button class="chip" aria-pressed="true">−7</button>
+        <button class="chip">Δ7</button>
+        <button class="chip">ø7</button>
+        <button class="chip">°</button>
+        <button class="chip">+</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Bass</span>
+      <input class="chord-input" type="text" value="" placeholder="(none)" style="font-size: var(--fs-14); color: var(--text-secondary);">
+    </div>
+    <div class="row">
+      <span class="label">Alternate chord</span>
+      <input class="chord-input" type="text" value="" placeholder="(none)" style="font-size: var(--fs-14); color: var(--text-secondary);">
+    </div>
+    <div class="row">
+      <span class="label">Section</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip">A</button>
+        <button class="chip">B</button>
+        <button class="chip">C</button>
+        <button class="chip">D</button>
+        <button class="chip" title="Verse">V</button>
+        <button class="chip" aria-pressed="true">none</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Barline (left)</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip smufl" aria-pressed="true" title="Single">&#xE030;</button>
+        <button class="chip smufl" title="Double">&#xE031;</button>
+        <button class="chip smufl" title="Repeat start">&#xE040;</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Barline (right)</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip smufl" aria-pressed="true" title="Single">&#xE030;</button>
+        <button class="chip smufl" title="Double">&#xE031;</button>
+        <button class="chip smufl" title="Repeat end">&#xE041;</button>
+        <button class="chip smufl" title="Final">&#xE032;</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Ending</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip" aria-pressed="true">none</button>
+        <button class="chip">1.</button>
+        <button class="chip">2.</button>
+        <button class="chip">3.</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Symbol</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip" aria-pressed="true">none</button>
+        <button class="chip smufl" title="Segno">&#xE047;</button>
+        <button class="chip smufl" title="Coda">&#xE048;</button>
+        <button class="chip smufl" title="Fermata"><span class="scale-up">&#xE4C0;</span></button>
+        <button class="chip">D.C.</button>
+        <button class="chip">D.S.</button>
+        <button class="chip">Fine</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Bar content</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip">Chord</button>
+        <button class="chip">N.C.</button>
+        <button class="chip" title="Invisible root — moving bass over a held chord">Invisible root</button>
+        <button class="chip smufl" title="Repeat one bar">&#xE500;</button>
+        <button class="chip smufl" title="Repeat two bars">&#xE501;</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Spacer (after this bar)</span>
+      <div class="chips" role="radiogroup">
+        <button class="chip" aria-pressed="true">none</button>
+        <button class="chip" title="Vertical spacer × 1">×1</button>
+        <button class="chip" title="Vertical spacer × 2">×2</button>
+        <button class="chip" title="Vertical spacer × 3">×3</button>
+        <button class="chip" title="Mark this bar as the playback end">END</button>
+      </div>
+    </div>
+    <div class="row">
+      <span class="label">Text label</span>
+      <input class="chord-input" type="text" value="" placeholder="(no text — e.g. Repeat 4×, to Bridge)" style="font-size: var(--fs-14); color: var(--text-secondary);">
+    </div>
+    <div class="footer">
+      <button class="btn btn-secondary btn-sm" style="flex: 1;">Duplicate</button>
+      <button class="btn btn-ghost btn-sm" style="color: var(--danger-fg);">Delete</button>
+    </div>
+  </aside>
+</main>
+
+<footer class="status" role="status" aria-live="polite">
+  <span class="item"><span class="ok">●</span>Parsed · 0 warnings</span>
+  <span class="item">3 sections · 24 bars</span>
+  <span class="item">Key Em · 4/4 · 124 BPM</span>
+  <span class="spacer"></span>
+  <span class="item">Bar 7 selected</span>
+  <span class="item">irealb://</span>
+</footer>
+
+</body>
+</html>

--- a/ui_kits/web/editor-irealb.html
+++ b/ui_kits/web/editor-irealb.html
@@ -595,9 +595,9 @@ a { color: inherit; text-decoration: none; }
 <div class="toolbar" role="toolbar" aria-label="Editor tools">
   <div class="tool-group">
     <span class="label">Format</span>
-    <div class="segmented" role="tablist">
-      <a href="editor.html" aria-pressed="false">ChordPro</a>
-      <a href="editor-irealb.html" aria-pressed="true">iReal Pro</a>
+    <div class="segmented" role="group" aria-label="Format">
+      <a href="editor.html">ChordPro</a>
+      <a href="editor-irealb.html" aria-current="page">iReal Pro</a>
     </div>
   </div>
   <div class="tool-group">
@@ -608,14 +608,14 @@ a { color: inherit; text-decoration: none; }
   </div>
   <div class="tool-group">
     <span class="label">Width</span>
-    <div class="segmented" role="tablist" aria-label="Chord width">
+    <div class="segmented" role="group" aria-label="Chord width">
       <button aria-pressed="true" title="Normal width">N</button>
       <button aria-pressed="false" title="Small width — compresses chord glyphs horizontally so several chords fit in a tight bar">S</button>
     </div>
   </div>
   <div class="tool-group">
     <span class="label">Chord</span>
-    <div class="segmented" role="tablist" aria-label="Chord input target">
+    <div class="segmented" role="group" aria-label="Chord input target">
       <button aria-pressed="true">Regular</button>
       <button aria-pressed="false" title="Small alternate chord rendered above the primary chord">Alternate</button>
     </div>
@@ -942,7 +942,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Quality</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip">M</button>
         <button class="chip">−</button>
         <button class="chip">7</button>
@@ -963,7 +963,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Section</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip">A</button>
         <button class="chip">B</button>
         <button class="chip">C</button>
@@ -974,7 +974,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Barline (left)</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip smufl" aria-pressed="true" title="Single">&#xE030;</button>
         <button class="chip smufl" title="Double">&#xE031;</button>
         <button class="chip smufl" title="Repeat start">&#xE040;</button>
@@ -982,7 +982,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Barline (right)</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip smufl" aria-pressed="true" title="Single">&#xE030;</button>
         <button class="chip smufl" title="Double">&#xE031;</button>
         <button class="chip smufl" title="Repeat end">&#xE041;</button>
@@ -991,7 +991,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Ending</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip" aria-pressed="true">none</button>
         <button class="chip">1.</button>
         <button class="chip">2.</button>
@@ -1000,7 +1000,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Symbol</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip" aria-pressed="true">none</button>
         <button class="chip smufl" title="Segno">&#xE047;</button>
         <button class="chip smufl" title="Coda">&#xE048;</button>
@@ -1012,7 +1012,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Bar content</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip">Chord</button>
         <button class="chip">N.C.</button>
         <button class="chip" title="Invisible root — moving bass over a held chord">Invisible root</button>
@@ -1022,7 +1022,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <div class="row">
       <span class="label">Spacer (after this bar)</span>
-      <div class="chips" role="radiogroup">
+      <div class="chips" role="group">
         <button class="chip" aria-pressed="true">none</button>
         <button class="chip" title="Vertical spacer × 1">×1</button>
         <button class="chip" title="Vertical spacer × 2">×2</button>

--- a/ui_kits/web/editor-irealb.html
+++ b/ui_kits/web/editor-irealb.html
@@ -11,8 +11,8 @@
 <style>
 @font-face {
   font-family: "Bravura Text";
-  src: url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura/redist/woff/BravuraText.woff2") format("woff2"),
-       url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura/redist/woff/BravuraText.woff") format("woff");
+  src: url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura@v1.392/redist/woff/BravuraText.woff2") format("woff2"),
+       url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura@v1.392/redist/woff/BravuraText.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: swap;

--- a/ui_kits/web/editor-irealb.html
+++ b/ui_kits/web/editor-irealb.html
@@ -9,10 +9,20 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&family=Noto+Sans+JP:wght@400;500;700;900&family=Roboto:wght@400;500;700;900&family=Source+Serif+4:ital,wght@0,400;0,700;0,900;1,400&display=swap">
 <link rel="stylesheet" href="../../tokens.css">
 <style>
+/* Static design-system mock — narrow exception to ADR-0014.
+   ADR-0014 rejects runtime Bravura loading for the production
+   `chordsketch-render-ireal` crate (offline rendering, CDN-failure-as-
+   render-failure). This file is a static reference mock, not a render
+   function: it can require network at view time and is acceptable
+   to break when offline. The URL is pinned to bravura-1.392 so the
+   asset cannot silently change under us. Do NOT copy this @font-face
+   pattern into `@chordsketch/ui-web`, the desktop app, or any
+   production rendering surface — those targets must follow ADR-0014's
+   inline-SVG-paths approach. */
 @font-face {
   font-family: "Bravura Text";
-  src: url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura@v1.392/redist/woff/BravuraText.woff2") format("woff2"),
-       url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura@v1.392/redist/woff/BravuraText.woff") format("woff");
+  src: url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura@bravura-1.392/redist/woff/BravuraText.woff2") format("woff2"),
+       url("https://cdn.jsdelivr.net/gh/steinbergmedia/bravura@bravura-1.392/redist/woff/BravuraText.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -62,7 +72,7 @@ a { color: inherit; text-decoration: none; }
 .segmented { display: inline-flex; border: 1px solid var(--border-strong); border-radius: var(--r-2); overflow: hidden; }
 .segmented a, .segmented button { background: var(--surface); border: 0; padding: 0 var(--sp-3); height: 28px; font: 500 var(--fs-13)/1 var(--font-jp); color: var(--text-secondary); cursor: pointer; border-right: 1px solid var(--border); display: inline-flex; align-items: center; text-decoration: none; }
 .segmented a:last-child, .segmented button:last-child { border-right: 0; }
-.segmented [aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); }
+.segmented [aria-pressed="true"], .segmented [aria-current="page"] { background: var(--ink-1000); color: var(--ink-0); }
 
 /* ---------- Page ---------- */
 .page { flex: 1; max-width: var(--maxw-app); width: 100%; margin: 0 auto; padding: var(--sp-8) var(--sp-6); display: grid; grid-template-columns: 1fr 320px; gap: var(--sp-8); align-items: start; }
@@ -89,7 +99,7 @@ a { color: inherit; text-decoration: none; }
    ============================================================ */
 .chart { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-10) var(--sp-12); color: var(--ink-1000); }
 
-.chart-header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: baseline; gap: var(--sp-4); padding-bottom: var(--sp-6); margin-bottom: var(--sp-6); border-bottom: 1px solid var(--border); font-family: "Source Serif 4", Georgia, "Times New Roman", serif; color: var(--ink-1000); }
+.chart-header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: baseline; gap: var(--sp-4); padding-bottom: var(--sp-6); margin-bottom: var(--sp-6); border-bottom: 1px solid var(--border); font-family: var(--font-chart-serif); color: var(--ink-1000); }
 .chart-header .style { font-style: italic; font-size: var(--fs-14); }
 .chart-header .title { font-weight: 700; font-size: var(--fs-18); text-align: center; }
 .chart-header .type { text-align: right; font-size: var(--fs-14); }
@@ -103,9 +113,9 @@ a { color: inherit; text-decoration: none; }
 
 /* 4 bars per line in equal-width columns. iReal Pro's printed layouts
    alternate between equal and content-driven widths depending on the
-   chart, but the equal-grid look is closer to the engraved feel of the
-   iReal Pro "Even 8ths 3" / "Rock 3" printed exports, and avoids flex
-   auto-width reflowing the chart awkwardly when content density differs. */
+   chart; the equal-grid look reads as more "engraved" and avoids flex
+   auto-width reflowing the chart awkwardly when content density differs
+   between bars. */
 .chart-line { display: grid; grid-template-columns: repeat(4, 1fr); align-items: stretch; }
 /* Coda destination — same column geometry as the main chart so the bars
    line up vertically with the form above; only an extra margin separates
@@ -218,7 +228,7 @@ a { color: inherit; text-decoration: none; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: "Roboto", system-ui, sans-serif;
+  font-family: var(--font-chord);
   font-weight: 900;
   font-size: var(--fs-15);
   z-index: 3;
@@ -238,7 +248,7 @@ a { color: inherit; text-decoration: none; }
      glyphs. Bravura's timeSig digits sit close to the baseline by
      design, which makes a stacked time signature look bottom-heavy
      in plain CSS line-boxes; standard text digits center naturally. */
-  font-family: "Roboto", system-ui, sans-serif;
+  font-family: var(--font-chord);
   font-size: 18px;
   font-weight: 700;
   line-height: 1;
@@ -260,7 +270,7 @@ a { color: inherit; text-decoration: none; }
   position: absolute;
   left: var(--sp-5);
   bottom: -22px;
-  font-family: "Source Serif 4", Georgia, serif;
+  font-family: var(--font-chart-serif);
   font-style: italic;
   font-size: var(--fs-13);
   color: var(--ink-1000);
@@ -307,7 +317,7 @@ a { color: inherit; text-decoration: none; }
   border-left: 1.5px solid var(--ink-1000);
   box-sizing: border-box;
   padding: 2px 0 0 5px;
-  font-family: "Roboto", system-ui, sans-serif;
+  font-family: var(--font-chord);
   font-weight: 700;
   font-size: 14px;
   color: var(--ink-1000);
@@ -338,7 +348,7 @@ a { color: inherit; text-decoration: none; }
      fighting a music-font weight mismatch. Accidentals (♯ ♭) still
      come from Bravura since Roboto lacks proper music sharp / flat
      shapes. */
-  font-family: "Roboto", system-ui, -apple-system, sans-serif;
+  font-family: var(--font-chord);
   font-weight: 500;
   letter-spacing: -0.01em;
   color: var(--ink-1000);
@@ -393,7 +403,7 @@ a { color: inherit; text-decoration: none; }
 
 /* No-Chord bar: literal "N.C." rendered in the chord typeface so it sits
    on the same baseline as a regular chord. */
-.chord.nc { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: 22px; letter-spacing: 0.02em; }
+.chord.nc { font-family: var(--font-chord); font-weight: 700; font-size: 22px; letter-spacing: 0.02em; }
 
 /* Invisible-root: the chord root is intentionally not rendered (the
    chord is held; only the bass moves). Visually this is a slash chord
@@ -402,7 +412,7 @@ a { color: inherit; text-decoration: none; }
    glyph, not a chart rendering. */
 .chord.invisible-root { display: inline-flex; flex-direction: column; align-items: center; line-height: 1; gap: 0; }
 .chord.invisible-root .bass {
-  font-family: "Roboto", system-ui, sans-serif;
+  font-family: var(--font-chord);
   font-weight: 700;
   font-size: 22px;
   border-top: 1.5px solid var(--ink-1000);
@@ -433,7 +443,7 @@ a { color: inherit; text-decoration: none; }
    the bar. */
 .chord-stack { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 1px; }
 .chord-stack .alt {
-  font-family: "Roboto", system-ui, sans-serif;
+  font-family: var(--font-chord);
   font-weight: 700;
   font-size: 13px;
   color: var(--text-secondary);
@@ -469,7 +479,7 @@ a { color: inherit; text-decoration: none; }
   right: 0;
   bottom: -2px;
   transform: translate(50%, 100%);
-  font-family: "Roboto", system-ui, sans-serif;
+  font-family: var(--font-chord);
   font-weight: 700;
   font-size: 11px;
   letter-spacing: 0.08em;
@@ -538,10 +548,10 @@ a { color: inherit; text-decoration: none; }
 .inspector header .pos { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); }
 .inspector .row { display: flex; flex-direction: column; gap: var(--sp-2); margin-bottom: var(--sp-4); }
 .inspector .row > .label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); }
-.inspector input.chord-input { width: 100%; height: 36px; padding: 0 var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-2); font: 500 var(--fs-18)/1 "Roboto", system-ui, sans-serif; color: var(--ink-1000); background: var(--ink-50); }
+.inspector input.chord-input { width: 100%; height: 36px; padding: 0 var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-2); font: 500 var(--fs-18)/1 var(--font-chord); color: var(--ink-1000); background: var(--ink-50); }
 .inspector input.chord-input:focus { outline: none; border-color: var(--crimson-500); background: var(--surface); box-shadow: var(--focus-ring); }
 .inspector .chips { display: flex; flex-wrap: wrap; gap: var(--sp-1); }
-.inspector .chip { display: inline-flex; align-items: center; padding: var(--sp-1) var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-full); background: var(--surface); font: 500 var(--fs-13)/1 "Roboto", system-ui, sans-serif; color: var(--text-secondary); cursor: pointer; min-height: 28px; }
+.inspector .chip { display: inline-flex; align-items: center; padding: var(--sp-1) var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-full); background: var(--surface); font: 500 var(--fs-13)/1 var(--font-chord); color: var(--text-secondary); cursor: pointer; min-height: 28px; }
 /* SMuFL music-symbol chips render their glyph larger than the regular
    text-chip font-size, since Bravura draws the visible ink at a small
    fraction of the rendered em-square. */
@@ -572,7 +582,7 @@ a { color: inherit; text-decoration: none; }
 <body>
 
 <header class="topnav">
-  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+  <a class="brand" href="../../design-system.html">
     <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
     ChordSketch
   </a>

--- a/ui_kits/web/editor-irealb.html
+++ b/ui_kits/web/editor-irealb.html
@@ -104,8 +104,8 @@ a { color: inherit; text-decoration: none; }
 /* 4 bars per line in equal-width columns. iReal Pro's printed layouts
    alternate between equal and content-driven widths depending on the
    chart, but the equal-grid look is closer to the engraved feel of the
-   Even 8ths 3 / Rock 3 PDFs in /tmp/, and avoids flex auto-width
-   reflowing the chart awkwardly when content density differs. */
+   iReal Pro "Even 8ths 3" / "Rock 3" printed exports, and avoids flex
+   auto-width reflowing the chart awkwardly when content density differs. */
 .chart-line { display: grid; grid-template-columns: repeat(4, 1fr); align-items: stretch; }
 /* Coda destination — same column geometry as the main chart so the bars
    line up vertically with the form above; only an extra margin separates
@@ -205,7 +205,7 @@ a { color: inherit; text-decoration: none; }
 
 /* Section marker — small black-filled square with white letter, anchored at
    the top-left of the first bar of a section. Matches iReal Pro's printed
-   chart convention (see /tmp/Even 8ths 3.pdf, /tmp/Rock 3.pdf). */
+   chart convention for section labels. */
 .bar .section-marker {
   position: absolute;
   left: -20px;
@@ -324,10 +324,9 @@ a { color: inherit; text-decoration: none; }
    superscript next to the root. Quality (m, 7, ø7, Δ7, m7♭5) — small
    subscript that hangs slightly below the baseline. Multiple
    sub-quality lines stack vertically (e.g. "7♯9" over "♯5").
-   Matches iReal Pro's chart engraving in /tmp/Even 8ths 3.pdf and
-   /tmp/Rock 3.pdf. Implemented with inline-block + vertical-align so
-   the typography flows like text (the PDFs are typeset, not laid out
-   with flexbox). */
+   Matches iReal Pro's chart engraving style. Implemented with
+   inline-block + vertical-align so the typography flows like text
+   (iReal Pro PDFs are typeset, not laid out with flexbox). */
 .chord {
   display: inline-block;
   white-space: nowrap;

--- a/ui_kits/web/editor.html
+++ b/ui_kits/web/editor.html
@@ -135,7 +135,7 @@ a { color: inherit; }
   </div>
 </div>
 
-<div class="editor">
+<main class="editor">
   <section class="pane source">
     <header class="pane-head">
       <p class="eyebrow">Source · ChordPro</p>
@@ -164,7 +164,7 @@ a { color: inherit; }
       <div class="line"><span class="pair"><span class="chord">Em7</span><span class="lyric">To the place </span></span><span class="pair"><span class="chord">C7♭9</span><span class="lyric">I belong, </span></span><span class="pair"><span class="chord">G/D</span><span class="lyric">West Virginia</span></span></div>
     </div>
   </section>
-</div>
+</main>
 
 <footer class="status" role="status" aria-live="polite">
   <span class="item"><span class="ok">●</span>Parsed · 0 warnings</span>

--- a/ui_kits/web/editor.html
+++ b/ui_kits/web/editor.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Editor — ChordSketch</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&family=Noto+Sans+JP:wght@400;500;700;900&family=Roboto:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../../tokens.css">
+<style>
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; display: flex; flex-direction: column; min-height: 100vh; }
+a { color: inherit; }
+
+.topnav { height: 56px; background: var(--surface); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 var(--sp-6); gap: var(--sp-4); }
+.topnav .brand { display: flex; align-items: center; gap: var(--sp-3); font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-16); letter-spacing: -0.01em; text-decoration: none; }
+.topnav .brand .mark { width: 24px; height: 24px; border-radius: var(--r-1); display: block; }
+.topnav .crumbs { display: flex; align-items: center; gap: var(--sp-3); margin-left: var(--sp-6); font-size: var(--fs-14); color: var(--text-secondary); }
+.topnav .crumbs a { text-decoration: none; }
+.topnav .crumbs .sep { color: var(--text-tertiary); }
+.topnav .crumbs .current { color: var(--text-primary); font-weight: 500; }
+.topnav .save-state { display: inline-flex; align-items: center; gap: var(--sp-2); font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-13); color: var(--text-secondary); margin-left: var(--sp-3); }
+.topnav .save-state.saved { color: var(--success-fg); }
+.topnav .save-state.unsaved { color: var(--warning-fg); }
+.topnav .save-state .dot { width: 6px; height: 6px; border-radius: var(--r-full); background: currentColor; }
+.topnav .actions { margin-left: auto; display: flex; align-items: center; gap: var(--sp-2); }
+
+.btn { display: inline-flex; align-items: center; gap: var(--sp-2); height: 36px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid transparent; font: 500 var(--fs-14)/1 var(--font-jp); cursor: pointer; transition: background var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out); text-decoration: none; }
+.btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.btn-primary { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.btn-primary:hover { background: var(--crimson-600); }
+.btn-secondary { background: var(--surface); color: var(--text-primary); border-color: var(--border-strong); }
+.btn-secondary:hover { background: var(--ink-100); }
+.btn-ghost { background: transparent; color: var(--text-secondary); }
+.btn-ghost:hover { background: var(--ink-100); color: var(--text-primary); }
+.btn-icon { padding: 0; width: 36px; justify-content: center; }
+.btn-sm { height: 28px; padding: 0 var(--sp-3); font-size: var(--fs-13); }
+
+.toolbar { display: flex; align-items: center; gap: var(--sp-2); padding: var(--sp-2) var(--sp-6); background: var(--surface); border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+.tool-group { display: flex; align-items: center; gap: var(--sp-1); padding: 0 var(--sp-3); border-right: 1px solid var(--border); height: 28px; }
+.tool-group:last-of-type { border-right: 0; }
+.tool-group .label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); margin-right: var(--sp-2); }
+.segmented { display: inline-flex; border: 1px solid var(--border-strong); border-radius: var(--r-2); overflow: hidden; }
+.segmented a, .segmented button { background: var(--surface); border: 0; padding: 0 var(--sp-3); height: 28px; font: 500 var(--fs-13)/1 var(--font-jp); color: var(--text-secondary); cursor: pointer; border-right: 1px solid var(--border); display: inline-flex; align-items: center; text-decoration: none; }
+.segmented a:last-child, .segmented button:last-child { border-right: 0; }
+.segmented [aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); }
+
+.editor { flex: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 0; }
+@media (max-width: 900px) { .editor { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; } .source { border-right: 0 !important; border-bottom: 1px solid var(--border); } }
+
+.pane { display: flex; flex-direction: column; min-height: 0; }
+.pane-head { display: flex; align-items: center; justify-content: space-between; padding: var(--sp-3) var(--sp-6); background: var(--canvas); border-bottom: 1px solid var(--border); }
+.pane-head .eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0; }
+.pane-head .meta { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); }
+.source { background: var(--surface); border-right: 1px solid var(--border); }
+.preview { background: var(--surface); }
+.pane-body { flex: 1; overflow: auto; padding: var(--sp-8); }
+
+.source-code { font-family: var(--font-mono); font-size: var(--fs-14); line-height: 1.857; color: var(--text-primary); white-space: pre; counter-reset: line; padding: 0; }
+.source-code .row { display: grid; grid-template-columns: 36px 1fr; gap: var(--sp-4); }
+.source-code .row::before { content: counter(line); counter-increment: line; font-family: var(--font-mono); font-size: var(--fs-13); color: var(--text-tertiary); text-align: right; user-select: none; padding-right: var(--sp-2); border-right: 1px solid var(--border); }
+.tok-directive { color: var(--text-secondary); }
+.tok-key { color: var(--info-fg); }
+.tok-chord { color: var(--crimson-500); font-weight: 600; }
+.tok-bracket { color: var(--text-tertiary); }
+.tok-comment { color: var(--text-tertiary); font-style: italic; }
+.tok-section { color: var(--ink-700); font-weight: 600; }
+
+.section-label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); border-top: 1px solid var(--border); padding-top: var(--sp-3); margin: var(--sp-6) 0 var(--sp-4); }
+.section-label:first-child { margin-top: 0; border-top: 0; padding-top: 0; }
+.line { font-size: 0; margin-bottom: var(--sp-3); }
+.pair { display: inline-flex; flex-direction: column; align-items: flex-start; vertical-align: bottom; }
+.pair .chord { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
+.pair .lyric { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-18); line-height: 1.5; white-space: pre; }
+.preview h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-30); line-height: 1.2; letter-spacing: -0.02em; margin: 0 0 var(--sp-2); }
+.preview .pane-body > .meta { font-family: var(--font-mono); font-size: var(--fs-13); color: var(--text-secondary); margin: 0 0 var(--sp-6); }
+
+.status { display: flex; align-items: center; padding: var(--sp-2) var(--sp-6); background: var(--surface); border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); gap: var(--sp-6); }
+.status .item { display: inline-flex; align-items: center; gap: var(--sp-2); }
+.status .spacer { flex: 1; }
+.status .ok { color: var(--success-fg); }
+</style>
+</head>
+<body>
+
+<header class="topnav">
+  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+    <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
+    ChordSketch
+  </a>
+  <div class="crumbs">
+    <a href="library.html">Library</a>
+    <span class="sep">›</span>
+    <span class="current">Country Roads</span>
+  </div>
+  <span class="save-state saved" aria-live="polite"><span class="dot"></span>Saved · 14:32</span>
+  <div class="actions">
+    <button class="btn btn-ghost btn-sm">⌘K · Commands</button>
+    <button class="btn btn-ghost btn-icon" aria-label="Undo"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-15-6.7L3 13"/></svg></button>
+    <button class="btn btn-ghost btn-icon" aria-label="Redo"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 15-6.7L21 13"/></svg></button>
+    <a href="viewer.html" class="btn btn-secondary">Preview</a>
+    <button class="btn btn-primary">Save</button>
+  </div>
+</header>
+
+<div class="toolbar" role="toolbar" aria-label="Editor tools">
+  <div class="tool-group">
+    <span class="label">Format</span>
+    <div class="segmented" role="tablist">
+      <a href="editor.html" aria-pressed="true">ChordPro</a>
+      <a href="editor-irealb.html" aria-pressed="false">iReal Pro</a>
+    </div>
+  </div>
+  <div class="tool-group">
+    <span class="label">Transpose</span>
+    <button class="btn btn-secondary btn-sm" aria-label="Transpose down">−</button>
+    <span style="font-family: var(--font-mono); font-size: var(--fs-13); padding: 0 var(--sp-2); min-width: 28px; text-align: center;">+0</span>
+    <button class="btn btn-secondary btn-sm" aria-label="Transpose up">+</button>
+  </div>
+  <div class="tool-group">
+    <span class="label">View</span>
+    <div class="segmented" role="tablist">
+      <button aria-pressed="true">Split</button>
+      <button>Source</button>
+      <button>Preview</button>
+    </div>
+  </div>
+  <div class="tool-group">
+    <span class="label">Insert</span>
+    <button class="btn btn-ghost btn-sm">[Chord]</button>
+    <button class="btn btn-ghost btn-sm">{directive}</button>
+    <button class="btn btn-ghost btn-sm">Section</button>
+  </div>
+</div>
+
+<div class="editor">
+  <section class="pane source">
+    <header class="pane-head">
+      <p class="eyebrow">Source · ChordPro</p>
+      <span class="meta">UTF-8 · LF · 14 lines</span>
+    </header>
+    <div class="pane-body">
+<pre class="source-code"><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">title</span><span class="tok-bracket">: </span>Country Roads<span class="tok-bracket">}</span></span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">artist</span><span class="tok-bracket">: </span>John Denver<span class="tok-bracket">}</span></span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">key</span><span class="tok-bracket">: </span><span class="tok-key">G</span><span class="tok-bracket">}</span></span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">capo</span><span class="tok-bracket">: </span>0<span class="tok-bracket">}</span></span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">tempo</span><span class="tok-bracket">: </span>82<span class="tok-bracket">}</span></span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">time</span><span class="tok-bracket">: </span>4/4<span class="tok-bracket">}</span></span></span><span class="row"><span> </span></span><span class="row"><span><span class="tok-comment"># Verse 1</span></span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">start_of_verse</span><span class="tok-bracket">}</span></span></span><span class="row"><span><span class="tok-bracket">[</span><span class="tok-chord">G</span><span class="tok-bracket">]</span>Almost heaven, <span class="tok-bracket">[</span><span class="tok-chord">Em</span><span class="tok-bracket">]</span>West Virginia</span></span><span class="row"><span><span class="tok-bracket">[</span><span class="tok-chord">D</span><span class="tok-bracket">]</span>Blue Ridge Mountains, <span class="tok-bracket">[</span><span class="tok-chord">C</span><span class="tok-bracket">]</span>Shenandoah <span class="tok-bracket">[</span><span class="tok-chord">G</span><span class="tok-bracket">]</span>River</span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">end_of_verse</span><span class="tok-bracket">}</span></span></span><span class="row"><span> </span></span><span class="row"><span><span class="tok-bracket">{</span><span class="tok-directive">start_of_chorus</span><span class="tok-bracket">}</span></span></span></pre>
+    </div>
+  </section>
+
+  <section class="pane preview">
+    <header class="pane-head">
+      <p class="eyebrow">Preview · HTML</p>
+      <span class="meta">Live · Key G</span>
+    </header>
+    <div class="pane-body">
+      <h1>Country Roads</h1>
+      <p class="meta">John Denver · Key G · Capo 0 · BPM 82 · 4/4</p>
+
+      <p class="section-label">Verse 1</p>
+      <div class="line"><span class="pair"><span class="chord">Gmaj7</span><span class="lyric">Almost heaven, </span></span><span class="pair"><span class="chord">Em7</span><span class="lyric">West Virginia</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">D7sus4</span><span class="lyric">Blue Ridge Mountains, </span></span><span class="pair"><span class="chord">Cmaj7</span><span class="lyric">Shenandoah </span></span><span class="pair"><span class="chord">G/B</span><span class="lyric">River</span></span></div>
+
+      <p class="section-label">Chorus</p>
+      <div class="line"><span class="pair"><span class="chord">G</span><span class="lyric">Country roads, </span></span><span class="pair"><span class="chord">D/F#</span><span class="lyric">take me home</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">Em7</span><span class="lyric">To the place </span></span><span class="pair"><span class="chord">C7♭9</span><span class="lyric">I belong, </span></span><span class="pair"><span class="chord">G/D</span><span class="lyric">West Virginia</span></span></div>
+    </div>
+  </section>
+</div>
+
+<footer class="status" role="status" aria-live="polite">
+  <span class="item"><span class="ok">●</span>Parsed · 0 warnings</span>
+  <span class="item">14 lines · 287 chars</span>
+  <span class="item">5 chords · 2 sections</span>
+  <span class="spacer"></span>
+  <span class="item">Ln 11, Col 28</span>
+  <span class="item">UTF-8</span>
+  <span class="item">ChordPro</span>
+</footer>
+
+</body>
+</html>

--- a/ui_kits/web/editor.html
+++ b/ui_kits/web/editor.html
@@ -45,7 +45,7 @@ a { color: inherit; }
 .segmented { display: inline-flex; border: 1px solid var(--border-strong); border-radius: var(--r-2); overflow: hidden; }
 .segmented a, .segmented button { background: var(--surface); border: 0; padding: 0 var(--sp-3); height: 28px; font: 500 var(--fs-13)/1 var(--font-jp); color: var(--text-secondary); cursor: pointer; border-right: 1px solid var(--border); display: inline-flex; align-items: center; text-decoration: none; }
 .segmented a:last-child, .segmented button:last-child { border-right: 0; }
-.segmented [aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); }
+.segmented [aria-pressed="true"], .segmented [aria-current="page"] { background: var(--ink-1000); color: var(--ink-0); }
 
 .editor { flex: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 0; }
 @media (max-width: 900px) { .editor { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; } .source { border-right: 0 !important; border-bottom: 1px solid var(--border); } }
@@ -72,7 +72,7 @@ a { color: inherit; }
 .section-label:first-child { margin-top: 0; border-top: 0; padding-top: 0; }
 .line { font-size: 0; margin-bottom: var(--sp-3); }
 .pair { display: inline-flex; flex-direction: column; align-items: flex-start; vertical-align: bottom; }
-.pair .chord { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
+.pair .chord { font-family: var(--font-chord); font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
 .pair .lyric { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-18); line-height: 1.5; white-space: pre; }
 .preview h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-30); line-height: 1.2; letter-spacing: -0.02em; margin: 0 0 var(--sp-2); }
 .preview .pane-body > .meta { font-family: var(--font-mono); font-size: var(--fs-13); color: var(--text-secondary); margin: 0 0 var(--sp-6); }
@@ -86,7 +86,7 @@ a { color: inherit; }
 <body>
 
 <header class="topnav">
-  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+  <a class="brand" href="../../design-system.html">
     <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
     ChordSketch
   </a>

--- a/ui_kits/web/editor.html
+++ b/ui_kits/web/editor.html
@@ -108,9 +108,9 @@ a { color: inherit; }
 <div class="toolbar" role="toolbar" aria-label="Editor tools">
   <div class="tool-group">
     <span class="label">Format</span>
-    <div class="segmented" role="tablist">
-      <a href="editor.html" aria-pressed="true">ChordPro</a>
-      <a href="editor-irealb.html" aria-pressed="false">iReal Pro</a>
+    <div class="segmented" role="group" aria-label="Format">
+      <a href="editor.html" aria-current="page">ChordPro</a>
+      <a href="editor-irealb.html">iReal Pro</a>
     </div>
   </div>
   <div class="tool-group">
@@ -121,7 +121,7 @@ a { color: inherit; }
   </div>
   <div class="tool-group">
     <span class="label">View</span>
-    <div class="segmented" role="tablist">
+    <div class="segmented" role="group" aria-label="View">
       <button aria-pressed="true">Split</button>
       <button>Source</button>
       <button>Preview</button>

--- a/ui_kits/web/library.html
+++ b/ui_kits/web/library.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Library — ChordSketch</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../../tokens.css">
+<style>
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+
+.topnav { height: 56px; background: var(--surface); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 var(--sp-6); position: sticky; top: 0; z-index: 10; gap: var(--sp-4); }
+.topnav .brand { display: flex; align-items: center; gap: var(--sp-3); font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-16); letter-spacing: -0.01em; text-decoration: none; }
+.topnav .brand .mark { width: 24px; height: 24px; border-radius: var(--r-1); display: block; }
+.topnav .nav-links { display: flex; gap: var(--sp-1); margin-left: var(--sp-6); }
+.topnav .nav-links a { font-family: var(--font-jp); font-size: var(--fs-14); padding: var(--sp-1) var(--sp-3); border-radius: var(--r-2); text-decoration: none; color: var(--text-secondary); }
+.topnav .nav-links a[aria-current="page"] { background: var(--ink-100); color: var(--text-primary); }
+.topnav .nav-links a:hover:not([aria-current="page"]) { color: var(--text-primary); }
+.topnav .search { margin-left: auto; flex: 0 1 360px; position: relative; }
+.topnav .search input { width: 100%; height: 36px; padding: 0 var(--sp-3) 0 36px; border: 1px solid var(--border); border-radius: var(--r-2); background: var(--ink-50); font: 400 var(--fs-14)/1 var(--font-jp); color: var(--text-primary); transition: border-color var(--dur-1) var(--ease-out), box-shadow var(--dur-1) var(--ease-out); }
+.topnav .search input:focus { outline: none; border-color: var(--crimson-500); box-shadow: var(--focus-ring); }
+.topnav .search svg { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--text-tertiary); }
+.topnav .actions { display: flex; align-items: center; gap: var(--sp-3); }
+
+.page { max-width: var(--maxw-app); margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.page-head { display: flex; align-items: end; justify-content: space-between; gap: var(--sp-6); margin-bottom: var(--sp-8); flex-wrap: wrap; }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-2); }
+.page-head h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0; }
+.page-head p { color: var(--text-secondary); margin: var(--sp-3) 0 0; font-size: var(--fs-14); }
+
+.btn { display: inline-flex; align-items: center; gap: var(--sp-2); height: 36px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid transparent; font: 500 var(--fs-14)/1 var(--font-jp); cursor: pointer; transition: background var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out); text-decoration: none; }
+.btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.btn-primary { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.btn-primary:hover { background: var(--crimson-600); }
+.btn-secondary { background: var(--surface); color: var(--text-primary); border-color: var(--border-strong); }
+.btn-secondary:hover { background: var(--ink-100); }
+.btn-ghost { background: transparent; color: var(--text-secondary); }
+.btn-ghost:hover { background: var(--ink-100); color: var(--text-primary); }
+
+.filters { display: flex; gap: var(--sp-3); flex-wrap: wrap; margin-bottom: var(--sp-8); }
+.filter { display: inline-flex; align-items: center; gap: var(--sp-2); height: 32px; padding: 0 var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-full); background: var(--surface); font: 500 var(--fs-13)/1 var(--font-jp); color: var(--text-secondary); cursor: pointer; }
+.filter[aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); border-color: var(--ink-1000); }
+.filter:hover:not([aria-pressed="true"]) { background: var(--ink-100); color: var(--text-primary); }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--sp-6); }
+.song-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5); transition: border-color var(--dur-2) var(--ease-out), transform var(--dur-2) var(--ease-out), box-shadow var(--dur-2) var(--ease-out); cursor: pointer; }
+.song-card:hover { border-color: var(--border-strong); transform: translateY(-1px); box-shadow: var(--e-1); }
+.song-card .artist { font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-13); color: var(--text-secondary); margin: 0 0 var(--sp-2); }
+.song-card h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-18); line-height: 1.4; letter-spacing: -0.01em; margin: 0 0 var(--sp-4); }
+.song-card .meta { display: flex; gap: var(--sp-3); flex-wrap: wrap; font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-secondary); margin-bottom: var(--sp-4); font-variant-numeric: tabular-nums; }
+.song-card .footer { display: flex; align-items: center; justify-content: space-between; padding-top: var(--sp-3); border-top: 1px solid var(--border); }
+.song-card .badges { display: flex; gap: var(--sp-2); }
+.badge { display: inline-flex; align-items: center; padding: 2px var(--sp-2); border-radius: var(--r-1); font-family: var(--font-mono); font-weight: 600; font-size: var(--fs-12); }
+.badge.key { background: var(--ink-1000); color: var(--ink-0); }
+.badge.key.crimson { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.badge.format { background: var(--ink-100); color: var(--text-strong); border: 1px solid var(--border); }
+.song-card time { font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-12); color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
+
+.avatars { display: inline-flex; }
+.avatars > * { width: 24px; height: 24px; border-radius: var(--r-full); border: 2px solid var(--surface); margin-left: -8px; background: var(--ink-200); display: flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: 10px; color: var(--text-secondary); }
+.avatars > *:first-child { margin-left: 0; }
+
+.pagination { margin-top: var(--sp-12); display: flex; justify-content: center; gap: var(--sp-2); }
+.pagination a, .pagination span { display: inline-flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; padding: 0 var(--sp-2); border-radius: var(--r-2); font: 500 var(--fs-13)/1 var(--font-latin); color: var(--text-secondary); text-decoration: none; font-variant-numeric: tabular-nums; }
+.pagination a:hover { background: var(--ink-100); color: var(--text-primary); }
+.pagination a[aria-current="page"] { background: var(--ink-1000); color: var(--ink-0); }
+</style>
+</head>
+<body>
+
+<header class="topnav">
+  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+    <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
+    ChordSketch
+  </a>
+  <nav class="nav-links">
+    <a href="library.html" aria-current="page">Library</a>
+    <a href="viewer.html">Viewer</a>
+    <a href="editor.html">Editor</a>
+    <a href="#">Setlists</a>
+  </nav>
+  <div class="search">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+    <input type="search" placeholder="Search songs, artists, keys …" aria-label="Search library">
+  </div>
+  <div class="actions">
+    <button class="btn btn-ghost" aria-label="Notifications"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 1 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg></button>
+    <span class="avatars" aria-hidden="true"><span style="background: var(--crimson-500); color: var(--fg-on-crimson);">SL</span></span>
+  </div>
+</header>
+
+<main class="page">
+  <header class="page-head">
+    <div>
+      <p class="eyebrow">Library</p>
+      <h1>All songs</h1>
+      <p>248 songs · 12 setlists</p>
+    </div>
+    <div style="display: flex; gap: var(--sp-3);">
+      <button class="btn btn-secondary"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12l7-7 7 7"/></svg>Import</button>
+      <button class="btn btn-primary"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>New</button>
+    </div>
+  </header>
+
+  <div class="filters" role="toolbar" aria-label="Filters">
+    <button class="filter" aria-pressed="true">All</button>
+    <button class="filter">ChordPro</button>
+    <button class="filter">iReal Pro</button>
+    <button class="filter">Drafts</button>
+    <button class="filter">Recently edited</button>
+    <button class="filter">With Capo</button>
+  </div>
+
+  <div class="grid">
+    <article class="song-card">
+      <p class="artist">John Denver</p>
+      <h3>Country Roads</h3>
+      <div class="meta"><span>Key G</span><span>BPM 82</span><span>Capo 0</span><span>4/4</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">ChordPro</span><span class="badge key crimson">G</span></div>
+        <time datetime="2026-05-08">2 hours ago</time>
+      </div>
+    </article>
+    <article class="song-card">
+      <p class="artist">Oasis</p>
+      <h3>Wonderwall</h3>
+      <div class="meta"><span>Key Em</span><span>BPM 87</span><span>Capo 0</span><span>4/4</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">ChordPro</span><span class="badge key">Em</span></div>
+        <time datetime="2026-05-07">1 day ago</time>
+      </div>
+    </article>
+    <article class="song-card">
+      <p class="artist">The Beatles</p>
+      <h3>Yesterday</h3>
+      <div class="meta"><span>Key F</span><span>BPM 96</span><span>Capo 0</span><span>4/4</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">ChordPro</span><span class="badge key">F</span></div>
+        <time datetime="2026-05-06">2 days ago</time>
+      </div>
+    </article>
+    <article class="song-card">
+      <p class="artist">The Beatles</p>
+      <h3>Let It Be</h3>
+      <div class="meta"><span>Key C</span><span>BPM 73</span><span>Capo 0</span><span>4/4</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">ChordPro</span><span class="badge key">C</span></div>
+        <time datetime="2026-05-04">4 days ago</time>
+      </div>
+    </article>
+    <article class="song-card">
+      <p class="artist">Bill Evans Trio</p>
+      <h3>Autumn Leaves</h3>
+      <div class="meta"><span>Key Em</span><span>BPM 124</span><span>Capo 0</span><span>4/4</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">iReal Pro</span><span class="badge key">Em</span></div>
+        <time datetime="2026-05-02">6 days ago</time>
+      </div>
+    </article>
+    <article class="song-card">
+      <p class="artist">Ben E. King</p>
+      <h3>Stand By Me</h3>
+      <div class="meta"><span>Key A</span><span>BPM 118</span><span>Capo 0</span><span>4/4</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">ChordPro</span><span class="badge key">A</span></div>
+        <time datetime="2026-04-30">8 days ago</time>
+      </div>
+    </article>
+    <article class="song-card">
+      <p class="artist">Leonard Cohen</p>
+      <h3>Hallelujah</h3>
+      <div class="meta"><span>Key C</span><span>BPM 72</span><span>Capo 0</span><span>6/8</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">ChordPro</span><span class="badge key">C</span></div>
+        <time datetime="2026-04-26">2 weeks ago</time>
+      </div>
+    </article>
+    <article class="song-card">
+      <p class="artist">Eagles</p>
+      <h3>Hotel California</h3>
+      <div class="meta"><span>Key Bm</span><span>BPM 75</span><span>Capo 7</span><span>4/4</span></div>
+      <div class="footer">
+        <div class="badges"><span class="badge format">iReal Pro</span><span class="badge key">Bm</span></div>
+        <time datetime="2026-04-22">2 weeks ago</time>
+      </div>
+    </article>
+  </div>
+
+  <nav class="pagination" aria-label="Pagination">
+    <a href="#" aria-label="Previous">←</a>
+    <a href="#" aria-current="page">1</a>
+    <a href="#">2</a>
+    <a href="#">3</a>
+    <span>…</span>
+    <a href="#">31</a>
+    <a href="#" aria-label="Next">→</a>
+  </nav>
+</main>
+
+</body>
+</html>

--- a/ui_kits/web/library.html
+++ b/ui_kits/web/library.html
@@ -62,7 +62,7 @@ a { color: inherit; }
 .song-card time { font-family: var(--font-latin); font-weight: 500; font-size: var(--fs-12); color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
 
 .avatars { display: inline-flex; }
-.avatars > * { width: 24px; height: 24px; border-radius: var(--r-full); border: 2px solid var(--surface); margin-left: -8px; background: var(--ink-200); display: flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: 10px; color: var(--text-secondary); }
+.avatars > * { width: 24px; height: 24px; border-radius: var(--r-full); border: 2px solid var(--surface); margin-left: -8px; background: var(--ink-200); display: flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-10); color: var(--text-secondary); }
 .avatars > *:first-child { margin-left: 0; }
 
 .pagination { margin-top: var(--sp-12); display: flex; justify-content: center; gap: var(--sp-2); }
@@ -74,7 +74,7 @@ a { color: inherit; }
 <body>
 
 <header class="topnav">
-  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+  <a class="brand" href="../../design-system.html">
     <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
     ChordSketch
   </a>

--- a/ui_kits/web/viewer.html
+++ b/ui_kits/web/viewer.html
@@ -63,7 +63,7 @@ a { color: inherit; }
 .section-label:first-child { margin-top: 0; border-top: 0; padding-top: 0; }
 .line { font-size: 0; margin-bottom: var(--sp-3); }
 .pair { display: inline-flex; flex-direction: column; align-items: flex-start; vertical-align: bottom; }
-.pair .chord { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
+.pair .chord { font-family: var(--font-chord); font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
 .pair .lyric { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-18); line-height: 1.5; white-space: pre; }
 
 .sidebar { position: sticky; top: 72px; }
@@ -78,14 +78,14 @@ a { color: inherit; }
 
 .contributors { display: flex; align-items: center; gap: var(--sp-3); }
 .avatars { display: inline-flex; }
-.avatars > * { width: 28px; height: 28px; border-radius: var(--r-full); border: 2px solid var(--surface); margin-left: -8px; background: var(--ink-200); display: flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: 11px; color: var(--text-secondary); }
+.avatars > * { width: 28px; height: 28px; border-radius: var(--r-full); border: 2px solid var(--surface); margin-left: -8px; background: var(--ink-200); display: flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-10); color: var(--text-secondary); }
 .avatars > *:first-child { margin-left: 0; }
 </style>
 </head>
 <body>
 
 <header class="topnav">
-  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+  <a class="brand" href="../../design-system.html">
     <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
     ChordSketch
   </a>

--- a/ui_kits/web/viewer.html
+++ b/ui_kits/web/viewer.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Viewer — ChordSketch</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&family=Noto+Sans+JP:wght@400;500;700;900&family=Roboto:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../../tokens.css">
+<style>
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+
+.topnav { height: 56px; background: var(--surface); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 var(--sp-6); position: sticky; top: 0; z-index: 10; gap: var(--sp-4); }
+.topnav .brand { display: flex; align-items: center; gap: var(--sp-3); font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-16); letter-spacing: -0.01em; text-decoration: none; }
+.topnav .brand .mark { width: 24px; height: 24px; border-radius: var(--r-1); display: block; }
+.topnav .crumbs { display: flex; align-items: center; gap: var(--sp-3); margin-left: var(--sp-6); font-size: var(--fs-14); color: var(--text-secondary); }
+.topnav .crumbs a { text-decoration: none; }
+.topnav .crumbs a:hover { color: var(--text-primary); }
+.topnav .crumbs .sep { color: var(--text-tertiary); }
+.topnav .crumbs .current { color: var(--text-primary); font-weight: 500; }
+.topnav .actions { margin-left: auto; display: flex; align-items: center; gap: var(--sp-2); }
+
+.btn { display: inline-flex; align-items: center; gap: var(--sp-2); height: 36px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid transparent; font: 500 var(--fs-14)/1 var(--font-jp); cursor: pointer; transition: background var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out); text-decoration: none; }
+.btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.btn-primary { background: var(--crimson-500); color: var(--fg-on-crimson); }
+.btn-primary:hover { background: var(--crimson-600); }
+.btn-secondary { background: var(--surface); color: var(--text-primary); border-color: var(--border-strong); }
+.btn-secondary:hover { background: var(--ink-100); }
+.btn-ghost { background: transparent; color: var(--text-secondary); }
+.btn-ghost:hover { background: var(--ink-100); color: var(--text-primary); }
+.btn-icon { padding: 0; width: 36px; justify-content: center; }
+.btn-sm { height: 28px; padding: 0 var(--sp-3); font-size: var(--fs-13); }
+
+.layout { display: grid; grid-template-columns: 1fr 280px; gap: var(--sp-12); max-width: var(--maxw-app); margin: 0 auto; padding: var(--sp-10) var(--sp-6); align-items: start; }
+@media (max-width: 960px) { .layout { grid-template-columns: 1fr; } .sidebar { order: 2; } }
+
+.song-head { margin-bottom: var(--sp-8); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-2); }
+.song-head h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-48); line-height: 1.1; letter-spacing: -0.02em; margin: 0 0 var(--sp-2); }
+.song-head .artist { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-18); color: var(--text-secondary); margin: 0; }
+.song-head .meta-row { display: flex; gap: var(--sp-3); flex-wrap: wrap; align-items: center; margin-top: var(--sp-6); padding-top: var(--sp-5); border-top: 1px solid var(--border); }
+.meta-pill { display: inline-flex; align-items: baseline; gap: var(--sp-2); padding: var(--sp-2) var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2); background: var(--surface); }
+.meta-pill .label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); }
+.meta-pill .value { font-family: var(--font-mono); font-weight: 600; font-size: var(--fs-14); color: var(--text-primary); font-variant-numeric: tabular-nums; }
+.meta-pill.crimson .value { color: var(--crimson-500); }
+
+.action-bar { display: flex; gap: var(--sp-2); flex-wrap: wrap; align-items: center; padding: var(--sp-3); margin-bottom: var(--sp-8); background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); position: sticky; top: 72px; z-index: 5; }
+.action-group { display: flex; align-items: center; gap: var(--sp-1); padding: 0 var(--sp-3); border-right: 1px solid var(--border); }
+.action-group:last-of-type { border-right: 0; }
+.action-group .label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-tertiary); margin-right: var(--sp-2); }
+.segmented { display: inline-flex; border: 1px solid var(--border-strong); border-radius: var(--r-2); overflow: hidden; }
+.segmented button { background: var(--surface); border: 0; padding: 0 var(--sp-3); height: 28px; font: 500 var(--fs-13)/1 var(--font-jp); color: var(--text-secondary); cursor: pointer; border-right: 1px solid var(--border); }
+.segmented button:last-child { border-right: 0; }
+.segmented button[aria-pressed="true"] { background: var(--ink-1000); color: var(--ink-0); }
+.spacer { flex: 1; }
+
+.chord-sheet-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-10) var(--sp-12); }
+.section-label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); border-top: 1px solid var(--border); padding-top: var(--sp-3); margin: var(--sp-8) 0 var(--sp-4); }
+.section-label:first-child { margin-top: 0; border-top: 0; padding-top: 0; }
+.line { font-size: 0; margin-bottom: var(--sp-3); }
+.pair { display: inline-flex; flex-direction: column; align-items: flex-start; vertical-align: bottom; }
+.pair .chord { font-family: "Roboto", system-ui, sans-serif; font-weight: 700; font-size: var(--fs-16); color: var(--crimson-500); line-height: 1.4; min-height: 1.4em; }
+.pair .lyric { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-18); line-height: 1.5; white-space: pre; }
+
+.sidebar { position: sticky; top: 72px; }
+.side-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-5); margin-bottom: var(--sp-4); }
+.side-card h3 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-secondary); margin: 0 0 var(--sp-3); }
+.side-card ul { list-style: none; padding: 0; margin: 0; }
+.side-card li { font-size: var(--fs-14); padding: var(--sp-2) 0; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; gap: var(--sp-2); }
+.side-card li:last-child { border-bottom: 0; }
+.side-card li a { text-decoration: none; }
+.side-card li a:hover { color: var(--crimson-600); }
+.side-card .muted { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--fs-12); }
+
+.contributors { display: flex; align-items: center; gap: var(--sp-3); }
+.avatars { display: inline-flex; }
+.avatars > * { width: 28px; height: 28px; border-radius: var(--r-full); border: 2px solid var(--surface); margin-left: -8px; background: var(--ink-200); display: flex; align-items: center; justify-content: center; font-family: var(--font-latin); font-weight: 600; font-size: 11px; color: var(--text-secondary); }
+.avatars > *:first-child { margin-left: 0; }
+</style>
+</head>
+<body>
+
+<header class="topnav">
+  <a class="brand" href="../../ChordSketch%20Design%20System.html">
+    <img class="mark" src="../../assets/logo.svg" alt="" width="24" height="24">
+    ChordSketch
+  </a>
+  <div class="crumbs">
+    <a href="library.html">Library</a>
+    <span class="sep">›</span>
+    <a href="#">Folk standards</a>
+    <span class="sep">›</span>
+    <span class="current">Country Roads</span>
+  </div>
+  <div class="actions">
+    <button class="btn btn-ghost btn-icon" aria-label="Print"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect width="12" height="8" x="6" y="14"/></svg></button>
+    <button class="btn btn-ghost btn-icon" aria-label="Share"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" x2="15.42" y1="13.51" y2="17.49"/><line x1="15.41" x2="8.59" y1="6.51" y2="10.49"/></svg></button>
+    <a class="btn btn-secondary" href="editor.html"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>Edit</a>
+  </div>
+</header>
+
+<main class="layout">
+  <article>
+    <header class="song-head">
+      <p class="eyebrow">John Denver · Folk Standards</p>
+      <h1>Country Roads</h1>
+      <p class="artist">Written by Bill Danoff, Taffy Nivert, John Denver · 1971</p>
+      <div class="meta-row">
+        <span class="meta-pill crimson"><span class="label">Key</span><span class="value">G</span></span>
+        <span class="meta-pill"><span class="label">Capo</span><span class="value">0</span></span>
+        <span class="meta-pill"><span class="label">BPM</span><span class="value">82</span></span>
+        <span class="meta-pill"><span class="label">Time</span><span class="value">4/4</span></span>
+        <span class="meta-pill"><span class="label">Format</span><span class="value">ChordPro</span></span>
+      </div>
+    </header>
+
+    <div class="action-bar" role="toolbar" aria-label="Viewer actions">
+      <div class="action-group">
+        <span class="label">Transpose</span>
+        <button class="btn btn-secondary btn-sm" aria-label="Transpose down">−</button>
+        <span style="font-family: var(--font-mono); font-size: var(--fs-13); padding: 0 var(--sp-2); min-width: 28px; text-align: center;">0</span>
+        <button class="btn btn-secondary btn-sm" aria-label="Transpose up">+</button>
+      </div>
+      <div class="action-group">
+        <span class="label">Capo</span>
+        <button class="btn btn-secondary btn-sm">0</button>
+      </div>
+      <div class="action-group">
+        <span class="label">Format</span>
+        <div class="segmented" role="tablist">
+          <button aria-pressed="true">ChordPro</button>
+          <button aria-pressed="false">iReal Pro</button>
+        </div>
+      </div>
+      <span class="spacer"></span>
+      <button class="btn btn-ghost btn-sm" title="Export as plain text">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="21" y1="6" x2="3" y2="6"/>
+          <line x1="21" y1="12" x2="3" y2="12"/>
+          <line x1="21" y1="18" x2="13" y2="18"/>
+        </svg>Text
+      </button>
+      <button class="btn btn-ghost btn-sm" title="Export as PDF">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+          <path d="M14 2v6h6"/>
+          <path d="M12 18v-6"/>
+          <path d="M9 15l3 3 3-3"/>
+        </svg>PDF
+      </button>
+    </div>
+
+    <section class="chord-sheet-card">
+      <p class="section-label">Verse 1</p>
+      <div class="line"><span class="pair"><span class="chord">G</span><span class="lyric">Almost heaven, </span></span><span class="pair"><span class="chord">Em</span><span class="lyric">West Virginia</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">D</span><span class="lyric">Blue Ridge Mountains, </span></span><span class="pair"><span class="chord">C</span><span class="lyric">Shenandoah </span></span><span class="pair"><span class="chord">G</span><span class="lyric">River</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">G</span><span class="lyric">Life is old there, </span></span><span class="pair"><span class="chord">Em</span><span class="lyric">older than the trees</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">D</span><span class="lyric">Younger than the mountains, </span></span><span class="pair"><span class="chord">C</span><span class="lyric">blowing like a </span></span><span class="pair"><span class="chord">G</span><span class="lyric">breeze</span></span></div>
+
+      <p class="section-label">Chorus</p>
+      <div class="line"><span class="pair"><span class="chord">G</span><span class="lyric">Country roads, </span></span><span class="pair"><span class="chord">D</span><span class="lyric">take me home</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">Em</span><span class="lyric">To the place </span></span><span class="pair"><span class="chord">C</span><span class="lyric">I belong, </span></span><span class="pair"><span class="chord">G</span><span class="lyric">West Virginia</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">D</span><span class="lyric">Mountain mama, </span></span><span class="pair"><span class="chord">C</span><span class="lyric">take me </span></span><span class="pair"><span class="chord">G</span><span class="lyric">home, country roads</span></span></div>
+
+      <p class="section-label">Verse 2</p>
+      <div class="line"><span class="pair"><span class="chord">G</span><span class="lyric">All my memories </span></span><span class="pair"><span class="chord">Em</span><span class="lyric">gather 'round her</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">D</span><span class="lyric">Miner's lady, </span></span><span class="pair"><span class="chord">C</span><span class="lyric">stranger to blue </span></span><span class="pair"><span class="chord">G</span><span class="lyric">water</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">G</span><span class="lyric">Dark and dusty, </span></span><span class="pair"><span class="chord">Em</span><span class="lyric">painted on the sky</span></span></div>
+      <div class="line"><span class="pair"><span class="chord">D</span><span class="lyric">Misty taste of moonshine, </span></span><span class="pair"><span class="chord">C</span><span class="lyric">teardrop in my </span></span><span class="pair"><span class="chord">G</span><span class="lyric">eye</span></span></div>
+    </section>
+  </article>
+
+  <aside class="sidebar">
+    <div class="side-card">
+      <h3>Sections</h3>
+      <ul>
+        <li><a href="#">Verse 1</a><span class="muted">L1–L4</span></li>
+        <li><a href="#">Chorus</a><span class="muted">L5–L7</span></li>
+        <li><a href="#">Verse 2</a><span class="muted">L8–L11</span></li>
+        <li><a href="#">Bridge</a><span class="muted">L12–L13</span></li>
+        <li><a href="#">Outro</a><span class="muted">L14</span></li>
+      </ul>
+    </div>
+    <div class="side-card">
+      <h3>Setlists</h3>
+      <ul>
+        <li><a href="#">Live · 2026-05-12</a><span class="muted">3 / 14</span></li>
+        <li><a href="#">Open mic · weekly</a><span class="muted">7 / 9</span></li>
+        <li><a href="#">Acoustic standards</a><span class="muted">12 / 24</span></li>
+      </ul>
+    </div>
+    <div class="side-card">
+      <h3>Contributors</h3>
+      <div class="contributors">
+        <span class="avatars" aria-hidden="true">
+          <span style="background: var(--crimson-500); color: var(--fg-on-crimson);">SL</span>
+          <span style="background: var(--ink-700); color: var(--ink-0);">MC</span>
+          <span style="background: var(--ink-300); color: var(--text-strong);">+3</span>
+        </span>
+        <span style="font-size: var(--fs-13); color: var(--text-secondary);">5 contributors</span>
+      </div>
+    </div>
+  </aside>
+</main>
+
+</body>
+</html>

--- a/ui_kits/web/viewer.html
+++ b/ui_kits/web/viewer.html
@@ -131,7 +131,7 @@ a { color: inherit; }
       </div>
       <div class="action-group">
         <span class="label">Format</span>
-        <div class="segmented" role="tablist">
+        <div class="segmented" role="group" aria-label="Format">
           <button aria-pressed="true">ChordPro</button>
           <button aria-pressed="false">iReal Pro</button>
         </div>


### PR DESCRIPTION
## Summary

Lands the initial ChordSketch design system as static HTML/CSS/Markdown
artefacts in the repo:

- `DESIGN.md` — design-system rationale and usage guide
- `tokens.css` — single source of truth for color, typography, space,
  radius, elevation, and motion
- `design-system.html` — design-system landing page
- `preview/` — 10 component preview pages (buttons, badges, cards,
  forms, modals, navigation, progress, tables, toasts, avatars) plus
  an index
- `ui_kits/web/` — four product-surface demos: editor, viewer,
  library, and iReal Pro chart editor (uses Bravura Text SMuFL
  glyphs at runtime via a documented carve-out from ADR-0014 — the
  carve-out applies to this static demo only and does NOT propagate
  into the production renderer)
- `.gitignore` — adds `tmp/` so local scratch / reference assets
  are not tracked
- `CLAUDE.md` — adds a discoverability paragraph pointing future
  contributors at the design-system reference

No new dependencies. Fonts (Inter, JetBrains Mono, Noto Sans JP,
Roboto, Source Serif 4) and Bravura Text load from Google Fonts and
jsdelivr at runtime. The Bravura URL is pinned to the
`bravura-1.392` tag.

## Why

Token decisions and component states drift quickly without a
versioned artefact to anchor them. Capturing the current system in
the repo lets future iterations diff against a known baseline and
gives the in-flight ui_kits feature follow-ups (#2439–#2447) a stable
foundation to build on.

## Test plan

- [ ] `python3 -m http.server` from repo root, open
      `design-system.html` and `preview/index.html` — every linked
      page loads without 404
- [ ] `ui_kits/web/editor-irealb.html`: chart line indents from edge,
      barlines align with chord baselines, fermata glyph is centred in
      its inspector chip and matches Segno/Coda chip widths
- [ ] `ui_kits/web/{editor,viewer,library}.html`: layouts render with
      tokens applied (no hardcoded colors / sizes)
- [ ] `grep -RP "[\xe3\x81-\x83][\x80-\xbf]{2}" DESIGN.md tokens.css preview ui_kits design-system.html` returns nothing (no Japanese strings, per `.claude/rules/english-only.md`)
- [ ] `grep -RPn '"Roboto"|"Source Serif 4"' preview ui_kits design-system.html` returns nothing — chart-surface fonts go through `var(--font-chord)` and `var(--font-chart-serif)`

## Out of scope

The bar-grid feature additions tracked under #2439–#2447 are
intentionally deferred to follow-up PRs that build on this
foundation.

Closes #2452