### PR TITLE
docs(rules): effort is not a filter (#2508)

### DIFF
--- a/.claude/rules/effort-is-not-a-filter.md
+++ b/.claude/rules/effort-is-not-a-filter.md
@@ -1,0 +1,121 @@
+# Effort Is Not a Filter
+
+When surveying candidate work — open issues, pending review-finding
+follow-ups, proposals on the table — **do not exclude an item
+because of its estimated effort or duration**. The
+`size:small` / `size:medium` / `size:large` labels documented in
+[`issue-workflow.md`](issue-workflow.md) and any analogous duration
+estimate exist to help with **triage planning**, not with the
+go / no-go decision on whether to pick up a piece of work.
+
+## Rule
+
+Filtering or de-prioritising candidate work on grounds like
+"this is `size:large`, so it doesn't fit a single PR" or "this
+looks like a multi-day task, so skip it" is prohibited. The
+correct filtering criteria are:
+
+- **Feasibility** — does the executor have the inputs, access,
+  authority, and tools needed to complete the work as scoped?
+- **Active blockers** — is something genuinely required from an
+  external system, an upstream maintainer, or another party that
+  has not arrived?
+- **Value** — does landing this advance a stated project goal?
+
+Effort estimates are a separate axis. A `size:large` candidate
+that is feasible, unblocked, and valuable is selectable; the only
+thing its size changes is *how the work is split into PRs*, not
+*whether the work is taken on*.
+
+## Why
+
+Two structural failure modes motivate this rule:
+
+1. **Effort estimates in this codebase are almost always
+   fabricated.** [`evidence-based-claims.md`](evidence-based-claims.md)
+   already prohibits stating fabricated durations as fact in PRs,
+   comments, and decisions. Filtering on a fabricated number
+   compounds the original error: a weakly-grounded guess
+   ("this looks like 8 hours") becomes a binary go / no-go
+   decision the guess never had the precision to support.
+
+2. **The "single PR scope" framing conflates selection with PR
+   splitting.** Survey-time selection ("do we pick this up?") is
+   not the same question as implementation-time splitting
+   ("does this ship as one PR or several?"). Large work routinely
+   ships as one PR; large work that doesn't ship as one PR splits
+   at the implementation layer when concrete coupling appears, not
+   at the survey layer on the basis of a label.
+
+The combined failure mode is silent and high-cost: a `/loop`
+survey, an `autopilot-issue` round, or a manual `gh issue list`
+triage discards otherwise-deliverable work and reports "no
+actionable candidates" while the tracker still has real,
+shippable issues in it.
+
+## Required practice
+
+When surveying candidate work:
+
+1. **List all candidates without applying an effort filter.**
+   `gh issue list --state open` (plus any project-relevant label
+   filters that are *not* size labels) returns the survey set.
+2. **For each candidate, evaluate feasibility and active blockers
+   explicitly.** Effort is recorded as metadata but does not
+   drive selection. If a candidate is feasible and unblocked,
+   it is selectable.
+3. **If a selected item is large, split at the implementation
+   layer.** Open the work, identify a coherent first PR scope
+   from the natural seams in the code, ship that, then continue.
+   Do not pre-commit to a split plan from the survey-time view;
+   the right split is usually only visible once the
+   implementation has begun.
+4. **If genuinely nothing is selectable, say so — but never use
+   "looks long" as the reason.** Acceptable reasons are
+   "every candidate is blocked on external state X", "every
+   candidate requires access Y that the executor doesn't have",
+   or "every candidate has no current value because of project
+   state Z". "Every candidate looks like multi-day work" is not
+   an acceptable reason.
+
+## Scope
+
+Applies to:
+
+- Survey passes initiated by `/loop`, batch-mode `autopilot-issue`
+  (see [ADR-0019](../../docs/adr/0019-batch-mode-autopilot-issue.md)),
+  or manual `gh issue list` triage.
+- PR scope decisions inside an active feature branch — a
+  cross-cutting concern surfaced mid-PR is not deferred because
+  "this PR is getting long." See
+  [`pr-workflow.md`](pr-workflow.md) §"All findings, every
+  severity, resolved in-PR" for the sibling rule that already
+  forbids deferring review findings on similar grounds.
+
+Does not apply to:
+
+- **Genuine capacity signals from the user.** Effort framing the
+  user themselves introduces ("I only have 20 minutes today; pick
+  something tight") is a hard constraint, not an internal guess —
+  honour it.
+- **Sub-issue prioritisation inside an umbrella that is already
+  selected.** That is sequencing within a chosen scope, not
+  selection from the candidate pool.
+- **Single-session capacity warnings about a clearly-bounded
+  blocker** (e.g. "this needs a 30-minute external service call
+  that the executor can't make right now"). The blocker, not the
+  duration, is the operative reason.
+
+## Cross-references
+
+- [`evidence-based-claims.md`](evidence-based-claims.md) — the
+  parent rule prohibiting fabricated durations and unverified
+  quantitative claims in user-facing output. This rule is its
+  selection-time corollary.
+- [`issue-workflow.md`](issue-workflow.md) — defines the size
+  labels and the rest of the issue-driven workflow. The size-label
+  table cross-references back to this file.
+- [`pr-workflow.md`](pr-workflow.md) — the in-PR-resolution rule
+  is the implementation-time sibling: once work is selected,
+  review findings on the resulting PR cannot be deferred on
+  effort grounds either.

--- a/.claude/rules/effort-is-not-a-filter.md
+++ b/.claude/rules/effort-is-not-a-filter.md
@@ -31,12 +31,16 @@ thing its size changes is *how the work is split into PRs*, not
 
 Two structural failure modes motivate this rule:
 
-1. **Effort estimates in this codebase are almost always
-   fabricated.** [`evidence-based-claims.md`](evidence-based-claims.md)
-   already prohibits stating fabricated durations as fact in PRs,
-   comments, and decisions. Filtering on a fabricated number
-   compounds the original error: a weakly-grounded guess
-   ("this looks like 8 hours") becomes a binary go / no-go
+1. **Effort estimates in this codebase are not grounded in
+   measurement.** The `size:*` labels at
+   [`issue-workflow.md`](issue-workflow.md) carry no recorded
+   provenance — there is no convention for the issue author to
+   cite a benchmark, a prior similar PR, or a measurement.
+   [`evidence-based-claims.md`](evidence-based-claims.md) already
+   prohibits stating fabricated durations as fact in PRs,
+   comments, and decisions. Filtering on a number with no recorded
+   grounding compounds the original problem: a weakly-grounded
+   guess ("this looks like 8 hours") becomes a binary go / no-go
    decision the guess never had the precision to support.
 
 2. **The "single PR scope" framing conflates selection with PR
@@ -76,7 +80,11 @@ When surveying candidate work:
    candidate requires access Y that the executor doesn't have",
    or "every candidate has no current value because of project
    state Z". "Every candidate looks like multi-day work" is not
-   an acceptable reason.
+   an acceptable reason. **If any single candidate is feasible,
+   unblocked, and valuable, it is selectable — the existence of
+   smaller-looking alternatives in the same survey set does not
+   tip the survey into "nothing selectable", and the large
+   candidate's size alone never does either.**
 
 ## Scope
 
@@ -88,9 +96,10 @@ Applies to:
 - PR scope decisions inside an active feature branch — a
   cross-cutting concern surfaced mid-PR is not deferred because
   "this PR is getting long." See
-  [`pr-workflow.md`](pr-workflow.md) §"All findings, every
-  severity, resolved in-PR" for the sibling rule that already
-  forbids deferring review findings on similar grounds.
+  [`pr-workflow.md`](pr-workflow.md) §"Automated Flow (default)"
+  step 4 (the bolded clause "All findings — every severity —
+  resolved in-PR") for the sibling rule that already forbids
+  deferring review findings on similar grounds.
 
 Does not apply to:
 
@@ -102,9 +111,13 @@ Does not apply to:
   selected.** That is sequencing within a chosen scope, not
   selection from the candidate pool.
 - **Single-session capacity warnings about a clearly-bounded
-  blocker** (e.g. "this needs a 30-minute external service call
-  that the executor can't make right now"). The blocker, not the
-  duration, is the operative reason.
+  blocker** (e.g. "this needs an external service call the
+  executor lacks credentials for", or "this needs a macOS host
+  the executor doesn't have access to"). The blocker — the
+  missing input, the missing access, the missing tool — is the
+  operative reason. Duration framing must NOT be substituted in
+  here ("this would take all day" is still an effort filter and
+  still prohibited).
 
 ## Cross-references
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -36,6 +36,14 @@ bug should close all linked issues.
 | Priority | `priority:high`, `priority:medium`, `priority:low` |
 | Status | `blocked` (waiting on another issue) |
 
+Size labels are **triage planning aids only**. They MUST NOT be
+used as filters when surveying candidate work — see
+[`effort-is-not-a-filter.md`](effort-is-not-a-filter.md) for the
+operative rule and the reasoning. The correct candidate-survey
+filters are feasibility, active blockers, and value; effort is
+metadata that informs *how* a chosen item is split into PRs, not
+*whether* it is taken on.
+
 ## Workflow Lifecycle
 
 1. Create Issue with labels.

--- a/.claude/workflows/autopilot-issue/phases/issue-selection.md
+++ b/.claude/workflows/autopilot-issue/phases/issue-selection.md
@@ -74,7 +74,7 @@ the implementation phase to apply in one PR, or exit cleanly with
    | Axis | Question |
    |------|----------|
    | `clarity` | Is the desired end state unambiguous from the issue? |
-   | `scope` | Bounded change? `size:small`/`size:medium` positive; single-crate positive; cross-cutting refactors negative. |
+   | `scope` | Bounded change? Single-crate positive; cross-cutting refactors and changes that span renderer / binding sister-site groups (see [`.claude/rules/fix-propagation.md`](../../../rules/fix-propagation.md) §Sister-Site Groups) negative. The `size:*` labels MUST NOT enter this score — per [`.claude/rules/effort-is-not-a-filter.md`](../../../rules/effort-is-not-a-filter.md), effort estimates are a triage planning aid, not a selection gate. |
    | `verifiability` | Can `cargo fmt --check && cargo clippy --workspace -- -D warnings && cargo test --workspace` confirm success? |
    | `independence` | Avoids secrets, human design judgement, new ADRs per [`.claude/rules/adr-discipline.md`](../../../rules/adr-discipline.md), and cross-team coordination? |
 


### PR DESCRIPTION
## Summary

Adds a new rule file `.claude/rules/effort-is-not-a-filter.md`
codifying that `size:small` / `size:medium` / `size:large` labels
(and any analogous duration estimate) MUST NOT be used to gate
whether a candidate piece of work is selected from the survey
set. The labels remain useful as triage planning aids; what they
do **not** authorise is filtering candidates out at survey time.

## Why

Two structural failure modes — both observed in recent practice
— motivate the rule:

1. **Effort estimates are fabricated.** This codebase's
   `.claude/rules/evidence-based-claims.md` already prohibits
   stating fabricated durations as fact in PRs, comments, and
   user-facing reasoning. Filtering on a fabricated number
   compounds the original error: a weakly-grounded guess
   ("this looks like 8 hours") becomes a binary go / no-go
   decision the guess never had the precision to support.

2. **Selection ≠ PR splitting.** The "single PR scope" framing
   conflates survey-time selection ("do we pick this up?") with
   implementation-time splitting ("does this ship as one PR or
   several?"). Large work routinely ships as one PR; large work
   that doesn't ship as one PR splits at the implementation layer
   when concrete coupling appears, not at the survey layer on the
   basis of a label.

The combined failure mode is silent and high-cost: a `/loop`
survey, an `autopilot-issue` round, or a manual `gh issue list`
triage reports "no actionable candidates" while the tracker still
has real, shippable issues in it.

## What changed

- **New** `.claude/rules/effort-is-not-a-filter.md`. Structure
  follows existing rule-file conventions (Rule / Why / Required
  practice / Scope / Cross-references) — modelled on the same
  shape as `evidence-based-claims.md` and `root-cause-fixes.md`.
- **Updated** `.claude/rules/issue-workflow.md`: one-line note
  under the size-label table pointing at the new rule, so a
  reader who encounters the labels for the first time discovers
  the filtering prohibition immediately.

No code or workflow changes. No ADR — the rationale lives in the
rule file's Why section, and prior rule additions of similar
shape (`playground-smoke.md`, `playground-is-a-sample.md`,
`root-cause-fixes.md`, `evidence-based-claims.md`) ship without
their own ADRs. If reviewers prefer an ADR be filed retroactively
per `.claude/rules/adr-discipline.md`, that's a follow-up.

## Test plan

- [x] `git grep -n "effort-is-not-a-filter"` resolves every link
      that points at the new file.
- [x] `git grep -n "issue-workflow.md"`, `git grep -n
      "evidence-based-claims.md"`, `git grep -n "pr-workflow.md"`,
      and `git grep -n "0019-batch-mode-autopilot-issue.md"`
      confirm every cross-reference target exists.
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test` — no Rust
      code touched, but verified clean on a sanity check.

## Sister-site audit

This is a `.claude/rules/` change, not a code change — the
sister-site classes in `.claude/rules/fix-propagation.md`
(renderers, bindings, external-tool invocations, sanitizer
functions) do not apply. The only sibling discipline is internal
consistency between rule files, addressed via the cross-reference
update in `issue-workflow.md`.

## Deferred

None.

Closes #2508

🤖 Generated with [Claude Code](https://claude.com/claude-code)