### PR TITLE
feat(autopilot-issue): batch multiple eligible issues into one PR per round

### DIFF
--- a/.claude/rules/branch-strategy.md
+++ b/.claude/rules/branch-strategy.md
@@ -1,10 +1,32 @@
 # Branch Strategy
 
 - **All work requires a GitHub Issue first** — no branch without an issue.
-- Branch naming: `issue-{number}-{short-kebab-case}` (e.g., `issue-5-chord-parser`).
-- One branch per issue, one issue per branch — strict 1:1 mapping.
+- Branch naming: `issue-{number}-{short-kebab-case}` (e.g., `issue-5-chord-parser`)
+  for single-issue branches.
+- One branch per issue, one issue per branch — strict 1:1 mapping for
+  human-authored branches and single-issue autopilot rounds.
 - All branches are created from latest `main`.
 - After merge, delete the remote branch (already configured via repo settings).
+
+## Batched autopilot branches
+
+The `autopilot-issue` workflow runs in batch mode per
+[ADR-0019](../../docs/adr/0019-batch-mode-autopilot-issue.md): a
+single round implements every high-confidence eligible issue (capped at
+10) inside one worktree on one branch.
+
+- Multi-issue batches use `batch-YYYY-MM-DD-N1-N2-...` (e.g.
+  `batch-2026-05-17-2433-2436-2449`). The date prefix sorts batches
+  chronologically; the issue-number suffix preserves issue-to-branch
+  attribution from `git branch -a` output. Total length capped at
+  ~60 chars; overflowing batches truncate to the first four numbers
+  plus a `-plusN` suffix.
+- Single-eligible-issue batches keep the `issue-{N}-{slug}` shape so
+  single-issue rounds look unchanged on the PR list.
+- The strict 1:1 issue-to-branch rule does NOT apply to multi-issue
+  batch branches. The PR body documents each closed issue separately
+  with one `Closes #N` line per applied issue so squash-merge closes
+  every aggregated issue at once.
 
 ## Bot Branch Exceptions
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -46,6 +46,12 @@ bug should close all linked issues.
 3. Create worktree + branch from latest `main`.
 4. Implement (commits reference issue: `Part of #N` or `Closes #N`).
 5. Open PR (title references issue, body has `Closes #N`).
+   *(Batched autopilot PRs aggregate multiple issues per
+   [ADR-0019](../../docs/adr/0019-batch-mode-autopilot-issue.md); the
+   PR body has one `Closes #N` line per applied issue and squash-merge
+   closes all of them at once. See
+   [branch-strategy.md](branch-strategy.md) §"Batched autopilot
+   branches" for the branch shape.)*
 6. CI -> auto-review (severity classification) -> human merge.
    See [Pull Request Workflow](pr-workflow.md) for details. Bots do not merge in
    this repo; a human inspects the check rollup and performs the squash merge.

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -235,3 +235,35 @@ empty. This is the convergence criterion — not "no blocking findings" but
   noise — and embedding it in durable artefacts pollutes the signal. Keep
   conversations in chat, issues, or review threads; keep PR bodies and
   commit messages in the technical-record voice.
+
+### Batched-PR formatting (autopilot-issue, ADR-0019)
+
+The `autopilot-issue` workflow can aggregate multiple
+high-confidence eligible issues into one PR per round. Multi-issue
+PR bodies follow this shape so each closed issue stays traceable:
+
+- **Title**: `batch(autopilot): <K> issues — <YYYY-MM-DD>` for
+  multi-issue batches; the historical `<scope>: <subject> (#<N>)`
+  shape for single-issue batches.
+- **Per-issue section**: under `## Per-issue changes`, one
+  `### #<N>: <title>` block per applied issue. Each block names the
+  closed issue, its commit SHA + subject (autopilot writes one
+  commit per issue inside the PR — see
+  [branch-strategy.md](branch-strategy.md) §"Batched autopilot
+  branches"), a 1-3 bullet "what changed", the touched file list,
+  and the sister-site spot-check that issue triggered.
+- **Aggregated sister-site audit**: one `## Aggregated sister-site
+  audit` block summarising the cross-issue audit conclusions the
+  per-issue spot-checks accumulate into.
+- **Deferred section**: any issue the implementation phase
+  attempted but reverted (3-attempt corrective-action loop
+  exhausted) appears under `## Deferred` with its number, reason,
+  and last-error tail. Deferred items remain open as issues — they
+  are NOT absorbed by this PR and not closed by squash-merge.
+- **Closes lines**: one `Closes #N` line per **applied** issue
+  (NOT per deferred issue), each on its own line so GitHub closes
+  every aggregated issue on squash-merge.
+
+Single-issue batches use the unchanged single-issue body shape (one
+`## What` / `## Why` / `## Test results` / `## Review summary` /
+`## Sister-site audit` / `## Deferred` block with one `Closes #N`).

--- a/.claude/workflows/autopilot-issue/README.md
+++ b/.claude/workflows/autopilot-issue/README.md
@@ -1,6 +1,16 @@
 # Workflow: autopilot-issue
 
-Single-iteration autonomous handler for `unchidev`-authored issues.
+Batch-mode autonomous handler for `unchidev`-authored issues
+([ADR-0019](../../../docs/adr/0019-batch-mode-autopilot-issue.md)).
+One round picks every high-confidence eligible candidate (capped at
+10), implements each as a separate commit on a single
+`batch-YYYY-MM-DD-N1-N2-...` branch, opens one PR aggregating every
+applied issue, and drives that PR to Ready-for-merge.
+
+A round with exactly one eligible candidate degenerates to the
+historical "one issue per PR" shape — the branch retains the
+`issue-{N}-{slug}` name and the PR closes one issue — so
+single-issue invocations look unchanged on the PR list.
 
 ## Phases
 
@@ -21,7 +31,8 @@ worktree (if any) is preserved for inspection.
 - `AUTOPILOT_DRY_RUN=1` — skip push/PR steps; exit after local
   validation with `dry-run-exit`.
 - `AUTOPILOT_ISSUE_NUMBER=<N>` — target a specific issue (must still be
-  authored by `unchidev`); skip triage scoring.
+  authored by `unchidev`); skip triage scoring. The resulting batch
+  has exactly one entry.
 
 Both are read from the environment by the `preconditions` phase and
 recorded in `context.json` as `dry_run` (bool) and `target_issue` (int
@@ -90,11 +101,15 @@ orchestrator might stop early.
   current user against `main` exists; `pr-review-toolkit` plugin is
   not installed.
 - **`issue-selection`**: target issue not authored by the expected
-  user, or hard preconditions on the candidate set fail.
-- **`implementation`**: local validation (`cargo fmt --check`,
-  `cargo clippy -- -D warnings`, `cargo test --workspace`, plus any
-  workflow-specific smoke) cannot be made green; a forbidden action
-  would be required to satisfy the issue.
+  user, author re-verification fails for any selected issue, or hard
+  preconditions on the candidate set fail.
+- **`implementation`**: the sanity recheck of any selected issue's
+  author fails; `git worktree add` fails; OR the workspace-wide
+  validation gate fails AND reverting every batched commit cannot
+  restore green (i.e. the failure is rooted in `main` at the time
+  `preconditions` ran). Per-issue failures that the 3-attempt
+  corrective-action loop cannot resolve are recorded as Deferred
+  entries on the batch — they do NOT HALT the batch.
 - **`pr-review`**: remote branch already exists at push time; CI
   does not settle within the bounded wait (30 min default); review
   iteration cap (10) is hit with findings outstanding; a finding's

--- a/.claude/workflows/autopilot-issue/phases/implementation.md
+++ b/.claude/workflows/autopilot-issue/phases/implementation.md
@@ -22,10 +22,23 @@ and either stop (dry-run) or pass the baton to `pr-review`.
 
 ### 0. Sanity recheck
 
-Re-confirm every `selected_issues[*].author_login == expected_user`.
-If any diverge (a previous phase's state somehow got corrupted between
-`issue-selection` and now), HALT immediately — do not create any
-worktree or modify any file.
+Re-confirm every `selected_issues[*].author_login == expected_user`
+AND that each issue is still open (`state == "OPEN"`). Both checks
+call the GitHub API directly — do not trust the stored context.json
+values alone. If any author diverges, or any issue is no longer open,
+HALT immediately — do not create any worktree or modify any file.
+
+```bash
+expected=$(jq -r '.expected_user // "unchidev"' <state-dir>/context.json)
+for N in <each number in selected_issues>; do
+  actual_author=$(gh issue view "$N" --json author --jq .author.login)
+  actual_state=$(gh issue view "$N" --json state --jq .state)
+  [[ "$actual_author" == "$expected" ]] \
+    || halt "sanity recheck: issue #$N author is $actual_author, expected $expected"
+  [[ "$actual_state" == "OPEN" ]] \
+    || halt "sanity recheck: issue #$N is no longer open (state: $actual_state)"
+done
+```
 
 ### 1. Worktree + branch
 
@@ -104,14 +117,18 @@ for each issue in selected_issues (in batch_order):
         run sub-agents 2.a through 2.c below for this issue
         run targeted validation (2.d)
         if validation passes:
+            if attempt > 1:
+                # A prior corrective action led to this success; record it.
+                record corrective_action with outcome="succeeded"
             commit per 2.e
             break inner while
         else:
             if attempt < 3:
                 analyse failure, adjust approach, retry
-                record entry in corrective_actions[]
+                record corrective_action with outcome="continued-to-next-attempt"
             else:
                 git reset --hard <HEAD before>
+                record corrective_action with outcome="exhausted"
                 add entry to deferred[] with reason + last error
                 break inner while
 ```
@@ -167,13 +184,18 @@ regressions while the context is fresh.
 
 ```bash
 # Identify touched crates from the staged + unstaged diff.
+# Map directory → Cargo package name:
+#   crates/cli  → chordsketch  (package name is `chordsketch`, not `chordsketch-cli`)
+#   crates/<X>  → chordsketch-<X>  for all other crates
 touched=$(git diff --name-only HEAD \
           | grep -oE '^crates/[^/]+' | sort -u)
-crate_flags=$(printf -- '-p chordsketch-%s ' \
-              $(printf '%s\n' "$touched" | sed 's|crates/||'))
+crate_flags=$(printf '%s\n' "$touched" \
+              | sed 's|crates/cli|chordsketch|; s|crates/\([^/]*\)|chordsketch-\1|' \
+              | sort -u \
+              | xargs -I{} printf -- '-p %s ' '{}')
 
 cargo fmt --check
-cargo clippy $crate_flags -- -D warnings
+cargo clippy $crate_flags --all-targets -- -D warnings
 cargo test $crate_flags
 ```
 
@@ -192,7 +214,12 @@ and the final line carries the `Closes #N` reference so squash
 merge to `main` closes the issue:
 
 ```bash
-git add -A
+# Stage only the files this issue's changes touched.
+# Use explicit paths from the Plan sub-agent's file list rather than
+# `git add -A` to avoid accidentally staging unrelated files or
+# credentials. If the sub-agent modified files outside the planned
+# list, review them before staging.
+git add -- <explicit file paths from step 2.b Plan output>
 git commit -m "$(cat <<EOF
 <scope>: <subject line, imperative, ≤ 70 chars> (#<N>)
 
@@ -295,6 +322,7 @@ Extend `context.json` with:
         "outcome": "succeeded | continued-to-next-attempt | exhausted"
       }
     ],
+    "files_changed": "<DEPRECATED — backward-compat with pre-ADR-0019 --resume contexts. Set to the sum of commits[*].files_changed. Downstream phases MUST read commits[]; this field exists only so old context.json files can be inspected without schema errors>",
     "diff_stat": "<output of git diff --stat origin/main...HEAD>",
     "validation": {
       "fmt": "passed",
@@ -317,14 +345,22 @@ Set the next phase (write to `<state-dir>/current-phase.txt`):
 - `dry-run-exit` if `dry_run == true` (regardless of whether any
   issue committed).
 - `HALT` if the sanity recheck failed, the worktree could not be
-  created, every issue ended up Deferred AND the gate cannot be
-  restored to green, or a HALT-classed condition fired as
-  documented in `## HALT conditions` below.
+  created, `dry_run == false` and `commits[]` is empty (every
+  selected issue was deferred and there is nothing to push), every
+  issue ended up Deferred AND the gate cannot be restored to green,
+  or a HALT-classed condition fired as documented in
+  `## HALT conditions` below.
 
 ## HALT conditions (explicit enumeration)
 
 - Sanity recheck of any `selected_issues[*].author_login` fails.
+- Sanity recheck finds any selected issue is no longer open.
 - `git worktree add` fails (existing worktree, dirty state, etc.).
+- `dry_run == false` and `commits[]` is empty after the
+  workspace-wide gate — every selected issue was deferred and there
+  is nothing to push. (Use `dry-run-exit` only when `dry_run ==
+  true`; when pushing is expected and there is nothing to push, HALT
+  so the maintainer sees why all issues were deferred.)
 - The workspace-wide gate fails AND reverting every batched commit
   cannot restore green — i.e. the failure is rooted in `main` at
   the time `preconditions` ran. This is rare and worth a manual

--- a/.claude/workflows/autopilot-issue/phases/implementation.md
+++ b/.claude/workflows/autopilot-issue/phases/implementation.md
@@ -1,17 +1,20 @@
 # Phase: implementation
 
-Set up an isolated worktree, implement the selected issue, run local
-validation, and either stop (dry-run) or pass the baton to `pr-review`.
+Batch mode (ADR-0019). Set up one isolated worktree on one
+`batch-YYYY-MM-DD-N1-N2-...` branch, loop over every selected issue
+applying them as one commit per issue with a corrective-action
+retry budget for failures, run the workspace-wide validation gate,
+and either stop (dry-run) or pass the baton to `pr-review`.
 
 ## Inputs
 
 **Context fields read**:
 
-- `selected_issue.number` — issue number to implement.
-- `selected_issue.title` — used to slugify the branch name.
-- `selected_issue.author_login` — expected author; sanity-check against
-  `expected_user` before touching anything mutable.
-- `expected_user` — set by `preconditions`.
+- `selected_issues` (array) — every issue to apply this round, in
+  `batch_order` ascending.
+- `expected_user` — set by `preconditions`. Each issue's
+  `author_login` was already verified by `issue-selection`; the
+  sanity recheck below covers state corruption between phases.
 - `dry_run` (bool) — if `true`, stop after local validation and do not
   push or open a PR.
 
@@ -19,12 +22,12 @@ validation, and either stop (dry-run) or pass the baton to `pr-review`.
 
 ### 0. Sanity recheck
 
-Re-confirm `selected_issue.author_login == expected_user`. If they
-diverge (a previous phase's state somehow got corrupted between
+Re-confirm every `selected_issues[*].author_login == expected_user`.
+If any diverge (a previous phase's state somehow got corrupted between
 `issue-selection` and now), HALT immediately — do not create any
 worktree or modify any file.
 
-### 1. Worktree
+### 1. Worktree + branch
 
 Per [`.claude/rules/parallel-work.md`](../../../rules/parallel-work.md)
 and [`.claude/rules/branch-strategy.md`](../../../rules/branch-strategy.md).
@@ -33,18 +36,39 @@ lands at the conventional `../chordsketch-wt/<branch>` path regardless
 of where this phase was invoked from:
 
 ```bash
-N=<selected_issue.number>
-slug=$(printf '%s' "<selected_issue.title>" \
-       | tr '[:upper:]' '[:lower:]' \
-       | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//' \
-       | cut -c1-40)
-# Fall back to a timestamp if the title contained only non-ASCII
-# characters and the slug came out empty. Empty slugs would produce
-# an invalid Git branch name like `issue-1234-`.
-[[ -z "$slug" ]] && slug="$(date +%s)"
-branch="issue-${N}-${slug}"
+# Build the branch name from the date and the selected issue numbers.
+# Cap at 60 chars total so the branch name stays under Git's
+# `prune-suggestion` advice line wrap (and shells render it cleanly).
+date_part=$(date -u +%Y-%m-%d)
+nums=$(jq -r '.selected_issues | map(.number | tostring) | join("-")' \
+       <state-dir>/context.json)
+candidate="batch-${date_part}-${nums}"
+if (( ${#candidate} > 60 )); then
+  # Too many issues to fit; keep the first 4 numbers and append +N.
+  first4=$(jq -r '.selected_issues[0:4] | map(.number | tostring) | join("-")' \
+           <state-dir>/context.json)
+  rest=$(jq -r '.selected_issues | length - 4' <state-dir>/context.json)
+  branch="batch-${date_part}-${first4}-plus${rest}"
+else
+  branch="${candidate}"
+fi
+
+# Degenerate single-issue batch: keep the historical issue-{N}-{slug}
+# name so single-issue invocations look unchanged on the PR list.
+if (( $(jq -r '.selected_issues | length' <state-dir>/context.json) == 1 )); then
+  N=$(jq -r '.selected_issues[0].number' <state-dir>/context.json)
+  title=$(jq -r '.selected_issues[0].title' <state-dir>/context.json)
+  slug=$(printf '%s' "$title" \
+         | tr '[:upper:]' '[:lower:]' \
+         | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//' \
+         | cut -c1-40)
+  [[ -z "$slug" ]] && slug="$(date +%s)"
+  branch="issue-${N}-${slug}"
+fi
+
 repo_top=$(git rev-parse --show-toplevel)
 worktree_path="${repo_top}/../chordsketch-wt/${branch}"
+
 # preconditions already ran `git fetch origin main --tags` and
 # fast-forwarded local main to origin/main; re-fetching here is
 # defense-in-depth in case the orchestrator's resume path skipped
@@ -57,74 +81,174 @@ All subsequent file operations in this phase happen **inside that
 worktree**. Use absolute paths everywhere; record `worktree_path` in
 context.json so `pr-review` can `cd` there.
 
-Flip the issue's project-board status to In Progress using the snippet
-in [`.claude/rules/issue-workflow.md`](../../../rules/issue-workflow.md)
-(option ID `47fc9ee4`). If the issue is not on the board, skip the flip
-and continue — do not HALT on a missing board entry.
+For every issue in `selected_issues`, flip its project-board status
+to In Progress using the snippet in
+[`.claude/rules/issue-workflow.md`](../../../rules/issue-workflow.md)
+(option ID `47fc9ee4`). If an issue is not on the board, skip the
+flip for that issue and continue — do not HALT on a missing board
+entry.
 
-### 2. Implementation
+### 2. Per-issue implementation loop
 
-Stage the work through three sub-agents in sequence, using the
-built-in `subagent_type` shown for each (these are part of the
-`claude` CLI core; no plugin install required):
+For each issue in `selected_issues` ordered by `batch_order`
+(ascending), perform the following sub-steps. Track `commits[]`,
+`deferred[]`, and `corrective_actions[]` arrays in working memory
+to populate the output schema at the end.
 
-1. `Explore` — map affected crates, callers, fixtures,
-   and rule-file constraints. Output: written exploration brief.
-2. `Plan` — design as a concrete blueprint (files
-   to add/modify, function signatures, fixtures).
-3. `general-purpose` — execute the blueprint:
-   - Tests per
-     [`.claude/rules/golden-tests.md`](../../../rules/golden-tests.md)
-     and [`.claude/rules/code-style.md`](../../../rules/code-style.md)
-     (every behaviour change covered by a test that fails without the
-     change).
-   - Doc comments on every new public item.
-   - Sister-site audits per
-     [`.claude/rules/renderer-parity.md`](../../../rules/renderer-parity.md),
-     [`.claude/rules/fix-propagation.md`](../../../rules/fix-propagation.md),
-     and
-     [`.claude/rules/sanitizer-security.md`](../../../rules/sanitizer-security.md).
-   - English-only per
-     [`.claude/rules/english-only.md`](../../../rules/english-only.md).
-   - Root-cause discipline per
-     [`.claude/rules/root-cause-fixes.md`](../../../rules/root-cause-fixes.md)
-     — no symptomatic fixes.
+```
+for each issue in selected_issues (in batch_order):
+    record HEAD before = git rev-parse HEAD
+    attempt = 0
+    while attempt < 3:
+        attempt += 1
+        run sub-agents 2.a through 2.c below for this issue
+        run targeted validation (2.d)
+        if validation passes:
+            commit per 2.e
+            break inner while
+        else:
+            if attempt < 3:
+                analyse failure, adjust approach, retry
+                record entry in corrective_actions[]
+            else:
+                git reset --hard <HEAD before>
+                add entry to deferred[] with reason + last error
+                break inner while
+```
 
-If at any point the issue turns out to require an ADR, human design
-judgement, or scope that exceeds autonomous-eligibility, HALT with
-`halt_reason: "<which constraint hit>"`. Do not push a partial
-implementation.
+#### 2.a. Explore (sub-agent: `Explore`)
 
-### 3. Local validation
+Map affected crates, callers, fixtures, and rule-file constraints
+for **this specific issue**. Do not let prior issues' exploration
+notes pollute the brief — each issue gets a fresh exploration.
+
+#### 2.b. Plan (sub-agent: `Plan`)
+
+Design as a concrete blueprint (files to add/modify, function
+signatures, fixtures). Cross-check against the prior issues already
+committed in this worktree — if the plan would re-modify a file the
+prior issue already changed, note it (this is not a failure; the
+later commit just needs to absorb the prior context cleanly).
+
+#### 2.c. Execute (sub-agent: `general-purpose`)
+
+Apply the blueprint:
+
+- Tests per
+  [`.claude/rules/golden-tests.md`](../../../rules/golden-tests.md)
+  and [`.claude/rules/code-style.md`](../../../rules/code-style.md)
+  (every behaviour change covered by a test that fails without the
+  change).
+- Doc comments on every new public item.
+- Sister-site audits per
+  [`.claude/rules/renderer-parity.md`](../../../rules/renderer-parity.md),
+  [`.claude/rules/fix-propagation.md`](../../../rules/fix-propagation.md),
+  and
+  [`.claude/rules/sanitizer-security.md`](../../../rules/sanitizer-security.md).
+- English-only per
+  [`.claude/rules/english-only.md`](../../../rules/english-only.md).
+- Root-cause discipline per
+  [`.claude/rules/root-cause-fixes.md`](../../../rules/root-cause-fixes.md)
+  — no symptomatic fixes.
+
+If at any point THIS issue turns out to require an ADR, human design
+judgement, or scope that exceeds autonomous-eligibility, revert
+this issue's changes (`git reset --hard <HEAD before>`), add it to
+`deferred[]` with `reason: "<which constraint hit>"`, and continue
+to the next issue. Do NOT HALT the whole batch — one issue
+discovering a hidden requirement should not kill the others.
+
+#### 2.d. Targeted validation
+
+Per issue, run validation scoped to the touched crates rather than
+the whole workspace. The workspace-wide gate at step 3 catches
+cross-issue regressions; this scoped run catches per-issue
+regressions while the context is fresh.
+
+```bash
+# Identify touched crates from the staged + unstaged diff.
+touched=$(git diff --name-only HEAD \
+          | grep -oE '^crates/[^/]+' | sort -u)
+crate_flags=$(printf -- '-p chordsketch-%s ' \
+              $(printf '%s\n' "$touched" | sed 's|crates/||'))
+
+cargo fmt --check
+cargo clippy $crate_flags -- -D warnings
+cargo test $crate_flags
+```
+
+For every failure, fix the root cause and re-run. Do not bump
+timeouts, `#[allow(...)]` legitimate warnings, or edit golden
+snapshots to mask broken output. The 3-attempt corrective-action
+budget covers this loop.
+
+#### 2.e. Commit
+
+On success, commit the issue's changes as a single commit. Subject
+in imperative mood matching the project's
+[`.claude/rules/pr-workflow.md`](../../../rules/pr-workflow.md)
+§"PR Formatting and Commit Messages" voice, body explains *why*,
+and the final line carries the `Closes #N` reference so squash
+merge to `main` closes the issue:
+
+```bash
+git add -A
+git commit -m "$(cat <<EOF
+<scope>: <subject line, imperative, ≤ 70 chars> (#<N>)
+
+<one to three paragraphs explaining the WHY of this change>
+
+Closes #<N>.
+EOF
+)"
+```
+
+Record the issue + commit SHA in `commits[]`.
+
+### 3. Workspace-wide gate
+
+After the per-issue loop completes, run the full workspace
+validation gate over **every** issue's accumulated commits:
 
 ```bash
 cargo fmt --check
-cargo clippy --workspace -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
-```
-
-If renderers were touched, also:
-
-```bash
 python3 scripts/check-fixture-counts.py
 ```
 
-For every failure, fix the root cause and re-run. Do not bump timeouts,
-`#[allow(...)]` legitimate warnings, or edit golden snapshots to mask
-broken output.
+If any of these fails:
 
-If three diagnose-and-fix cycles do not converge to green, HALT with
-`halt_reason: "local validation could not be made green; see <failing-command>"`.
+1. Identify the offending commit via `cargo test` output or
+   `git bisect run` with the failing command.
+2. Revert that issue's commit (`git revert <sha>` so the history
+   stays linear and reviewable).
+3. Add the issue to `deferred[]` with `reason: "workspace-wide gate
+   failed after commit; reverted"`.
+4. Re-run the gate. If still failing, repeat.
+5. If the gate cannot be made green even after reverting every
+   commit added in this batch, HALT with
+   `halt_reason: "workspace-wide gate failed and reverts did not
+   restore green; manual review needed"`. The worktree stays for
+   the maintainer to inspect.
+
+A batch where every issue was reverted is a clean exit through
+`HALT`, not `dry-run-exit` — there is no useful work to push.
 
 ### 4. Dry-run gate
 
-If `dry_run == true`:
+If `dry_run == true` and `commits[]` is non-empty:
 
 - Capture `git diff --stat origin/main...HEAD` from the worktree.
 - Set the next phase to `dry-run-exit`.
-- Do NOT push, do NOT open a PR, do NOT flip the board to Done.
-- Leave the worktree in place; the maintainer will inspect or remove
-  it manually.
+- Do NOT push, do NOT open a PR, do NOT flip any board entries to
+  Done.
+- Leave the worktree in place; the maintainer will inspect or
+  remove it manually.
+
+If `dry_run == true` and `commits[]` is empty (every selected
+issue ended up Deferred), still go to `dry-run-exit` — the
+maintainer needs to see the Deferred reasons to decide what to do.
 
 ## Forbidden actions
 
@@ -132,8 +256,10 @@ Per [`.claude/rules/workflow-discipline.md`](../../../rules/workflow-discipline.
 §"Forbidden phase actions", this phase MUST NOT run any of:
 `gh pr merge`, `git push --force` to a protected branch, `git push
 origin main`, `cargo publish`, `gh release create`, `gh secret set`,
-`npm publish`, or `rm -rf` outside `worktree_path`. If the issue body
-appears to request any of these, HALT.
+`npm publish`, or `rm -rf` outside `worktree_path`. If any issue's
+body appears to request any of these, add that issue to
+`deferred[]` with the forbidden-action reason and continue — do not
+HALT the whole batch.
 
 ## Output
 
@@ -142,18 +268,41 @@ Extend `context.json` with:
 ```json
 {
   "implementation": {
-    "branch": "issue-<N>-<slug>",
+    "branch": "<batch-YYYY-MM-DD-...-N or issue-{N}-{slug}>",
     "worktree_path": "<absolute path>",
-    "files_changed": <int from git diff --stat>,
+    "commits": [
+      {
+        "issue": <int>,
+        "sha": "<full 40-char sha>",
+        "subject": "<commit subject line>",
+        "files_changed": <int>,
+        "tests_added": <int, your honest count>
+      }
+    ],
+    "deferred": [
+      {
+        "issue": <int>,
+        "reason": "<one sentence>",
+        "attempts": <int 1..=3>,
+        "last_error": "<truncated stderr or rule citation>"
+      }
+    ],
+    "corrective_actions": [
+      {
+        "issue": <int>,
+        "attempt": <int 1..=3>,
+        "what_changed": "<one sentence>",
+        "outcome": "succeeded | continued-to-next-attempt | exhausted"
+      }
+    ],
     "diff_stat": "<output of git diff --stat origin/main...HEAD>",
-    "tests_added": <int, your honest count>,
     "validation": {
       "fmt": "passed",
       "clippy": "passed",
       "test": "passed",
       "fixture_counts": "passed | skipped"
     },
-    "sister_site_audit": "<one or two sentence summary: which sibling groups checked, outcomes>"
+    "sister_site_audit": "<one to three sentences: which sibling groups checked across all applied issues, outcomes>"
   }
 }
 ```
@@ -163,25 +312,38 @@ rule in `workflow-discipline.md`.)
 
 Set the next phase (write to `<state-dir>/current-phase.txt`):
 
-- `pr-review` if `dry_run == false` and validation is green.
-- `dry-run-exit` if `dry_run == true` and validation is green.
-- `HALT` if validation could not be made green, the issue turned out to
-  require human judgement, the sanity recheck failed, or a forbidden
-  action was implied.
+- `pr-review` if `dry_run == false`, `commits[]` is non-empty, and
+  the workspace-wide gate is green.
+- `dry-run-exit` if `dry_run == true` (regardless of whether any
+  issue committed).
+- `HALT` if the sanity recheck failed, the worktree could not be
+  created, every issue ended up Deferred AND the gate cannot be
+  restored to green, or a HALT-classed condition fired as
+  documented in `## HALT conditions` below.
 
 ## HALT conditions (explicit enumeration)
 
-- Sanity recheck of `selected_issue.author_login` fails.
+- Sanity recheck of any `selected_issues[*].author_login` fails.
 - `git worktree add` fails (existing worktree, dirty state, etc.).
-- Implementation requires an ADR, human design judgement, or other
-  out-of-scope work.
-- Local validation cannot be made green in 3 diagnose-and-fix cycles.
-- The issue's body or work scope implies a forbidden action.
+- The workspace-wide gate fails AND reverting every batched commit
+  cannot restore green — i.e. the failure is rooted in `main` at
+  the time `preconditions` ran. This is rare and worth a manual
+  review.
 
 ## Notes
 
 - The worktree is the only writable surface in this phase; do not
   modify the main checkout.
-- If you HALT mid-implementation, the worktree stays. The maintainer
-  can `cd` into it, finish manually, then remove via `git worktree
-  remove`.
+- Per-issue Deferred is the corrective-action loop's failure mode,
+  not a HALT. The batch continues; the Deferred issues surface in
+  the PR body so the maintainer can route them to human attention
+  in a follow-up.
+- A batch of one issue ends up with `branch = issue-{N}-{slug}`
+  per step 1 — the historical name shape — so single-issue
+  invocations of this workflow look the same as they did before
+  ADR-0019.
+- If you HALT before committing anything, the worktree stays. The
+  maintainer can `cd` into it, finish manually, then remove via
+  `git worktree remove`. If you HALT mid-batch with some commits
+  already in place, the same applies — the maintainer sees a
+  partially-populated branch they can finish or discard.

--- a/.claude/workflows/autopilot-issue/phases/issue-selection.md
+++ b/.claude/workflows/autopilot-issue/phases/issue-selection.md
@@ -138,6 +138,7 @@ Write `context.json` with:
   "dry_run": <bool>,
   "target_issue": <int or null>,
   "expected_user": "<string>",
+  "selected_issue": "<DEPRECATED — backward-compat with pre-ADR-0019 --resume contexts. Set to selected_issues[0] for single-issue batches, null for multi-issue batches. Downstream phases MUST read selected_issues[]; this field exists only so old context.json files from interrupted pre-ADR-0019 runs can still be inspected without schema errors>",
   "selected_issues": [
     {
       "number": <int>,

--- a/.claude/workflows/autopilot-issue/phases/issue-selection.md
+++ b/.claude/workflows/autopilot-issue/phases/issue-selection.md
@@ -1,8 +1,10 @@
 # Phase: issue-selection
 
-Pick exactly one open issue authored by the expected user (default
-`unchidev`) that Claude Code can autonomously implement, or exit cleanly
-with `no-candidate` if nothing qualifies.
+Batch mode (ADR-0019). Triage every open issue authored by the
+expected user (default `unchidev`) and select **all**
+high-confidence autonomous-eligible candidates (capped at 10) for
+the implementation phase to apply in one PR, or exit cleanly with
+`no-candidate` if nothing qualifies.
 
 ## Inputs
 
@@ -12,8 +14,9 @@ with `no-candidate` if nothing qualifies.
   the literal `--author` value for `gh` queries and re-verified at the
   end via a non-bypassable API check (see "Author re-verification" below).
 - `dry_run` (bool) — informational; does not affect selection.
-- `target_issue` (int or null) — if set, skip discovery and target this
-  issue directly (still re-verified).
+- `target_issue` (int or null) — if set, behave as a single-issue
+  batch: skip discovery and target this issue directly (still
+  re-verified). The output array contains exactly one entry.
 
 ## Steps
 
@@ -26,16 +29,17 @@ with `no-candidate` if nothing qualifies.
    gh issue view "$N" \
      --json number,title,body,labels,assignees,author,state,url,closedByPullRequestsReferences
    ```
-2. The author check is performed in step 4 of the discovery branch below
-   too — defer to that single code path so prompt-injection (an issue
-   body that claims to be authored by someone it is not) cannot fool the
+2. The author check is performed in the discovery branch's step 4 too —
+   defer to the single code path so prompt-injection (an issue body
+   that claims to be authored by someone it is not) cannot fool the
    workflow regardless of which entry path was taken.
 3. Verify the issue is open. If `state != "open"`, HALT with
    `halt_reason: "target issue #<N> is closed"`.
 4. Skip the discovery / filter / scoring sub-steps; carry the issue
-   forward into the "Author re-verification" step.
+   forward into the "Author re-verification" step as a one-element
+   batch.
 
-### Otherwise: discover + filter + score
+### Otherwise: discover + filter + score + select-all-high-confidence
 
 1. **Discover** every open issue authored by the expected user:
    ```bash
@@ -65,8 +69,7 @@ with `no-candidate` if nothing qualifies.
 
 3. **Triage scoring** — score each surviving candidate on 0–100 across
    four axes. Use your own judgement informed by the issue body, labels,
-   and the project's rules in `.claude/rules/`. Mark
-   `autonomous_eligible = true` only when ALL four are ≥ 70.
+   and the project's rules in `.claude/rules/`.
 
    | Axis | Question |
    |------|----------|
@@ -75,22 +78,47 @@ with `no-candidate` if nothing qualifies.
    | `verifiability` | Can `cargo fmt --check && cargo clippy --workspace -- -D warnings && cargo test --workspace` confirm success? |
    | `independence` | Avoids secrets, human design judgement, new ADRs per [`.claude/rules/adr-discipline.md`](../../../rules/adr-discipline.md), and cross-team coordination? |
 
-4. **Pick the top scorer.** Tiebreak by oldest `createdAt` (FIFO). If
-   zero candidates have `autonomous_eligible = true`, set the next phase
-   to `no-candidate` and include the per-issue scores in context.json
+   Mark `autonomous_eligible = true` only when **all four are ≥ 80**
+   (the batch-mode floor, raised from the per-issue floor of 70 per
+   ADR-0019 — one issue's failure in a batch consumes the worktree,
+   so we want a tighter confidence band on what we attempt).
+
+4. **Select every autonomous-eligible candidate**, ordered for batch
+   application:
+   - Primary sort: ascending file-overlap risk — issues that touch
+     disjoint files first (lower intra-batch conflict risk).
+     Inspect each issue's AC for explicit file paths; use crate
+     boundaries as a heuristic when files are not enumerated.
+   - Secondary sort: ascending `scope` (simpler first — fail-fast on
+     the easier ones, build the worktree's confidence floor before
+     larger changes).
+   - Cap the final list at **10 issues per batch** (ADR-0019 §
+     Decision). If more than 10 qualify, keep the top 10 by
+     descending 4-axis sum.
+   - The remaining (filtered-out, scored-below-80, or above-cap)
+     issues stay in `triage.scores` with `autonomous_eligible:
+     false` and a one-sentence rationale so the maintainer can see
+     why each was skipped.
+
+5. **Carry the selected array forward** into the "Author
+   re-verification" step. If zero candidates have
+   `autonomous_eligible = true`, set the next phase to
+   `no-candidate` and include the per-issue scores in context.json
    so the maintainer can see why.
 
 ### Author re-verification (non-bypassable)
 
-Regardless of which branch above selected the candidate, perform this
-final check before writing `selected_issue` to context.json:
+Regardless of which branch above selected the candidates, perform
+this final check **for every selected issue** before writing
+`selected_issues` to context.json:
 
 ```bash
-selected=<chosen issue number>
 expected=$(jq -r '.expected_user // "unchidev"' <state-dir>/context.json)
-actual=$(gh issue view "$selected" --json author --jq .author.login)
-[[ "$actual" == "$expected" ]] \
-  || halt "selected issue #$selected is authored by $actual, not $expected"
+for N in <each selected issue number>; do
+  actual=$(gh issue view "$N" --json author --jq .author.login)
+  [[ "$actual" == "$expected" ]] \
+    || halt "selected issue #$N is authored by $actual, not $expected"
+done
 ```
 
 This guards against (a) prompt-injection in issue bodies attempting to
@@ -110,17 +138,23 @@ Write `context.json` with:
   "dry_run": <bool>,
   "target_issue": <int or null>,
   "expected_user": "<string>",
-  "selected_issue": {
-    "number": <int>,
-    "title": "<string>",
-    "author_login": "<must equal expected_user>",
-    "url": "<https://github.com/...>",
-    "labels": ["<label>", ...],
-    "createdAt": "<ISO 8601>"
-  },
+  "selected_issues": [
+    {
+      "number": <int>,
+      "title": "<string>",
+      "author_login": "<must equal expected_user>",
+      "url": "<https://github.com/...>",
+      "labels": ["<label>", ...],
+      "createdAt": "<ISO 8601>",
+      "batch_order": <int, 0-indexed application order>,
+      "predicted_touched_paths": ["<best-effort guess from AC>", ...]
+    }
+  ],
   "triage": {
     "considered_count": <int, total open issues authored by expected_user>,
     "post_filter_count": <int>,
+    "selected_count": <int, length of selected_issues>,
+    "cap_applied": <bool, true if more than 10 qualified and were capped>,
     "scores": [
       {
         "number": <int>,
@@ -136,29 +170,44 @@ Write `context.json` with:
 }
 ```
 
-When the next phase is `no-candidate`, omit `selected_issue` and ensure
-the `triage` block explains why every candidate was rejected.
+When the next phase is `no-candidate`, omit `selected_issues` and
+ensure the `triage` block explains why every candidate was rejected.
 
 Set the next phase (write to `<state-dir>/current-phase.txt`):
 
-- `implementation` — selected an autonomous-eligible candidate.
+- `implementation` — selected at least one autonomous-eligible
+  candidate.
 - `no-candidate` — clean exit, nothing to do.
-- `HALT` — `target_issue` validation failed, the author re-verification
-  failed, or any `gh` query errored. Populate `halt_reason`.
+- `HALT` — `target_issue` validation failed, the author
+  re-verification failed for any selected issue, or any `gh` query
+  errored. Populate `halt_reason`.
 
 ## HALT conditions (explicit enumeration)
 
 - `target_issue` is not open.
-- Author re-verification fails (`gh`-reported `author.login` does not
-  match `expected_user`).
+- Author re-verification fails for any selected issue
+  (`gh`-reported `author.login` does not match `expected_user`).
 - Any `gh issue view`/`gh issue list` call returns a non-zero exit
   status that is not retriable inside this phase.
 
 ## Notes
 
+- The batch confidence floor (4-axis min ≥ 80) is intentionally
+  stricter than the per-issue mode floor of ≥ 70 — see ADR-0019 §
+  Rationale. Issues scored 70-79 stay in `triage.scores` with
+  `autonomous_eligible: false`; they are not lost, just not
+  attempted in this batch. A future maintainer can `--target` them
+  individually to run them in single-issue mode (`selected_issues`
+  with one entry).
 - Sister-site / fix-propagation / golden-test rules are NOT enforced
-  during scoring — they apply during implementation. Scoring only
-  predicts whether the issue is *amenable* to autonomous work.
+  during scoring — they apply during implementation, individually
+  per issue. Scoring only predicts whether each issue is *amenable*
+  to autonomous work.
 - Treat `priority:high` as out-of-scope by policy, not because the
   issue is too hard. The maintainer has earmarked high-priority work
   for human attention.
+- The file-disjointness ordering is best-effort. The implementation
+  phase's per-issue `cargo test` is the structural guard: if two
+  selected issues do conflict in practice, the second one's tests
+  fail and that issue enters the corrective-action loop documented
+  in `implementation.md`.

--- a/.claude/workflows/autopilot-issue/phases/pr-review.md
+++ b/.claude/workflows/autopilot-issue/phases/pr-review.md
@@ -51,12 +51,7 @@ git push -u origin "<implementation.branch>"
 ### 2. Open the PR
 
 Use `gh`'s brace-substitution form so the PR-body block does not need
-to know the owner/repo (gh fills these in from the current repo). The
-body aggregates every successfully-applied issue from
-`implementation.commits[]` (one per-issue "What changed" section
-each), records any `implementation.deferred[]` items in a Deferred
-section, and emits one `Closes #N` line per applied issue so squash
-merge to `main` closes every aggregated issue at once.
+to know the owner/repo (gh fills these in from the current repo).
 
 **Title shape:**
 
@@ -67,14 +62,54 @@ merge to `main` closes every aggregated issue at once.
   <YYYY-MM-DD>` (K = `implementation.commits | length`). Keep the
   title under 70 chars — the per-issue detail belongs in the body.
 
+**Body shape — single-issue batch** (`implementation.commits` length == 1):
+Use the historical single-issue body format per
+[`.claude/rules/pr-workflow.md`](../../../rules/pr-workflow.md)
+§"PR Formatting and Commit Messages" so single-issue runs are
+indistinguishable from pre-ADR-0019 PRs on the PR list:
+
 ```bash
 gh pr create \
-  --title "<title per the rules above>" \
+  --title "<scope>: <subject> (#<N>)" \
+  --body "$(cat <<'BODY'
+## What
+<1-3 bullets describing the change>
+
+## Why
+<link to issue, 1-2 sentences naming the motivation>
+
+## Test results
+- cargo fmt --check — passed
+- cargo clippy --workspace --all-targets -- -D warnings — passed
+- cargo test --workspace — passed
+- <fixture-specific or scripts/* check, if applicable>
+
+## Review summary
+<one-line summary of what auto-review will be checking>
+
+## Sister-site audit
+<from context.implementation.sister_site_audit>
+
+## Deferred
+<none, or one-line justification per deferred item>
+
+Closes #<N>
+BODY
+)"
+```
+
+**Body shape — multi-issue batch** (`implementation.commits` length ≥ 2):
+Aggregate every successfully-applied issue (one per-issue "What changed"
+section each), record any `implementation.deferred[]` items, and emit
+one `Closes #N` line per applied issue so squash merge closes every
+aggregated issue at once:
+
+```bash
+gh pr create \
+  --title "batch(autopilot): <K> issues — <YYYY-MM-DD>" \
   --body "$(cat <<'BODY'
 ## Summary
-<one paragraph naming the batch — for a single-issue batch just
-restate the issue's purpose; for a multi-issue batch, list the K
-issues with one-line each>
+<one paragraph listing the K applied issues with one line each>
 
 ## Per-issue changes
 <For each entry in implementation.commits, in commit order, emit:
@@ -100,16 +135,14 @@ above accumulate into>
 
 ## Deferred
 <For each entry in implementation.deferred, emit one bullet:
-- #<N> (<reason>; attempts: <N>): <last_error truncated to one line>
-The Deferred items remain open as issues — they are not absorbed by
-this PR and not closed by merge.>
+- #<N> (<reason>; attempts: <attempts>): <last_error truncated to one line>
+Deferred items remain open as issues — they are not absorbed by this
+PR and not closed by merge.>
 
 ## Review summary
 <one-line summary of what auto-review will be checking>
 
-<For each entry in implementation.commits, append one `Closes #<N>`
-line on its own line so GitHub closes every applied issue on
-squash-merge:>
+<One `Closes #<N>` line per applied issue on its own line:>
 Closes #<N1>
 Closes #<N2>
 ...

--- a/.claude/workflows/autopilot-issue/phases/pr-review.md
+++ b/.claude/workflows/autopilot-issue/phases/pr-review.md
@@ -1,14 +1,17 @@
 # Phase: pr-review
 
-Commit, push, open the PR, wait for CI, drive the review loop to
-convergence, and post a Ready-for-merge comment. Do NOT merge.
+Push the implementation phase's per-issue commits, open the batched
+PR, wait for CI, drive the review loop to convergence, and post a
+Ready-for-merge comment. Do NOT merge.
 
 ## Inputs
 
 **Context fields read**:
 
-- `selected_issue.number`, `selected_issue.title`, `selected_issue.url`
+- `selected_issues[*]` — every issue the implementation phase
+  attempted. Use `number`, `title`, `url` for the PR body.
 - `implementation.branch`, `implementation.worktree_path`,
+  `implementation.commits[]`, `implementation.deferred[]`,
   `implementation.diff_stat`, `implementation.sister_site_audit`
 
 ## Steps
@@ -16,15 +19,13 @@ convergence, and post a Ready-for-merge comment. Do NOT merge.
 Work inside `implementation.worktree_path` for every command in this
 phase.
 
-### 1. Commit + push
+### 1. Push the existing commits
 
-Commit using the project's neutral technical voice per
-[`.claude/rules/pr-workflow.md`](../../../rules/pr-workflow.md)
-§"PR Formatting and Commit Messages":
-
-- Imperative mood subject line, ≤ 70 chars
-- No session dates, no quoted messages, no `@handle` attributions
-- Body explains *why*, not *what* (the diff already says what)
+The `implementation` phase already created one commit per
+successfully-applied issue on `implementation.branch` (ADR-0019;
+batch-mode workflow). This phase does NOT author any new commits
+before opening the PR — it only pushes what implementation produced
+and then enters the review-and-fix loop in step 5.
 
 Before pushing, verify the remote branch does not already exist (a
 stale ref from a previous failed run would cause a non-fast-forward
@@ -50,37 +51,68 @@ git push -u origin "<implementation.branch>"
 ### 2. Open the PR
 
 Use `gh`'s brace-substitution form so the PR-body block does not need
-to know the owner/repo (gh fills these in from the current repo). Body
-sections match `.claude/rules/pr-workflow.md` ("What", "Why", "Test
-results", "Review summary"). The "Test plan" / "Test results" wording
-matches the project's review template:
+to know the owner/repo (gh fills these in from the current repo). The
+body aggregates every successfully-applied issue from
+`implementation.commits[]` (one per-issue "What changed" section
+each), records any `implementation.deferred[]` items in a Deferred
+section, and emits one `Closes #N` line per applied issue so squash
+merge to `main` closes every aggregated issue at once.
+
+**Title shape:**
+
+- **Single-issue batch** (length 1): keep the historical
+  `<scope>: <subject> (#<N>)` form so single-issue runs look the
+  same on the PR list as they did before ADR-0019.
+- **Multi-issue batch**: `batch(autopilot): <K> issues —
+  <YYYY-MM-DD>` (K = `implementation.commits | length`). Keep the
+  title under 70 chars — the per-issue detail belongs in the body.
 
 ```bash
 gh pr create \
-  --title "<imperative-mood title, <=70 chars>" \
+  --title "<title per the rules above>" \
   --body "$(cat <<'BODY'
-## What
-<1-3 bullets describing the change>
+## Summary
+<one paragraph naming the batch — for a single-issue batch just
+restate the issue's purpose; for a multi-issue batch, list the K
+issues with one-line each>
 
-## Why
-<link to issue, 1-2 sentences naming the motivation>
+## Per-issue changes
+<For each entry in implementation.commits, in commit order, emit:
 
-## Test results
+### #<N>: <issue title> ([link])
+- Closes #<N>
+- Commit: `<short sha>` <subject>
+- What changed: <1-3 bullets pulled from the commit body's why>
+- Files: <abbreviated path list from the commit's git diff --stat>
+- Sister-site spot-check: <which sibling group was checked for this issue>
+>
+
+## Workspace gate
 - cargo fmt --check — passed
-- cargo clippy --workspace -- -D warnings — passed
+- cargo clippy --workspace --all-targets -- -D warnings — passed
 - cargo test --workspace — passed
 - <fixture-specific or scripts/* check, if applicable>
+
+## Aggregated sister-site audit
+<from context.implementation.sister_site_audit; one to three sentences
+covering the cross-issue audit conclusions the per-issue spot-checks
+above accumulate into>
+
+## Deferred
+<For each entry in implementation.deferred, emit one bullet:
+- #<N> (<reason>; attempts: <N>): <last_error truncated to one line>
+The Deferred items remain open as issues — they are not absorbed by
+this PR and not closed by merge.>
 
 ## Review summary
 <one-line summary of what auto-review will be checking>
 
-## Sister-site audit
-<from context.implementation.sister_site_audit>
-
-## Deferred
-<none, or one-line justification per deferred item, linked to an existing tracker>
-
-Closes #<selected_issue.number>
+<For each entry in implementation.commits, append one `Closes #<N>`
+line on its own line so GitHub closes every applied issue on
+squash-merge:>
+Closes #<N1>
+Closes #<N2>
+...
 BODY
 )"
 ```
@@ -269,12 +301,17 @@ one comment on the PR:
 ```
 Ready for merge.
 
+- Applied issues: <K> (#<N1>, #<N2>, ...)
+- Deferred issues: <M> (#<N3>, #<N4>, ...; see PR body for reasons)
 - Full check rollup: green
 - Auto-review: converged on HEAD
 - Sister-site audit: <one line>
 
 Merge is held for explicit maintainer action per ADR-0013.
 ```
+
+Omit the "Deferred issues" line if `implementation.deferred[]` is
+empty.
 
 Do NOT call `gh pr merge`. The four-clause merge gate in
 [`.claude/rules/pr-workflow.md`](../../../rules/pr-workflow.md)
@@ -329,6 +366,9 @@ Extend `context.json` with:
     "url": "<https://github.com/.../pull/<N>>",
     "head_sha": "<git sha at Ready-for-merge>",
     "ci_status": "passed",
+    "applied_issue_count": <int, length of implementation.commits at Ready-for-merge>,
+    "deferred_issue_count": <int, length of implementation.deferred at Ready-for-merge>,
+    "applied_issues": [<int>, ...],
     "review_iterations": <int 0..=10>,
     "findings_resolved": {
       "high": <int>,
@@ -369,7 +409,13 @@ Set the next phase (write to `<state-dir>/current-phase.txt`):
 
 - This workflow's contract ends at posting the Ready-for-merge comment.
   Cleanup (worktree removal, branch deletion, project-board flip to
-  Done) is the maintainer's responsibility after the squash-merge — or
-  a follow-up workflow's, not this one's.
+  Done for each applied issue) is the maintainer's responsibility
+  after the squash-merge — or a follow-up workflow's, not this one's.
 - If you HALT after the PR is open, leave the PR open and the worktree
   intact. The maintainer can pick up either by hand.
+- The `implementation` phase already validated each issue's commit
+  individually plus the workspace-wide gate over the accumulated
+  commits. The CI matrix on PR open re-runs the same gate plus
+  cross-platform builds; CI failures here are usually platform-specific
+  (macOS / iOS / Windows targets the local Linux gate cannot exercise),
+  not regressions the per-issue loop should have caught.

--- a/.claude/workflows/autopilot-issue/workflow.json
+++ b/.claude/workflows/autopilot-issue/workflow.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot-issue",
-  "description": "Single-iteration autonomous issue handler. Pick one open issue authored by unchidev that Claude Code can autonomously implement, do the work in a worktree, run local validation, and (unless dry_run) push, open a PR, and drive review to convergence up to the Ready-for-merge gate.",
+  "description": "Batch-mode autonomous issue handler (ADR-0019). Triage all open issues authored by unchidev, select every high-confidence (4-axis min >=80) candidate up to a cap of 10, implement them in one worktree as one commit per issue on a single batch-YYYY-MM-DD-N1-N2-... branch, run local validation after each issue + a final workspace-wide gate, and (unless dry_run) push, open one PR that aggregates every successful issue, and drive review to convergence up to the Ready-for-merge gate.",
   "entryPhase": "preconditions",
   "phases": {
     "preconditions": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,14 @@ under `.claude/workflow-state/<name>/` (git-ignored).
 | `scripts/test_run_workflow.py` | End-to-end smoke test for the orchestrator (stubs `claude`, `flock`, `timeout`) |
 
 Architectural rationale: [ADR-0018](docs/adr/0018-phase-based-shell-orchestrated-workflows.md).
-Production workflow: `autopilot-issue` (pick an unchidev-authored
-issue, implement, drive review to convergence, stop at Ready-for-merge).
+Production workflow: `autopilot-issue` — batch-mode autonomous
+handler per [ADR-0019](docs/adr/0019-batch-mode-autopilot-issue.md).
+One round picks every high-confidence (4-axis min ≥80)
+unchidev-authored issue (capped at 10), implements each as one
+commit per issue on a single `batch-YYYY-MM-DD-N1-N2-...` branch,
+opens one aggregated PR, and drives it to Ready-for-merge.
+Single-eligible-candidate rounds degenerate to the historical
+`issue-{N}-{slug}` branch / one-issue PR shape transparently.
 
 ## Architecture
 

--- a/docs/adr/0019-batch-mode-autopilot-issue.md
+++ b/docs/adr/0019-batch-mode-autopilot-issue.md
@@ -1,0 +1,172 @@
+# 0019. Batch-mode autopilot-issue workflow
+
+- **Status**: Accepted
+- **Date**: 2026-05-17
+
+## Context
+
+The `autopilot-issue` workflow ([ADR-0018](0018-phase-based-shell-orchestrated-workflows.md))
+shipped as a strictly per-issue handler: each run picked one
+autonomous-eligible issue authored by `unchidev`, opened one PR for
+it, drove that PR to Ready-for-merge, and stopped. A 5-round session
+on 2026-05-16/17 produced PRs #2472, #2474, #2475, #2477, #2487, #2489
+following that mode.
+
+The observed cost per merged PR was ~45-90 min of wall-clock.
+Breaking that down:
+
+- Implementation phase: ~15-30 min (actual coding).
+- Per-PR ceremony (worktree create, branch push, PR open): ~2 min.
+- CI matrix on PR open: ~8-10 min (cross-platform builds dominate).
+- Auto-review iteration: 5-15 min (one full review, often one delta).
+- CI matrix re-run after each fix commit: ~8-10 min per iteration.
+- Manual merge + cleanup: ~1 min.
+
+For an issue whose actual code change is 20 lines, the per-PR fixed
+cost (CI, auto-review ceremony, merge gate) dwarfs the implementation
+time by 2-3x. Across the 5 rounds we observed this loop tax compound
+into ~5 hours of wall-clock for ~6 merged PRs that collectively
+changed ~600 lines of code.
+
+## Decision
+
+The `autopilot-issue` workflow now operates in **batch mode**:
+
+1. `issue-selection` returns the array of all
+   high-confidence autonomous-eligible candidates (4-axis triage min
+   ≥ 80), capped at 10 per round.
+2. `implementation` loops over the selected issues in dependency /
+   simplicity order, applying each in turn within a single worktree
+   and a single branch named `batch-YYYY-MM-DD-N1-N2-...`. One
+   commit per issue (`feat(crate): subject (#N)` with `Closes #N` in
+   the body) preserves issue-to-change attribution for in-PR
+   review and `git bisect`.
+3. `pr-review` opens **one PR** that aggregates every successful
+   issue. PR body documents each issue separately under
+   per-issue "What changed" sections, lists `Closes #N` once per
+   issue, and emits one combined sister-site audit.
+4. Per-issue failures during execution attempt a corrective-action
+   retry loop (up to 3 attempts) before reverting the issue's
+   commit and marking it as a Deferred entry in the PR body. The
+   remainder of the batch continues.
+
+Squash-merge to `main` collapses every issue's commit into one
+landing commit per established practice
+([pr-workflow.md](../../.claude/rules/pr-workflow.md)), but the
+in-PR per-issue commits remain visible on the PR for review.
+
+## Rationale
+
+The fixed CI / auto-review / merge cost dominates per-PR wall-clock
+when issues are small. Batching trades a smaller number of larger
+PRs for a much larger number of smaller PRs at the same total work:
+
+| Mode | PRs for 6 issues | CI matrix runs | Auto-review cycles |
+|---|---|---|---|
+| Per-issue (old) | 6 | ~12 (open + 1 fix-commit each) | 6 separate, ~12 total iterations |
+| Batch (new) | 1 | ~2 (open + 1 fix-commit) | 1 review pass, ~2 delta cycles |
+
+Even accounting for the larger diff in batched PRs (~600 lines vs
+~100 lines per issue) increasing the auto-review compute cost
+linearly, the ~6x reduction in CI matrix runs is the dominant saving.
+
+**4-axis confidence floor raised to ≥80**: per-issue mode used a
+floor of ≥70 for "autonomous-eligible". In batch mode, one issue's
+failure can poison the whole batch (it consumes the worktree,
+forces the fallback retry-loop, and risks polluting later issues'
+context). Raising the bar to ≥80 picks fewer issues per round but
+those that are picked succeed at a higher rate. Issues in the
+70-79 band are not lost — they remain eligible for single-issue
+mode (which we keep as a degenerate case: a batch of 1).
+
+**Cap at 10**: PRs of arbitrary size exist (legitimate sweeping
+refactors, generated-code bumps), but autopilot-produced batches
+should remain reviewable by a human as a unit. 10 small issues is
+~600 lines of curated diff plus tests — at the upper end of
+practical single-sitting review.
+
+**Branch naming `batch-YYYY-MM-DD-N1-N2-...`**: keeps the
+established `issue-{N}-{slug}` convention for the degenerate
+single-issue batch case (a 1-issue batch is still
+`issue-{N}-{slug}`), while making multi-issue batches discoverable
+in `git branch -a` output. The date prefix sorts batches
+chronologically and avoids ambiguity with reissued issue numbers.
+
+## Consequences
+
+**Positive**:
+
+- ~6x fewer CI matrix runs and ~6x fewer auto-review cycles for
+  the same merged-issue throughput.
+- Sister-site audit happens once per batch instead of N times,
+  catching cross-issue interactions that per-PR audits miss by
+  construction.
+- Larger PRs invite more rigorous human review on the merge
+  button, which is healthy for a workflow where the PR contents
+  were produced autonomously.
+
+**Negative**:
+
+- Larger PRs are harder to review at one sitting. Mitigated by the
+  one-commit-per-issue convention so reviewers can step through
+  the diff issue-by-issue.
+- A batch failure (e.g. CI red after step 8 of 10) requires more
+  context to disentangle than a per-issue PR. Mitigated by the
+  per-issue commit history: a reviewer can `git log` to find which
+  commit introduced the regression and ask autopilot to revert
+  that one in a fix commit.
+- If two issues edit the same file with different intents, the
+  second one's commit may have to absorb the first's changes into
+  its context. The triage filter already prefers file-disjoint
+  candidates; the implementation phase's per-issue cargo test
+  catches conflicts before the batch commits compound.
+
+## Alternatives considered
+
+- **Keep per-issue mode**: rejected — the observed 45-90 min/PR
+  wall-clock is dominated by per-PR fixed cost, and that cost
+  doesn't shrink with codebase familiarity. The structural problem
+  is structural; only batching addresses it.
+- **Stack multiple PRs (one per issue, but as a chain)**: rejected —
+  GitHub does not first-class PR stacks. Tools like `git town` /
+  `Graphite` could simulate this but introduce a hard dependency
+  this repo does not currently take. The CI re-run cost on each
+  PR in the stack also doesn't shrink (each stacked PR still
+  triggers its own CI matrix).
+- **Parallel single-issue PRs via the existing one-pr-at-a-time
+  exception clause**: rejected — the exception requires strictly
+  disjoint files, which is unenforceable across autopilot-eligible
+  issues whose surface areas overlap (iReal parser issues, for
+  instance, all touch `crates/ireal/src/parser.rs`). Even where
+  files are disjoint, the cap on macOS runner concurrency in
+  `.claude/rules/ci-parallelization.md` §5 makes 5+ parallel PRs
+  saturate the runner pool and queue.
+
+## References
+
+- [ADR-0013](0013-conditional-bot-driven-merge.md) — bot-merge
+  conditions still apply to batched PRs (per-session permission,
+  full check rollup, auto-review converged, direct squash).
+- [ADR-0018](0018-phase-based-shell-orchestrated-workflows.md) — the
+  phase-based orchestrator this decision rides on.
+- `.claude/rules/branch-strategy.md` — updated in the same PR to
+  recognise `batch-*` branch names.
+- `.claude/rules/issue-workflow.md` — updated to note that batched
+  PRs autopilot-produced are the expected shape.
+- `.claude/rules/pr-workflow.md` — updated to describe the
+  multi-issue PR-body convention.
+
+## Watch signals
+
+Revisit if any of these surface:
+
+- A single batch produces a PR diff > ~1500 lines or > ~25 files
+  consistently (cap was set assuming ~60 lines / 3 files per
+  batched issue average; reality may differ).
+- Auto-review's full-review pass exceeds its 30-minute timeout
+  budget more often than not.
+- Maintainer review-button reaction time grows because batched PRs
+  are harder to context-switch into than per-issue PRs.
+- A specific sister-site class (e.g. iReal parser) repeatedly has
+  intra-batch conflicts that the per-issue cargo test catches but
+  the corrective-action loop can't unwind cleanly.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,3 +96,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0016](0016-dependabot-review-skill.md) | Dependabot review moves from a CI bot to a session skill; major bumps are no longer suppressed | Accepted (2026-05-03) |
 | [0017](0017-react-renders-from-ast.md) | React surface renders from AST; Rust HTML renderer demoted to static-output | Accepted (2026-05-10) |
 | [0018](0018-phase-based-shell-orchestrated-workflows.md) | Phase-based shell-orchestrated workflows (declines cc-wf-studio / n8n / Agent SDK as substitutes) | Accepted (2026-05-16) |
+| [0019](0019-batch-mode-autopilot-issue.md) | Batch-mode autopilot-issue workflow (one PR aggregates multiple eligible issues per round) | Accepted (2026-05-17) |


### PR DESCRIPTION
## Summary

Reshapes the `autopilot-issue` workflow from per-issue-per-PR to **batch mode** (ADR-0019). One round picks every high-confidence autonomous-eligible candidate (capped at 10), implements each as one commit per issue on a single `batch-YYYY-MM-DD-N1-N2-...` branch, and opens one PR aggregating every successful issue. Single-eligible-candidate rounds degenerate to the historical `issue-{N}-{slug}` shape transparently.

## Why

The 5-round session on 2026-05-16/17 took ~45-90 min wall-clock per merged PR. Implementation was 15-30 min; the remainder was per-PR fixed cost (CI matrix x2, auto-review ceremony, merge gate). Batching N eligible issues into one PR collapses that fixed cost N-fold for the same merged-issue throughput. ADR-0019 lays out the trade-offs.

## What changed

- **`docs/adr/0019-batch-mode-autopilot-issue.md`** (new) — design ADR. Documents the per-PR vs intra-PR cost trade-off, the 4-axis confidence floor raised to ≥80 (vs the per-issue mode's ≥70 — one issue's failure in a batch consumes the worktree), the 10-issue cap, the branch-naming + commit-granularity conventions, and the watch signals that should prompt revisiting.
- **`.claude/workflows/autopilot-issue/workflow.json`** — `description` rewritten to reflect batch semantics.
- **`.claude/workflows/autopilot-issue/phases/issue-selection.md`** — returns `selected_issues[]` array (was `selected_issue` scalar). Selects all candidates with 4-axis min ≥80, ordered by file-disjointness then ascending scope, capped at 10.
- **`.claude/workflows/autopilot-issue/phases/implementation.md`** — single worktree, single `batch-*` branch, per-issue loop with 3-attempt corrective-action retry and Deferred fallback. Per-issue commit (`feat(scope): subject (#N)` + `Closes #N`) preserves issue-to-change attribution. Workspace-wide gate at the end with bisect-and-revert if it fails.
- **`.claude/workflows/autopilot-issue/phases/pr-review.md`** — no longer authors commits (the implementation phase did that per-issue). Pushes the accumulated commits, opens one PR with per-issue "What changed" sections + aggregated sister-site audit + Deferred section + one `Closes #N` per applied issue. Ready-for-merge comment reports applied vs deferred counts.
- **`.claude/workflows/autopilot-issue/README.md`** — phase contract and HALT-trigger table updated for batch.
- **`.claude/rules/branch-strategy.md`** — new "Batched autopilot branches" section recognising the `batch-*` name shape. Strict 1:1 issue-to-branch rule explicitly does not apply to multi-issue batch branches.
- **`.claude/rules/issue-workflow.md`** — step 5 notes that batched autopilot PRs aggregate multiple `Closes #N` lines.
- **`.claude/rules/pr-workflow.md`** — new "Batched-PR formatting" section documenting the multi-issue PR body shape.
- **`CLAUDE.md`** — autopilot-issue description points at ADR-0019 and explains the degenerate single-issue case.

## Verification

- [x] `python3 scripts/validate-workflow.py autopilot-issue` — OK (workflow.json + phase files internally consistent).
- [x] `python3 scripts/test_validate_workflow.py` — 11 tests passed.
- [x] `python3 scripts/test_run_workflow.py` — 15 tests passed (orchestrator end-to-end smoke).
- [x] Manual review of every phase file's "Output" section against the orchestrator's context.json schema-evolution rule (`.claude/rules/workflow-discipline.md`) — all changes are additive; the old `selected_issue` / `implementation.files_changed` etc. callers (none currently) will not silently break.

## Sister-site audit

- Workflow definition (`.claude/workflows/autopilot-issue/`): every phase file updated in lockstep with `workflow.json`; the workflow graph in `workflow.json` is unchanged.
- Rule files (`.claude/rules/branch-strategy.md`, `issue-workflow.md`, `pr-workflow.md`): updated to describe the new convention so future PRs can be linted against accurate text.
- ADR index (`docs/adr/README.md`): one-line entry added for ADR-0019.
- Other phase-based workflows: only `autopilot-issue` exists today; the orchestrator's footer contract is unchanged so future workflows added under `.claude/workflows/` continue to inherit the same `command mv` / state-write semantics.
- Bindings / renderers: not in scope (workflow contract change, not crate code).

## Out of scope

- Running the new workflow on actual issues. The maintainer triggers `./scripts/run-workflow.sh autopilot-issue` separately when ready.

Closes #2492.