### PR TITLE
batch(ui_kits): 3 issues — 2026-05-18

### DIFF
--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -170,9 +170,9 @@ a { color: inherit; text-decoration: none; }
    data-barline-right attribute below), so we never need `!important`
    to override. */
 .chart-line .bar:last-child { border-right: 1.5px solid var(--ink-1000); }
-.bar[data-barline-right="double"],
-.bar[data-barline-right="repeat"],
-.bar[data-barline-right="end"] { border-right: 0; }
+.chart-line .bar[data-barline-right="double"],
+.chart-line .bar[data-barline-right="repeat"],
+.chart-line .bar[data-barline-right="end"] { border-right: 0; }
 
 /* All barlines render at the same vertical extent: single barlines use
    border-left at the bar's full height, and special barlines use SMuFL

--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -816,7 +816,7 @@ a { color: inherit; text-decoration: none; }
             <select id="key-root" style="color: var(--crimson-500); font-weight: 700;">
               <option>C</option><option>C♯/D♭</option><option>D</option><option>D♯/E♭</option><option selected>E</option><option>F</option><option>F♯/G♭</option><option>G</option><option>G♯/A♭</option><option>A</option><option>A♯/B♭</option><option>B</option>
             </select>
-            <div class="segmented key-mode" role="group" aria-labelledby="key-field-label" aria-label="Key mode">
+            <div class="segmented key-mode" role="group" aria-labelledby="key-field-label">
               <button type="button" aria-pressed="false">Major</button>
               <button type="button" aria-pressed="true">Minor</button>
             </div>

--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -165,10 +165,14 @@ a { color: inherit; text-decoration: none; }
 .bar:hover { background: rgba(189, 22, 66, 0.05); }
 .bar.active { background: var(--crimson-50); outline: 1.5px solid var(--crimson-500); outline-offset: -1.5px; z-index: 2; }
 
-/* End-of-line single barline. Skipped when the last bar already carries
-   its own glyph-based barline (repeat-end or final), so we never need
-   `!important` to override. */
-.chart-line .bar:last-child:not(.repeat-end):not(.final) { border-right: 1.5px solid var(--ink-1000); }
+/* End-of-line single barline. Skipped when the bar carries its own
+   glyph-based right barline (`double`, `repeat`, or `end` via the
+   data-barline-right attribute below), so we never need `!important`
+   to override. */
+.chart-line .bar:last-child { border-right: 1.5px solid var(--ink-1000); }
+.bar[data-barline-right="double"],
+.bar[data-barline-right="repeat"],
+.bar[data-barline-right="end"] { border-right: 0; }
 
 /* All barlines render at the same vertical extent: single barlines use
    border-left at the bar's full height, and special barlines use SMuFL
@@ -179,12 +183,19 @@ a { color: inherit; text-decoration: none; }
   --barline-h: 58px;
   min-height: var(--barline-h);
 }
-.bar.repeat-start,
-.bar.repeat-end,
-.bar.final { position: relative; }
-.bar.repeat-start::before,
-.bar.repeat-end::after,
-.bar.final::after {
+/* Glyph-based barlines — iReal Pro models each bar as having two
+   independently-configurable sides. data-barline-left and
+   data-barline-right each take one of: `single` (default; rendered
+   by the .bar's border-left or the :last-child border-right above),
+   `double`, `repeat`, `end`. The non-single values emit a SMuFL
+   glyph via ::before / ::after and suppress the corresponding
+   border on the bar. */
+.bar[data-barline-left="double"]::before,
+.bar[data-barline-left="repeat"]::before,
+.bar[data-barline-left="end"]::before,
+.bar[data-barline-right="double"]::after,
+.bar[data-barline-right="repeat"]::after,
+.bar[data-barline-right="end"]::after {
   font-family: var(--font-music);
   font-weight: normal;
   /* Empirically tuned so the visible Bravura barline strokes occupy the
@@ -192,9 +203,9 @@ a { color: inherit; text-decoration: none; }
      border-left used on adjacent single barlines. Verified by reading
      pixel data from a Playwright screenshot of the rendered DOM:
        single barline:   y=1..57, h=57
-       repeat-start:     y=1..57, h=57
-       repeat-end:       y=1..57, h=57
-       final:            y=1..57, h=57
+       repeat (left):    y=1..57, h=57
+       repeat (right):   y=1..57, h=57
+       end (final):      y=1..57, h=57
      The values below (font-size 71px, top -1px) were the last in a
      series of probe edits at this `--barline-h: 58px` setting. If the
      bar height is changed, both numbers must be re-tuned — Bravura's
@@ -206,12 +217,24 @@ a { color: inherit; text-decoration: none; }
   top: -1px;
   pointer-events: none;
 }
-.bar.repeat-start { border-left: 0; padding-left: calc(var(--sp-4) + 12px); }
-.bar.repeat-start::before { content: "\E040"; left: -2px; }    /* repeatLeft */
-.bar.repeat-end   { border-right: 0; padding-right: calc(var(--sp-3) + 12px); }
-.bar.repeat-end::after   { content: "\E041"; right: -2px; }    /* repeatRight */
-.bar.final        { border-right: 0; padding-right: calc(var(--sp-3) + 10px); }
-.bar.final::after        { content: "\E032"; right: -2px; }    /* barlineFinal */
+/* Left-barline variants. Each suppresses the default border-left and
+   reserves padding-left so the glyph's visible ink doesn't collide
+   with chord content. */
+.bar[data-barline-left="double"] { border-left: 0; padding-left: calc(var(--sp-3) + 8px); }
+.bar[data-barline-left="double"]::before { content: "\E031"; left: -2px; }    /* barlineDouble */
+.bar[data-barline-left="repeat"] { border-left: 0; padding-left: calc(var(--sp-4) + 12px); }
+.bar[data-barline-left="repeat"]::before { content: "\E040"; left: -2px; }    /* repeatLeft */
+.bar[data-barline-left="end"]    { border-left: 0; padding-left: calc(var(--sp-3) + 10px); }
+.bar[data-barline-left="end"]::before    { content: "\E032"; left: -2px; }    /* barlineFinal */
+/* Right-barline variants. The :last-child default border-right is
+   suppressed above for non-single right values, and the glyph is
+   anchored to the bar's right edge. */
+.bar[data-barline-right="double"] { padding-right: calc(var(--sp-3) + 8px); }
+.bar[data-barline-right="double"]::after { content: "\E031"; right: -2px; }   /* barlineDouble */
+.bar[data-barline-right="repeat"] { padding-right: calc(var(--sp-3) + 12px); }
+.bar[data-barline-right="repeat"]::after { content: "\E041"; right: -2px; }   /* repeatRight */
+.bar[data-barline-right="end"]    { padding-right: calc(var(--sp-3) + 10px); }
+.bar[data-barline-right="end"]::after    { content: "\E032"; right: -2px; }   /* barlineFinal */
 
 /* Section marker — small black-filled square with white letter, anchored at
    the top-left of the first bar of a section. Matches iReal Pro's printed
@@ -765,8 +788,14 @@ a { color: inherit; text-decoration: none; }
             </optgroup>
           </select>
         </div>
-        <div class="meta-field"><label for="key">Key</label>
-          <select id="key" style="color: var(--crimson-500); font-weight: 700;"><option>C</option><option>D</option><option selected>Em</option><option>F</option><option>G</option><option>Am</option></select>
+        <div class="meta-field"><label for="key-root">Key</label>
+          <select id="key-root" style="color: var(--crimson-500); font-weight: 700;">
+            <option>C</option><option>C♯/D♭</option><option>D</option><option>D♯/E♭</option><option selected>E</option><option>F</option><option>F♯/G♭</option><option>G</option><option>G♯/A♭</option><option>A</option><option>A♯/B♭</option><option>B</option>
+          </select>
+          <div class="segmented" role="group" aria-label="Key mode">
+            <button aria-pressed="false">Major</button>
+            <button aria-pressed="true">Minor</button>
+          </div>
         </div>
         <div class="meta-field"><label for="time">Time</label>
           <select id="time">
@@ -795,7 +824,7 @@ a { color: inherit; text-decoration: none; }
         <!-- Line 1 — chart begins with time signature, then repeat-start barline -->
         <div class="chart-line">
           <span class="time-sig"><span>4</span><span>4</span></span>
-          <div class="bar repeat-start">
+          <div class="bar" data-barline-left="repeat">
             <span class="section-marker">A</span>
             <span class="chord">
               <span class="chord-root">A</span><span class="chord-qual">−7</span>
@@ -814,7 +843,7 @@ a { color: inherit; text-decoration: none; }
         <div class="chart-line">
           <div class="bar"><span class="chord"><span class="chord-root">F</span><span class="chord-acc">&#x266F;</span><span class="chord-qual">ø7</span></span></div>
           <div class="bar"><span class="chord"><span class="chord-root">B</span><span class="chord-qual">7<span class="smufl">&#x266D;</span>9</span></span></div>
-          <div class="bar active repeat-end ending ending-1" aria-current="true">
+          <div class="bar active ending ending-1" data-barline-right="repeat" aria-current="true">
             <span class="ending-bracket">1.</span>
             <span class="chord"><span class="chord-root">E</span><span class="chord-qual">−7</span></span>
           </div>
@@ -886,7 +915,7 @@ a { color: inherit; text-decoration: none; }
           <div class="bar"><span class="chord"><span class="chord-root">D</span><span class="chord-qual">−7</span></span></div>
           <div class="bar"><span class="chord"><span class="chord-root">G</span><span class="chord-qual stacked"><span>7<span class="smufl">&#x266D;</span>9</span><span><span class="smufl">&#x266F;</span>5</span></span></span></div>
           <div class="bar"><span class="chord"><span class="chord-root">C</span><span class="chord-qual">Δ7<span class="smufl">&#x266F;</span>11</span></span></div>
-          <div class="bar final">
+          <div class="bar" data-barline-right="end">
             <span class="chord"><span class="chord-root">B</span><span class="chord-qual">−7</span></span>
             <span class="chord" data-beat="3"><span class="chord-root">E</span><span class="chord-qual">7<span class="smufl">&#x266D;</span>9</span></span>
             <span class="glyph-mark" data-beat="3" aria-label="Coda">&#xE048;</span>
@@ -905,17 +934,25 @@ a { color: inherit; text-decoration: none; }
           </div>
           <div class="bar"><span class="chord"><span class="chord-root">D</span><span class="chord-qual">7</span></span></div>
           <div class="bar"><span class="chord"><span class="chord-root">G</span><span class="chord-qual">Δ7</span></span></div>
-          <div class="bar final last-bar">
+          <div class="bar last-bar" data-barline-right="end">
             <span class="chord"><span class="chord-root">E</span><span class="chord-qual">−7</span></span>
             <span class="end-mark">END</span>
           </div>
         </div>
 
+        <!-- Vertical spacer between the Coda destination and the
+             showcase line. iReal Pro's Symbols palette lets the user
+             insert Vertical Spacers between sections; the ×2
+             multiplier corresponds to the .chart-line-spacer.x2 size
+             token (×1 and ×3 use the .x1 / .x3 modifiers on the same
+             element). -->
+        <div class="chart-line-spacer x2" aria-hidden="true"></div>
+
         <!-- Showcase line — bars demonstrating bar-content variants that
              aren't part of the Autumn Leaves form: N.C. (no chord),
              invisible-root chord with a moving bass, repeat-1-bar slash
              glyph, and repeat-2-bars slash glyph. -->
-        <div class="chart-line" style="margin-top: var(--sp-12);">
+        <div class="chart-line">
           <div class="bar">
             <span class="chord nc">N.C.</span>
             <span class="text-mark">free time</span>
@@ -928,7 +965,29 @@ a { color: inherit; text-decoration: none; }
           <div class="bar">
             <span class="repeat-bar smufl" aria-label="Repeat 1 bar">&#xE500;</span>
           </div>
-          <div class="bar final"><span class="repeat-bar smufl" aria-label="Repeat 2 bars">&#xE501;</span></div>
+          <div class="bar" data-barline-right="end"><span class="repeat-bar smufl" aria-label="Repeat 2 bars">&#xE501;</span></div>
+        </div>
+
+        <!-- Barline-variants showcase. data-barline-left and
+             data-barline-right pick the bar's left and right barlines
+             independently (single / double / repeat / end). Bar 2
+             below carries `double` on the left AND `repeat` on the
+             right — a non-trivial combination the previous
+             single-class model could not express. -->
+        <div class="chart-line-spacer" aria-hidden="true"></div>
+        <div class="chart-line">
+          <div class="bar" data-barline-right="double">
+            <span class="chord"><span class="chord-root">C</span><span class="chord-qual">Δ7</span></span>
+          </div>
+          <div class="bar" data-barline-left="double" data-barline-right="repeat">
+            <span class="chord"><span class="chord-root">G</span><span class="chord-qual">7</span></span>
+          </div>
+          <div class="bar" data-barline-left="repeat">
+            <span class="chord"><span class="chord-root">F</span><span class="chord-qual">Δ7</span></span>
+          </div>
+          <div class="bar" data-barline-right="end">
+            <span class="chord"><span class="chord-root">C</span></span>
+          </div>
         </div>
       </div>
 

--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -793,8 +793,8 @@ a { color: inherit; text-decoration: none; }
             <option>C</option><option>C♯/D♭</option><option>D</option><option>D♯/E♭</option><option selected>E</option><option>F</option><option>F♯/G♭</option><option>G</option><option>G♯/A♭</option><option>A</option><option>A♯/B♭</option><option>B</option>
           </select>
           <div class="segmented" role="group" aria-label="Key mode">
-            <button aria-pressed="false">Major</button>
-            <button aria-pressed="true">Minor</button>
+            <button type="button" aria-pressed="false">Major</button>
+            <button type="button" aria-pressed="true">Minor</button>
           </div>
         </div>
         <div class="meta-field"><label for="time">Time</label>

--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -87,6 +87,20 @@ a { color: inherit; text-decoration: none; }
 .meta-field label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-tertiary); }
 .meta-field input, .meta-field select { height: 32px; padding: 0 var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2); background: var(--ink-50); font: 500 var(--fs-14)/1 var(--font-mono); color: var(--text-primary); transition: border-color var(--dur-1) var(--ease-out), background var(--dur-1) var(--ease-out); font-variant-numeric: tabular-nums; }
 .meta-field input:focus, .meta-field select:focus { outline: none; border-color: var(--crimson-500); background: var(--surface); box-shadow: var(--focus-ring); }
+/* Key field: root <select> and Major/Minor segmented control share
+   one horizontal row so the field's vertical height matches every
+   other .meta-field (label + 32px control). Without this wrapper
+   the .meta-field's `flex-direction: column` would stack the
+   segmented control below the select and break meta-grid row
+   alignment. */
+.meta-field .key-field-row { display: flex; gap: var(--sp-2); align-items: stretch; min-width: 0; }
+.meta-field .key-field-row > select { flex: 1; min-width: 0; }
+/* Bump the segmented control from its toolbar default (28px) up to
+   the meta-field input height (32px) so the two controls share a
+   baseline. Buttons fill the parent so the active-state background
+   covers the full chip area. */
+.meta-field .key-field-row > .segmented { height: 32px; }
+.meta-field .key-field-row > .segmented button { height: 100%; }
 
 /* ============================================================
    iReal Pro chart — engraved in black on white, no cell grid.
@@ -184,12 +198,16 @@ a { color: inherit; text-decoration: none; }
   min-height: var(--barline-h);
 }
 /* Glyph-based barlines — iReal Pro models each bar as having two
-   independently-configurable sides. data-barline-left and
-   data-barline-right each take one of: `single` (default; rendered
-   by the .bar's border-left or the :last-child border-right above),
-   `double`, `repeat`, `end`. The non-single values emit a SMuFL
-   glyph via ::before / ::after and suppress the corresponding
-   border on the bar. */
+   independently-configurable sides. `data-barline-left` and
+   `data-barline-right` each take one of the three NON-SINGLE values
+   `double` / `repeat` / `end`; omit the attribute entirely for
+   `single` (the default, rendered by the .bar's `border-left` or
+   the `:last-child` `border-right` above). An unrecognised value
+   (e.g. the old class names `final` or `repeat-end`) falls through
+   silently to the default — new bars must use only the three values
+   listed below. The runtime sister site at
+   `packages/playground/src/irealpro/chart.tsx` (helper
+   `barlineSide()`) and `chart.css` keep this enum in lockstep. */
 .bar[data-barline-left="double"]::before,
 .bar[data-barline-left="repeat"]::before,
 .bar[data-barline-left="end"]::before,
@@ -520,7 +538,12 @@ a { color: inherit; text-decoration: none; }
   white-space: nowrap;
 }
 
-/* Vertical spacer between chart-line rows. */
+/* Vertical spacer between chart-line rows. The base class is the
+   ×1 size; ×2 and ×3 add an explicit modifier. There is intentionally
+   no `.x1` modifier — writing `class="chart-line-spacer x1"` is
+   harmless (no rule matches, base size wins) but is the typo that
+   would silently render identical to the default, so prefer
+   `class="chart-line-spacer"` for the ×1 case. */
 .chart-line-spacer { height: var(--sp-6); }
 .chart-line-spacer.x2 { height: var(--sp-12); }
 .chart-line-spacer.x3 { height: var(--sp-20); }
@@ -788,13 +811,15 @@ a { color: inherit; text-decoration: none; }
             </optgroup>
           </select>
         </div>
-        <div class="meta-field"><label for="key-root">Key</label>
-          <select id="key-root" style="color: var(--crimson-500); font-weight: 700;">
-            <option>C</option><option>C♯/D♭</option><option>D</option><option>D♯/E♭</option><option selected>E</option><option>F</option><option>F♯/G♭</option><option>G</option><option>G♯/A♭</option><option>A</option><option>A♯/B♭</option><option>B</option>
-          </select>
-          <div class="segmented" role="group" aria-label="Key mode">
-            <button type="button" aria-pressed="false">Major</button>
-            <button type="button" aria-pressed="true">Minor</button>
+        <div class="meta-field"><label for="key-root" id="key-field-label">Key</label>
+          <div class="key-field-row">
+            <select id="key-root" style="color: var(--crimson-500); font-weight: 700;">
+              <option>C</option><option>C♯/D♭</option><option>D</option><option>D♯/E♭</option><option selected>E</option><option>F</option><option>F♯/G♭</option><option>G</option><option>G♯/A♭</option><option>A</option><option>A♯/B♭</option><option>B</option>
+            </select>
+            <div class="segmented key-mode" role="group" aria-labelledby="key-field-label" aria-label="Key mode">
+              <button type="button" aria-pressed="false">Major</button>
+              <button type="button" aria-pressed="true">Minor</button>
+            </div>
           </div>
         </div>
         <div class="meta-field"><label for="time">Time</label>
@@ -944,8 +969,7 @@ a { color: inherit; text-decoration: none; }
              showcase line. iReal Pro's Symbols palette lets the user
              insert Vertical Spacers between sections; the ×2
              multiplier corresponds to the .chart-line-spacer.x2 size
-             token (×1 and ×3 use the .x1 / .x3 modifiers on the same
-             element). -->
+             token (×1 is the bare class, ×3 uses .chart-line-spacer.x3). -->
         <div class="chart-line-spacer x2" aria-hidden="true"></div>
 
         <!-- Showcase line — bars demonstrating bar-content variants that

--- a/packages/playground/src/irealpro/chart.css
+++ b/packages/playground/src/irealpro/chart.css
@@ -92,30 +92,44 @@
 .bar:hover { background: rgba(189, 22, 66, 0.05); }
 .bar.active { background: var(--cs-crimson-50); outline: 1.5px solid var(--cs-crimson-500); outline-offset: -1.5px; z-index: 2; }
 
-/* End-of-line single barline. Skipped when the last bar already carries
-   its own glyph-based barline (repeat-end or final), so we never need
-   `!important` to override. */
-.chart-line .bar:last-child:not(.repeat-end):not(.final) { border-right: 1.5px solid var(--cs-ink-1000); }
+/* End-of-line single barline. Skipped when the bar carries its own
+   glyph-based right barline (`double`, `repeat`, or `end` via the
+   data-barline-right attribute below), so we never need `!important`
+   to override. The data-barline-right suppression rule below matches
+   the `:last-child` rule's specificity (`.chart-line` + `.bar` +
+   attribute = 0,2,1) so the cascade-order tie-break favours the
+   later (suppression) rule — the pre-#2497 `:not(.repeat-end):not(.final)`
+   workaround silently missed `double-end`, painting both a SMuFL
+   `\E031` glyph and the default 1.5px border-right on `:last-child`
+   double-ended bars. */
+.chart-line .bar:last-child { border-right: 1.5px solid var(--cs-ink-1000); }
+.chart-line .bar[data-barline-right="double"],
+.chart-line .bar[data-barline-right="repeat"],
+.chart-line .bar[data-barline-right="end"] { border-right: 0; }
 
 /* All barlines render at the same vertical extent: single barlines use
    border-left at the bar's full height, and special barlines use SMuFL
    glyphs sized to match. The bar's min-height drives both via the
-   shared `--barline-h` token, so changing the bar height keeps the
+   shared `--cs-barline-h` token, so changing the bar height keeps the
    single barline and the engraved glyphs in lockstep. */
 .bar {
   --cs-barline-h: 58px;
   min-height: var(--cs-barline-h);
 }
-.bar.repeat-start,
-.bar.repeat-end,
-.bar.double-start,
-.bar.double-end,
-.bar.final { position: relative; }
-.bar.repeat-start::before,
-.bar.double-start::before,
-.bar.repeat-end::after,
-.bar.double-end::after,
-.bar.final::after {
+/* Glyph-based barlines — iReal Pro models each bar as having two
+   independently-configurable sides. `data-barline-left` and
+   `data-barline-right` each take one of `double`, `repeat`, `end`
+   (omit the attribute for `single`). Unknown values fall through
+   silently — keep the value set in sync with the `barlineSide()`
+   helper in `chart.tsx`. */
+.bar[data-barline-left],
+.bar[data-barline-right] { position: relative; }
+.bar[data-barline-left="double"]::before,
+.bar[data-barline-left="repeat"]::before,
+.bar[data-barline-left="end"]::before,
+.bar[data-barline-right="double"]::after,
+.bar[data-barline-right="repeat"]::after,
+.bar[data-barline-right="end"]::after {
   font-family: var(--cs-font-music);
   font-weight: normal;
   /* Empirically tuned so the visible Bravura barline strokes occupy the
@@ -123,12 +137,12 @@
      border-left used on adjacent single barlines. Verified by reading
      pixel data from a Playwright screenshot of the rendered DOM:
        single barline:   y=1..57, h=57
-       repeat-start:     y=1..57, h=57
-       repeat-end:       y=1..57, h=57
-       final:            y=1..57, h=57
+       repeat (left):    y=1..57, h=57
+       repeat (right):   y=1..57, h=57
+       end (final):      y=1..57, h=57
      The values below (font-size 71px, top -1px) were the last in a
-     series of probe edits at this `--cs-barline-h: 58px` setting. If the
-     bar height is changed, both numbers must be re-tuned — Bravura's
+     series of probe edits at this `--cs-barline-h: 58px` setting. If
+     the bar height is changed, both numbers must be re-tuned — Bravura's
      glyph metrics aren't perfectly proportional with font-size. */
   font-size: 71px;
   line-height: 1;
@@ -137,27 +151,30 @@
   top: -1px;
   pointer-events: none;
 }
-.bar.repeat-start { border-left: 0; padding-left: calc(var(--cs-sp-4) + 12px); }
-.bar.repeat-start::before { content: "\E040"; left: -2px; }    /* repeatLeft */
-.bar.repeat-end   { border-right: 0; padding-right: calc(var(--cs-sp-3) + 12px); }
-.bar.repeat-end::after   { content: "\E041"; right: -2px; }    /* repeatRight */
-.bar.final        { border-right: 0; padding-right: calc(var(--cs-sp-3) + 10px); }
-.bar.final::after        { content: "\E032"; right: -2px; }    /* barlineFinal */
-/* SMuFL barlineDouble (U+E031). Drawn as a `::before` on the bar whose
-   `bar.start === 'double'` (typical for the first bar of a new section)
-   and as a `::after` on the bar whose `bar.end === 'double'` (typical
-   for the bar that closes a section into the next). The next sibling
-   bar's normal left border is suppressed via the adjacent-sibling rule
-   below so a double-end isn't paired with a single barline next to it. */
-.bar.double-start { border-left: 0; padding-left: calc(var(--cs-sp-4) + 8px); }
-.bar.double-start::before { content: "\E031"; left: -2px; }    /* barlineDouble */
-.bar.double-end   { border-right: 0; padding-right: calc(var(--cs-sp-3) + 8px); }
-.bar.double-end::after   { content: "\E031"; right: -2px; }    /* barlineDouble */
-/* When a `.double-end` bar is directly followed by another bar within
-   the same chart-line, the next bar's `border-left: 1.5px` would paint
-   a single barline immediately right of the engraved double — producing
-   a triple-line look. Suppress the next bar's left border in that case. */
-.bar.double-end + .bar { border-left: 0; }
+/* Left-barline variants. Each suppresses the default `border-left`
+   and reserves padding-left so the glyph's visible ink doesn't
+   collide with chord content. */
+.bar[data-barline-left="double"] { border-left: 0; padding-left: calc(var(--cs-sp-4) + 8px); }
+.bar[data-barline-left="double"]::before { content: "\E031"; left: -2px; }   /* barlineDouble */
+.bar[data-barline-left="repeat"] { border-left: 0; padding-left: calc(var(--cs-sp-4) + 12px); }
+.bar[data-barline-left="repeat"]::before { content: "\E040"; left: -2px; }   /* repeatLeft */
+.bar[data-barline-left="end"]    { border-left: 0; padding-left: calc(var(--cs-sp-3) + 10px); }
+.bar[data-barline-left="end"]::before    { content: "\E032"; left: -2px; }   /* barlineFinal */
+/* Right-barline variants. The `:last-child` default `border-right`
+   is suppressed above for non-single right values, and the glyph is
+   anchored to the bar's right edge. */
+.bar[data-barline-right="double"] { padding-right: calc(var(--cs-sp-3) + 8px); }
+.bar[data-barline-right="double"]::after { content: "\E031"; right: -2px; }  /* barlineDouble */
+.bar[data-barline-right="repeat"] { padding-right: calc(var(--cs-sp-3) + 12px); }
+.bar[data-barline-right="repeat"]::after { content: "\E041"; right: -2px; }  /* repeatRight */
+.bar[data-barline-right="end"]    { padding-right: calc(var(--cs-sp-3) + 10px); }
+.bar[data-barline-right="end"]::after    { content: "\E032"; right: -2px; }  /* barlineFinal */
+/* When a `data-barline-right="double"` bar is directly followed by
+   another bar within the same chart-line, the next bar's default
+   `border-left: 1.5px` would paint a single barline immediately right
+   of the engraved double — producing a triple-line look. Suppress
+   the next bar's left border in that case. */
+.bar[data-barline-right="double"] + .bar { border-left: 0; }
 /* iReal Pro encodes section transitions symmetrically: the closing
    bar of section N has `end = Double` and the opening bar of section
    N+1 has `start = Double`. Both refer to the same visible double
@@ -165,8 +182,8 @@
    (the convention for the printed app) and suppress the previous
    bar's end-double glyph so the chart doesn't show two engraved
    doubles separated by a cell gap. */
-.bar.double-end:has(+ .bar.double-start)::after { content: none; }
-.bar.double-end:has(+ .bar.double-start) { padding-right: 0; }
+.bar[data-barline-right="double"]:has(+ .bar[data-barline-left="double"])::after { content: none; }
+.bar[data-barline-right="double"]:has(+ .bar[data-barline-left="double"]) { padding-right: 0; }
 
 /* Section marker — small black-filled square with white letter, sitting
    centered above the bar's left barline (iReal Pro's printed-chart

--- a/packages/playground/src/irealpro/chart.css
+++ b/packages/playground/src/irealpro/chart.css
@@ -97,7 +97,7 @@
    data-barline-right attribute below), so we never need `!important`
    to override. The data-barline-right suppression rule below matches
    the `:last-child` rule's specificity (`.chart-line` + `.bar` +
-   attribute = 0,2,1) so the cascade-order tie-break favours the
+   attribute = 0,3,0; attribute selectors are class-level) so the cascade-order tie-break favours the
    later (suppression) rule — the pre-#2497 `:not(.repeat-end):not(.final)`
    workaround silently missed `double-end`, painting both a SMuFL
    `\E031` glyph and the default 1.5px border-right on `:last-child`

--- a/packages/playground/src/irealpro/chart.tsx
+++ b/packages/playground/src/irealpro/chart.tsx
@@ -388,23 +388,50 @@ function sectionLabelText(label: SectionLabel): string | null {
   return label.value ?? null;
 }
 
-function barlineClass(bar: Bar): string[] {
-  const out: string[] = [];
-  if (bar.start === 'open_repeat') out.push('repeat-start');
-  if (bar.start === 'double') out.push('double-start');
-  if (bar.end === 'close_repeat') out.push('repeat-end');
-  if (bar.end === 'double') out.push('double-end');
-  if (bar.end === 'final') out.push('final');
-  if (bar.endMark) out.push('last-bar');
-  if (bar.active) out.push('active');
+/** Barline glyph kind painted by `[data-barline-left|right]` CSS
+ * selectors. `single` (the default) is encoded by attribute absence
+ * so the CSS only needs three explicit values. Mirrors the
+ * static design-system reference at
+ * `design-system/ui_kits/web/editor-irealb.html`. */
+type BarlineSide = 'double' | 'repeat' | 'end';
+
+function barlineSide(kind: Bar['start'] | Bar['end'], side: 'start' | 'end'): BarlineSide | null {
+  switch (kind) {
+    case 'double':
+      return 'double';
+    case 'open_repeat':
+      return side === 'start' ? 'repeat' : null;
+    case 'close_repeat':
+      return side === 'end' ? 'repeat' : null;
+    case 'final':
+      return side === 'end' ? 'end' : null;
+    default:
+      return null;
+  }
+}
+
+interface BarVisualState {
+  classes: string[];
+  barlineLeft: BarlineSide | null;
+  barlineRight: BarlineSide | null;
+}
+
+function barVisualState(bar: Bar): BarVisualState {
+  const classes: string[] = [];
+  if (bar.endMark) classes.push('last-bar');
+  if (bar.active) classes.push('active');
   if (bar.ending !== null && bar.ending !== undefined) {
     // `0` is the Untitled sentinel — emit a distinct class so CSS
     // hooks can target it explicitly and don't read it as a
     // numbered bracket.
-    out.push('ending');
-    out.push(bar.ending === 0 ? 'ending-untitled' : `ending-${bar.ending}`);
+    classes.push('ending');
+    classes.push(bar.ending === 0 ? 'ending-untitled' : `ending-${bar.ending}`);
   }
-  return out;
+  return {
+    classes,
+    barlineLeft: barlineSide(bar.start, 'start'),
+    barlineRight: barlineSide(bar.end, 'end'),
+  };
 }
 
 interface BarCellProps {
@@ -420,7 +447,8 @@ function BarCell({
   sectionLabel,
   beats,
 }: BarCellProps): JSX.Element {
-  const classes = ['bar', ...barlineClass(bar)];
+  const visual = barVisualState(bar);
+  const classes = ['bar', ...visual.classes];
   const sectionMarker =
     isFirstOfSection && sectionLabel ? sectionLabelText(sectionLabel) : null;
 
@@ -461,6 +489,8 @@ function BarCell({
   return (
     <div
       className={classes.join(' ')}
+      data-barline-left={visual.barlineLeft ?? undefined}
+      data-barline-right={visual.barlineRight ?? undefined}
       style={{ ['--cs-beats' as string]: String(beats) }}
     >
       {sectionMarker !== null && (


### PR DESCRIPTION
## Summary

Three deferred acceptance criteria on the iReal Pro editor demo at
`design-system/ui_kits/web/editor-irealb.html`, plus sister-site
propagation of the data-attribute barline model to the runtime
playground per `.claude/rules/fix-propagation.md`.

## Per-issue changes

### #2446: Set / Set-and-Transpose key-signature controls plus full 14-option time-signature picker

The 14-option time-signature picker and the Set / Set-and-Transpose
buttons were already shipped by the design-system PR; the deferred
item was the Major / Minor mode picker on the Key field. Replaced
the single Key dropdown — which mixed major (`C`, `D`, `F`, `G`)
and minor (`Em`, `Am`) keys in one flat list — with a chromatic
root picker covering all 12 roots (`C`, `C♯/D♭`, `D`, `D♯/E♭`, `E`,
`F`, `F♯/G♭`, `G`, `G♯/A♭`, `A`, `A♯/B♭`, `B`) plus a Major / Minor
segmented control. Default selection (E + Minor) preserves the
chart's `Em` reading in the status bar and player-controls strip.

Layout: select and segmented sit side-by-side inside a
`.key-field-row` flex wrapper, both at 32px, so the Key field stays
the same height as every other `.meta-field` in the meta grid
(label + single 32px control). A11y: the segmented group carries
`aria-labelledby="key-field-label"` so screen readers associate
the mode toggle with the visible "Key" label.

Touched: `design-system/ui_kits/web/editor-irealb.html`.

### #2443: Make bar's left and right barlines independently configurable

Replaced the `.repeat-start` / `.repeat-end` / `.final` class trio
with two independent attributes — `data-barline-left` and
`data-barline-right` — each taking one of `double` / `repeat` /
`end` (omit the attribute for `single`). CSS picks the correct
SMuFL glyph per side (`E031` barlineDouble, `E040` repeatLeft,
`E041` repeatRight, `E032` barlineFinal) and suppresses the
corresponding border. The new barline-variants showcase row at the
bottom of the chart contains a bar with `data-barline-left="double"`
AND `data-barline-right="repeat"` — the non-trivial combination
the previous class-based model could not express.

**Sister-site propagation (Medium)**: the playground at
`packages/playground/src/irealpro/chart.{tsx,css}` is the live
runtime sister site of this static reference — same class trio,
same Bravura glyphs, same pixel-tuned values. Refactored the
playground to the data-attribute model in lockstep:

- `chart.tsx`: replaced `barlineClass(bar)` with
  `barVisualState(bar)` + a `barlineSide(kind, side)` helper that
  is the single source of truth for the kind→attribute mapping.
- `chart.css`: replaced `.bar.repeat-start` etc. with
  `[data-barline-left|right="..."]` selectors. Pixel-alignment
  values preserved verbatim; the double-then-double
  section-transition `:has(+ ...)` rule survives the rename.

The propagation also fixes a sister-site bug previously hidden by
the class model: `chart.css`'s
`:last-child:not(.repeat-end):not(.final)` border-right rule
silently missed `.double-end`, so a `:last-child` double-ended bar
painted both the SMuFL `\E031` glyph AND the default 1.5px
border-right. The new attribute-driven suppression matches every
glyph-emitting right barline (`double`/`repeat`/`end`), closing
the bug class permanently.

Touched: `design-system/ui_kits/web/editor-irealb.html`,
`packages/playground/src/irealpro/chart.tsx`,
`packages/playground/src/irealpro/chart.css`.

### #2442: Add bar-level symbol library — Vertical Spacer demonstration

The bar-level symbol palette in the inspector (Repeat 1 / Repeat 2
/ Fermata / Vertical Spacer ×1·×2·×3 / END) and most of the
chart-side renderings were already shipped by the design-system
PR. The deferred item was the chart-side demonstration of
`.chart-line-spacer` — the CSS existed but was not exercised in
markup. Added two spacer instances:

- A `.chart-line-spacer.x2` between the Coda destination and the
  bar-content showcase line.
- A baseline `.chart-line-spacer` (×1 = `--sp-6`) between the
  bar-content showcase line and the new barline-variants showcase
  row (introduced by #2443 above).

Two different sizes (×1 and ×2) appear, demonstrating the
multiplier controls the amount of whitespace.

Updated the CSS comment to document that there is intentionally NO
`.x1` modifier rule (the bare class is ×1) — the prior comment
suggested `.x1` and `.x3` modifiers both exist, which would have
made `class="chart-line-spacer x1"` silently render at the default
height.

Touched: `design-system/ui_kits/web/editor-irealb.html`.

## Aggregated sister-site audit

- `packages/playground/src/irealpro/chart.{tsx,css}` — propagated
  in this PR (data-attribute model + b4f689c specificity fix +
  `.double-end` border-right bug fix).
- `@chordsketch/ui-irealb-editor` — grid editor renders via a
  different code path (no CSS-based barline rendering); `style.css`
  has no barline rules. No propagation required.
- `chordsketch-render-ireal` (Rust SVG renderer) — independent
  implementation, not a CSS sister site.
- `@chordsketch/react` `chordpro-jsx` walker — ChordPro-only, not
  an iReal Pro consumer.
- `crates/render-{text,html,pdf}` — ChordPro-only; iReal Pro has
  no text/HTML/PDF renderer to mirror.

## Test plan

- [ ] CI green on every check (re-runs on new commit `40f35ab`).
- [ ] Auto-review delta on `40f35ab` returns no findings.
- [ ] Open `design-system/ui_kits/web/editor-irealb.html` in a
      browser and verify Key field height matches sibling fields,
      Autumn Leaves barlines render unchanged, and the barline-
      variants showcase row shows left-double + right-repeat on
      bar 2.
- [ ] Build the playground (`pnpm -F @chordsketch/playground build`)
      and verify the iReal Pro preview renders identically to
      `main` for the Autumn Leaves sample.

## Deferred

None. All three issues' acceptance criteria are addressed, and the
sister-site propagation gap that the project-rules review surfaced
is fixed in this PR per the user's explicit "address everything
in-PR" directive.

Closes #2442
Closes #2443
Closes #2446
