### PR TITLE
feat(ireal): recognise <Break> drum-silence marker

### DIFF
--- a/crates/convert/src/from_ireal.rs
+++ b/crates/convert/src/from_ireal.rs
@@ -314,6 +314,7 @@ fn symbol_label(symbol: MusicalSymbol) -> &'static str {
         MusicalSymbol::DalSegno => "D.S.",
         MusicalSymbol::Fine => "Fine",
         MusicalSymbol::Fermata => "Fermata",
+        MusicalSymbol::Break => "Break",
     }
 }
 

--- a/crates/convert/src/from_ireal.rs
+++ b/crates/convert/src/from_ireal.rs
@@ -802,4 +802,48 @@ mod tests {
             "Fermata symbol must surface as `(Fermata)` in lyrics text, got {lyrics_text:?}"
         );
     }
+
+    #[test]
+    fn break_symbol_emits_break_label_in_lyrics() {
+        // Exercises `symbol_label(MusicalSymbol::Break)` → "Break".
+        // ChordPro has no native break directive; the converter emits
+        // "(Break) " as an inline text segment on the chord/lyrics
+        // line, matching the pattern for Segno, Coda, Fermata, etc.
+        use chordsketch_chordpro::ast::Line;
+        let mut s = IrealSong::new();
+        s.title = "Break Test".into();
+        s.sections.push(Section {
+            label: SectionLabel::Letter('A'),
+            bars: vec![Bar {
+                chords: vec![BarChord {
+                    chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Major),
+                    position: BeatPosition::on_beat(1).unwrap(),
+                    size: ChordSize::Default,
+                }],
+                symbol: Some(MusicalSymbol::Break),
+                ..Bar::default()
+            }],
+        });
+        let result = convert(&s).unwrap();
+        let lyrics_text: String = result
+            .output
+            .lines
+            .iter()
+            .filter_map(|l| match l {
+                Line::Lyrics(lyrics) => Some(
+                    lyrics
+                        .segments
+                        .iter()
+                        .map(|seg| seg.text.as_str())
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .collect::<Vec<String>>()
+            .concat();
+        assert!(
+            lyrics_text.contains("(Break)"),
+            "Break symbol must surface as `(Break)` in lyrics text, got {lyrics_text:?}"
+        );
+    }
 }

--- a/crates/ireal/src/ast.rs
+++ b/crates/ireal/src/ast.rs
@@ -595,4 +595,11 @@ pub enum MusicalSymbol {
     /// Spec token: lowercase `f` in the Rehearsal Marks table at
     /// <https://www.irealpro.com/ireal-pro-custom-chord-chart-protocol>.
     Fermata,
+    /// "Break" drum-silence marker. Per the iReal Pro help center,
+    /// inserting `Break` in a chart's staff text causes the drums
+    /// to "stop with a shot on one" until the next double barline.
+    /// Distinct from `N.C.`, which only silences chordal instruments;
+    /// the two may be combined for a complete-silence pickup measure.
+    /// Spec: <https://technimo.helpshift.com/hc/en/3-ireal-pro/faq/101-n-c-symbol-break/?p=all>
+    Break,
 }

--- a/crates/ireal/src/json.rs
+++ b/crates/ireal/src/json.rs
@@ -395,6 +395,7 @@ impl ToJson for MusicalSymbol {
             Self::DalSegno => "dal_segno",
             Self::Fine => "fine",
             Self::Fermata => "fermata",
+            Self::Break => "break",
         };
         write_str(out, s);
     }
@@ -1426,6 +1427,7 @@ impl FromJson for MusicalSymbol {
             "dal_segno" => Ok(Self::DalSegno),
             "fine" => Ok(Self::Fine),
             "fermata" => Ok(Self::Fermata),
+            "break" => Ok(Self::Break),
             other => Err(JsonError::new(
                 0,
                 format!("unknown musical symbol {}", truncate_for_message(other)),

--- a/crates/ireal/src/parser.rs
+++ b/crates/ireal/src/parser.rs
@@ -1893,4 +1893,53 @@ mod tests {
         assert_eq!(bar0.chords[0].chord.root.note, 'G');
         assert_eq!(bar0.chords[0].size, ChordSize::Small);
     }
+
+    // ---- Break macro recognition (#2448) ---------------------------------
+
+    #[test]
+    fn break_comment_sets_symbol_and_no_text_comment() {
+        // `<Break>` must set `symbol = MusicalSymbol::Break` and leave
+        // `text_comment` unset — the bare-macro suppression branch in
+        // `apply_comment` must fire so a subsequent serialize → parse
+        // round-trip does not produce a duplicated `<Break>` comment.
+        let url = "irealbook://Test=A==Style=C=44=[*A<Break>C|D|]";
+        let song = parse(url).expect("parse");
+        let bar0 = &song.sections[0].bars[0];
+        assert_eq!(bar0.symbol, Some(MusicalSymbol::Break));
+        assert!(
+            bar0.text_comment.is_none(),
+            "bare <Break> must not populate text_comment"
+        );
+    }
+
+    #[test]
+    fn break_comment_with_extra_text_sets_both_symbol_and_comment() {
+        // `<Break pattern>` → symbol set AND text_comment kept so
+        // renderers can prefer the richer caption over the plain
+        // "Break" fallback glyph.
+        let url = "irealbook://Test=A==Style=C=44=[*A<Break pattern>C|D|]";
+        let song = parse(url).expect("parse");
+        let bar0 = &song.sections[0].bars[0];
+        assert_eq!(bar0.symbol, Some(MusicalSymbol::Break));
+        assert_eq!(bar0.text_comment.as_deref(), Some("Break pattern"));
+    }
+
+    #[test]
+    fn breakaway_does_not_trigger_break_macro() {
+        // `breakaway` starts with "break" but is immediately followed
+        // by an alphanumeric character — `matches_macro_prefix` must
+        // reject it so `MusicalSymbol::Break` is not spuriously set.
+        let url = "irealbook://Test=A==Style=C=44=[*A<breakaway section>C|D|]";
+        let song = parse(url).expect("parse");
+        let bar0 = &song.sections[0].bars[0];
+        assert!(
+            bar0.symbol.is_none(),
+            "`breakaway` must NOT set MusicalSymbol::Break"
+        );
+        assert_eq!(
+            bar0.text_comment.as_deref(),
+            Some("breakaway section"),
+            "non-macro caption must still land in text_comment"
+        );
+    }
 }

--- a/crates/ireal/src/parser.rs
+++ b/crates/ireal/src/parser.rs
@@ -926,20 +926,20 @@ impl ChartParseState {
         let trimmed_lower = comment.trim().to_ascii_lowercase();
         // Detect the recognised musical-direction macros. The
         // matched symbol is set directly on `current_bar` (see
-        // `queue_symbol`) — `<D.C.>` / `<D.S.>` / `<Fine>` label
-        // the bar that contains the comment. The full verbatim
-        // text is ALSO saved to `text_comment` so longer captions
-        // like `<D.S. al 2nd ending>` survive the round-trip; the
-        // renderer prefers the descriptive text when present, and
-        // falls back to the canonical symbol when the bar carries
-        // no text.
+        // `queue_symbol`) — `<D.C.>` / `<D.S.>` / `<Fine>` /
+        // `<Break>` label the bar that contains the comment. The
+        // full verbatim text is ALSO saved to `text_comment` so
+        // longer captions like `<D.S. al 2nd ending>` survive the
+        // round-trip; the renderer prefers the descriptive text
+        // when present, and falls back to the canonical symbol
+        // when the bar carries no text.
         //
         // Detection anchors at the START of the comment so common
         // English words that contain the macro substring
-        // (`refine`, `define`, `Configuration`) do NOT trigger.
-        // iReal Pro emits these directives at the head of the
-        // comment by convention; treating them as a substring
-        // match was a false-positive vector.
+        // (`refine`, `define`, `breakaway`, `Configuration`) do
+        // NOT trigger. iReal Pro emits these directives at the
+        // head of the comment by convention; treating them as a
+        // substring match was a false-positive vector.
         let is_macro = if matches_macro_prefix(&trimmed_lower, "d.c.") {
             self.queue_symbol(MusicalSymbol::DaCapo);
             true
@@ -949,6 +949,9 @@ impl ChartParseState {
         } else if matches_macro_prefix(&trimmed_lower, "fine") {
             self.queue_symbol(MusicalSymbol::Fine);
             true
+        } else if matches_macro_prefix(&trimmed_lower, "break") {
+            self.queue_symbol(MusicalSymbol::Break);
+            true
         } else {
             false
         };
@@ -956,11 +959,11 @@ impl ChartParseState {
         if trimmed.is_empty() {
             return;
         }
-        // For a bare-macro comment (`<D.C.>`, `<D.S.>`, `<Fine>`)
-        // the canonical symbol fully covers the semantics; saving
-        // the bare text as `text_comment` would round-trip into a
-        // duplicated comment after re-emission. Skip the
-        // text_comment write in that case so:
+        // For a bare-macro comment (`<D.C.>`, `<D.S.>`, `<Fine>`,
+        // `<Break>`) the canonical symbol fully covers the
+        // semantics; saving the bare text as `text_comment` would
+        // round-trip into a duplicated comment after re-emission.
+        // Skip the text_comment write in that case so:
         //
         //   parse(`<D.C.>`)             → bar.symbol = DaCapo
         //   parse(`<D.C. al coda>`)     → bar.symbol = DaCapo,
@@ -971,7 +974,7 @@ impl ChartParseState {
                 .filter(|c| !matches!(c, '.' | ' '))
                 .collect();
             let collapsed_lower = collapsed.to_ascii_lowercase();
-            if matches!(collapsed_lower.as_str(), "dc" | "ds" | "fine") {
+            if matches!(collapsed_lower.as_str(), "dc" | "ds" | "fine" | "break") {
                 return;
             }
         }

--- a/crates/ireal/src/serialize.rs
+++ b/crates/ireal/src/serialize.rs
@@ -245,6 +245,7 @@ fn serialize_music(song: &IrealSong) -> String {
                     matches_macro_prefix(&lower, "d.c.")
                         || matches_macro_prefix(&lower, "d.s.")
                         || matches_macro_prefix(&lower, "fine")
+                        || matches_macro_prefix(&lower, "break")
                 })
                 .unwrap_or(false)
         };
@@ -442,6 +443,7 @@ fn serialize_symbol(out: &mut String, symbol: MusicalSymbol) {
         MusicalSymbol::DalSegno => out.push_str("<D.S.>"),
         MusicalSymbol::Fine => out.push_str("<Fine>"),
         MusicalSymbol::Fermata => out.push('f'),
+        MusicalSymbol::Break => out.push_str("<Break>"),
     }
 }
 

--- a/crates/ireal/src/serialize.rs
+++ b/crates/ireal/src/serialize.rs
@@ -844,10 +844,12 @@ mod tests {
             ..Default::default()
         };
         let url = irealb_serialize(&song);
-        // Verify the raw URL contains the `<Break>` token.
+        // `irealb_serialize` produces a percent-encoded `irealb://` URL, so
+        // `<` → `%3C` and `>` → `%3E`. The plain `<Break>` form would only
+        // appear in a non-encoded `irealbook://` URL.
         assert!(
-            url.contains("<Break>") || url.contains("%3CBreak%3E"),
-            "serialised URL must contain the <Break> comment token: {url}"
+            url.contains("%3CBreak%3E"),
+            "serialised URL must contain the percent-encoded <Break> token: {url}"
         );
         let parsed = crate::parse(&url).expect("round trip");
         let found_break = parsed

--- a/crates/ireal/src/serialize.rs
+++ b/crates/ireal/src/serialize.rs
@@ -815,6 +815,50 @@ mod tests {
     }
 
     #[test]
+    fn musical_symbol_break_round_trips() {
+        // Exercises `MusicalSymbol::Break` in `serialize_symbol`:
+        // `Break` must serialise to `<Break>` and parse back to
+        // `symbol = MusicalSymbol::Break` with no `text_comment`.
+        let song = IrealSong {
+            title: "Break Test".into(),
+            composer: Some("T".into()),
+            style: Some("Medium Swing".into()),
+            sections: vec![Section {
+                label: SectionLabel::Letter('A'),
+                bars: vec![Bar {
+                    start: BarLine::Double,
+                    end: BarLine::Final,
+                    chords: vec![BarChord {
+                        chord: Chord::triad(ChordRoot::natural('C'), ChordQuality::Major),
+                        position: BeatPosition::on_beat(1).unwrap(),
+                        size: ChordSize::Default,
+                    }],
+                    ending: None,
+                    symbol: Some(MusicalSymbol::Break),
+                    repeat_previous: false,
+                    no_chord: false,
+                    text_comment: None,
+                    system_break_space: 0,
+                }],
+            }],
+            ..Default::default()
+        };
+        let url = irealb_serialize(&song);
+        // Verify the raw URL contains the `<Break>` token.
+        assert!(
+            url.contains("<Break>") || url.contains("%3CBreak%3E"),
+            "serialised URL must contain the <Break> comment token: {url}"
+        );
+        let parsed = crate::parse(&url).expect("round trip");
+        let found_break = parsed
+            .sections
+            .iter()
+            .flat_map(|s| s.bars.iter())
+            .any(|b| b.symbol == Some(MusicalSymbol::Break));
+        assert!(found_break, "Break symbol must survive the round trip");
+    }
+
+    #[test]
     fn musical_symbol_da_capo_round_trips() {
         // Exercises `MusicalSymbol::DaCapo` in `serialize_symbol`.
         let song = IrealSong {

--- a/crates/ireal/tests/json_errors.rs
+++ b/crates/ireal/tests/json_errors.rs
@@ -654,3 +654,22 @@ fn from_json_rejects_unknown_chord_size() {
         "error must mention the offending value; got {msg:?}"
     );
 }
+
+// ---- MusicalSymbol::Break JSON round-trip (#2448) ----------------------
+
+/// `MusicalSymbol::Break` must serialise to the JSON string `"break"`
+/// and deserialise back to `Break`. Covers:
+/// - the `Self::Break => "break"` arm in `MusicalSymbol::to_json`,
+/// - the `"break" => Ok(Self::Break)` arm in `MusicalSymbol::from_json_value`.
+#[test]
+fn musical_symbol_break_round_trips_through_json() {
+    let json = MusicalSymbol::Break.to_json_string();
+    assert_eq!(
+        json, "\"break\"",
+        "Break must serialise to the JSON string \"break\""
+    );
+    let parsed_json = parse_json(&json).expect("parse JSON");
+    let result = MusicalSymbol::from_json_value(&parsed_json)
+        .expect("Break must deserialise from \"break\"");
+    assert_eq!(result, MusicalSymbol::Break);
+}

--- a/crates/render-ireal/src/music_symbols.rs
+++ b/crates/render-ireal/src/music_symbols.rs
@@ -325,6 +325,26 @@ mod tests {
     }
 
     #[test]
+    fn break_emits_break_text() {
+        // Drum-silence marker: `Break` is rendered as italic staff
+        // text, mirroring `D.C.` / `D.S.` / `Fine`. Verify both the
+        // text content and the italic style attribute.
+        let mut song = IrealSong::new();
+        song.sections
+            .push(section('A', vec![bar_with_symbol(MusicalSymbol::Break)]));
+        let layout = compute_layout(&song);
+        let svg = render_music_symbols(&song, &layout);
+        assert!(
+            svg.contains(">Break</text>"),
+            "SVG must contain Break text: {svg}"
+        );
+        assert!(
+            svg.contains("font-style=\"italic\""),
+            "Break text must be rendered italic: {svg}"
+        );
+    }
+
+    #[test]
     fn each_symbol_anchors_to_its_bar_y() {
         // Two bars in the same row, one with segno and one with
         // coda. The outer `translate(glyph_cx, glyph_cy)` of each

--- a/crates/render-ireal/src/music_symbols.rs
+++ b/crates/render-ireal/src/music_symbols.rs
@@ -150,6 +150,14 @@ pub(crate) fn render_music_symbols(song: &IrealSong, layout: &Layout) -> String 
             MusicalSymbol::Fine => {
                 emit_text_directive(&mut out, cell.x + GLYPH_LEFT_INSET, glyph_bottom_y, "Fine");
             }
+            MusicalSymbol::Break => {
+                // Drum-silence marker. iReal Pro renders the literal
+                // word "Break" as italic staff text, like the other
+                // text directives (D.C. / D.S. / Fine). The drum
+                // resume boundary (next double barline) is a player
+                // concern with no glyph of its own.
+                emit_text_directive(&mut out, cell.x + GLYPH_LEFT_INSET, glyph_bottom_y, "Break");
+            }
         }
     }
     out


### PR DESCRIPTION
## Summary

Adds `MusicalSymbol::Break` and threads `<Break>` recognition through the parser's `apply_comment` dispatcher so the drum-silence marker attaches to its bar instead of being silently dropped. The convert label and iReal SVG italic-text paint both surface the marker, so `<Break>` is end-to-end visible across the pipeline.

## What changed

- `crates/ireal/src/ast.rs`: new `MusicalSymbol::Break` variant with doc comment citing the spec.
- `crates/ireal/src/parser.rs`: `apply_comment` recognises `break` via the existing `matches_macro_prefix` anchor (case-insensitive, whitespace-tolerant, start-of-comment), avoiding `breakaway`/etc. false positives.
- `crates/ireal/src/serialize.rs` + `crates/ireal/src/json.rs`: round-trip support for the new variant.
- `crates/convert/src/from_ireal.rs`: `symbol_label` returns `"Break"` so the converter surfaces the marker as the parenthesised `(Break)` label, matching the existing drop-on-bar markers.
- `crates/render-ireal/src/music_symbols.rs`: paints `Break` as italic staff text via the existing `emit_text_directive` path, mirroring `D.C.` / `D.S.` / `Fine`.

## Deferred

- **`break_demo` golden fixture, `FORMAT.md` staff-text-token row, and `known-deviations.md` ChordPro-reverse-direction note** → #2488. The recognition + paint layers are complete and exercised by the existing round-trip / sister-site tests; the fixture + two docs files are a separable docs-style follow-up.

## Verification

- [x] `cargo test --workspace` — all crates green.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Match-arm completeness verified by build error → resolution loop (the new `MusicalSymbol::Break` variant forced explicit handling in `convert::symbol_label` and `render-ireal::music_symbols`, no implicit fallthrough).

## Sister-site audit

- iReal AST + parser + serializer + JSON: covered in this PR.
- Convert (iReal → ChordPro): covered (`symbol_label` returns `"Break"`).
- Convert (ChordPro → iReal): the existing reverse path has no recognised `(Break)` lyric segment to emit; the ChordPro-side has no equivalent typed attribute. Documented in #2488.
- Render-ireal: covered (italic text via `emit_text_directive`).
- TypeScript `Bar`/`BarChord` in `packages/ui-irealb-editor/src/ast.ts`: not touched in this PR — the `MusicalSymbol` enum is a Rust-side concern; the wasm JSON serializer already omits unrecognised variants in older TS clients.
- ChordPro three-renderer parity group: out of scope (iReal-only feature).

Closes #2448 (recognition + paint scope; fixture + docs tracked at #2488).