### PR TITLE
chore(release): refresh MacPorts Portfile for v0.5.0

### DIFF
--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -37,24 +37,14 @@ long_description    ChordSketch is a Rust implementation of the ChordPro file \
                     HTML, or PDF output. Full compatibility with the ChordPro \
                     specification.
 
-# Source-tarball checksums lag the github.setup version above by one
-# release: the v0.5.0 source tarball does not exist until the v0.5.0
-# tag is pushed (which happens after the release-cut PR merges). The
-# values below are the v0.4.0 tarball's checksums — they will be
-# refreshed in the post-release Portfile PR per docs/releasing.md
-# §MacPorts (mirroring the v0.4.0 follow-up PR #2417). The
-# macports-portfile-sync CI guard tolerates this release-cut window
-# per #2413.
-checksums           rmd160  352a8c7890868eddd71818da86e2d5aeb330caaf \
-                    sha256  1edf4cc2e0c3303e0be47a0ac012c028f3a1f42414559ab21e800f5b8df41b15 \
-                    size    7148594
+# Source-tarball checksums for v0.5.0. Regenerate on each release —
+# the canonical procedure lives in `docs/releasing.md` §MacPorts.
+checksums           rmd160  9a661359e1bab8230b984b6903a54cdb6035cbad \
+                    sha256  21392bc0a7cc829da7bb03adf70cbbd450cc2a6a7eb6b4a7c1102cfbda01ed87 \
+                    size    7739468
 
-# Cargo crate manifest auto-generated from HEAD's Cargo.lock at
-# release-cut time via `scripts/macports-regen-cargo-crates.py --apply
-# --from-ref HEAD` per #2413 (the v0.5.0 tag does not yet exist).
-# The next normal CI run after the v0.5.0 tag is pushed will validate
-# this block against `git show v0.5.0:Cargo.lock`. Do not edit by
-# hand — regenerate per docs/releasing.md §MacPorts.
+# Cargo crate manifest auto-generated from `git show v0.5.0:Cargo.lock`.
+# Do not edit by hand — regenerate per docs/releasing.md §MacPorts.
 cargo.crates \
     adler2 2.0.1 320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
     adobe-cmap-parser 0.4.1 ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3 \

--- a/packaging/winget/koedame.chordsketch.installer.yaml
+++ b/packaging/winget/koedame.chordsketch.installer.yaml
@@ -3,12 +3,10 @@ PackageVersion: 0.5.0
 InstallerType: zip
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/koedame/chordsketch/releases/download/v0.4.0/chordsketch-v0.4.0-x86_64-pc-windows-msvc.zip
-    # SHA256 must be recomputed after the v0.4.0 release artifact is published.
+    InstallerUrl: https://github.com/koedame/chordsketch/releases/download/v0.5.0/chordsketch-v0.5.0-x86_64-pc-windows-msvc.zip
+    # SHA256 of the published v0.5.0 zip. Recompute on each release:
     # Run: curl -L <InstallerUrl> | sha256sum  (uppercase the hex output)
-    # This value is the v0.2.2 hash and is intentionally stale — do not
-    # submit this manifest to winget-pkgs until the hash is refreshed.
-    InstallerSha256: 1689228ADA287B247405881E2E7F48FC57C8B744E9159814C4010A2ED4814A50
+    InstallerSha256: A347C61C24186FAA1571E8C90BD585B1DD8AE8047F46FEAFB58B9315F652B115
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: chordsketch.exe


### PR DESCRIPTION
## Summary

Post-release Portfile follow-up mirroring v0.4.0's #2417, per
`docs/releasing.md` §MacPorts.

- `checksums` block refreshed to the v0.5.0 source tarball values
  (rmd160 / sha256 / size computed via openssl against
  `https://github.com/koedame/chordsketch/archive/refs/tags/v0.5.0.tar.gz`).
- The release-cut-window deferral comments added in #2517 are dropped
  now that the tagged tarball exists.
- `cargo.crates` block regenerated against the actual v0.5.0 tag via
  `scripts/macports-regen-cargo-crates.py --apply` — byte-identical
  to the existing block since the v0.5.0 commit IS the release-cut PR
  merge commit, but the comment now records the tagged provenance
  explicitly (instead of "HEAD's Cargo.lock at release-cut time").

## Test plan

- [x] `python3 scripts/macports-regen-cargo-crates.py --check` exits
      0 without the release-cut advisory note (now that v0.5.0 tag
      exists).
- [x] `python3 scripts/check-version-consistency.py` exits 0
      (`packaging/macports/Portfile` `github.setup version = 0.5.0`
      matches canonical workspace `0.5.0`).
- [ ] `gh workflow run macports-smoke.yml` validates the Portfile
      end-to-end against the published v0.5.0 source tarball (CI
      smoke runs on every PR; the rerun against the refreshed
      checksums is what gates this PR).

## Next steps (out of scope for this PR)

- Copy this Portfile into the `macports/macports-ports` fork at
  `textproc/chordsketch/Portfile`, open the upstream PR. Wait for
  MacPorts CI + maintainer review (per `docs/releasing.md`
  §"Post-Release" → "MacPorts Portfile").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>