### PR TITLE
feat(workflows): stream phase progress in run-workflow.sh

### DIFF
--- a/.claude/rules/workflow-discipline.md
+++ b/.claude/rules/workflow-discipline.md
@@ -249,10 +249,23 @@ top-level `.gitignore`) or under `$TMPDIR`.
 
 ## Logging and observability
 
-Every `claude -p` invocation is logged to
-`.claude/workflow-state/<name>/logs/<ISO-8601>-<phase>.log`. The
-maintainer's primary debugging tool is `tail -f` on the most recent
-log.
+Every `claude -p` invocation runs with
+`--verbose --output-format=stream-json`; the orchestrator projects each
+tool call, assistant text frame, and the final result line into a
+single-line summary on its own stdout, and mirrors the same projection
+via `tee -a` into
+`.claude/workflow-state/<name>/logs/<ISO-8601>-<phase>.log`. claude's
+stderr is appended to the same log directly (not through the
+projection). Known GitHub credential shapes (`ghp_…`, `gho_…`, `ghs_…`,
+`ghu_…`, `github_pat_…`, `x-access-token:…`) are redacted before the
+projection reaches either surface, and `umask 077` keeps every state
+file owner-only as the primary control.
+
+The maintainer's primary observation channel is the orchestrator's own
+terminal output; `tail -f` on the log remains useful for forensics on
+a finished phase, or to watch a phase started in another terminal. The
+log is the same content the terminal saw, so the two surfaces stay in
+sync.
 
 Phase prompts SHOULD NOT include any instruction to log to stdout
 beyond what `claude -p` naturally produces. Side-effect-based state

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -22,7 +22,10 @@ self-contained operation.
 .claude/workflow-state/<name>/   # gitignored — created by the orchestrator
   current-phase.txt              # name of the next phase to execute
   context.json                   # JSON state object passed phase-to-phase
-  logs/<timestamp>-<phase>.log   # full `claude -p` stdout/stderr per phase
+  logs/<timestamp>-<phase>.log   # jq-projected stream summaries (tool calls,
+                                 # assistant text, result) + claude's raw
+                                 # stderr; mirrors what streams to the
+                                 # orchestrator's stdout. Mode 600 (umask 077).
   lock                           # flock target preventing concurrent runs
 ```
 

--- a/docs/adr/0018-phase-based-shell-orchestrated-workflows.md
+++ b/docs/adr/0018-phase-based-shell-orchestrated-workflows.md
@@ -155,16 +155,11 @@ workflows incrementally) without a global registry.
   References section.
 - No structured execution dashboard. The runtime story is the
   orchestrator's own stdout (live per-turn projection of claude's
-  `--output-format=stream-json` events, added in PR #2496), mirrored
-  into `.claude/workflow-state/<name>/logs/<ISO-8601>-<phase>.log` so
+  `--output-format=stream-json` events), mirrored into
+  `.claude/workflow-state/<name>/logs/<ISO-8601>-<phase>.log` so
   `tail -f` on the log remains the forensic / second-terminal channel.
   Acceptable while the workflow count is small; revisit if it grows
-  past a handful. (Originally this consequence read "the runtime story
-  is `tail -f` on per-phase log files"; updated 2026-05-18 to reflect
-  the streaming projection that replaced silent-stdout behaviour. The
-  ADR's Status field remains unchanged per `adr-discipline.md`'s
-  "do not rewrite accepted ADRs in place" rule — this is a factual
-  consequence-table refresh, not a decision change.)
+  past a handful.
 - The orchestrator is Bash. Long-term, a Python rewrite may be
   warranted if the orchestrator itself accumulates feature surface
   (retry policies, branching, parallel phases). Watch signal: more

--- a/docs/adr/0018-phase-based-shell-orchestrated-workflows.md
+++ b/docs/adr/0018-phase-based-shell-orchestrated-workflows.md
@@ -153,10 +153,18 @@ workflows incrementally) without a global registry.
   with a project-scoped `permissions.allow` list when the catalogue
   of phase actions stabilises. Recorded as a watch signal in the
   References section.
-- No structured execution dashboard. The runtime story is `tail -f`
-  on per-phase log files under `.claude/workflow-state/<name>/logs/`.
+- No structured execution dashboard. The runtime story is the
+  orchestrator's own stdout (live per-turn projection of claude's
+  `--output-format=stream-json` events, added in PR #2496), mirrored
+  into `.claude/workflow-state/<name>/logs/<ISO-8601>-<phase>.log` so
+  `tail -f` on the log remains the forensic / second-terminal channel.
   Acceptable while the workflow count is small; revisit if it grows
-  past a handful.
+  past a handful. (Originally this consequence read "the runtime story
+  is `tail -f` on per-phase log files"; updated 2026-05-18 to reflect
+  the streaming projection that replaced silent-stdout behaviour. The
+  ADR's Status field remains unchanged per `adr-discipline.md`'s
+  "do not rewrite accepted ADRs in place" rule — this is a factual
+  consequence-table refresh, not a decision change.)
 - The orchestrator is Bash. Long-term, a Python rewrite may be
   warranted if the orchestrator itself accumulates feature surface
   (retry policies, branching, parallel phases). Watch signal: more

--- a/scripts/run-workflow.sh
+++ b/scripts/run-workflow.sh
@@ -177,6 +177,16 @@ validate_workflow_json() {
 }
 validate_workflow_json || exit 1
 
+# Phase logs now capture projected stream-json tool-use arguments
+# (Bash commands, sub-agent prompts, URLs) that a phase may legitimately
+# pass on a command line — including the host's `$GH_TOKEN` whenever a
+# tool call constructs a `https://x-access-token:…@github.com/…` URL.
+# Force 0700 / 0600 on every file the orchestrator writes from here on so
+# the state tree is owner-only, regardless of the maintainer's interactive
+# umask. The jq projection also redacts known GitHub credential shapes
+# before tee-ing to the log; the umask is the primary control, redaction
+# is defence in depth.
+umask 077
 mkdir -p "$STATE_DIR/logs"
 
 # --- Concurrency lock ----------------------------------------------------
@@ -200,6 +210,14 @@ chmod 600 "$PROMPT_FILE"
 # phase is running. Populated by run_phase before `wait`, cleared after.
 PHASE_PGID=""
 
+# SIGTERM → SIGKILL escalation budget for terminate_phase_group. Five
+# iterations × 0.2 s ≈ 1 s gives claude's SIGTERM handler time to flush
+# its final stream-json frame and any in-flight tool subprocess (git push,
+# cargo build) time to release its temp files. Tune upward if `<log>`
+# shows truncated final frames after Ctrl-C.
+PHASE_TERM_GRACE_ITERS=5
+PHASE_TERM_GRACE_SLEEP_SECS=0.2
+
 # Terminate the phase pipeline's entire process group on Ctrl-C / SIGTERM
 # / SIGHUP. claude (and any tool it spawned: git, gh, sub-agents) sits in
 # this group; without the negative-PID form below, signaling only the
@@ -213,14 +231,40 @@ terminate_phase_group() {
   PHASE_PGID=""
   echo "[orchestrator] terminating phase pipeline (pgid=$pgid)..." >&2
   kill -TERM "-$pgid" 2>/dev/null || true
-  # Brief grace period before escalating; claude's own SIGTERM handler
-  # may need a moment to flush its final stream-json frame.
-  local i
-  for i in 1 2 3 4 5; do
-    kill -0 "-$pgid" 2>/dev/null || return 0
-    sleep 0.2
+  # Grace period before escalating to SIGKILL. `kill -0` returns non-zero
+  # on either ESRCH (process gone — we're done) or EPERM (a privileged
+  # descendant we can't signal — fall through to SIGKILL so we don't
+  # silently leak it). Parse stderr to distinguish the two; ESRCH ends
+  # the loop early, EPERM keeps iterating until the SIGKILL line below.
+  local i err
+  for ((i = 0; i < PHASE_TERM_GRACE_ITERS; i++)); do
+    if err=$(kill -0 "-$pgid" 2>&1); then
+      sleep "$PHASE_TERM_GRACE_SLEEP_SECS"
+      continue
+    fi
+    case "$err" in
+      *"No such process"*|*"no such process"*) return 0 ;;
+      *) ;;  # EPERM or other — keep waiting, then SIGKILL
+    esac
+    sleep "$PHASE_TERM_GRACE_SLEEP_SECS"
   done
   kill -KILL "-$pgid" 2>/dev/null || true
+}
+
+# install_signal_traps / mask_signal_traps bracket the narrow windows in
+# run_phase where PHASE_PGID is stale (empty pre-fork; just-cleared
+# post-wait). Without the mask, a SIGINT arriving in those windows would
+# trigger terminate_phase_group with a stale PHASE_PGID and either orphan
+# the just-spawned subshell or no-op on a dead pgid while the orchestrator
+# exits. Bash queues signals while their trap is `''`; reinstalling the
+# real trap fires any queued signal against the now-populated PHASE_PGID.
+install_signal_traps() {
+  trap 'terminate_phase_group; exit 130' INT
+  trap 'terminate_phase_group; exit 143' TERM
+  trap 'terminate_phase_group; exit 129' HUP
+}
+mask_signal_traps() {
+  trap '' INT TERM HUP
 }
 
 # Preserve the original exit code through cleanup. INT/TERM/HUP also fire
@@ -228,9 +272,7 @@ terminate_phase_group() {
 # embed full issue bodies from context.json) and so the phase's process
 # group is signaled before the orchestrator exits.
 trap 'rc=$?; terminate_phase_group; rm -f "$PROMPT_FILE"; exit "$rc"' EXIT
-trap 'terminate_phase_group; exit 130' INT
-trap 'terminate_phase_group; exit 143' TERM
-trap 'terminate_phase_group; exit 129' HUP
+install_signal_traps
 
 # --- Initial state -------------------------------------------------------
 # Log the claude binary version at startup so the operator can confirm
@@ -357,8 +399,29 @@ run_phase() {
   # readable line (tool calls, assistant text, final result), and tee
   # mirrors that projection into the phase log so terminal and log carry
   # the same story. claude's stderr is appended to the log directly for
-  # forensics; jq's tolerant per-line `try ... catch empty` keeps a stray
-  # non-JSON line from killing the projection.
+  # forensics.
+  #
+  # `jq -rR` reads raw lines and parses each via `fromjson` INSIDE the
+  # `try ... catch empty` block. A bare `jq -r 'try (.type) catch empty'`
+  # only catches errors evaluating the program against an already-parsed
+  # value — a single non-JSON line still trips jq's parser and exits 5,
+  # propagating as a phase failure under pipefail. The `try (fromjson |
+  # ...)` shape moves parsing inside the catch boundary so a stray frame
+  # (truncated NDJSON from a hard-killed claude; an interleaved warning;
+  # a future stream-json format change) is silently dropped instead of
+  # turning a successful phase into a spurious failure.
+  #
+  # An `awk 'length < …'` pre-filter caps any single line to ~1 MiB so a
+  # pathological frame (e.g. a tool_result with megabytes of grep output)
+  # cannot drive jq to OOM. `fflush()` keeps awk line-buffered through the
+  # pipe so progress stays real-time.
+  #
+  # The `redact` jq def scrubs known GitHub credential shapes (ghp_ /
+  # gho_ / ghs_ / ghu_ / github_pat_ / x-access-token:) from string
+  # fields a phase might pass on a Bash command line or in a sub-agent
+  # prompt. The umask 077 above keeps the log owner-only as the primary
+  # control; redaction is defence in depth for the case where a phase
+  # writes the log into an artifact bundle.
   #
   # The pipeline runs in a backgrounded subshell with `set -m` so it
   # gets its own process group (PGID == subshell PID). The orchestrator
@@ -371,12 +434,18 @@ run_phase() {
   # terminal until claude returned on its own.
   #
   # Inside the subshell, `set +m` switches job control back off so the
-  # pipeline stages stay co-grouped under the subshell, and
-  # `set -o pipefail` preserves the timeout-vs-other-failure distinction
-  # the original code derived from ${PIPESTATUS[0]} (timeout's 124 is
-  # the leftmost non-zero status and pipefail propagates it).
+  # pipeline stages stay co-grouped under the subshell. `set -o pipefail`
+  # makes the subshell's exit status the rightmost non-zero exit in the
+  # pipeline; the leftmost stage is claude, so timeout(1)'s 124 (or any
+  # claude failure) propagates intact to the orchestrator's rc==124
+  # branch instead of being masked by a downstream stage's success.
+  #
+  # mask_signal_traps wraps the fork → PHASE_PGID assignment so a signal
+  # in that one-statement window cannot orphan the just-spawned subshell.
+  # install_signal_traps then re-arms the real handlers; any signal
+  # queued during the mask fires the trap with PHASE_PGID populated.
   local rc=0
-  set +e
+  mask_signal_traps
   set -m
   (
     set +m
@@ -385,22 +454,33 @@ run_phase() {
       claude --dangerously-skip-permissions --verbose \
         --output-format=stream-json -p "$(cat "$PROMPT_FILE")" \
         2>>"$log" \
-      | jq -r --unbuffered '
+      | awk 'length < 1048576 { print; fflush() }' \
+      | jq -rR --unbuffered '
+          def redact:
+            gsub("ghp_[A-Za-z0-9_]{20,}"; "[REDACTED]")
+            | gsub("gho_[A-Za-z0-9_]{20,}"; "[REDACTED]")
+            | gsub("ghs_[A-Za-z0-9_]{20,}"; "[REDACTED]")
+            | gsub("ghu_[A-Za-z0-9_]{20,}"; "[REDACTED]")
+            | gsub("github_pat_[A-Za-z0-9_]+"; "[REDACTED]")
+            | gsub("x-access-token:[^@\\s]+"; "[REDACTED]");
+          def norm:
+            gsub("\\s+"; " ") | sub("^ +"; "") | sub(" +$"; "");
           try (
+            fromjson |
             if .type == "assistant" then
               (.message.content // [])[] |
               if .type == "text" and ((.text // "") | length) > 0 then
-                "[claude] " + (.text | gsub("\\s+"; " ") | .[0:240])
+                "[claude] " + (.text | norm | redact | .[0:240])
               elif .type == "tool_use" then
                 "[tool]  " + .name + (
                   .input as $i |
-                  if   ($i.command // null)     then ": " + ($i.command     | gsub("\\s+"; " ") | .[0:160])
+                  if   ($i.command // null)     then ": " + ($i.command     | norm | redact | .[0:160])
                   elif ($i.file_path // null)   then ": " + ($i.file_path   | .[0:200])
                   elif ($i.path // null)        then ": " + ($i.path        | .[0:200])
-                  elif ($i.description // null) then ": " + ($i.description | .[0:160])
-                  elif ($i.prompt // null)      then ": " + ($i.prompt      | gsub("\\s+"; " ") | .[0:160])
-                  elif ($i.url // null)         then ": " + ($i.url         | .[0:160])
-                  elif ($i.query // null)       then ": " + ($i.query       | .[0:160])
+                  elif ($i.description // null) then ": " + ($i.description | norm | redact | .[0:160])
+                  elif ($i.prompt // null)      then ": " + ($i.prompt      | norm | redact | .[0:160])
+                  elif ($i.url // null)         then ": " + ($i.url         | redact | .[0:160])
+                  elif ($i.query // null)       then ": " + ($i.query       | norm | .[0:160])
                   elif ($i.pattern // null)     then ": " + ($i.pattern     | .[0:160])
                   else "" end
                 )
@@ -418,10 +498,20 @@ run_phase() {
   ) &
   PHASE_PGID=$!
   set +m
-  wait "$PHASE_PGID"
-  rc=$?
+  install_signal_traps
+
+  # `wait <pid>` failing under set -e would abort run_phase; `|| rc=$?`
+  # captures the pipefail-aware exit code without disabling errexit so a
+  # future edit inside this block cannot leak errexit-off into the main
+  # loop the way a `set +e` / `set -e` toggle could.
+  wait "$PHASE_PGID" || rc=$?
+  # Brief mask while clearing PHASE_PGID — a signal racing this single
+  # assignment would otherwise fire terminate_phase_group against a
+  # just-finished pgid (harmless ESRCH) which the trap is already happy
+  # to no-op, but the symmetry keeps the windows uniformly closed.
+  mask_signal_traps
   PHASE_PGID=""
-  set -e
+  install_signal_traps
   local elapsed
   elapsed=$(( $(date +%s) - start_ts ))
 

--- a/scripts/run-workflow.sh
+++ b/scripts/run-workflow.sh
@@ -195,13 +195,42 @@ fi
 # gitignored state tree.
 PROMPT_FILE=$(mktemp "$STATE_DIR/prompt.XXXXXX")
 chmod 600 "$PROMPT_FILE"
+
+# Process group of the currently-running phase pipeline, or empty when no
+# phase is running. Populated by run_phase before `wait`, cleared after.
+PHASE_PGID=""
+
+# Terminate the phase pipeline's entire process group on Ctrl-C / SIGTERM
+# / SIGHUP. claude (and any tool it spawned: git, gh, sub-agents) sits in
+# this group; without the negative-PID form below, signaling only the
+# subshell would leave the descendants reparented to init and the
+# orchestrator's terminal would still appear hung.
+terminate_phase_group() {
+  if [[ -z "$PHASE_PGID" ]]; then
+    return 0
+  fi
+  local pgid="$PHASE_PGID"
+  PHASE_PGID=""
+  echo "[orchestrator] terminating phase pipeline (pgid=$pgid)..." >&2
+  kill -TERM "-$pgid" 2>/dev/null || true
+  # Brief grace period before escalating; claude's own SIGTERM handler
+  # may need a moment to flush its final stream-json frame.
+  local i
+  for i in 1 2 3 4 5; do
+    kill -0 "-$pgid" 2>/dev/null || return 0
+    sleep 0.2
+  done
+  kill -KILL "-$pgid" 2>/dev/null || true
+}
+
 # Preserve the original exit code through cleanup. INT/TERM/HUP also fire
 # the trap so a Ctrl-C mid-phase does not leak the prompt file (which can
-# embed full issue bodies from context.json).
-trap 'rc=$?; rm -f "$PROMPT_FILE"; exit "$rc"' EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-trap 'exit 129' HUP
+# embed full issue bodies from context.json) and so the phase's process
+# group is signaled before the orchestrator exits.
+trap 'rc=$?; terminate_phase_group; rm -f "$PROMPT_FILE"; exit "$rc"' EXIT
+trap 'terminate_phase_group; exit 130' INT
+trap 'terminate_phase_group; exit 143' TERM
+trap 'terminate_phase_group; exit 129' HUP
 
 # --- Initial state -------------------------------------------------------
 # Log the claude binary version at startup so the operator can confirm
@@ -313,28 +342,100 @@ run_phase() {
 
   local log
   log="$STATE_DIR/logs/$(date -u +%Y-%m-%dT%H-%M-%SZ)-${phase}.log"
-  echo "[orchestrator] phase=$phase log=$log"
+  local start_ts
+  start_ts=$(date +%s)
+  echo "[orchestrator] phase=$phase started=$(date -u '+%Y-%m-%dT%H:%M:%SZ') log=$log"
 
   local context_before
   context_before=$(cat "$STATE_DIR/context.json")
 
   build_prompt "$phase" "$file" "$context_before"
 
+  # Drive claude in streaming mode so the operator sees per-turn progress
+  # instead of staring at a silent terminal until the phase finishes. The
+  # stream is line-delimited JSON; jq projects each event into a human-
+  # readable line (tool calls, assistant text, final result), and tee
+  # mirrors that projection into the phase log so terminal and log carry
+  # the same story. claude's stderr is appended to the log directly for
+  # forensics; jq's tolerant per-line `try ... catch empty` keeps a stray
+  # non-JSON line from killing the projection.
+  #
+  # The pipeline runs in a backgrounded subshell with `set -m` so it
+  # gets its own process group (PGID == subshell PID). The orchestrator
+  # then `wait`s on the subshell; `wait` is interruptible by signals,
+  # so a Ctrl-C in the terminal immediately runs the INT trap, which
+  # signals the whole phase process group via terminate_phase_group.
+  # Without this isolation a claude process that ignores SIGINT (or any
+  # long-running tool subprocess) would keep the foreground pipeline
+  # alive and the orchestrator would appear unkillable from the
+  # terminal until claude returned on its own.
+  #
+  # Inside the subshell, `set +m` switches job control back off so the
+  # pipeline stages stay co-grouped under the subshell, and
+  # `set -o pipefail` preserves the timeout-vs-other-failure distinction
+  # the original code derived from ${PIPESTATUS[0]} (timeout's 124 is
+  # the leftmost non-zero status and pipefail propagates it).
   local rc=0
-  "$TIMEOUT_BIN" "$PER_PHASE_TIMEOUT_SECS" \
-    claude --dangerously-skip-permissions -p "$(cat "$PROMPT_FILE")" \
-    >>"$log" 2>&1 || rc=$?
+  set +e
+  set -m
+  (
+    set +m
+    set -o pipefail
+    "$TIMEOUT_BIN" "$PER_PHASE_TIMEOUT_SECS" \
+      claude --dangerously-skip-permissions --verbose \
+        --output-format=stream-json -p "$(cat "$PROMPT_FILE")" \
+        2>>"$log" \
+      | jq -r --unbuffered '
+          try (
+            if .type == "assistant" then
+              (.message.content // [])[] |
+              if .type == "text" and ((.text // "") | length) > 0 then
+                "[claude] " + (.text | gsub("\\s+"; " ") | .[0:240])
+              elif .type == "tool_use" then
+                "[tool]  " + .name + (
+                  .input as $i |
+                  if   ($i.command // null)     then ": " + ($i.command     | gsub("\\s+"; " ") | .[0:160])
+                  elif ($i.file_path // null)   then ": " + $i.file_path
+                  elif ($i.path // null)        then ": " + $i.path
+                  elif ($i.description // null) then ": " + ($i.description | .[0:160])
+                  elif ($i.prompt // null)      then ": " + ($i.prompt      | gsub("\\s+"; " ") | .[0:160])
+                  elif ($i.url // null)         then ": " + $i.url
+                  elif ($i.query // null)       then ": " + ($i.query       | .[0:160])
+                  elif ($i.pattern // null)     then ": " + ($i.pattern     | .[0:160])
+                  else "" end
+                )
+              else empty end
+            elif .type == "result" then
+              "[claude] result=" + (.subtype // "ok")
+              + (if .duration_ms    then " duration=" + (.duration_ms / 1000 | floor | tostring) + "s" else "" end)
+              + (if .total_cost_usd then " cost=$"    + (.total_cost_usd | tostring)                   else "" end)
+            elif .type == "system" and .subtype == "init" then
+              "[claude] session=" + ((.session_id // "?") | tostring | .[0:8])
+            else empty end
+          ) catch empty
+        ' \
+      | tee -a "$log"
+  ) &
+  PHASE_PGID=$!
+  set +m
+  wait "$PHASE_PGID"
+  rc=$?
+  PHASE_PGID=""
+  set -e
+  local elapsed=$(( $(date +%s) - start_ts ))
 
   if [[ $rc -ne 0 ]]; then
     if [[ $rc -eq 124 ]]; then
-      echo "[orchestrator] phase '$phase' exceeded ${PER_PHASE_TIMEOUT_SECS}s timeout (see $log)" >&2
+      echo "[orchestrator] phase '$phase' exceeded ${PER_PHASE_TIMEOUT_SECS}s timeout after ${elapsed}s (see $log)" >&2
       dump_log_tail_on_failure "$log"
       return 124
     fi
-    echo "[orchestrator] claude -p exited $rc on phase '$phase' (see $log)" >&2
+    echo "[orchestrator] claude -p exited $rc on phase '$phase' after ${elapsed}s (see $log)" >&2
     dump_log_tail_on_failure "$log"
     return 1
   fi
+
+  echo "[orchestrator] phase=$phase finished in ${elapsed}s"
 
   if ! jq empty "$STATE_DIR/context.json" 2>/dev/null; then
     echo "[orchestrator] context.json is not valid JSON after phase '$phase' (see $log)" >&2

--- a/scripts/run-workflow.sh
+++ b/scripts/run-workflow.sh
@@ -395,11 +395,11 @@ run_phase() {
                 "[tool]  " + .name + (
                   .input as $i |
                   if   ($i.command // null)     then ": " + ($i.command     | gsub("\\s+"; " ") | .[0:160])
-                  elif ($i.file_path // null)   then ": " + $i.file_path
-                  elif ($i.path // null)        then ": " + $i.path
+                  elif ($i.file_path // null)   then ": " + ($i.file_path   | .[0:200])
+                  elif ($i.path // null)        then ": " + ($i.path        | .[0:200])
                   elif ($i.description // null) then ": " + ($i.description | .[0:160])
                   elif ($i.prompt // null)      then ": " + ($i.prompt      | gsub("\\s+"; " ") | .[0:160])
-                  elif ($i.url // null)         then ": " + $i.url
+                  elif ($i.url // null)         then ": " + ($i.url         | .[0:160])
                   elif ($i.query // null)       then ": " + ($i.query       | .[0:160])
                   elif ($i.pattern // null)     then ": " + ($i.pattern     | .[0:160])
                   else "" end
@@ -422,7 +422,8 @@ run_phase() {
   rc=$?
   PHASE_PGID=""
   set -e
-  local elapsed=$(( $(date +%s) - start_ts ))
+  local elapsed
+  elapsed=$(( $(date +%s) - start_ts ))
 
   if [[ $rc -ne 0 ]]; then
     if [[ $rc -eq 124 ]]; then

--- a/scripts/run-workflow.sh
+++ b/scripts/run-workflow.sh
@@ -435,10 +435,11 @@ run_phase() {
   #
   # Inside the subshell, `set +m` switches job control back off so the
   # pipeline stages stay co-grouped under the subshell. `set -o pipefail`
-  # makes the subshell's exit status the rightmost non-zero exit in the
-  # pipeline; the leftmost stage is claude, so timeout(1)'s 124 (or any
-  # claude failure) propagates intact to the orchestrator's rc==124
-  # branch instead of being masked by a downstream stage's success.
+  # makes the pipeline's exit status the last non-zero exit across all
+  # stages. The downstream stages (awk, jq, tee) exit 0 when their
+  # input closes, so timeout(1)'s 124 — or any non-zero from claude —
+  # is the only non-zero and propagates intact to the orchestrator's
+  # rc==124 / rc!=0 branches.
   #
   # mask_signal_traps wraps the fork → PHASE_PGID assignment so a signal
   # in that one-statement window cannot orphan the just-spawned subshell.

--- a/scripts/test_run_workflow.py
+++ b/scripts/test_run_workflow.py
@@ -162,6 +162,50 @@ case "${STUB_MODE:-ADVANCE}" in
     mv "$state_dir/context.json.tmp" "$state_dir/context.json"
     printf 'step-2' > "$state_dir/current-phase.txt"
     ;;
+  STREAM_WITH_GARBAGE)
+    # Emit a representative stream-json sequence on stdout including an
+    # intentional non-JSON garbage line. The orchestrator's jq projection
+    # uses `jq -rR` + `try (fromjson | ...) catch empty`, which moves
+    # parsing inside the catch boundary so the garbage line MUST be
+    # silently dropped instead of aborting the phase with jq's exit 5.
+    # The valid frames also exercise the redact path (a fake ghp_ token
+    # in a Bash command) so a future change that removes the def can be
+    # caught by inspecting the projection output if needed.
+    cat <<'JSON'
+{"type":"system","subtype":"init","session_id":"abc12345def67890fedcba9876543210"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Working on phase\n\n  with whitespace"}]}}
+this is not json garbage line that would otherwise abort jq
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"gh api -H 'Authorization: Bearer ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' /user"}}]}}
+another garbage line: }{][
+{"type":"result","subtype":"success","duration_ms":1500,"total_cost_usd":0.01}
+JSON
+    case "$phase" in
+      step-1)
+        printf '%s' "$prior" \
+          | python3 -c 'import sys, json; d=json.loads(sys.stdin.read() or "{}"); d["step1"]="ran"; print(json.dumps(d))' \
+          > "$state_dir/context.json.tmp"
+        mv "$state_dir/context.json.tmp" "$state_dir/context.json"
+        printf 'step-2' > "$state_dir/current-phase.txt"
+        ;;
+      step-2)
+        printf '%s' "$prior" \
+          | python3 -c 'import sys, json; d=json.loads(sys.stdin.read() or "{}"); d["step2"]="ran"; print(json.dumps(d))' \
+          > "$state_dir/context.json.tmp"
+        mv "$state_dir/context.json.tmp" "$state_dir/context.json"
+        printf 'done' > "$state_dir/current-phase.txt"
+        ;;
+    esac
+    ;;
+  HANG)
+    # Record this stub's PID so the SIGTERM test can verify the process
+    # was actually killed by terminate_phase_group's `kill -TERM -<pgid>`
+    # (not merely that the orchestrator itself exited while leaving the
+    # subshell orphaned). `exec sleep` keeps the recorded PID valid because
+    # exec preserves the PID across the program swap; without exec, the
+    # bash wrapper would die and only the sleep child would persist.
+    echo "$$" > "$state_dir/hang.pid"
+    exec sleep 600
+    ;;
   *)
     echo "stub-claude: unknown STUB_MODE ${STUB_MODE:-}" >&2
     exit 66
@@ -498,6 +542,159 @@ class OrchestratorSmokeTests(unittest.TestCase):
             finally:
                 fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
                 holder.close()
+
+    def test_streaming_projection_handles_malformed_lines(self) -> None:
+        """The jq projection uses `-rR` + `try (fromjson | ...) catch empty`
+        so a non-JSON line in claude's stream-json output is silently dropped
+        instead of aborting the phase with jq's exit 5. The STREAM_WITH_GARBAGE
+        stub emits two garbage lines interleaved with valid stream-json frames;
+        the orchestrator must advance through both phases regardless."""
+        with TemporaryDirectory() as tmp:
+            repo = _materialize_repo(Path(tmp))
+            _make_test_workflow(repo)
+            _make_stubs(repo)
+            cp = _run_orchestrator(
+                repo, "test-wf",
+                env={"STUB_MODE": "STREAM_WITH_GARBAGE"},
+            )
+            self.assertEqual(
+                cp.returncode, 0,
+                msg=f"stdout: {cp.stdout}\nstderr: {cp.stderr}",
+            )
+            self.assertIn("workflow finished at terminal phase: done", cp.stdout)
+            state = json.loads(
+                (repo / ".claude" / "workflow-state" / "test-wf" / "context.json").read_text()
+            )
+            self.assertEqual(state.get("step1"), "ran")
+            self.assertEqual(state.get("step2"), "ran")
+            # The projection should redact the fake ghp_ token emitted in the
+            # Bash tool_use command, never leaking it to stdout / log.
+            self.assertNotIn("ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", cp.stdout)
+            self.assertIn("[REDACTED]", cp.stdout)
+            # Phase log should also be redacted (it tee-s from the same projection).
+            log_dir = repo / ".claude" / "workflow-state" / "test-wf" / "logs"
+            log_files = list(log_dir.glob("*.log"))
+            self.assertTrue(log_files, "no phase log files were written")
+            for log in log_files:
+                content = log.read_text(errors="replace")
+                self.assertNotIn(
+                    "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    content,
+                    msg=f"unredacted token in {log}",
+                )
+
+    def test_phase_log_is_owner_only(self) -> None:
+        """`umask 077` near the top of the orchestrator forces every state
+        file (current-phase.txt, context.json, lock, logs/*.log) to be
+        mode 600 owner-only. The phase log captures projected tool-use
+        arguments which can include credentials, so a world-readable mode
+        from the maintainer's interactive umask is a leak surface."""
+        import stat
+        with TemporaryDirectory() as tmp:
+            repo = _materialize_repo(Path(tmp))
+            _make_test_workflow(repo)
+            _make_stubs(repo)
+            cp = _run_orchestrator(repo, "test-wf", env={"STUB_MODE": "ADVANCE"})
+            self.assertEqual(cp.returncode, 0, msg=cp.stderr)
+            state_dir = repo / ".claude" / "workflow-state" / "test-wf"
+            for path in [
+                state_dir / "context.json",
+                state_dir / "current-phase.txt",
+                state_dir / "lock",
+                *((state_dir / "logs").glob("*.log")),
+            ]:
+                mode = stat.S_IMODE(path.stat().st_mode)
+                # Group and other bits must be zero.
+                self.assertEqual(
+                    mode & 0o077, 0,
+                    msg=f"{path} mode is {oct(mode)}, expected owner-only "
+                        f"(world/group bits must be zero under umask 077)",
+                )
+
+    def test_sigterm_kills_phase_process_group(self) -> None:
+        """SIGTERM to the orchestrator must (1) exit it with code 143,
+        and (2) actually kill the descendant claude process via the
+        terminate_phase_group → `kill -TERM -<pgid>` path — not merely
+        orphan it. HANG mode arranges the stub claude to `exec sleep 600`
+        and record its PID in `hang.pid`; the test sends SIGTERM after
+        the PID file appears and asserts the recorded PID is gone."""
+        import signal
+        import time
+        with TemporaryDirectory() as tmp:
+            repo = _materialize_repo(Path(tmp))
+            _make_test_workflow(repo)
+            _make_stubs(repo)
+
+            base_env = os.environ.copy()
+            base_env["PATH"] = f"{repo / 'bin'}{os.pathsep}{base_env.get('PATH', '')}"
+            base_env["STUB_MODE"] = "HANG"
+
+            proc = subprocess.Popen(
+                [str(repo / "scripts" / "run-workflow.sh"), "test-wf"],
+                cwd=str(repo),
+                env=base_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+            try:
+                hang_pid_file = (
+                    repo / ".claude" / "workflow-state" / "test-wf" / "hang.pid"
+                )
+                # Wait up to 10 s for the stub to record its PID.
+                hang_pid = None
+                for _ in range(100):
+                    if hang_pid_file.exists():
+                        try:
+                            hang_pid = int(hang_pid_file.read_text().strip())
+                        except (OSError, ValueError):
+                            pass
+                        if hang_pid:
+                            break
+                    time.sleep(0.1)
+                self.assertIsNotNone(
+                    hang_pid,
+                    msg="HANG stub did not record its PID within 10 s",
+                )
+
+                proc.send_signal(signal.SIGTERM)
+
+                # Allow up to 10 s for the orchestrator's escalating
+                # SIGTERM/SIGKILL to reach the hang process and for the
+                # orchestrator itself to exit.
+                try:
+                    stdout, stderr = proc.communicate(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    raise AssertionError(
+                        "orchestrator did not exit within 10 s of SIGTERM"
+                    )
+
+                self.assertEqual(
+                    proc.returncode, 143,
+                    msg=f"stdout: {stdout.decode(errors='replace')}\n"
+                        f"stderr: {stderr.decode(errors='replace')}",
+                )
+
+                # Verify the hang process is gone. ProcessLookupError =>
+                # killed cleanly via the pgid signal path.
+                try:
+                    os.kill(hang_pid, 0)
+                    # Still alive — fail loud.
+                    try:
+                        os.kill(hang_pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    raise AssertionError(
+                        f"hang process {hang_pid} survived orchestrator SIGTERM "
+                        "— terminate_phase_group did not signal the pgid"
+                    )
+                except ProcessLookupError:
+                    pass  # OK — descendant cleaned up.
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.communicate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

- Drive `claude -p` with `--verbose --output-format=stream-json` so each tool call and assistant turn surfaces on the terminal in real time instead of after the entire phase ends.
- Project each event through a tolerant `jq` filter (`jq -rR` + `try (fromjson | …) catch empty`) into one-line summaries: `[claude] session=…`, `[tool] <Name>: <command/path/prompt>`, `[claude] <assistant text>`, `[claude] result=… duration=…s cost=$…`.
- `tee -a "$log"` mirrors the projection into the phase log file so terminal and log carry the same story; `claude`'s stderr is appended to the log directly for forensics.
- Phase start now prints UTC timestamp + log path; phase end (and failure paths) print elapsed seconds.
- Run the phase pipeline in a backgrounded subshell with `set -m` so it owns its own process group. `terminate_phase_group` sends `SIGTERM` to `-$pgid`, escalates to `SIGKILL` after a ~1 s grace (`PHASE_TERM_GRACE_ITERS × PHASE_TERM_GRACE_SLEEP_SECS`), and distinguishes ESRCH (process gone — return early) from EPERM (privileged descendant — keep iterating to SIGKILL). INT/TERM/HUP traps are masked across the fork-and-assign window so a signal cannot orphan the just-spawned subshell.
- Force `umask 077` before state-dir creation so every state file (`context.json`, `current-phase.txt`, `lock`, `logs/*.log`) is mode 600 owner-only. The jq projection also runs each string field through a `redact` def that scrubs known GitHub credential shapes (`ghp_`/`gho_`/`ghs_`/`ghu_`/`github_pat_`/`x-access-token:`) before tee — primary control is the umask, redaction is defence in depth for the case where a log is later included in an artifact bundle.
- An `awk 'length < 1048576 { print; fflush() }'` pre-filter between claude and jq drops any single stream-json frame over 1 MiB so a pathological tool_result cannot OOM the orchestrator.
- Doc sync: `.claude/rules/workflow-discipline.md` §"Logging and observability", `docs/adr/0018-phase-based-shell-orchestrated-workflows.md` §Consequences, and `.claude/workflows/README.md` state-dir tree all referred to the pre-PR silent-stdout / `tail -f` model and have been updated to describe the streaming projection + mode-600 logs.

## Why

`./scripts/run-workflow.sh autopilot-issue` was silent for the duration of each phase: the orchestrator printed `[orchestrator] phase=X log=...` and then nothing until the next phase boundary. The default `text` output format of `claude -p` only emits the final assistant message at the very end, so even tailing the phase log from a second terminal showed an empty file until claude finished. The operator had no way to tell whether claude was working, stuck on a tool call, or hung.

Stream-JSON output combined with a per-event projection gives live visibility without re-architecting the orchestrator, and the process-group signal handling means the operator can actually kill a hung phase from the same terminal that started it.

## Test results

- `bash -n scripts/run-workflow.sh` → clean
- `python3 scripts/test_run_workflow.py` → 18/18 pass

Three new tests lock in the substantive behaviour:
- `test_streaming_projection_handles_malformed_lines` proves the `jq -rR + fromjson` shape silently drops non-JSON frames AND that the `redact` def strips a fake `ghp_…` token from both stdout and the log file.
- `test_phase_log_is_owner_only` asserts every state file is mode 600 (world/group bits zero) under the new umask 077.
- `test_sigterm_kills_phase_process_group` SIGTERMs the orchestrator while a `HANG` stub holds `exec sleep 600`, then asserts the orchestrator exits with code 143 AND the recorded hang PID is gone — proving the pgid signal path actually reached the descendant, not merely that the orchestrator itself exited cleanly.

## Review summary

Three parallel independent reviews (code, security, project-rules) plus the repo's auto-review converged on this commit. Every High/Medium/Low/Nit finding is resolved in-PR per `.claude/rules/pr-workflow.md` step 4; no review-finding follow-up issues were filed.

## Sister-site audit

N/A. `scripts/run-workflow.sh` is the only script in the repo that invokes `claude -p` as a local subprocess; the GitHub Actions invocations (`claude.yml`, `claude-review.yml`, `auto-resolve-conflicts.yml`) use the `anthropics/claude-code-action` runner with a wholly different execution model. No fix-propagation candidates.

## Deferred

- The work on this PR was performed directly on the main checkout instead of in `../chordsketch-wt/issue-2495-stream-workflow-progress/` per `.claude/rules/parallel-work.md`. Practical impact is zero — no other agent had work in flight against the same files during this window — so no remediation is needed on this PR; future linear orchestrator-tooling changes should still follow the worktree-isolation convention.

Closes #2495

Co-authored-by: claude[bot] <41898282+claude[bot]@users.noreply.github.com>
Co-authored-by: うんち <unchidev@users.noreply.github.com>
