### PR TITLE
fix(.claude): harden autopilot-issue against mv -i alias hang and pr-review context.json drift

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -57,7 +57,9 @@ self-contained operation.
 Every phase Markdown file must end with prose instructing Claude to:
 
 1. Atomically rewrite `<state-dir>/context.json` (write to `.tmp`, then
-   `mv`).
+   `command mv` over the real path — NOT plain `mv`, which expands to
+   `mv -i` under a zsh `alias mv='mv -i'` and hangs the phase on the
+   interactive y/n prompt because the inner shell has no stdin).
 2. Write the next phase name to `<state-dir>/current-phase.txt`.
 3. If halting, set `next_phase` to `"HALT"` in context.json AND write
    `HALT` to current-phase.txt AND set a one-sentence `halt_reason`.

--- a/.claude/workflows/autopilot-issue/phases/pr-review.md
+++ b/.claude/workflows/autopilot-issue/phases/pr-review.md
@@ -40,7 +40,7 @@ if git ls-remote --exit-code origin "<implementation.branch>" >/dev/null 2>&1; t
   # Substitute the orchestrator-supplied state directory path below.
   jq --arg reason "remote branch <implementation.branch> already exists; manual cleanup required" \
     '. + {halt_reason: $reason}' '<state-dir>/context.json' > '<state-dir>/context.json.tmp' \
-    && mv '<state-dir>/context.json.tmp' '<state-dir>/context.json'
+    && command mv '<state-dir>/context.json.tmp' '<state-dir>/context.json'
   printf 'HALT' > '<state-dir>/current-phase.txt'
   exit 0
 fi
@@ -280,6 +280,34 @@ Do NOT call `gh pr merge`. The four-clause merge gate in
 [`.claude/rules/pr-workflow.md`](../../../rules/pr-workflow.md)
 §"Bot-driven merge: conditional permission" requires per-session
 permission this workflow does not assume.
+
+### 5. Persist state BEFORE exiting
+
+This step is the most common failure mode of this phase: pushing fix
+commits and posting the Ready-for-merge comment is the *visible*
+work, but the orchestrator advances only when the state files have
+been semantically updated. Round 2's pr-review correctly did all of
+the visible work, then exited without writing the `pr` field or
+flipping `current-phase.txt` — the orchestrator reported exit 3
+("phase did not semantically update context.json") even though the PR
+was in fact ready. The maintainer then had to do the merge by hand
+because the workflow looked HALTed.
+
+Before exiting, verify in this exact order:
+
+1. `context.json` contains the populated `pr` object (every field in
+   the §"Output" schema below). A `pr.number` of `0` or a missing key
+   counts as a contract violation.
+2. `current-phase.txt` contains `ready-for-merge` on a single line —
+   not `pr-review`, not blank, not `HALT` unless an actual HALT
+   condition fired.
+3. The atomic rewrite uses `command mv` (NOT `mv`), per the
+   orchestrator's "Required final actions" footer.
+
+If any of those is false, the inner phase will look "successful" to a
+human reading the PR comments but the orchestrator will exit 3 and
+the maintainer will absorb the recovery cost. Treat this checklist as
+load-bearing.
 
 ## Forbidden actions
 

--- a/.claude/workflows/autopilot-issue/phases/pr-review.md
+++ b/.claude/workflows/autopilot-issue/phases/pr-review.md
@@ -281,7 +281,7 @@ Do NOT call `gh pr merge`. The four-clause merge gate in
 §"Bot-driven merge: conditional permission" requires per-session
 permission this workflow does not assume.
 
-### 5. Persist state BEFORE exiting
+### 7. Persist state BEFORE exiting
 
 This step is the most common failure mode of this phase: pushing fix
 commits and posting the Ready-for-merge comment is the *visible*

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,13 @@ apps/desktop/src-tauri/gen/
 # .claude/workflow-state/ is not. See .claude/workflows/README.md.
 .claude/workflow-state/
 
+# Claude Code session-level lock created by the harness when ScheduleWakeup
+# is armed. The file lives at the repo root scope but is local to the session
+# that wrote it. When the workflow orchestrator runs inside a session that has
+# armed a wakeup, this file shows up as untracked and the preconditions phase
+# treats it as a dirty tree and HALTs. The lock must not be committed.
+.claude/scheduled_tasks.lock
+
 # Playwright MCP server scratch dir
 # Created at the repo root when the Playwright MCP server captures
 # page snapshots (`page-*.yml`) or console logs (`console-*.log`)

--- a/scripts/run-workflow.sh
+++ b/scripts/run-workflow.sh
@@ -263,8 +263,13 @@ Before you stop, perform every one of the following:
 
 1. Atomically write the updated state to `<state-dir>/context.json`
    (substitute the orchestrator-supplied path above). Write to
-   `<state-dir>/context.json.tmp` first, then `mv` it over the real path.
-   Do not leave the file half-written if you are interrupted.
+   `<state-dir>/context.json.tmp` first, then `command mv` it over the
+   real path. Use `command mv` (NOT plain `mv`) so any `alias
+   mv='mv -i'` in the user's interactive shell does not turn the
+   rename into an interactive y/n prompt that hangs the phase
+   indefinitely; the inner shell has no stdin, so a prompted `mv -i`
+   blocks forever. Do not leave the file half-written if you are
+   interrupted.
 2. Write the chosen next phase name to `<state-dir>/current-phase.txt`
    on a single line (no trailing prose). Valid next-phase identifiers are
    listed in this workflow's `workflow.json` under `phases.<current>.next`


### PR DESCRIPTION
## Summary

Fixes three workflow bugs that cost ~30-60 min of manual recovery per `autopilot-issue` run during the 5-round loop session that motivated #2490. Two more #2490 AC items are deferred with explanations.

## What changed

### 1. `scripts/run-workflow.sh` + `.claude/workflows/README.md` + `.claude/workflows/autopilot-issue/phases/pr-review.md` — `command mv` instead of `mv`

The orchestrator's "Required final actions" footer told phase Claudes to do `mv tmp final`. Under zsh's common `alias mv='nocorrect mv -i'` (which is the user-shell-default in this repo's maintainer environment), the alias expanded the call to `mv -i tmp final`. With no interactive stdin in the inner Claude shell, that prompted indefinitely on the y/n overwrite confirmation — the orchestrator's per-phase timeout never fired because `mv` was actually waiting on a pseudo-TTY, not idling. The maintainer had to `kill` the hung `mv -i` PID by hand to advance.

`command mv` invokes the binary directly and ignores any user alias, so the same instruction works regardless of profile.

### 2. `.gitignore` — `.claude/scheduled_tasks.lock`

`ScheduleWakeup` (the Claude Code harness's wakeup-scheduler tool) creates `.claude/scheduled_tasks.lock` at the repo root inside any session that armed a heartbeat. The lock is session-local — it never belongs in version control — but the `preconditions` phase's clean-tree check (`git status --short`) sees it as untracked and HALTs. Adding it to `.gitignore` makes the workflow runnable inside a wakeup-using Claude session without a `.git/info/exclude` workaround.

### 3. `.claude/workflows/autopilot-issue/phases/pr-review.md` — load-bearing pre-exit checklist

`pr-review` had no explicit step tying the visible work (push fix commit, post Ready-for-merge comment) to the state files the orchestrator inspects (`context.json` `pr` field, `current-phase.txt`). One run during the motivating loop did every visible step correctly and then exited without updating either file; the orchestrator reported `exit 3` (`phase did not semantically update context.json`) as a contract violation, and the human maintainer absorbed the recovery cost (~30 min of inspecting the PR comments, confirming the actual review was clean, and merging by hand).

A new "Persist state BEFORE exiting" step calls out this specific failure mode by name and lists the exact ordered checklist the phase must satisfy before exit. The checklist references the same `command mv` convention from change 1 so the two fixes reinforce each other.

## Deferred from #2490 (with reasons)

- **Branch protection merge queue removal (ADR-0015 alignment)** — the `main` branch still has `MQ_kwDORz-wls4AArnt` (SQUASH / ALLGREEN) attached despite ADR-0015 disabling its use, which is why every PR merge in this repo falls back to a GraphQL `mergePullRequest` mutation workaround. The mutation that removes it is a live repo-settings change that the maintainer must run interactively (it affects every contributor's `gh pr merge --squash`, not just autopilot's). Suggested command for the maintainer:

  ```bash
  gh api graphql -f query='mutation { deleteMergeQueue(input: {mergeQueueId: "MQ_kwDORz-wls4AArnt"}) { repository { name } } }'
  ```

  (Or via the repo settings UI under Branches → main → "Require merge queue".)

- **Docs-only CI path filtering** — appears to conflict with `.claude/rules/ci-parallelization.md` (whose "Unconditional CI over path filters" stance is durable feedback from the maintainer). Whether macOS aarch64 + iOS Simulator + XCFramework cells count as "guarantee-style checks" subject to that rule is a judgment call I'd rather defer to the rule's author than make unilaterally. Tracked as a follow-up so the rule clarification happens before the workflow edit.

## Verification

- [x] `python3 scripts/validate-workflow.py autopilot-issue` — OK.
- [x] `python3 scripts/test_run_workflow.py` — 15 tests passed (orchestrator end-to-end smoke).
- [x] `python3 scripts/test_validate_workflow.py` — 11 tests passed.
- [x] Hand-verified `command mv` invariance against `alias mv='nocorrect mv -i'`: `command mv` does NOT trigger the interactive prompt because the alias resolution is bypassed.

## Sister-site audit

- Other `.claude/workflows/<workflow>/` directories: only `autopilot-issue` exists today. The orchestrator's footer change applies to every future workflow added under `.claude/workflows/`; the README contract is updated in lockstep.
- Bindings / renderers: not in scope (workflow plumbing change, not crate code).

Closes #2490 (subset; merge queue + CI filter deferred as noted above).