### PR TITLE
docs(ireal): cite official iReal Pro spec URLs

### DIFF
--- a/crates/ireal/ARCHITECTURE.md
+++ b/crates/ireal/ARCHITECTURE.md
@@ -8,22 +8,30 @@ of those tickets.
 
 ## Reference data model
 
-The open-protocol `irealbook://` URL form is publicly specified by
-iReal Pro in the [iReal Pro Custom Chord Chart Protocol][spec] and
-on the companion [developer docs page][devdocs]. The obfuscated
-`irealb://` export is not covered by that spec and remains a
-reverse-engineered format. For the *AST shape* — what fields a
-chart carries, how chords sit inside bars, how repeats and endings
-nest — the closest public artefact is the
-[`daumling/ireal-renderer`][1] JS project, which the AC for #2055
-explicitly nominates as the reference. We ported that data model
-and intentionally did **not** port the JS rendering code —
-rendering lives in `chordsketch-render-ireal` (#2058) and binds to
-the data model through this crate's public API.
+iReal Pro publishes the [Custom Chord Chart Protocol][spec] (the
+chord-chart token grammar) and a companion
+[developer docs page][devdocs] (overview of the `irealb://` and
+`irealbook://` URL prefixes used to embed charts). The chord-chart
+grammar this crate's parser accepts is a **subset of that spec
+extended with internal tokens** observed in real exports; the
+detailed delta from the spec, the obfuscated `irealb://` body
+encoding (`MUSIC_PREFIX` + `obfusc50`), and the legacy 6-field
+`irealbook://` layout are all documented in
+[`FORMAT.md`](FORMAT.md). None of those URL-encoding concerns
+affect the **AST shape** described in the rest of this document.
+
+For the AST shape itself — what fields a chart carries, how chords
+sit inside bars, how repeats and endings nest — the closest public
+artefact is the [`daumling/ireal-renderer`][daumling] JavaScript
+project, which the AC for #2055 explicitly nominates as the
+reference. We ported that data model and intentionally did **not**
+port the JS rendering code — rendering lives in
+`chordsketch-render-ireal` (#2058) and binds to the data model
+through this crate's public API.
 
 [spec]: https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol
 [devdocs]: https://www.irealpro.com/developer-docs
-[1]: https://github.com/daumling/ireal-renderer
+[daumling]: https://github.com/daumling/ireal-renderer
 
 ## Field-level rationale
 

--- a/crates/ireal/ARCHITECTURE.md
+++ b/crates/ireal/ARCHITECTURE.md
@@ -8,15 +8,21 @@ of those tickets.
 
 ## Reference data model
 
-The iReal Pro chart format has no published spec. The closest
-public artefact is the [`daumling/ireal-renderer`][1] JS project,
-which the AC for #2055 explicitly nominates as the reference. We
-ported the **data model** (what fields a chart carries, how chords
-sit inside bars, how repeats and endings nest) and intentionally
-did **not** port the JS rendering code — rendering lives in
-`chordsketch-render-ireal` (#2058) and binds to the data model
-through this crate's public API.
+The open-protocol `irealbook://` URL form is publicly specified by
+iReal Pro in the [iReal Pro Custom Chord Chart Protocol][spec] and
+on the companion [developer docs page][devdocs]. The obfuscated
+`irealb://` export is not covered by that spec and remains a
+reverse-engineered format. For the *AST shape* — what fields a
+chart carries, how chords sit inside bars, how repeats and endings
+nest — the closest public artefact is the
+[`daumling/ireal-renderer`][1] JS project, which the AC for #2055
+explicitly nominates as the reference. We ported that data model
+and intentionally did **not** port the JS rendering code —
+rendering lives in `chordsketch-render-ireal` (#2058) and binds to
+the data model through this crate's public API.
 
+[spec]: https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol
+[devdocs]: https://www.irealpro.com/developer-docs
 [1]: https://github.com/daumling/ireal-renderer
 
 ## Field-level rationale

--- a/crates/ireal/FORMAT.md
+++ b/crates/ireal/FORMAT.md
@@ -241,13 +241,19 @@ distinguishes:
 - `Y+` (Vertical spacer): no AST representation (visual hint
   only).
 - `f` (Fermata): the spec lists this alongside `S` (Segno) and
-  `Q` (Coda) as a rehearsal-mark / bar-attached symbol; the
-  parser falls through `f` to the chord-detection path and may
-  consume it as part of a chord-quality token rather than
-  recording it as a `MusicalSymbol`. Adding the AST variant and
-  parser branch is a separate concern and is not blocking; until
-  it lands, the spec's `f` token is a known gap relative to the
-  published grammar.
+  `Q` (Coda) as a rehearsal-mark / bar-attached symbol. The
+  parser has no `f` branch in the music-token loop: the
+  chord-detection path is gated on `A..=G | W` (so lowercase `f`
+  cannot start a chord), and `consume_chord_token`'s
+  quality-continuation allowlist does not include `f` (so a
+  trailing `f` after a chord root terminates the chord token
+  rather than being absorbed into it). With no rule matching, `f`
+  takes the same generic "drop one char" fall-through as
+  unrecognised punctuation — the path noted at the bottom of the
+  chord-chart token grammar table above. Adding a `MusicalSymbol`
+  variant and the matching parser branch is a separate concern
+  and is not blocking; until it lands, the spec's `f` token is a
+  known gap relative to the published grammar.
 - `*X*` closing-`*` sentinel: each `*X` greedily becomes a
   section marker, so `*m*X` parses as **two** sections (`m`
   followed by `X`). This mirrors pianosnake's behaviour — the

--- a/crates/ireal/FORMAT.md
+++ b/crates/ireal/FORMAT.md
@@ -1,16 +1,38 @@
-# `irealb://` URL format
+# `irealb://` and `irealbook://` URL formats
 
-Notes on the iReal Pro export URL formats. The open-protocol
-`irealbook://` plain-text shape is publicly specified by iReal Pro
-in the [iReal Pro Custom Chord Chart Protocol][spec] and on the
-companion [developer docs page][devdocs]; the chord-chart grammar
-documented below follows that spec. The obfuscated `irealb://`
-export — the `MUSIC_PREFIX` magic and the `obfusc50` unscramble that
-wrap the same chord-chart body — is **not** covered by the published
-spec and remains a reverse-engineered format. For that half we
-follow the open-source [`pianosnake/ireal-reader`][1] JavaScript
-parser and the [`ironss/accompaniser`][2] de-obfuscation routine it
-cites. This document reflects what the `chordsketch-ireal` parser
+Notes on the iReal Pro export URL formats. iReal Pro publishes the
+[Custom Chord Chart Protocol][spec] (the chord-chart token
+grammar — `*X` rehearsal marks, barlines, repeats, `n` no-chord,
+`Y/YY/YYY` vertical spacers, etc.) and a companion
+[developer docs page][devdocs] (overview of the `irealb://` and
+`irealbook://` URL prefixes used to embed charts).
+
+What the published spec covers, and how this parser relates to it:
+
+- The **chord-chart token grammar** documented in the table below is
+  a **subset of the published spec extended with internal tokens**
+  observed in real exports (`Kcl`, `XyQ`, `LZ|`). Spec tokens the
+  parser does not yet implement (`f` Fermata) are listed under
+  "Out of scope" at the bottom.
+- The **6-field `irealbook://` URL layout** this parser accepts —
+  `Title=Composer=Style=Key=TimeSig=Music`, packed-digit timesig in
+  slot 5, plain-text music body — does **not** match the spec's
+  6-field example, which uses the literal `n` placeholder in slot 5
+  ("no longer used") and embeds the time signature inside the chord
+  stream as a `T..` token. The shape documented below is the legacy
+  iRealBook layout that pianosnake/ireal-reader implements;
+  spec-conformant parsing of the slot-5-`n` shape is tracked
+  separately.
+- The **obfuscated `irealb://` body** — the `MUSIC_PREFIX` sentinel
+  plus the `obfusc50` per-50-char permutation — is **not** covered
+  by the published spec at all. For that half the public references
+  are the open-source [`pianosnake/ireal-reader`][pianosnake]
+  JavaScript parser and the [`ironss/accompaniser`][accompaniser]
+  de-obfuscation routine it cites.
+- The **`===`-separated multi-song envelope** is likewise not in the
+  published spec; pianosnake/ireal-reader is the reference.
+
+This document reflects what the `chordsketch-ireal` parser
 (`src/parser.rs`) implements; the grammar here covers the subset
 the parser handles — features that the iReal app supports but our
 parser folds into `ChordQuality::Custom` (or simply skips) are
@@ -18,8 +40,8 @@ listed under "Out of scope" at the bottom.
 
 [spec]: https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol
 [devdocs]: https://www.irealpro.com/developer-docs
-[1]: https://github.com/pianosnake/ireal-reader
-[2]: https://github.com/ironss/accompaniser
+[pianosnake]: https://github.com/pianosnake/ireal-reader
+[accompaniser]: https://github.com/ironss/accompaniser
 
 ## URL shape
 
@@ -28,9 +50,14 @@ irealb://<percent-encoded-body>
 irealbook://<percent-encoded-body>
 ```
 
-Both prefixes carry the same body grammar. iReal generates
-`irealbook://` when the export holds a named playlist; `irealb://`
-appears for single charts.
+Both prefixes are accepted by `strip_prefix` and dispatch is driven
+by the body's part count + the presence of the `MUSIC_PREFIX`
+sentinel, **not** by the URL prefix. In practice the iReal Pro app
+exports obfuscated bodies under `irealb://` (7..=9 fields, music
+slot starts with the sentinel) and emits the legacy plain-text
+`irealbook://` shape (6 fields, no sentinel) for older / embedded
+exports; the parser accepts either prefix for either shape so a
+mis-labelled export still round-trips.
 
 ### File extension convention
 
@@ -84,7 +111,7 @@ checking which slot starts with the [`MUSIC_PREFIX`](#music-prefix):
 
 | Part count | Layout |
 |---|---|
-| 6 (no part starts with `MUSIC_PREFIX`) | iRealBook six-field: `Title=Composer=Style=Key=TimeSig=Music`. Music body is plain text (no music prefix, no `obfusc50` scramble); time signature is a packed-digit field (`44`, `34`, `68`, `128`) outside the chord stream. Tempo and transpose default to `None` / `0`. |
+| 6 (no part starts with `MUSIC_PREFIX`) | iRealBook six-field: `Title=Composer=Style=Key=TimeSig=Music`. Music body is plain text (no music prefix, no `obfusc50` scramble); time signature is a packed-digit field (`44`, `34`, `68`, `128`) outside the chord stream. Tempo and transpose default to `None` / `0`. **Divergence from spec**: the published [Custom Chord Chart Protocol][spec] documents a different 6-field shape — `Title=Composer=Style=Key=n=Music` with the literal `n` placeholder ("no longer used") in slot 5 and the time signature embedded inside the chord stream as a `T..` token. The shape parsed here is the legacy iRealBook layout that [`pianosnake/ireal-reader`][pianosnake] implements; spec-conformant parsing of the slot-5-`n` shape is a separate concern. |
 | 7 | `Title=Composer=Style=Key=Music=BPM=Repeats` |
 | 8 (parts[4] starts with prefix) | `Title=Composer=Style=Key=Music=CompStyle=BPM=Repeats` |
 | 8 (parts[5] starts with prefix) | `Title=Composer=Style=Key=Transpose=Music=BPM=Repeats` |
@@ -213,6 +240,14 @@ distinguishes:
 - `U` (Player-only ending): no AST representation.
 - `Y+` (Vertical spacer): no AST representation (visual hint
   only).
+- `f` (Fermata): the spec lists this alongside `S` (Segno) and
+  `Q` (Coda) as a rehearsal-mark / bar-attached symbol; the
+  parser falls through `f` to the chord-detection path and may
+  consume it as part of a chord-quality token rather than
+  recording it as a `MusicalSymbol`. Adding the AST variant and
+  parser branch is a separate concern and is not blocking; until
+  it lands, the spec's `f` token is a known gap relative to the
+  published grammar.
 - `*X*` closing-`*` sentinel: each `*X` greedily becomes a
   section marker, so `*m*X` parses as **two** sections (`m`
   followed by `X`). This mirrors pianosnake's behaviour — the
@@ -229,8 +264,18 @@ The parser **rejects** as malformed:
 
 ## References
 
-- pianosnake/ireal-reader — JavaScript reference parser.
-- ironss/accompaniser — Lua port; original obfuscation source.
-- daumling/ireal-renderer — JavaScript reference renderer (the
-  AST shape in `src/ast.rs` is modelled on this project's data
-  model).
+- [iReal Pro Custom Chord Chart Protocol][spec] — official
+  spec for the chord-chart token grammar.
+- [iReal Pro Developer Docs][devdocs] — overview of the
+  `irealb://` / `irealbook://` URL prefixes (embedding /
+  cross-app pasteboard).
+- [`pianosnake/ireal-reader`][pianosnake] — JavaScript reference
+  parser; source for the obfuscated body shape and the legacy
+  6-field iRealBook layout.
+- [`ironss/accompaniser`][accompaniser] — Lua port; original
+  source of the `obfusc50` permutation algorithm.
+- [`daumling/ireal-renderer`][daumling] — JavaScript reference
+  renderer; the AST shape in `src/ast.rs` is modelled on this
+  project's data model.
+
+[daumling]: https://github.com/daumling/ireal-renderer

--- a/crates/ireal/FORMAT.md
+++ b/crates/ireal/FORMAT.md
@@ -1,15 +1,23 @@
 # `irealb://` URL format
 
-Reverse-engineered notes on the iReal Pro export URL format. There
-is no published spec; this document reflects what the
-`chordsketch-ireal` parser (`src/parser.rs`) implements, derived
-from the open-source [`pianosnake/ireal-reader`][1] JavaScript
-parser and the [`ironss/accompaniser`][2] de-obfuscation routine
-it cites. The grammar here covers the subset the parser handles —
-features that the iReal app supports but our parser folds into
-`ChordQuality::Custom` (or simply skips) are listed under
-"Out of scope" at the bottom.
+Notes on the iReal Pro export URL formats. The open-protocol
+`irealbook://` plain-text shape is publicly specified by iReal Pro
+in the [iReal Pro Custom Chord Chart Protocol][spec] and on the
+companion [developer docs page][devdocs]; the chord-chart grammar
+documented below follows that spec. The obfuscated `irealb://`
+export — the `MUSIC_PREFIX` magic and the `obfusc50` unscramble that
+wrap the same chord-chart body — is **not** covered by the published
+spec and remains a reverse-engineered format. For that half we
+follow the open-source [`pianosnake/ireal-reader`][1] JavaScript
+parser and the [`ironss/accompaniser`][2] de-obfuscation routine it
+cites. This document reflects what the `chordsketch-ireal` parser
+(`src/parser.rs`) implements; the grammar here covers the subset
+the parser handles — features that the iReal app supports but our
+parser folds into `ChordQuality::Custom` (or simply skips) are
+listed under "Out of scope" at the bottom.
 
+[spec]: https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol
+[devdocs]: https://www.irealpro.com/developer-docs
 [1]: https://github.com/pianosnake/ireal-reader
 [2]: https://github.com/ironss/accompaniser
 

--- a/crates/ireal/FORMAT.md
+++ b/crates/ireal/FORMAT.md
@@ -3,7 +3,7 @@
 Notes on the iReal Pro export URL formats. iReal Pro publishes the
 [Custom Chord Chart Protocol][spec] (the chord-chart token
 grammar — `*X` rehearsal marks, barlines, repeats, `n` no-chord,
-`Y/YY/YYY` vertical spacers, etc.) and a companion
+`Y+` vertical spacers, etc.) and a companion
 [developer docs page][devdocs] (overview of the `irealb://` and
 `irealbook://` URL prefixes used to embed charts).
 

--- a/crates/ireal/src/parser.rs
+++ b/crates/ireal/src/parser.rs
@@ -10,7 +10,7 @@
 //!
 //! iReal Pro publishes the [Custom Chord Chart Protocol][spec]
 //! (the chord-chart token grammar — `*X` rehearsal marks, barlines,
-//! repeats, `n` no-chord, `Y/YY/YYY` vertical spacers, etc.) and a
+//! repeats, `n` no-chord, `Y+` vertical spacers, etc.) and a
 //! companion [developer docs page][devdocs] (overview of the
 //! `irealb://` and `irealbook://` URL prefixes used to embed
 //! charts). The chord-chart grammar this parser accepts is a

--- a/crates/ireal/src/parser.rs
+++ b/crates/ireal/src/parser.rs
@@ -8,15 +8,23 @@
 //!
 //! # Format reference
 //!
-//! There is no published spec for the iReal Pro URL format. The
-//! nearest public reference is the open-source
-//! [`pianosnake/ireal-reader`][1] JavaScript parser, which itself
-//! cites [`ironss/accompaniser`][2] for the obfuscation
-//! algorithm. The Rust port here implements the same algorithm
-//! against the same shape of token grammar; round-trip golden
-//! tests in `tests/parser.rs` verify the result against
-//! known-good fixtures.
+//! The open-protocol `irealbook://` plain-text URL form is
+//! publicly specified by iReal Pro in the [iReal Pro Custom Chord
+//! Chart Protocol][spec] and on the companion [developer docs
+//! page][devdocs]; the chord-chart syntax this parser accepts is
+//! drawn from that spec. The obfuscated `irealb://` export — the
+//! `MUSIC_PREFIX` magic and the `obfusc50` unscramble that wrap
+//! the same chord-chart body — is **not** covered by the published
+//! spec and remains a reverse-engineered format. For that half the
+//! public reference is the open-source [`pianosnake/ireal-reader`][1]
+//! JavaScript parser, which itself cites [`ironss/accompaniser`][2]
+//! for the obfuscation algorithm. The Rust port here implements
+//! the same algorithms against the same shape of token grammar;
+//! round-trip golden tests in `tests/parser.rs` verify the result
+//! against known-good fixtures.
 //!
+//! [spec]: https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol
+//! [devdocs]: https://www.irealpro.com/developer-docs
 //! [1]: https://github.com/pianosnake/ireal-reader
 //! [2]: https://github.com/ironss/accompaniser
 //!

--- a/crates/ireal/src/parser.rs
+++ b/crates/ireal/src/parser.rs
@@ -8,25 +8,37 @@
 //!
 //! # Format reference
 //!
-//! The open-protocol `irealbook://` plain-text URL form is
-//! publicly specified by iReal Pro in the [iReal Pro Custom Chord
-//! Chart Protocol][spec] and on the companion [developer docs
-//! page][devdocs]; the chord-chart syntax this parser accepts is
-//! drawn from that spec. The obfuscated `irealb://` export — the
-//! `MUSIC_PREFIX` magic and the `obfusc50` unscramble that wrap
-//! the same chord-chart body — is **not** covered by the published
-//! spec and remains a reverse-engineered format. For that half the
-//! public reference is the open-source [`pianosnake/ireal-reader`][1]
-//! JavaScript parser, which itself cites [`ironss/accompaniser`][2]
-//! for the obfuscation algorithm. The Rust port here implements
+//! iReal Pro publishes the [Custom Chord Chart Protocol][spec]
+//! (the chord-chart token grammar — `*X` rehearsal marks, barlines,
+//! repeats, `n` no-chord, `Y/YY/YYY` vertical spacers, etc.) and a
+//! companion [developer docs page][devdocs] (overview of the
+//! `irealb://` and `irealbook://` URL prefixes used to embed
+//! charts). The chord-chart grammar this parser accepts is a
+//! **subset of that spec extended with internal tokens** observed
+//! in real exports (`Kcl`, `XyQ`, `LZ|`) — see
+//! `crates/ireal/FORMAT.md` for the exact token table and the
+//! deltas from the spec.
+//!
+//! What the spec does **not** cover, and what therefore remains
+//! reverse-engineered from external references, are: the
+//! `irealb://` body's `MUSIC_PREFIX` sentinel + `obfusc50`
+//! unscramble; the legacy 6-field `irealbook://` layout this
+//! parser accepts with a packed-digit time signature in slot 5
+//! (the spec's own 6-field example has the literal `n` placeholder
+//! in slot 5 and the time signature embedded inside the chord
+//! stream as a `T..` token); and the `===`-separated multi-song
+//! envelope. For those halves the public references are the
+//! open-source [`pianosnake/ireal-reader`][pianosnake] JavaScript
+//! parser and the [`ironss/accompaniser`][accompaniser]
+//! de-obfuscation routine it cites. The Rust port here implements
 //! the same algorithms against the same shape of token grammar;
 //! round-trip golden tests in `tests/parser.rs` verify the result
 //! against known-good fixtures.
 //!
 //! [spec]: https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol
 //! [devdocs]: https://www.irealpro.com/developer-docs
-//! [1]: https://github.com/pianosnake/ireal-reader
-//! [2]: https://github.com/ironss/accompaniser
+//! [pianosnake]: https://github.com/pianosnake/ireal-reader
+//! [accompaniser]: https://github.com/ironss/accompaniser
 //!
 //! # Scope
 //!


### PR DESCRIPTION
## What
- Replace the "no published spec" claim in `crates/ireal/FORMAT.md`, `crates/ireal/ARCHITECTURE.md`, and the `crates/ireal/src/parser.rs` module docstring with citations to iReal Pro's [Custom Chord Chart Protocol](https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol) and [developer docs](https://www.irealpro.com/developer-docs).
- Clarify the actual reverse-engineering scope. The published spec covers the chord-chart **token grammar** (`*X` rehearsal marks, barlines, repeats, `n` no-chord, `Y+` vertical spacers, `f` fermata, etc.). What the spec does **not** cover and therefore stays reverse-engineered: the `irealb://` body's `MUSIC_PREFIX` sentinel + `obfusc50` unscramble; the legacy 6-field `irealbook://` layout this parser implements (with packed-digit time signature in slot 5, distinct from the spec's slot-5-`n` shape); and the `===` multi-song envelope. Retain the pianosnake / ironss / daumling references as supporting material for those halves.
- Document the parser's chord-chart grammar as a subset of the spec extended with internal tokens (`Kcl`, `XyQ`, `LZ|`) observed in real exports, rather than as a one-to-one implementation of the spec. Add the spec's `f` (Fermata) token to the FORMAT.md Out-of-scope drops section, describing the parser's actual handling: `f` is not matched by any explicit rule in the music-token loop (the chord-detection branch is gated on `A..=G | W`, and `consume_chord_token`'s quality allowlist does not include `f`), so it takes the generic "drop one char" fall-through at `parser.rs:709`.
- Standardise on semantic markdown reference labels (`[spec]`, `[devdocs]`, `[pianosnake]`, `[accompaniser]`, `[daumling]`) across the three sister sites; the prior per-file `[1]` / `[2]` labels pointed at different repositories in different files.
- Widen FORMAT.md's title to "`irealb://` and `irealbook://` URL formats" to match the body's actual scope, and rewrite the pre-existing "Both prefixes carry the same body grammar" sentence so it matches `make_song`'s actual dispatch logic (part count + `MUSIC_PREFIX` presence, not URL prefix).

## Why
The previous wording falsely implied the entire URL grammar was undocumented, which would mislead a future maintainer into duplicating reverse-engineering work that the official spec already covers. Equally, an earlier draft of this PR overshot by implying full spec conformance ("drawn from that spec"), which would mislead in the opposite direction: the parser is a subset+extensions implementation, not a 1:1 spec follower. The current state addresses both directions honestly per `.claude/rules/evidence-based-claims.md` and `.claude/rules/code-style.md` Silent Fallback. Closes #2437.

## Test results
- cargo fmt --check — passed
- cargo clippy --workspace --all-targets -- -D warnings — passed
- cargo test --workspace — passed
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps — passed
- Doc-only change; no fixture or behavioural tests apply.

## Review summary
Two parallel review fan-outs (`/review`, `/security-review`, `pr-review-toolkit:code-reviewer`, `pr-review-toolkit:comment-analyzer`, `.claude/rules` cross-check) have been run — one against the original commit and one against the iteration-2 fix commit. The iteration-1 fan-out surfaced 2× High, 3× Medium, 4× Low, 2× Nit findings on the spec-accuracy framing (all resolved in commit `6dcd40b`). The iteration-2 fan-out then caught one additional Medium (the Fermata fall-through description in FORMAT.md was inaccurate — it claimed `f` reached the chord-detection path, but `f` is actually filtered out by the `A..=G | W` chord gate and hits the generic `parser.rs:709` drop path instead) plus two Nits, resolved in commit `067f15f`. `/security-review` reported no findings on either iteration (doc-only change; markdown and `//!` doc comments are out of scope per the skill's documentation exclusion).

## Sister-site audit
Grepped for `no published spec` / `no spec` / `published spec` / `reverse-engineered` across `crates/ireal/`, `crates/render-ireal/`, `crates/convert/`, `crates/cli/`, and the workspace root. Found a third site beyond the AC list — `crates/ireal/ARCHITECTURE.md:11` carried the same wrong claim — and corrected it in the same PR.

Remaining hits and their disposition:
- `crates/convert/known-deviations.md:148` ("introducing a multi-char `*XX` token would diverge from the published spec") — Classification: refers to the **iReal Pro** spec, not ChordPro. The surrounding subsection is about iReal `*X` section-marker token cycle-lossiness. Post-PR the text is consistent with the new framing: single-char `*X` IS the spec, and a multi-char `*XX` extension would diverge. No edit needed.
- `crates/chordpro/src/grid.rs:34` describes the ChordPro grid dialect — genuinely unrelated to iReal Pro, intentionally unmodified.

## Parallel-PR note
PR #2470 (`.claude/workflows/autopilot-issue/phases/pr-review.md` strengthening) is open simultaneously against `main`. The two PRs touch disjoint files. PR #2470 qualifies for `.claude/rules/one-pr-at-a-time.md`'s docs-only carve-out (no Rust, no `.github/workflows/`). PR #2468 does **not** strictly qualify because `crates/ireal/src/parser.rs` is a Rust file even though only its `//!` module docstring is touched. Flagging for maintainer judgement on whether to merge sequentially or allow the two to remain in flight together.

## Deferred
None. Every finding from both parallel review fan-outs is resolved in this PR.

Closes #2437