### PR TITLE
feat(render-ireal): paint ChordSize::Small chords with narrower font

### DIFF
--- a/crates/ireal/FORMAT.md
+++ b/crates/ireal/FORMAT.md
@@ -167,6 +167,7 @@ checks each token in this priority order:
 | `r` | Repeat previous two measures — currently collapses to the same `Bar::repeat_previous = true` flag as `x` / `Kcl`. A future schema split may distinguish 1-bar from 2-bar simile via a separate field. |
 | `Y+` | Vertical space hint at the start of a system. Counts consecutive `Y` characters and stamps the count on the bar currently being assembled as `Bar::system_break_space` (clamped to `0..=3` per the spec's `Y` / `YY` / `YYY` shorthand for small / medium / large between-system gap). The renderer applies `VERTICAL_BREAK_PER_LEVEL` SVG units of extra padding above every row whose first bar carries a non-zero hint. |
 | `n` | "No Chord" — sets `Bar::no_chord = true`. The renderer paints `N.C.` in the bar's centre. |
+| `s` / `l` | Chord-size markers (Custom Chord Chart Protocol). `s` ("small") switches the parser's running chord-size state to [`ChordSize::Small`]; `l` ("large") restores [`ChordSize::Default`]. The state persists across bar boundaries until the next marker and is stamped onto every [`BarChord`] emitted while active, so dense bars (multiple chords per measure) can be painted at a narrower font without losing per-chord granularity. The SVG renderer picks a ~70 % base font (`CHORD_FONT_SIZE_BASE_SMALL = 22` vs `CHORD_FONT_SIZE_BASE = 32`) and scales accidental / extension spans + baseline shifts proportionally for Small-tagged chords. |
 | `p` | Pause slash — discard. |
 | `U` | Player ending marker — discard. |
 | `S` | Segno — sets `Bar::symbol = Some(Segno)` on the current bar. |

--- a/crates/render-ireal/src/lib.rs
+++ b/crates/render-ireal/src/lib.rs
@@ -118,14 +118,14 @@ pub mod pdf;
 pub mod png;
 mod svg;
 
-use chordsketch_ireal::{BarChord, IrealSong};
+use chordsketch_ireal::{BarChord, ChordSize, IrealSong};
 
 pub use chord_typography::{ChordTypography, SpanKind, TypographySpan, chord_to_typography};
 pub use layout::{BarCoord, EmptyCell, Layout, compute_layout};
 pub use page::{
-    BAR_ROW_HEIGHT, BARS_PER_ROW, CHORD_FONT_SIZE_BASE, CHORD_FONT_SIZE_SUPERSCRIPT, GRID_TOP,
-    HEADER_BAND_HEIGHT, MARGIN_X, MARGIN_Y, MAX_BARS, MAX_CHORDS_PER_BAR, MAX_SECTIONS,
-    PAGE_HEIGHT, PAGE_WIDTH,
+    BAR_ROW_HEIGHT, BARS_PER_ROW, CHORD_FONT_SIZE_BASE, CHORD_FONT_SIZE_BASE_SMALL,
+    CHORD_FONT_SIZE_SUPERSCRIPT, GRID_TOP, HEADER_BAND_HEIGHT, MARGIN_X, MARGIN_Y, MAX_BARS,
+    MAX_CHORDS_PER_BAR, MAX_SECTIONS, PAGE_HEIGHT, PAGE_WIDTH,
 };
 
 /// Caller-supplied render configuration.
@@ -441,18 +441,27 @@ fn write_bar_chord_text(out: &mut String, cell: &BarCoord, chords: &[BarChord], 
         } else {
             String::new()
         };
+        // Pick the root font size from the chord's size hint. The
+        // iReal Pro `s` marker stamps `ChordSize::Small` on every
+        // chord between `s` and the next `l` so dense bars stay
+        // legible; the AST carries the hint per-chord so the renderer
+        // can paint each glyph at its own size without losing
+        // granularity.
+        let base = match bc.size {
+            ChordSize::Default => page::CHORD_FONT_SIZE_BASE,
+            ChordSize::Small => page::CHORD_FONT_SIZE_BASE_SMALL,
+        };
         out.push_str(&format!(
             "    <text x=\"{chord_x}\" y=\"{base_y}\" font-family=\"Roboto, sans-serif\" \
 font-weight=\"700\" font-size=\"{base}\" class=\"chord\"{transform_attr}>",
-            base = page::CHORD_FONT_SIZE_BASE,
         ));
         let typography = chord_typography::chord_to_typography(&bc.chord);
-        write_chord_spans(out, &typography);
+        write_chord_spans(out, &typography, base);
         out.push_str("</text>\n");
     }
 }
 
-fn write_chord_spans(out: &mut String, typography: &ChordTypography) {
+fn write_chord_spans(out: &mut String, typography: &ChordTypography, base_size: i32) {
     // Cumulative `dy` cursor position. SVG `dy` is relative to the
     // previous span's baseline, so each transition between baseline
     // states must emit the inverse of the previous shift before
@@ -460,8 +469,17 @@ fn write_chord_spans(out: &mut String, typography: &ChordTypography) {
     // accounting honest across Root → Accidental → Extension →
     // Slash → Bass → Accidental sequences.
     let mut current_dy: i32 = 0;
-    let acc_dy = page::CHORD_ACCIDENTAL_DY;
-    let qual_dy = page::CHORD_QUALITY_DY;
+    // Scale the accidental / extension sizes and their baseline
+    // shifts proportionally to `base_size`. At `base_size ==
+    // CHORD_FONT_SIZE_BASE` (32) these collapse to the original
+    // constants so existing Default-size golden snapshots stay
+    // byte-stable. For `CHORD_FONT_SIZE_BASE_SMALL` (22) the
+    // accidental / extension / dys shrink by the same ~70 %
+    // ratio so the engraved chord keeps its visual hierarchy.
+    let acc_size = (base_size * page::CHORD_FONT_SIZE_ACCIDENTAL) / page::CHORD_FONT_SIZE_BASE;
+    let ext_size = (base_size * page::CHORD_FONT_SIZE_SUPERSCRIPT) / page::CHORD_FONT_SIZE_BASE;
+    let acc_dy = (base_size * page::CHORD_ACCIDENTAL_DY) / page::CHORD_FONT_SIZE_BASE;
+    let qual_dy = (base_size * page::CHORD_QUALITY_DY) / page::CHORD_FONT_SIZE_BASE;
     for span in &typography.spans {
         let escaped = svg::escape_xml(&span.text);
         match span.kind {
@@ -470,10 +488,7 @@ fn write_chord_spans(out: &mut String, typography: &ChordTypography) {
                 let dy_attr = if restore == 0 {
                     String::new()
                 } else {
-                    format!(
-                        " font-size=\"{base}\" dy=\"{restore}\"",
-                        base = page::CHORD_FONT_SIZE_BASE
-                    )
+                    format!(" font-size=\"{base_size}\" dy=\"{restore}\"")
                 };
                 out.push_str(&format!(
                     "<tspan class=\"chord-root\"{dy_attr}>{escaped}</tspan>"
@@ -486,8 +501,7 @@ fn write_chord_spans(out: &mut String, typography: &ChordTypography) {
                 let target = acc_dy;
                 let shift = target - current_dy;
                 out.push_str(&format!(
-                    "<tspan class=\"chord-acc\" font-size=\"{size}\" dy=\"{shift}\">{escaped}</tspan>",
-                    size = page::CHORD_FONT_SIZE_ACCIDENTAL,
+                    "<tspan class=\"chord-acc\" font-size=\"{acc_size}\" dy=\"{shift}\">{escaped}</tspan>",
                 ));
                 current_dy = target;
             }
@@ -498,8 +512,7 @@ fn write_chord_spans(out: &mut String, typography: &ChordTypography) {
                 let target = qual_dy;
                 let shift = target - current_dy;
                 out.push_str(&format!(
-                    "<tspan class=\"chord-ext\" font-size=\"{size}\" dy=\"{shift}\">{escaped}</tspan>",
-                    size = page::CHORD_FONT_SIZE_SUPERSCRIPT,
+                    "<tspan class=\"chord-ext\" font-size=\"{ext_size}\" dy=\"{shift}\">{escaped}</tspan>",
                 ));
                 current_dy = target;
             }
@@ -508,10 +521,7 @@ fn write_chord_spans(out: &mut String, typography: &ChordTypography) {
                 let attrs = if restore == 0 {
                     String::new()
                 } else {
-                    format!(
-                        " font-size=\"{base}\" dy=\"{restore}\"",
-                        base = page::CHORD_FONT_SIZE_BASE
-                    )
+                    format!(" font-size=\"{base_size}\" dy=\"{restore}\"")
                 };
                 out.push_str(&format!(
                     "<tspan class=\"chord-slash\"{attrs}>{escaped}</tspan>"
@@ -523,10 +533,7 @@ fn write_chord_spans(out: &mut String, typography: &ChordTypography) {
                 let attrs = if restore == 0 {
                     String::new()
                 } else {
-                    format!(
-                        " font-size=\"{base}\" dy=\"{restore}\"",
-                        base = page::CHORD_FONT_SIZE_BASE
-                    )
+                    format!(" font-size=\"{base_size}\" dy=\"{restore}\"")
                 };
                 out.push_str(&format!(
                     "<tspan class=\"chord-bass\"{attrs}>{escaped}</tspan>"

--- a/crates/render-ireal/src/page.rs
+++ b/crates/render-ireal/src/page.rs
@@ -82,6 +82,18 @@ pub const MAX_BARS: usize = 4096;
 /// dominate the bar visually so each chord reads at a glance.
 pub const CHORD_FONT_SIZE_BASE: i32 = 32;
 
+/// Narrower base font for chords carrying the iReal Pro `s`
+/// marker ([`chordsketch_ireal::ChordSize::Small`]).
+///
+/// Sized at ~70 % of [`CHORD_FONT_SIZE_BASE`] (22 / 32 ≈ 0.6875),
+/// matching the iReal Pro spec's "narrower" intent for the `s`
+/// marker — dense bars with multiple chord changes stay legible
+/// without overflowing the cell. The renderer scales the
+/// accidental / extension spans and their baseline shifts
+/// proportionally from this base so the engraved chord keeps its
+/// visual hierarchy at the smaller size.
+pub const CHORD_FONT_SIZE_BASE_SMALL: i32 = 22;
+
 /// Smaller font size used for the quality / extension span
 /// (`Δ7`, `−7`, `ø7`, `sus4`). Mirrors iReal Pro's quality-glyph
 /// proportion — ≈ 50 % of the base size.

--- a/crates/render-ireal/tests/fixtures/chord_size_demo/expected.svg
+++ b/crates/render-ireal/tests/fixtures/chord_size_demo/expected.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <rect x="0" y="0" width="595" height="842" fill="white"/>
+  <text x="297" y="72" font-family="'Source Serif 4', Georgia, serif" font-weight="700" font-size="22" text-anchor="middle" class="title">A Walkin Thing</text>
+  <text x="40" y="72" font-family="'Source Serif 4', Georgia, serif" font-style="italic" font-size="13" class="meta">(Medium Swing)</text>
+  <text x="555" y="72" font-family="'Source Serif 4', Georgia, serif" font-style="italic" font-size="13" text-anchor="end" class="lead-sheet">Lead Sheet</text>
+  <line x1="40" y1="112" x2="555" y2="112" stroke="#E8E6EA" stroke-width="1"/>
+  <g class="bar-grid">
+    <line x1="40" y1="120" x2="40" y2="184" stroke="black" stroke-width="1" class="barline-single"/>
+    <text x="48" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">E</tspan><tspan class="chord-ext" font-size="11" dy="3">ø7</tspan></text>
+    <text x="106" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">A</tspan><tspan class="chord-ext" font-size="11" dy="3">7</tspan></text>
+    <line x1="168" y1="120" x2="168" y2="184" stroke="black" stroke-width="1" class="barline-single"/>
+    <text x="176" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="11" dy="3">−</tspan></text>
+    <text x="205" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="11" dy="3">−</tspan></text>
+    <text x="263" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="32" class="chord"><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="16" dy="5">−</tspan></text>
+    <line x1="296" y1="120" x2="296" y2="184" stroke="black" stroke-width="1" class="barline-single"/>
+    <text x="304" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="32" class="chord"><tspan class="chord-root">C</tspan><tspan class="chord-ext" font-size="16" dy="5">Δ7</tspan></text>
+    <line x1="424" y1="120" x2="424" y2="184" stroke="black" stroke-width="1" class="barline-single"/>
+    <line x1="555" y1="120" x2="555" y2="184" stroke="black" stroke-width="1" class="barline-single"/>
+    <text x="432" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="32" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="16" dy="5">7</tspan></text>
+    <text x="26" y="148" font-family="serif" font-weight="700" font-size="16" text-anchor="middle" class="time-sig-num">4</text>
+    <line x1="20" y1="153" x2="32" y2="153" stroke="black" stroke-width="1" class="time-sig-rule"/>
+    <text x="26" y="166" font-family="serif" font-weight="700" font-size="16" text-anchor="middle" class="time-sig-denom">4</text>
+    <rect x="31" y="104" width="18" height="18" fill="black" class="section-marker"/>
+    <text x="40" y="116" font-family="sans-serif" font-size="11" font-weight="700" fill="white" text-anchor="middle" class="section-label">A</text>
+  </g>
+</svg>

--- a/crates/render-ireal/tests/fixtures/chord_size_demo/expected.svg
+++ b/crates/render-ireal/tests/fixtures/chord_size_demo/expected.svg
@@ -10,7 +10,7 @@
     <text x="48" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">E</tspan><tspan class="chord-ext" font-size="11" dy="3">ø7</tspan></text>
     <text x="106" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">A</tspan><tspan class="chord-ext" font-size="11" dy="3">7</tspan></text>
     <line x1="168" y1="120" x2="168" y2="184" stroke="black" stroke-width="1" class="barline-single"/>
-    <text x="176" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="11" dy="3">−</tspan></text>
+    <text x="176" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">B</tspan><tspan class="chord-acc" font-size="13" dy="-6">♭</tspan><tspan class="chord-ext" font-size="11" dy="9">7</tspan><tspan class="chord-slash" font-size="22" dy="-3">/</tspan><tspan class="chord-bass">D</tspan></text>
     <text x="205" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="22" class="chord"><tspan class="chord-root">G</tspan><tspan class="chord-ext" font-size="11" dy="3">−</tspan></text>
     <text x="263" y="159" font-family="Roboto, sans-serif" font-weight="700" font-size="32" class="chord"><tspan class="chord-root">D</tspan><tspan class="chord-ext" font-size="16" dy="5">−</tspan></text>
     <line x1="296" y1="120" x2="296" y2="184" stroke="black" stroke-width="1" class="barline-single"/>

--- a/crates/render-ireal/tests/progressions.rs
+++ b/crates/render-ireal/tests/progressions.rs
@@ -12,8 +12,8 @@
 //! and re-run without the env var to confirm parity.
 
 use chordsketch_ireal::{
-    Bar, BarChord, BeatPosition, Chord, ChordQuality, ChordRoot, ChordSize, IrealSong, KeyMode,
-    KeySignature, Section, SectionLabel,
+    Accidental, Bar, BarChord, BeatPosition, Chord, ChordQuality, ChordRoot, ChordSize, IrealSong,
+    KeyMode, KeySignature, Section, SectionLabel,
 };
 use chordsketch_render_ireal::{RenderOptions, render_svg};
 
@@ -603,11 +603,39 @@ fn render_vertical_space_demo() {
 // restores the default size. Bar 1 packs two Small chords, bar 2 packs
 // three chords transitioning Small → Small → Default mid-bar, and
 // bars 3–4 sit at Default size to prove the state restored cleanly.
+//
+// Bar 2 opens with a Small B♭7/D chord that exercises two otherwise-
+// uncovered paths in `write_chord_spans`:
+//   • `SpanKind::Accidental` with `acc_size` (the ♭ flat glyph)
+//   • `SpanKind::Slash` restore format (non-zero `current_dy` after the
+//     extension span triggers a baseline-reset attr on the slash tspan)
 // ---------------------------------------------------------------------------
 
 fn small_bar_chord(note: char, quality: ChordQuality, beat: u8) -> BarChord {
     BarChord {
         chord: Chord::triad(ChordRoot::natural(note), quality),
+        position: BeatPosition::on_beat(beat).unwrap(),
+        size: ChordSize::Small,
+    }
+}
+
+/// Small chord with a flat accidental and a slash bass note.
+///
+/// Used to exercise the `SpanKind::Accidental` path (covered by the
+/// flat ♭ span) and the `SpanKind::Slash` restore path (triggered when
+/// an Extension span precedes the Slash span so `current_dy != 0` at
+/// the point the Slash span is emitted) in `write_chord_spans`.
+fn small_flat_slash_chord(note: char, quality: ChordQuality, bass: char, beat: u8) -> BarChord {
+    BarChord {
+        chord: Chord {
+            root: ChordRoot {
+                note,
+                accidental: Accidental::Flat,
+            },
+            quality,
+            bass: Some(ChordRoot::natural(bass)),
+            alternate: None,
+        },
         position: BeatPosition::on_beat(beat).unwrap(),
         size: ChordSize::Small,
     }
@@ -637,10 +665,11 @@ fn chord_size_demo() -> IrealSong {
         ],
         ..Bar::new()
     };
-    // Bar 2: `sD-,G-,lD-` — D-/G- Small, then D- restored to Default.
+    // Bar 2: B♭7/D Small (covers Accidental + Slash restore paths),
+    //        G- Small, D- restored to Default.
     let bar2 = Bar {
         chords: vec![
-            small_bar_chord('D', ChordQuality::Minor, 1),
+            small_flat_slash_chord('B', ChordQuality::Dominant7, 'D', 1),
             small_bar_chord('G', ChordQuality::Minor, 2),
             default_bar_chord('D', ChordQuality::Minor, 4),
         ],

--- a/crates/render-ireal/tests/progressions.rs
+++ b/crates/render-ireal/tests/progressions.rs
@@ -594,3 +594,75 @@ fn vertical_space_demo() -> IrealSong {
 fn render_vertical_space_demo() {
     check_golden("vertical_space_demo", &vertical_space_demo());
 }
+
+// ---------------------------------------------------------------------------
+// Fixture: chord-size transitions (s / l markers per #2433 / #2476)
+//
+// Mirrors the spec example "A Walkin Thing" — `sEh,A7,|...|sD-,G-,lD-` —
+// where the `s` marker shrinks subsequent chords until an `l` marker
+// restores the default size. Bar 1 packs two Small chords, bar 2 packs
+// three chords transitioning Small → Small → Default mid-bar, and
+// bars 3–4 sit at Default size to prove the state restored cleanly.
+// ---------------------------------------------------------------------------
+
+fn small_bar_chord(note: char, quality: ChordQuality, beat: u8) -> BarChord {
+    BarChord {
+        chord: Chord::triad(ChordRoot::natural(note), quality),
+        position: BeatPosition::on_beat(beat).unwrap(),
+        size: ChordSize::Small,
+    }
+}
+
+fn default_bar_chord(note: char, quality: ChordQuality, beat: u8) -> BarChord {
+    BarChord {
+        chord: Chord::triad(ChordRoot::natural(note), quality),
+        position: BeatPosition::on_beat(beat).unwrap(),
+        size: ChordSize::Default,
+    }
+}
+
+fn chord_size_demo() -> IrealSong {
+    let mut song = IrealSong::new();
+    song.title = "A Walkin Thing".into();
+    song.style = Some("Medium Swing".into());
+    song.key_signature = KeySignature {
+        root: ChordRoot::natural('D'),
+        mode: KeyMode::Minor,
+    };
+    // Bar 1: `sEh,A7` — both Small, packed on beats 1 and 3.
+    let bar1 = Bar {
+        chords: vec![
+            small_bar_chord('E', ChordQuality::HalfDiminished, 1),
+            small_bar_chord('A', ChordQuality::Dominant7, 3),
+        ],
+        ..Bar::new()
+    };
+    // Bar 2: `sD-,G-,lD-` — D-/G- Small, then D- restored to Default.
+    let bar2 = Bar {
+        chords: vec![
+            small_bar_chord('D', ChordQuality::Minor, 1),
+            small_bar_chord('G', ChordQuality::Minor, 2),
+            default_bar_chord('D', ChordQuality::Minor, 4),
+        ],
+        ..Bar::new()
+    };
+    // Bars 3 / 4: Default-size single chords confirm the state stuck.
+    let bar3 = Bar {
+        chords: vec![default_bar_chord('C', ChordQuality::Major7, 1)],
+        ..Bar::new()
+    };
+    let bar4 = Bar {
+        chords: vec![default_bar_chord('G', ChordQuality::Dominant7, 1)],
+        ..Bar::new()
+    };
+    song.sections.push(Section {
+        label: SectionLabel::Letter('A'),
+        bars: vec![bar1, bar2, bar3, bar4],
+    });
+    song
+}
+
+#[test]
+fn render_chord_size_demo() {
+    check_golden("chord_size_demo", &chord_size_demo());
+}


### PR DESCRIPTION
## Summary

Threads `BarChord.size` (added in #2477) through the iReal SVG render path so the spec's `s` / `l` toggle markers reach the visual layer. Small-tagged chords now render at a 70% scale instead of being silently upscaled to Default.

## What changed

- `crates/render-ireal/src/page.rs`: new `CHORD_FONT_SIZE_BASE_SMALL: i32 = 22` constant (~70% of 32). One-line comment explains the proportion choice — matches iReal Pro's visual squeeze when many chords are packed into one bar.
- `crates/render-ireal/src/lib.rs`: `write_bar_chord_text` picks base font size from `bc.size` (Default → `CHORD_FONT_SIZE_BASE`, Small → `CHORD_FONT_SIZE_BASE_SMALL`). Threads the selected size into `write_chord_spans` so accidentals and extensions scale proportionally rather than staying glued to the Default proportions.
- `crates/render-ireal/tests/fixtures/chord_size_demo/expected.svg`: new golden fixture covering Small → Default transitions on the spec's "A Walkin Thing" pattern (`sEh,A7,|...|sD-,G-,lD-`).
- `crates/render-ireal/tests/progressions.rs`: new fixture builder + test asserting the byte-for-byte SVG matches.
- `crates/ireal/FORMAT.md`: token grammar table row added for `s` / `l`.

## Verification

- [x] `cargo test --workspace` — all crates green.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Existing 10 render-ireal golden fixtures retain byte-for-byte equality (they use `ChordSize::Default`, so the threading is no-op on the Default path).

## Sister-site audit

- iReal AST: no changes (the `size` attribute was added in #2477 and is just being consumed here).
- iReal parser / serializer / JSON: no changes — already exercised by the iReal crate's own test suite.
- Convert (iReal ↔ ChordPro): no changes — converter still drops the size attribute, as documented in #2476 (ChordPro has no equivalent typed attribute).
- TypeScript `Bar`/`BarChord` in `packages/ui-irealb-editor/src/ast.ts`: not touched in this PR — JSON shape unchanged, additive font scaling is a renderer-internal concern.
- ChordPro three-renderer parity group: out of scope (iReal-only feature).
- Wasm bridge: no surface change — `renderIrealSvg` continues to take the same `IrealSong` input and emit SVG with the new font scaling applied automatically.

Closes #2476.