### PR TITLE
batch(ui_kits): 3 issues — 2026-05-18 (#2)

### DIFF
--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -567,7 +567,7 @@ a { color: inherit; text-decoration: none; }
 .chart-line-spacer.x3 { height: var(--sp-20); }
 
 /* Chord width modes. The chart-wide `.chart.compact` modifier scales
-   chord glyphs horizontally (Normal=1, Small=0.7) without touching
+   chord glyphs horizontally (Normal=1, Small=0.72) without touching
    vertical metrics — matches iReal Pro's N / S toggle. A second
    selector `.bar.compact-preview` lets a single bar demonstrate the
    compression in-place against neighbouring full-width bars, used by

--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -84,7 +84,12 @@ a { color: inherit; text-decoration: none; }
 .meta-card .composer { font-family: var(--font-jp); font-weight: 400; font-size: var(--fs-14); color: var(--text-secondary); margin: 0 0 var(--sp-5); }
 .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: var(--sp-4); }
 .meta-field { display: flex; flex-direction: column; gap: 4px; }
-.meta-field label { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-tertiary); }
+/* Field-caption typography — shared by the meta-card field labels
+   above the inputs and the width-mode showcase card captions below
+   the chart. Single source of truth so the two surfaces don't drift
+   apart when the design token set evolves. */
+.meta-field label,
+.width-mode-row > .width-mode-card > .caption { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-tertiary); }
 .meta-field input, .meta-field select { height: 32px; padding: 0 var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2); background: var(--ink-50); font: 500 var(--fs-14)/1 var(--font-mono); color: var(--text-primary); transition: border-color var(--dur-1) var(--ease-out), background var(--dur-1) var(--ease-out); font-variant-numeric: tabular-nums; }
 .meta-field input:focus, .meta-field select:focus { outline: none; border-color: var(--crimson-500); background: var(--surface); box-shadow: var(--focus-ring); }
 /* Key field: root <select> and Major/Minor segmented control share
@@ -568,9 +573,14 @@ a { color: inherit; text-decoration: none; }
    compression in-place against neighbouring full-width bars, used by
    the "Width modes" showcase row at the bottom of the demo chart;
    the two selectors share one transform so the visual scale stays
-   consistent whether the toggle is applied chart-wide or per-bar. */
+   consistent whether the toggle is applied chart-wide or per-bar.
+   The per-bar selector is gated by `:not(.compact)` on the ancestor
+   chart so a `.compact-preview` bar nested inside a `.chart.compact`
+   does NOT compose two transforms (scaleX(0.72)² ≈ 0.52 would
+   silently flatten the chord glyphs further than either mode
+   intends). */
 .chart.compact .chord,
-.bar.compact-preview .chord { transform: scaleX(0.72); transform-origin: left center; }
+.chart:not(.compact) .bar.compact-preview .chord { transform: scaleX(0.72); transform-origin: left center; }
 
 /* Width-mode showcase row. Two `.bar`s side-by-side, each carrying
    four chords packed at beats 1..4 — the canonical "this bar needs
@@ -582,11 +592,19 @@ a { color: inherit; text-decoration: none; }
    interactive in this static demo. */
 .width-mode-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-6); align-items: stretch; }
 .width-mode-row > .width-mode-card { display: flex; flex-direction: column; gap: var(--sp-2); }
-.width-mode-row > .width-mode-card > .caption { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-tertiary); }
 /* Standalone `.bar` (no enclosing `.chart-line`) — add the right
    barline that the `.chart-line .bar:last-child` selector would
-   normally provide so the cell reads as a closed bar. */
+   normally provide so the cell reads as a closed bar. Mirrors the
+   `data-barline-right` exclusion pattern from the chart-line bars
+   so a future maintainer who adds a glyph-based right barline to a
+   width-mode card (e.g. `data-barline-right="end"` for a final-bar
+   showcase) doesn't get a double-paint defect (border + SMuFL glyph
+   on the same edge) — same bug class fixed in PR #2497 / commit
+   b4f689c on the chart-line bars. */
 .width-mode-row > .width-mode-card > .bar { border-right: 1.5px solid var(--ink-1000); }
+.width-mode-row > .width-mode-card > .bar[data-barline-right="double"],
+.width-mode-row > .width-mode-card > .bar[data-barline-right="repeat"],
+.width-mode-row > .width-mode-card > .bar[data-barline-right="end"] { border-right: 0; }
 
 /* ---------- Player controls strip ----------
    Sits below the chart body. Mocks the iReal Pro editor's bottom strip:

--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -454,22 +454,35 @@ a { color: inherit; text-decoration: none; }
    on the same baseline as a regular chord. */
 .chord.nc { font-family: var(--font-chord); font-weight: 700; font-size: 22px; letter-spacing: 0.02em; }
 
-/* Invisible-root: the chord root is intentionally not rendered (the
-   chord is held; only the bass moves). Visually this is a slash chord
-   with the top half blank — a horizontal divider plus a bass note
-   below. The oval icon in the iReal Pro editor toolbar is a button
-   glyph, not a chart rendering. */
+/* Invisible-root: the chord is held but its root letter is replaced
+   with an oval glyph; only the bass moves. Visually this is a slash
+   chord whose top half carries a hollow ellipse the size of a chord
+   root, paired with the bass note below the divider. Convention
+   matches iReal Pro's chart rendering (per
+   https://technimo.helpshift.com/hc/en/3-ireal-pro/faq/125-oval-symbol-in-the-editor-invisible-root/).
+   The oval is drawn as a CSS ellipse rather than a SMuFL glyph
+   because Bravura ships no semantically-equivalent codepoint —
+   iReal Pro itself draws a stroked outline, not a music symbol. */
 .chord.invisible-root { display: inline-flex; flex-direction: column; align-items: center; line-height: 1; gap: 0; }
+.chord.invisible-root .root-oval {
+  /* Sized to roughly the visual envelope of a regular `.chord-root`
+     letter (44px font-size capital → ~30×22 ink box) so the cell's
+     vertical metrics line up with neighbouring bars without needing
+     a margin-top spacer below. */
+  display: inline-block;
+  width: 32px;
+  height: 22px;
+  border: 1.75px solid var(--ink-1000);
+  border-radius: 50%;
+  box-sizing: border-box;
+  margin-bottom: 4px;
+}
 .chord.invisible-root .bass {
   font-family: var(--font-chord);
   font-weight: 700;
   font-size: 22px;
   border-top: 1.5px solid var(--ink-1000);
   padding-top: 2px;
-  /* Reserve space ABOVE the divider equal to the chord-root height so
-     the invisible-root cell shares vertical metrics with neighbouring
-     bars. */
-  margin-top: 28px;
   min-width: 28px;
   text-align: center;
   line-height: 1;
@@ -550,8 +563,30 @@ a { color: inherit; text-decoration: none; }
 
 /* Chord width modes. The chart-wide `.chart.compact` modifier scales
    chord glyphs horizontally (Normal=1, Small=0.7) without touching
-   vertical metrics — matches iReal Pro's N / S toggle. */
-.chart.compact .chord { transform: scaleX(0.72); transform-origin: left center; }
+   vertical metrics — matches iReal Pro's N / S toggle. A second
+   selector `.bar.compact-preview` lets a single bar demonstrate the
+   compression in-place against neighbouring full-width bars, used by
+   the "Width modes" showcase row at the bottom of the demo chart;
+   the two selectors share one transform so the visual scale stays
+   consistent whether the toggle is applied chart-wide or per-bar. */
+.chart.compact .chord,
+.bar.compact-preview .chord { transform: scaleX(0.72); transform-origin: left center; }
+
+/* Width-mode showcase row. Two `.bar`s side-by-side, each carrying
+   four chords packed at beats 1..4 — the canonical "this bar needs
+   compact mode" case. The left card stays at Normal width so the
+   labels above each card read as a before/after pair. The right
+   card carries `.compact-preview` so it inherits the same transform
+   the chart-wide `.chart.compact` toggle would apply, demonstrating
+   the visual benefit without requiring the toolbar toggle to be
+   interactive in this static demo. */
+.width-mode-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-6); align-items: stretch; }
+.width-mode-row > .width-mode-card { display: flex; flex-direction: column; gap: var(--sp-2); }
+.width-mode-row > .width-mode-card > .caption { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-tertiary); }
+/* Standalone `.bar` (no enclosing `.chart-line`) — add the right
+   barline that the `.chart-line .bar:last-child` selector would
+   normally provide so the cell reads as a closed bar. */
+.width-mode-row > .width-mode-card > .bar { border-right: 1.5px solid var(--ink-1000); }
 
 /* ---------- Player controls strip ----------
    Sits below the chart body. Mocks the iReal Pro editor's bottom strip:
@@ -975,14 +1010,19 @@ a { color: inherit; text-decoration: none; }
         <!-- Showcase line — bars demonstrating bar-content variants that
              aren't part of the Autumn Leaves form: N.C. (no chord),
              invisible-root chord with a moving bass, repeat-1-bar slash
-             glyph, and repeat-2-bars slash glyph. -->
+             glyph, and repeat-2-bars slash glyph. Section letter [V]
+             (Verse) frames the line as a fifth section type alongside
+             A / B / C / D from the Autumn Leaves form above, matching
+             the V chip in the Inspector. -->
         <div class="chart-line">
           <div class="bar">
+            <span class="section-marker">V</span>
             <span class="chord nc">N.C.</span>
             <span class="text-mark">free time</span>
           </div>
           <div class="bar">
             <span class="chord invisible-root" aria-label="Invisible root over D bass">
+              <span class="root-oval" aria-hidden="true"></span>
               <span class="bass">D</span>
             </span>
           </div>
@@ -1011,6 +1051,35 @@ a { color: inherit; text-decoration: none; }
           </div>
           <div class="bar" data-barline-right="end">
             <span class="chord"><span class="chord-root">C</span></span>
+          </div>
+        </div>
+
+        <!-- Width-mode showcase. Same 4-chord packed bar rendered at
+             Normal width (left) and Small width (right) so the
+             toolbar's N / S toggle has a visible reference. The
+             chord set was chosen so each chord carries a sub-quality
+             (Δ7 / 7 / −7) — that's the highest-density layout where
+             chord glyphs overlap at full width and the compact
+             scaling delivers the cleanest payoff. -->
+        <div class="chart-line-spacer" aria-hidden="true"></div>
+        <div class="width-mode-row" role="group" aria-label="Chord width modes — Normal vs Small">
+          <div class="width-mode-card">
+            <span class="caption">Normal (N)</span>
+            <div class="bar">
+              <span class="chord"><span class="chord-root">D</span><span class="chord-qual">−7</span></span>
+              <span class="chord" data-beat="2"><span class="chord-root">G</span><span class="chord-qual">7</span></span>
+              <span class="chord" data-beat="3"><span class="chord-root">C</span><span class="chord-qual">Δ7</span></span>
+              <span class="chord" data-beat="4"><span class="chord-root">A</span><span class="chord-qual">−7</span></span>
+            </div>
+          </div>
+          <div class="width-mode-card">
+            <span class="caption">Small (S)</span>
+            <div class="bar compact-preview">
+              <span class="chord"><span class="chord-root">D</span><span class="chord-qual">−7</span></span>
+              <span class="chord" data-beat="2"><span class="chord-root">G</span><span class="chord-qual">7</span></span>
+              <span class="chord" data-beat="3"><span class="chord-root">C</span><span class="chord-qual">Δ7</span></span>
+              <span class="chord" data-beat="4"><span class="chord-root">A</span><span class="chord-qual">−7</span></span>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/playground/src/irealpro/chart.css
+++ b/packages/playground/src/irealpro/chart.css
@@ -408,22 +408,36 @@
    on the same baseline as a regular chord. */
 .chord.nc { font-family: var(--cs-font-chord); font-weight: 700; font-size: 22px; letter-spacing: 0.02em; }
 
-/* Invisible-root: the chord root is intentionally not rendered (the
-   chord is held; only the bass moves). Visually this is a slash chord
-   with the top half blank — a horizontal divider plus a bass note
-   below. The oval icon in the iReal Pro editor toolbar is a button
-   glyph, not a chart rendering. */
+/* Invisible-root: the chord is held but its root letter is replaced
+   with an oval glyph; only the bass moves. Visually this is a slash
+   chord whose top half carries a hollow ellipse the size of a chord
+   root, paired with the bass note below the divider. Convention
+   matches iReal Pro's chart rendering (per
+   https://technimo.helpshift.com/hc/en/3-ireal-pro/faq/125-oval-symbol-in-the-editor-invisible-root/).
+   The oval is drawn as a CSS ellipse rather than a SMuFL glyph
+   because Bravura ships no semantically-equivalent codepoint —
+   iReal Pro itself draws a stroked outline, not a music symbol.
+   Sister to `design-system/ui_kits/web/editor-irealb.html`. */
 .chord.invisible-root { display: inline-flex; flex-direction: column; align-items: center; line-height: 1; gap: 0; }
+.chord.invisible-root .root-oval {
+  /* Sized to roughly the visual envelope of a regular `.chord-root`
+     letter (44px font-size capital → ~30×22 ink box) so the cell's
+     vertical metrics line up with neighbouring bars without needing
+     a margin-top spacer below. */
+  display: inline-block;
+  width: 32px;
+  height: 22px;
+  border: 1.75px solid var(--cs-ink-1000);
+  border-radius: 50%;
+  box-sizing: border-box;
+  margin-bottom: 4px;
+}
 .chord.invisible-root .bass {
   font-family: var(--cs-font-chord);
   font-weight: 700;
   font-size: 22px;
   border-top: 1.5px solid var(--cs-ink-1000);
   padding-top: 2px;
-  /* Reserve space ABOVE the divider equal to the chord-root height so
-     the invisible-root cell shares vertical metrics with neighbouring
-     bars. */
-  margin-top: 28px;
   min-width: 28px;
   text-align: center;
   line-height: 1;

--- a/packages/playground/src/irealpro/chart.tsx
+++ b/packages/playground/src/irealpro/chart.tsx
@@ -469,6 +469,7 @@ function BarCell({
       const bassAcc = accidentalGlyph(bar.invisibleRoot.bass.accidental);
       return (
         <span className="chord invisible-root">
+          <span className="root-oval" aria-hidden="true" />
           <span className="bass">
             {bar.invisibleRoot.bass.note}
             {bassAcc && <span className="smufl">{bassAcc}</span>}


### PR DESCRIPTION
## Summary

Three remaining deferred acceptance criteria on the iReal Pro editor
demo at `design-system/ui_kits/web/editor-irealb.html`, plus
sister-site propagation of the invisible-root oval glyph to the
runtime playground per `.claude/rules/fix-propagation.md`.

## Per-issue changes

### #2444: Add [V] (Verse) section letter

The inspector chip row exposed `V` alongside A / B / C / D, but no
chart bar carried a `[V]` section-marker. Added
`<span class="section-marker">V</span>` to the first bar of the
showcase line (the N.C. bar). The showcase line is a natural fit
for "Verse" framing: iReal Pro charts typically use V for free /
sparse verse passages, which matches the line's mix of no-chord
and held-chord content.

Touched: `design-system/ui_kits/web/editor-irealb.html`.

### #2441: Invisible-root oval glyph

Previous CSS drew only a horizontal divider + bass note, silently
dropping the oval that the iReal Pro convention requires (per
<https://technimo.helpshift.com/hc/en/3-ireal-pro/faq/125-oval-symbol-in-the-editor-invisible-root/>).
The cell read as "/D" rather than "⬭/D".

Added a `.root-oval` element — a CSS-drawn stroked ellipse sized to
the regular chord-root letter's visual envelope (32 × 22 px, 1.75 px
`var(--ink-1000)` outline). Bravura ships no semantically-equivalent
SMuFL codepoint, so a CSS ellipse is the right primitive. The
previous `margin-top: 28px` placeholder on `.bass` collapsed into
the oval's intrinsic 22 + 4 px height — root-cause replacement, not
a layered patch.

**Sister-site propagation**: applied the same `.root-oval` rule +
`<span className="root-oval">` element to the playground at
`packages/playground/src/irealpro/chart.{css,tsx}`. The `bar.invisibleRoot`
AST field is currently unpopulated (no parser path emits it), so
the new code is inert today — but the propagation debt is closed
in lockstep with the static reference, and a future parser-emit
path will render the oval automatically.

Touched: `design-system/ui_kits/web/editor-irealb.html`,
`packages/playground/src/irealpro/chart.css`,
`packages/playground/src/irealpro/chart.tsx`.

### #2439: Normal / Small chord-width compression

The toolbar carried an N / S segmented control, and the CSS
`.chart.compact .chord` rule existed, but no chart instance
demonstrated the toggle's visual effect — a static demo can't
toggle, so the benefit was unverifiable.

Added a "Width modes" showcase row at the bottom of `.chart-body`.
Two cards side-by-side labelled "Normal (N)" and "Small (S)" render
the same Dm7 / G7 / Cmaj7 / Am7 packed bar (4 chords at beats 1-4,
each carrying a sub-quality so the layout is at peak density). The
Small card uses a new `.bar.compact-preview` selector that shares
the existing `.chart.compact .chord` transform via one
comma-separated rule — both chart-wide and per-bar compact go
through the same transform constant.

The per-bar selector is gated by `.chart:not(.compact)` so a
`.compact-preview` bar nested inside a `.chart.compact` cannot
silently compose two `scaleX(0.72)` transforms (0.72² ≈ 0.52 would
flatten chord glyphs further than either mode intends).

The new standalone bars (no `.chart-line` ancestor) get a right
border via `.width-mode-row > .width-mode-card > .bar`, with the
same `data-barline-right` exclusion pattern fixed in PR #2497 /
b4f689c so a future maintainer adding a glyph-based right barline
to a showcase cell doesn't reintroduce the same border-plus-glyph
double-paint defect.

Touched: `design-system/ui_kits/web/editor-irealb.html`.

## Aggregated sister-site audit

- `packages/playground/src/irealpro/chart.{tsx,css}` — propagated
  the invisible-root oval in this PR (#2441 sister site).
- `@chordsketch/ui-irealb-editor` — has no invisible-root /
  chord-width / section-letter handling at the CSS level. No
  propagation required.
- `chordsketch-render-ireal` (Rust SVG renderer) — independent
  implementation; the SVG renderer does not yet model invisible-root
  cells. Tracked under #2050 follow-ups per CLAUDE.md; not in scope
  here.
- `@chordsketch/react` chordpro-jsx walker — ChordPro-only, not an
  iReal Pro consumer.
- `crates/render-{text,html,pdf}` — ChordPro-only.

## Test plan

- [ ] CI green on every check.
- [ ] Auto-review delta converges to zero findings.
- [ ] Open `design-system/ui_kits/web/editor-irealb.html` in a
      browser and verify:
  - The first bar of the showcase line (N.C.) shows a `[V]`
    section marker
  - The invisible-root cell shows a stroked oval above the bass
    `D`, with vertical metrics matching neighbouring bars
  - The Width modes row at the bottom shows two side-by-side bars
    with the same 4 chords; the Small card's chords are visibly
    narrower than the Normal card's
- [ ] Build the playground (`pnpm -F @chordsketch/playground build`)
      and verify the existing iReal Pro preview renders identically
      to `main` (the new `.root-oval` is inert until a parser emits
      `bar.invisibleRoot`).

## Deferred

None. The originally-deferred playground sister-site propagation
of the invisible-root oval was addressed in commit `5e9d985`.

Closes #2439
Closes #2441
Closes #2444
