### PR TITLE
batch(ui_kits): 3 issues — 2026-05-18 (#3)

### DIFF
--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -505,18 +505,38 @@ a { color: inherit; text-decoration: none; }
   grid-column: 1 / -1;
 }
 
-/* Alternate chord — a smaller chord rendered ABOVE the primary chord in
-   the same beat column. Sits inline above the primary so it scrolls with
-   the bar. */
-.chord-stack { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 1px; }
+/* Alternate chord — a smaller chord rendered ABOVE the primary chord at
+   the same beat column. Mirrors iReal Pro's printed convention: the
+   alternate floats above the primary's top, in the inter-line
+   whitespace, as a smaller annotation that does not change the
+   primary's vertical placement within the bar. The `.alt` nests the
+   same `.chord` structure (`.chord-root` + `.chord-acc` + `.chord-qual`,
+   or `.chord.slash` + `.top` + `.bot`) as the primary so chord-symbol
+   grammar is shared end-to-end — the size rules below scale every
+   sub-element down to ~50% of the primary's 44px root. The
+   absolute-positioning approach is the SISTER SITE of the runtime
+   playground at `packages/playground/src/irealpro/chart.css`; both
+   surfaces use `position: absolute; bottom: 100%` so the alt does
+   not take up vertical space inside the bar's grid cell, keeping
+   primary chords aligned across bars. */
+.chord-stack { position: relative; display: inline-block; line-height: 1; }
 .chord-stack .alt {
-  font-family: var(--font-chord);
-  font-weight: 700;
-  font-size: 13px;
-  color: var(--text-secondary);
-  letter-spacing: -0.01em;
-  line-height: 1;
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 4px;
+  color: var(--ink-1000);
+  white-space: nowrap;
+  pointer-events: none;
 }
+.chord-stack .alt .chord { font-weight: 700; line-height: 1; }
+.chord-stack .alt .chord-root { font-size: 22px; }
+.chord-stack .alt .chord-acc { font-size: 13px; vertical-align: 0.55em; margin-left: 1px; }
+.chord-stack .alt .chord-qual { font-size: 13px; vertical-align: -0.15em; }
+.chord-stack .alt .chord-qual.stacked { vertical-align: -0.5em; line-height: 0.95; }
+.chord-stack .alt .chord.slash .top,
+.chord-stack .alt .chord.slash .bot { font-size: 16px; }
+.chord-stack .alt .chord.slash .bot { padding-top: 1px; margin-top: 1px; }
 
 /* Fermata glyph anchored above its chord. Bravura's fermataAbove visible
    ink sits in the top ~25% of the rendered font-size box; the element
@@ -641,7 +661,6 @@ a { color: inherit; text-decoration: none; }
   font-weight: 600;
   font-size: 10px;
   letter-spacing: 0;
-
   color: var(--ink-300);
 }
 .player-controls .pc-stat .value { font-weight: 600; color: var(--ink-0); }
@@ -979,7 +998,9 @@ a { color: inherit; text-decoration: none; }
           </div>
           <div class="bar">
             <span class="chord-stack">
-              <span class="alt">A7<span class="smufl">&#x266D;</span>13</span>
+              <span class="alt">
+                <span class="chord"><span class="chord-root">A</span><span class="chord-qual">7<span class="smufl">&#x266D;</span>13</span></span>
+              </span>
               <span class="chord"><span class="chord-root">A</span><span class="chord-qual">13</span></span>
             </span>
           </div>
@@ -1149,6 +1170,10 @@ a { color: inherit; text-decoration: none; }
       <input class="chord-input" type="text" value="" placeholder="(none)" style="font-size: var(--fs-14); color: var(--text-secondary);">
     </div>
     <div class="row">
+      <span class="label">Text</span>
+      <input class="chord-input" type="text" value="" placeholder="(no text — e.g. Repeat 4×, to Bridge)" style="font-size: var(--fs-14); color: var(--text-secondary);">
+    </div>
+    <div class="row">
       <span class="label">Section</span>
       <div class="chips" role="group">
         <button class="chip">A</button>
@@ -1216,10 +1241,6 @@ a { color: inherit; text-decoration: none; }
         <button class="chip" title="Vertical spacer × 3">×3</button>
         <button class="chip" title="Mark this bar as the playback end">END</button>
       </div>
-    </div>
-    <div class="row">
-      <span class="label">Text label</span>
-      <input class="chord-input" type="text" value="" placeholder="(no text — e.g. Repeat 4×, to Bridge)" style="font-size: var(--fs-14); color: var(--text-secondary);">
     </div>
     <div class="footer">
       <button class="btn btn-secondary btn-sm" style="flex: 1;">Duplicate</button>


### PR DESCRIPTION
## Summary

Three remaining acceptance criteria on the iReal Pro editor demo at
`design-system/ui_kits/web/editor-irealb.html`. Scaffolding for all
three features shipped with the design-system v1.0 PR (#2453), but
each issue had at least one acceptance criterion either drifted,
mis-placed, or not fully realised. This PR closes those gaps and
aligns the static reference's alt-chord rendering with the playground
sister site that already validated the better approach.

## Per-issue changes

### #2440: Alternate Chord display

Replaced the flat ``<span class="alt">A7♭13</span>`` with a
structured ``<span class="alt"><span class="chord"><span
class="chord-root">…</span><span class="chord-qual">…</span></span></span>``
that nests the same `.chord` grammar as the primary chord — root +
accidental + qual spans. The `.chord-stack` wrapper switches from
`flex-direction: column` to `position: relative` with the `.alt`
floating above the primary via `position: absolute; bottom: 100%`,
so the alt sits in the inter-line whitespace and does NOT push the
primary chord down inside the bar's grid cell. Adjacent bars'
primary chords stay vertically aligned.

**Sister-site alignment (Medium)**: the playground at
`packages/playground/src/irealpro/chart.{tsx,css}` already used the
absolute-positioning + structured-grammar approach
(`.chord-stack {position: relative}`, `.chord-stack .alt {position:
absolute; bottom: 100%;}`, scaled-down `.chord-root` / `.chord-acc`
/ `.chord-qual` sub-rules). The static reference's
`flex-direction: column` flat-span model had drifted from the
playground; this PR closes the drift in the direction the
playground already validated, per
`.claude/rules/fix-propagation.md` and
`.claude/rules/renderer-parity.md`'s sister-site discipline.

Touched: `design-system/ui_kits/web/editor-irealb.html`.

### #2445: Free-text bar annotation

Inspector "Text label" input row moved from the very bottom of the
inspector (between Spacer and Duplicate/Delete footer) to
immediately after the Bass/Alternate-chord rows and before Section
— matching the spec's "Inspector gains a Text input row,
immediately above (or near) the existing Bass / Barline rows".
Label renamed from "Text label" to "Text" so it reads in line with
the surrounding single-word row labels (Chord / Bass / Section /
Symbol).

Demo chart unchanged — still shows three text labels across the
form ("rit." on the form's last bar, "D.C. al Coda" on the
back-to-A bar, "free time" on the N.C. bar), satisfying the "at
least two arbitrary labels besides D.C. al Coda" criterion.

Touched: `design-system/ui_kits/web/editor-irealb.html`.

### #2447: Player-controls strip

Acceptance review of the strip shipped by the design-system v1.0 PR
(#2453, commit `b70986e`): all three acceptance criteria are met
as-is.

- Strip at the bottom of the chart card with all six slots
  (Style / Play / Time / Repeats / Tempo / Key).
- Design-token styling: `--ink-1000` background, `--font-mono`
  numerics, `--crimson-500` Play button, `--ink-300` muted stat
  labels.
- All dummy values (`00:00` / `1` / `124` / `Em`) and a
  non-functional Play button (no click handler).

Drive-by cleanup: removed a stray blank line in the
`.player-controls .pc-stat .label` CSS rule so the declarations
read contiguously.

Touched: `design-system/ui_kits/web/editor-irealb.html`.

## Aggregated sister-site audit

- `packages/playground/src/irealpro/chart.{tsx,css}` — the static
  reference now matches the runtime playground for the alt-chord
  rendering. No code change in the playground (it was already at
  the destination state); the static demo moves to its level.
- `packages/react/` — no `.chord-stack` reference here (alt is an
  iReal-Pro-only concept, not part of the ChordPro AST exposed
  via `@chordsketch/react`), so no React sister site to update.
- `packages/ui-irealb-editor/` — bar-grid GUI editor consumes the
  AST via the wasm bridge; alt-chord rendering is delegated to
  the playground's chart.tsx component, not duplicated here.

## Test results

Static HTML demo — no build step, no test suite. Verified:

- `<div>`, `<span>`, `<section>` tag balance: 99/99, 221/221, 2/2.
- `git diff --stat`: single file (`+37/-16`) — every line touched
  is in scope.

## Deferred

None.

Closes #2440
Closes #2445
Closes #2447

🤖 Generated with [Claude Code](https://claude.com/claude-code)