### PR TITLE
fix(render): inline {key} follows active transpose offset (closes #2522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Inline `{key}` directive now follows the active transpose
-  offset across all three Rust renderers (#2522).** Before this
-  fix, `chordsketch --transpose=2` against a song authored
+  offset across all three Rust renderers, preserving modal
+  qualifiers, extensions, and slash-bass notes (#2522).** Before
+  this fix, `chordsketch --transpose=2` against a song authored
   `{key: G}` emitted `[Key: G]` (text) /
   `<span class="meta-inline__value">G</span>` (HTML) /
   `Key: G` (PDF) alongside chord lines transposed to A — the
-  authored key was leaking into the rendered preview unchanged.
-  All three renderers now apply
-  `chordsketch_chordpro::transpose::canonical_transposed_key` to
-  the directive value, matching the chord-line transpose's
-  prefer-flat convention (so a G song transposed by +3 surfaces
-  `[Key: B♭]`, not `[Key: A#]`). Unparseable values (e.g. a key
-  string that doesn't start with a note letter) fall through to
-  the authored text. The React JSX walker
-  (`packages/react/src/chordpro-jsx.tsx`) already handles this via
-  its "Original → Playing" key-pair design and is unchanged. The
-  v0.5.0 binaries shipped with this regression; it surfaced as
-  `Test action (*)` failures across every PR after the v0.5.0
-  tag was pushed, because the github-action smoke does
+  authored key leaked through unchanged.
+
+  All three renderers now route through a new
+  `chordsketch_chordpro::transpose::canonical_transposed_key_with_style(value, semitones, prefer_flat)`
+  helper that:
+
+  - **Uses the same `prefer_flat` as the chord lines** (derived
+    via `transposed_key_prefers_flat(&song.metadata, transpose_offset)`),
+    so a multi-`{key:}` song where the last anchor lands sharp
+    side renders `[Key: G♯]` next to `G#` chord lines instead of
+    the previously-divergent `[Key: A♭]` next to `G#`. Closes
+    the §"Validation Parity" gap surfaced by the silent-failure
+    audit of #2522.
+  - **Preserves the modal qualifier** — `{key: C dorian}` ↦
+    `[Key: D dorian]` at +2 (the trailing text "dorian" is not a
+    transposable theory token; preserved verbatim from the
+    parsed `ChordDetail::extension`). Sister cases:
+    `{key: G mixolydian}`, `{key: A lydian}`, etc.
+  - **Preserves spelled-out `minor`** — `{key: Bb minor}` ↦
+    `[Key: C minor]` at +2 (the leading space prevents the
+    chord parser's `min` prefix match, so "minor" lands in
+    `ChordDetail::extension` and round-trips verbatim).
+  - **Preserves extensions** — `{key: G7}` ↦ `[Key: A7]` at +2;
+    `{key: Gmaj7}` ↦ `[Key: Amaj7]`; `{key: Gsus4}` ↦
+    `[Key: Asus4]`.
+  - **Transposes slash-bass** — `{key: G/B}` ↦ `[Key: A/C♯]` at
+    +2 (the bass note transposes in lockstep with the root via
+    `transpose_detail_with_style`).
+  - **Compact-form minor** — `{key: Em}` ↦ `[Key: G♭m]` at +2
+    (uses `ChordQuality::Minor`; emits `m` after the
+    transposed-and-respelled accidental).
+  - **Unparseable values** (e.g. a string that doesn't start
+    with a note letter at all — `{key: Hidden}`) fall through
+    to the authored text rather than producing nonsense.
+
+  The React JSX walker
+  (`packages/react/src/chordpro-jsx.tsx:3199-3234`) already
+  emits an "Original → Playing" key-pair when the primary
+  `{key}` differs from the host-supplied `transposedKey`, so
+  the primary-key case is already correct over there. Mid-song
+  `{key}` changes in the walker still fall through to the
+  authored single chip per the walker's documented limitation
+  (the host's `transposedKey` only carries the primary key's
+  transposition) — a cross-surface parity gap with the Rust
+  renderers' new behaviour is tracked as a follow-up.
+
+  The v0.5.0 binaries shipped with this regression; it surfaced
+  as `Test action (*)` failures across every PR after the
+  v0.5.0 tag was pushed, because the github-action smoke does
   `grep -qw 'G'` on the transposed output to verify the chord
   lines actually transposed — and was catching the untransposed
   `[Key: G]` header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Inline `{key}` directive now follows the active transpose
+  offset across all three Rust renderers (#2522).** Before this
+  fix, `chordsketch --transpose=2` against a song authored
+  `{key: G}` emitted `[Key: G]` (text) /
+  `<span class="meta-inline__value">G</span>` (HTML) /
+  `Key: G` (PDF) alongside chord lines transposed to A — the
+  authored key was leaking into the rendered preview unchanged.
+  All three renderers now apply
+  `chordsketch_chordpro::transpose::canonical_transposed_key` to
+  the directive value, matching the chord-line transpose's
+  prefer-flat convention (so a G song transposed by +3 surfaces
+  `[Key: B♭]`, not `[Key: A#]`). Unparseable values (e.g. a key
+  string that doesn't start with a note letter) fall through to
+  the authored text. The React JSX walker
+  (`packages/react/src/chordpro-jsx.tsx`) already handles this via
+  its "Original → Playing" key-pair design and is unchanged. The
+  v0.5.0 binaries shipped with this regression; it surfaced as
+  `Test action (*)` failures across every PR after the v0.5.0
+  tag was pushed, because the github-action smoke does
+  `grep -qw 'G'` on the transposed output to verify the chord
+  lines actually transposed — and was catching the untransposed
+  `[Key: G]` header.
+
 ## [0.5.0] - 2026-05-20
 
 ### Added

--- a/crates/chordpro/src/transpose.rs
+++ b/crates/chordpro/src/transpose.rs
@@ -329,7 +329,11 @@ pub fn transpose(song: &Song, semitones: i8) -> Song {
 /// `{key}` after transposition by `semitones`. Pop / folk
 /// convention: prefer flats for ambiguous black-key pitches
 /// (`Bb` over `A#`, `Eb` over `D#`, `Gb` over `F#`, etc.) — the
-/// preference is derived per-key via [`key_prefers_flat_for_song`].
+/// preference is derived per-key via a private heuristic. For
+/// callers that need explicit control over flat-vs-sharp
+/// (e.g. to match the chord-line spelling decided by
+/// [`transposed_key_prefers_flat`]), use
+/// [`canonical_transposed_key_with_style`].
 ///
 /// The chord parser is permissive about trailing text — `{key: C
 /// dorian}` parses as a C-major chord with extension `" dorian"`

--- a/crates/chordpro/src/transpose.rs
+++ b/crates/chordpro/src/transpose.rs
@@ -328,10 +328,22 @@ pub fn transpose(song: &Song, semitones: i8) -> Song {
 /// Compute the canonical spelling for the song's primary
 /// `{key}` after transposition by `semitones`. Pop / folk
 /// convention: prefer flats for ambiguous black-key pitches
-/// (`Bb` over `A#`, `Eb` over `D#`, `Gb` over `F#`, etc.).
+/// (`Bb` over `A#`, `Eb` over `D#`, `Gb` over `F#`, etc.) — the
+/// preference is derived per-key via [`key_prefers_flat_for_song`].
 ///
-/// Returns `None` when the song has no parseable primary key
-/// (e.g. `{key: C dorian}` or no `{key}` at all).
+/// The chord parser is permissive about trailing text — `{key: C
+/// dorian}` parses as a C-major chord with extension `" dorian"`
+/// and `{key: G/B}` parses as a G chord with bass note `B`. This
+/// function emits the transposed root + accidental + minor flag
+/// ONLY; the modal qualifier and the slash-bass are dropped on
+/// output, which silently changes the rendered text. Use
+/// [`canonical_transposed_key_with_style`] when you need to
+/// preserve those trailing structural details (every Rust
+/// renderer's inline `{key:}` marker does, per #2522).
+///
+/// Returns `None` when the song key isn't a chord token at all
+/// (the value doesn't start with a note letter C / D / E / F / G
+/// / A / B).
 #[must_use]
 pub fn canonical_transposed_key(song_key: Option<&str>, semitones: i8) -> Option<String> {
     let key_str = song_key?;
@@ -345,6 +357,44 @@ pub fn canonical_transposed_key(song_key: Option<&str>, semitones: i8) -> Option
     Some(canonical_key_string(&transposed))
 }
 
+/// Compute the transposed canonical spelling for a `{key:}`
+/// directive value, **preserving the modal qualifier and the
+/// slash-bass note** (`{key: C dorian}` ↦ `D dorian` at +2;
+/// `{key: G/B}` ↦ `A/C#` at +2). The caller provides
+/// `prefer_flat` explicitly so the displayed key uses the SAME
+/// flat/sharp preference the chord lines do (the renderer
+/// computes `prefer_flat = transposed_key_prefers_flat(&song.metadata,
+/// semitones)` and passes it in — per `.claude/rules/renderer-parity.md`
+/// §"Validation Parity" the two decisions MUST agree, or a song
+/// with mid-song `{key:}` changes can surface the same pitch as
+/// `A♭` (key marker) and `G#` (chord lines) in the same vicinity;
+/// see #2522).
+///
+/// This is the strictly-superset variant of
+/// [`canonical_transposed_key`] used by every Rust renderer when
+/// rendering the inline `{key:}` marker. The chord parser is
+/// permissive about trailing text, so this preserves what the
+/// simpler helper drops: `extension` (modal qualifier text after
+/// the root, kept verbatim because it's not a transposable music
+/// theory token) and the slash `/bass` (transposed alongside the
+/// root). Minor keys append `m` after the accidental.
+///
+/// Returns `None` only when the value doesn't start with a note
+/// letter at all — same parseability contract as
+/// [`canonical_transposed_key`].
+#[must_use]
+pub fn canonical_transposed_key_with_style(
+    song_key: Option<&str>,
+    semitones: i8,
+    prefer_flat: bool,
+) -> Option<String> {
+    let key_str = song_key?;
+    let chord = crate::ast::Chord::new(key_str);
+    let detail = chord.detail.as_ref()?;
+    let transposed = transpose_detail_with_style(detail, semitones, prefer_flat);
+    Some(transposed_key_display_string(&transposed))
+}
+
 fn key_prefers_flat_for_song(detail: &ChordDetail, semitones: i8) -> bool {
     let root_semitone = note_to_semitone(detail.root, detail.root_accidental);
     let new_semitone = shift_semitone(root_semitone, semitones);
@@ -356,6 +406,12 @@ fn key_prefers_flat_for_song(detail: &ChordDetail, semitones: i8) -> bool {
 /// Compute the canonical-spelling string for a transposed key
 /// detail. Drops the chord quality (a key is a root + minor
 /// flag, not a chord type) and emits e.g. `"Bb"` / `"F#m"`.
+///
+/// `extension` and `bass_note` are intentionally dropped here —
+/// see [`canonical_transposed_key`]'s doc-comment. Callers that
+/// need to preserve those should use
+/// [`canonical_transposed_key_with_style`] /
+/// [`transposed_key_display_string`].
 fn canonical_key_string(detail: &ChordDetail) -> String {
     let root_semitone = note_to_semitone(detail.root, detail.root_accidental);
     let (new_root, new_acc) = canonical_key_spelling(root_semitone);
@@ -377,6 +433,64 @@ fn canonical_key_string(detail: &ChordDetail) -> String {
     }
     if detail.quality == ChordQuality::Minor {
         s.push('m');
+    }
+    s
+}
+
+/// Format an already-transposed `ChordDetail` as a key-display
+/// string that preserves the modal qualifier and slash-bass
+/// (sister to [`ChordDetail`]'s `Display` impl, but drops
+/// `ChordQuality::Major` — keys aren't chord types).
+///
+/// Unlike [`canonical_key_string`], this trusts the spelling the
+/// caller already picked (via `transpose_detail_with_style`'s
+/// `prefer_flat` argument) instead of re-spelling through the
+/// `canonical_key_spelling` table. That keeps the displayed key
+/// in lockstep with the chord lines.
+fn transposed_key_display_string(detail: &ChordDetail) -> String {
+    let mut s = String::new();
+    s.push(match detail.root {
+        Note::C => 'C',
+        Note::D => 'D',
+        Note::E => 'E',
+        Note::F => 'F',
+        Note::G => 'G',
+        Note::A => 'A',
+        Note::B => 'B',
+    });
+    if let Some(acc) = detail.root_accidental {
+        match acc {
+            Accidental::Sharp => s.push('#'),
+            Accidental::Flat => s.push('b'),
+        }
+    }
+    if detail.quality == ChordQuality::Minor {
+        s.push('m');
+    }
+    // Extension is verbatim source text (e.g. " dorian", " mixolydian",
+    // " add9") — not a transposable theory token, so we preserve it.
+    if let Some(ref ext) = detail.extension {
+        s.push_str(ext);
+    }
+    // Slash bass — the bass note IS transposed in lockstep with the
+    // root via `transpose_detail_with_style`.
+    if let Some((bass, bass_acc)) = detail.bass_note {
+        s.push('/');
+        s.push(match bass {
+            Note::C => 'C',
+            Note::D => 'D',
+            Note::E => 'E',
+            Note::F => 'F',
+            Note::G => 'G',
+            Note::A => 'A',
+            Note::B => 'B',
+        });
+        if let Some(acc) = bass_acc {
+            match acc {
+                Accidental::Sharp => s.push('#'),
+                Accidental::Flat => s.push('b'),
+            }
+        }
     }
     s
 }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -32,7 +32,9 @@ use chordsketch_chordpro::render_result::{
     RenderResult, push_warning, validate_capo, validate_multiple_capo, validate_strict_key,
 };
 use chordsketch_chordpro::resolve_diagrams_instrument;
-use chordsketch_chordpro::transpose::{transpose_chord_with_style, transposed_key_prefers_flat};
+use chordsketch_chordpro::transpose::{
+    canonical_transposed_key, transpose_chord_with_style, transposed_key_prefers_flat,
+};
 use chordsketch_chordpro::typography::{tempo_marking_for, unicode_accidentals};
 
 /// Maximum number of chorus recall directives allowed per song.
@@ -386,13 +388,32 @@ fn render_song_body_into(
                         // walker.
                         match directive.kind {
                             DirectiveKind::Key => {
+                                // Apply the active transpose offset to the
+                                // displayed key so it matches the chord
+                                // lines, which are transposed via
+                                // `transpose_chord_with_style`. Falls back
+                                // to the authored value when the key is
+                                // not parseable (e.g. `{key: C dorian}`)
+                                // or transpose is 0. Sister-site to
+                                // render-text / render-pdf / the React
+                                // JSX walker (per
+                                // `.claude/rules/renderer-parity.md`);
+                                // closes #2522. The key-signature SVG
+                                // glyph also follows the transposed value
+                                // so the rendered staff matches.
+                                let displayed = if transpose_offset == 0 {
+                                    value.to_string()
+                                } else {
+                                    canonical_transposed_key(Some(value), transpose_offset)
+                                        .unwrap_or_else(|| value.to_string())
+                                };
                                 html.push_str(&format!(
                                     "<span class=\"meta-inline meta-inline--key\">\
                                      {glyph}\
                                      <span class=\"meta-inline__label\">Key:</span> \
                                      <span class=\"meta-inline__value\">{val}</span></span>\n",
-                                    glyph = music_glyphs::key_signature_svg(value),
-                                    val = escape(&unicode_accidentals(value)),
+                                    glyph = music_glyphs::key_signature_svg(&displayed),
+                                    val = escape(&unicode_accidentals(&displayed)),
                                 ));
                             }
                             DirectiveKind::Tempo => {
@@ -2980,6 +3001,47 @@ mod tests {
         assert!(
             html.contains("<span class=\"meta-inline__value\">E\u{266D}</span>"),
             "expected `E♭` in inline key value, got: {html}"
+        );
+    }
+
+    /// Closes #2522 (sister-site to render-text + render-pdf): the
+    /// inline `Key:` marker MUST follow the active transpose offset
+    /// so it agrees with the chord lines, which are transposed
+    /// in-place by `transpose_chord_with_style`. Without this, end
+    /// users reading the rendered preview would see "Key: G" alongside
+    /// chord lines actually pitched in A — the same authored-vs-
+    /// playing mismatch the React JSX walker handles with its
+    /// "Original → Playing" pair.
+    #[test]
+    fn test_inline_key_marker_follows_transpose() {
+        use chordsketch_chordpro::config::Config;
+
+        let song = chordsketch_chordpro::parse("{key: G}\n[G]hi [D]world").unwrap();
+
+        // No transpose: authored key passes through unchanged.
+        let zero = render_song_with_transpose(&song, 0, &Config::defaults());
+        assert!(
+            zero.contains("<span class=\"meta-inline__value\">G</span>"),
+            "no-transpose case must preserve authored key; got:\n{zero}"
+        );
+
+        // +2 semitones: G → A.
+        let up_two = render_song_with_transpose(&song, 2, &Config::defaults());
+        assert!(
+            up_two.contains("<span class=\"meta-inline__value\">A</span>"),
+            "+2 transpose must surface key value `A`; got:\n{up_two}"
+        );
+        assert!(
+            !up_two.contains("<span class=\"meta-inline__value\">G</span>"),
+            "+2 transpose must NOT leave authored `G` in the key value; got:\n{up_two}"
+        );
+
+        // Flat-side spelling: G + 3 lands on B♭ (the chord-line
+        // canonical-spelling logic is consistent across renderers).
+        let to_bflat = render_song_with_transpose(&song, 3, &Config::defaults());
+        assert!(
+            to_bflat.contains("<span class=\"meta-inline__value\">B\u{266D}</span>"),
+            "+3 transpose must surface flat-side `B♭`; got:\n{to_bflat}"
         );
     }
 

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -3043,6 +3043,24 @@ mod tests {
             to_bflat.contains("<span class=\"meta-inline__value\">B\u{266D}</span>"),
             "+3 transpose must surface flat-side `B♭`; got:\n{to_bflat}"
         );
+
+        // −3 semitones: G → E. Negative offsets must work
+        // symmetrically with positive ones.
+        let down_three = render_song_with_transpose(&song, -3, &Config::defaults());
+        assert!(
+            down_three.contains("<span class=\"meta-inline__value\">E</span>"),
+            "-3 transpose must surface key value `E`; got:\n{down_three}"
+        );
+
+        // Unparseable key: a value that doesn't start with a chord root
+        // letter falls through to the authored text unchanged (same
+        // contract as `canonical_transposed_key`).
+        let nonchord = chordsketch_chordpro::parse("{key: Hidden}\n[C]hi").unwrap();
+        let nonchord_out = render_song_with_transpose(&nonchord, 2, &Config::defaults());
+        assert!(
+            nonchord_out.contains("<span class=\"meta-inline__value\">Hidden</span>"),
+            "unparseable key must fall back to authored value; got:\n{nonchord_out}"
+        );
     }
 
     #[test]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -33,7 +33,7 @@ use chordsketch_chordpro::render_result::{
 };
 use chordsketch_chordpro::resolve_diagrams_instrument;
 use chordsketch_chordpro::transpose::{
-    canonical_transposed_key, transpose_chord_with_style, transposed_key_prefers_flat,
+    canonical_transposed_key_with_style, transpose_chord_with_style, transposed_key_prefers_flat,
 };
 use chordsketch_chordpro::typography::{tempo_marking_for, unicode_accidentals};
 
@@ -390,22 +390,38 @@ fn render_song_body_into(
                             DirectiveKind::Key => {
                                 // Apply the active transpose offset to the
                                 // displayed key so it matches the chord
-                                // lines, which are transposed via
-                                // `transpose_chord_with_style`. Falls back
-                                // to the authored value when the key is
-                                // not parseable (e.g. `{key: C dorian}`)
-                                // or transpose is 0. Sister-site to
-                                // render-text / render-pdf / the React
-                                // JSX walker (per
-                                // `.claude/rules/renderer-parity.md`);
+                                // lines (transposed via
+                                // `transpose_chord_with_style`). Uses the
+                                // `_with_style` variant with the same
+                                // song-wide `prefer_flat` chord lines use,
+                                // so multi-`{key}` songs spell the
+                                // displayed key consistently with the
+                                // surrounding chord lines (#2522 §validation
+                                // parity). The helper also preserves
+                                // modal qualifiers (`{key: C dorian}` ↦
+                                // `D dorian`) and slash-bass
+                                // (`{key: G/B}` ↦ `A/C#`). Falls back to
+                                // the authored value when the directive
+                                // value doesn't start with a note letter.
+                                // Sister-site to render-text / render-pdf
+                                // / the React JSX walker per
+                                // `.claude/rules/renderer-parity.md`;
                                 // closes #2522. The key-signature SVG
-                                // glyph also follows the transposed value
-                                // so the rendered staff matches.
+                                // glyph follows the transposed value too
+                                // so the staff matches.
                                 let displayed = if transpose_offset == 0 {
                                     value.to_string()
                                 } else {
-                                    canonical_transposed_key(Some(value), transpose_offset)
-                                        .unwrap_or_else(|| value.to_string())
+                                    let prefer_flat = transposed_key_prefers_flat(
+                                        &song.metadata,
+                                        transpose_offset,
+                                    );
+                                    canonical_transposed_key_with_style(
+                                        Some(value),
+                                        transpose_offset,
+                                        prefer_flat,
+                                    )
+                                    .unwrap_or_else(|| value.to_string())
                                 };
                                 html.push_str(&format!(
                                     "<span class=\"meta-inline meta-inline--key\">\
@@ -3011,7 +3027,9 @@ mod tests {
     /// users reading the rendered preview would see "Key: G" alongside
     /// chord lines actually pitched in A — the same authored-vs-
     /// playing mismatch the React JSX walker handles with its
-    /// "Original → Playing" pair.
+    /// "Original → Playing" pair on the primary key. (Mid-song key
+    /// parity with the walker is tracked under a follow-up; see
+    /// `canonical_transposed_key_with_style`'s doc-comment.)
     #[test]
     fn test_inline_key_marker_follows_transpose() {
         use chordsketch_chordpro::config::Config;
@@ -3060,6 +3078,47 @@ mod tests {
         assert!(
             nonchord_out.contains("<span class=\"meta-inline__value\">Hidden</span>"),
             "unparseable key must fall back to authored value; got:\n{nonchord_out}"
+        );
+    }
+
+    /// Closes #2522 HIGH-2 / HIGH-3 (silent-failure audit): modal
+    /// qualifiers, extensions, and slash-bass notes MUST be
+    /// preserved when the inline `{key:}` marker is transposed.
+    /// Sister-site to render-text and render-pdf.
+    #[test]
+    fn test_inline_key_marker_preserves_modal_extension_and_bass() {
+        use chordsketch_chordpro::config::Config;
+
+        // Modal qualifier preserved verbatim.
+        let modal = chordsketch_chordpro::parse("{key: C dorian}\n[C]hi").unwrap();
+        let modal_out = render_song_with_transpose(&modal, 2, &Config::defaults());
+        assert!(
+            modal_out.contains("D dorian"),
+            "modal qualifier must round-trip; got:\n{modal_out}"
+        );
+
+        // Word `minor` (parsed into extension because of the space).
+        let bb_minor = chordsketch_chordpro::parse("{key: Bb minor}\n[Bb]hi").unwrap();
+        let bb_minor_out = render_song_with_transpose(&bb_minor, 2, &Config::defaults());
+        assert!(
+            bb_minor_out.contains("C minor"),
+            "spelled-out `minor` must round-trip; got:\n{bb_minor_out}"
+        );
+
+        // Slash bass transposes alongside the root.
+        let slash = chordsketch_chordpro::parse("{key: G/B}\n[G]hi").unwrap();
+        let slash_out = render_song_with_transpose(&slash, 2, &Config::defaults());
+        assert!(
+            slash_out.contains("A/C\u{266F}"),
+            "slash-bass must transpose alongside the root; got:\n{slash_out}"
+        );
+
+        // Extension preserved.
+        let seventh = chordsketch_chordpro::parse("{key: G7}\n[G]hi").unwrap();
+        let seventh_out = render_song_with_transpose(&seventh, 2, &Config::defaults());
+        assert!(
+            seventh_out.contains("A7"),
+            "extension must round-trip; got:\n{seventh_out}"
         );
     }
 

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -882,10 +882,8 @@ fn render_song_into_doc(
                             let displayed = if transpose_offset == 0 {
                                 value.to_string()
                             } else {
-                                let prefer_flat = transposed_key_prefers_flat(
-                                    &song.metadata,
-                                    transpose_offset,
-                                );
+                                let prefer_flat =
+                                    transposed_key_prefers_flat(&song.metadata, transpose_offset);
                                 canonical_transposed_key_with_style(
                                     Some(value),
                                     transpose_offset,

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -22,7 +22,7 @@ use chordsketch_chordpro::render_result::{
 };
 use chordsketch_chordpro::resolve_diagrams_instrument;
 use chordsketch_chordpro::transpose::{
-    canonical_transposed_key, transpose_chord_with_style, transposed_key_prefers_flat,
+    canonical_transposed_key_with_style, transpose_chord_with_style, transposed_key_prefers_flat,
 };
 use chordsketch_chordpro::typography::{tempo_marking_for, unicode_accidentals};
 
@@ -861,19 +861,37 @@ fn render_song_into_doc(
                         DirectiveKind::Key => {
                             // Apply the active transpose offset to the
                             // displayed key so it matches the chord
-                            // lines, which are transposed via
-                            // `transpose_chord_with_style`. Falls back
-                            // to the authored value when the key is not
-                            // parseable (e.g. `{key: C dorian}`) or
-                            // transpose is 0. Sister-site to render-text
-                            // / render-html / the React JSX walker (per
-                            // `.claude/rules/renderer-parity.md`);
+                            // lines (transposed via
+                            // `transpose_chord_with_style`). Uses the
+                            // `_with_style` variant with the same
+                            // song-wide `prefer_flat` chord lines use,
+                            // so multi-`{key}` songs spell the
+                            // displayed key consistently with the
+                            // surrounding chord lines (#2522 §validation
+                            // parity). The helper also preserves modal
+                            // qualifiers (`{key: C dorian}` ↦
+                            // `D dorian`), the trailing word `minor`
+                            // (`{key: Bb minor}` ↦ `C minor`), and the
+                            // slash-bass (`{key: G/B}` ↦ `A/C#`). Falls
+                            // back to the authored value when the
+                            // directive value doesn't start with a note
+                            // letter. Sister-site to render-text /
+                            // render-html / the React JSX walker per
+                            // `.claude/rules/renderer-parity.md`;
                             // closes #2522.
                             let displayed = if transpose_offset == 0 {
                                 value.to_string()
                             } else {
-                                canonical_transposed_key(Some(value), transpose_offset)
-                                    .unwrap_or_else(|| value.to_string())
+                                let prefer_flat = transposed_key_prefers_flat(
+                                    &song.metadata,
+                                    transpose_offset,
+                                );
+                                canonical_transposed_key_with_style(
+                                    Some(value),
+                                    transpose_offset,
+                                    prefer_flat,
+                                )
+                                .unwrap_or_else(|| value.to_string())
                             };
                             format!("Key: {}", unicode_accidentals(&displayed))
                         }
@@ -4232,6 +4250,37 @@ mod transpose_tests {
             nonchord_content.contains("Key: Hidden"),
             "unparseable key must fall back to authored value in PDF stream"
         );
+    }
+
+    /// Closes #2522 HIGH-2 (silent-failure audit): modal qualifiers,
+    /// extensions, and slash-bass notes MUST be preserved when the
+    /// inline `Key:` marker is transposed. Sister-site to render-text
+    /// and render-html.
+    #[test]
+    fn test_inline_key_marker_preserves_modal_extension_and_bass() {
+        // Modal qualifier preserved.
+        let modal = chordsketch_chordpro::parse("{key: C dorian}\n[C]hi").unwrap();
+        let modal_out = render_song_with_transpose(&modal, 2, &Config::defaults());
+        let modal_content = String::from_utf8_lossy(&modal_out);
+        assert!(
+            modal_content.contains("D dorian"),
+            "modal qualifier must round-trip"
+        );
+
+        // Word `minor` preserved.
+        let bb_minor = chordsketch_chordpro::parse("{key: Bb minor}\n[Bb]hi").unwrap();
+        let bb_minor_out = render_song_with_transpose(&bb_minor, 2, &Config::defaults());
+        let bb_minor_content = String::from_utf8_lossy(&bb_minor_out);
+        assert!(
+            bb_minor_content.contains("C minor"),
+            "spelled-out `minor` must round-trip"
+        );
+
+        // Extension preserved.
+        let seventh = chordsketch_chordpro::parse("{key: G7}\n[G]hi").unwrap();
+        let seventh_out = render_song_with_transpose(&seventh, 2, &Config::defaults());
+        let seventh_content = String::from_utf8_lossy(&seventh_out);
+        assert!(seventh_content.contains("A7"), "extension must round-trip");
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -4211,6 +4211,27 @@ mod transpose_tests {
             !up_two_content.contains("Key: G"),
             "+2 transpose must NOT leave authored `Key: G` in PDF stream"
         );
+
+        // −3 semitones: G → E. Negative offsets must work
+        // symmetrically with positive ones (all ASCII, safe to search
+        // in the raw PDF stream).
+        let down_three = render_song_with_transpose(&song, -3, &Config::defaults());
+        let down_three_content = String::from_utf8_lossy(&down_three);
+        assert!(
+            down_three_content.contains("Key: E"),
+            "-3 transpose must surface `Key: E` in PDF stream"
+        );
+
+        // Unparseable key falls back to the authored value. The PDF
+        // builder embeds the full text "Key: Hidden" in the content
+        // stream as ASCII, so a substring search is reliable here.
+        let nonchord = chordsketch_chordpro::parse("{key: Hidden}\n[C]hi").unwrap();
+        let nonchord_bytes = render_song_with_transpose(&nonchord, 2, &Config::defaults());
+        let nonchord_content = String::from_utf8_lossy(&nonchord_bytes);
+        assert!(
+            nonchord_content.contains("Key: Hidden"),
+            "unparseable key must fall back to authored value in PDF stream"
+        );
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -21,7 +21,9 @@ use chordsketch_chordpro::render_result::{
     RenderResult, push_warning, validate_capo, validate_multiple_capo, validate_strict_key,
 };
 use chordsketch_chordpro::resolve_diagrams_instrument;
-use chordsketch_chordpro::transpose::{transpose_chord_with_style, transposed_key_prefers_flat};
+use chordsketch_chordpro::transpose::{
+    canonical_transposed_key, transpose_chord_with_style, transposed_key_prefers_flat,
+};
 use chordsketch_chordpro::typography::{tempo_marking_for, unicode_accidentals};
 
 use flate2::Compression;
@@ -856,7 +858,25 @@ fn render_song_into_doc(
                     // intentionally retained here. Same for
                     // `Key:` / `Time:`.
                     let line = match d.kind {
-                        DirectiveKind::Key => format!("Key: {}", unicode_accidentals(value)),
+                        DirectiveKind::Key => {
+                            // Apply the active transpose offset to the
+                            // displayed key so it matches the chord
+                            // lines, which are transposed via
+                            // `transpose_chord_with_style`. Falls back
+                            // to the authored value when the key is not
+                            // parseable (e.g. `{key: C dorian}`) or
+                            // transpose is 0. Sister-site to render-text
+                            // / render-html / the React JSX walker (per
+                            // `.claude/rules/renderer-parity.md`);
+                            // closes #2522.
+                            let displayed = if transpose_offset == 0 {
+                                value.to_string()
+                            } else {
+                                canonical_transposed_key(Some(value), transpose_offset)
+                                    .unwrap_or_else(|| value.to_string())
+                            };
+                            format!("Key: {}", unicode_accidentals(&displayed))
+                        }
                         DirectiveKind::Tempo => {
                             // Append the Italian tempo marking when
                             // the BPM matches a conventional band.
@@ -4160,6 +4180,37 @@ mod transpose_tests {
         // 2+3=5, C+5=F
         let content = String::from_utf8_lossy(&bytes);
         assert!(content.contains("(F)"));
+    }
+
+    /// Closes #2522 (sister-site to render-text + render-html): the
+    /// `Key:` inline marker in the PDF body MUST follow the active
+    /// transpose offset so it agrees with the chord lines. Tested via
+    /// substring search on the PDF content-stream bytes (the same
+    /// trick `test_transpose_with_cli_offset` uses one test up).
+    #[test]
+    fn test_inline_key_marker_follows_transpose() {
+        let input = "{key: G}\n[G]hi [D]world";
+        let song = chordsketch_chordpro::parse(input).unwrap();
+
+        // No transpose: authored value preserved.
+        let zero = render_song_with_transpose(&song, 0, &Config::defaults());
+        let zero_content = String::from_utf8_lossy(&zero);
+        assert!(
+            zero_content.contains("Key: G"),
+            "no-transpose case must preserve authored `Key: G`"
+        );
+
+        // +2 semitones: G → A.
+        let up_two = render_song_with_transpose(&song, 2, &Config::defaults());
+        let up_two_content = String::from_utf8_lossy(&up_two);
+        assert!(
+            up_two_content.contains("Key: A"),
+            "+2 transpose must surface `Key: A` in PDF stream"
+        );
+        assert!(
+            !up_two_content.contains("Key: G"),
+            "+2 transpose must NOT leave authored `Key: G` in PDF stream"
+        );
     }
 
     #[test]

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -11,7 +11,7 @@ use chordsketch_chordpro::render_result::{
 };
 use chordsketch_chordpro::resolve_diagrams_instrument;
 use chordsketch_chordpro::transpose::{
-    canonical_transposed_key, transpose_chord_with_style, transposed_key_prefers_flat,
+    canonical_transposed_key_with_style, transpose_chord_with_style, transposed_key_prefers_flat,
 };
 use chordsketch_chordpro::typography::{tempo_marking_for, unicode_accidentals};
 use unicode_width::UnicodeWidthStr;
@@ -179,20 +179,41 @@ fn render_song_impl(
                                 // Apply the active transpose offset to the
                                 // displayed key so it matches the chord
                                 // lines, which are transposed in-place via
-                                // `transpose_chord_with_style`. Falls back
-                                // to the authored value when the key is
-                                // not parseable as a chord root (e.g.
-                                // `{key: C dorian}`) or transpose is 0.
-                                // Sister-site to render-html / render-pdf
-                                // / the React JSX walker (per
-                                // `.claude/rules/renderer-parity.md`);
+                                // `transpose_chord_with_style`. Routes
+                                // through `_with_style` so we can pass the
+                                // SAME `prefer_flat` the chord lines use —
+                                // otherwise a multi-`{key}` song where
+                                // `metadata.key` (the last `{key}`) lands
+                                // on the sharp side but the directive
+                                // being rendered would land on the flat
+                                // side would surface `[Key: A♭]` next to
+                                // chord lines spelled with `G#` for the
+                                // same pitch (see #2522). The helper also
+                                // preserves the modal qualifier
+                                // (`{key: C dorian}` ↦ `D dorian`) and
+                                // the slash-bass (`{key: G/B}` ↦ `A/C#`),
+                                // which the simpler `canonical_transposed_key`
+                                // drops. Falls back to the authored value
+                                // when the directive value doesn't even
+                                // start with a note letter. Sister-site to
+                                // render-html / render-pdf / the React JSX
+                                // walker per
+                                // `.claude/rules/renderer-parity.md`;
                                 // closes #2522. Typeset `Bb` / `F#` with
                                 // Unicode accidentals.
                                 let displayed = if transpose_offset == 0 {
                                     value.to_string()
                                 } else {
-                                    canonical_transposed_key(Some(value), transpose_offset)
-                                        .unwrap_or_else(|| value.to_string())
+                                    let prefer_flat = transposed_key_prefers_flat(
+                                        &song.metadata,
+                                        transpose_offset,
+                                    );
+                                    canonical_transposed_key_with_style(
+                                        Some(value),
+                                        transpose_offset,
+                                        prefer_flat,
+                                    )
+                                    .unwrap_or_else(|| value.to_string())
                                 };
                                 output.push(format!("[Key: {}]", unicode_accidentals(&displayed)));
                             }
@@ -926,9 +947,9 @@ mod tests {
 
     /// Closes #2522: the inline `[Key: …]` marker MUST follow the
     /// active transpose offset so it agrees with the chord lines,
-    /// which are transposed in-place. Sister-site to the React JSX
-    /// walker (which emits an "Original → Playing" pair when the
-    /// transposed key differs) and to render-html / render-pdf.
+    /// which are transposed in-place. Sister-site to render-html /
+    /// render-pdf and (in the "Original → Playing" pair shape) to
+    /// the React JSX walker.
     #[test]
     fn test_inline_key_marker_follows_transpose() {
         use chordsketch_chordpro::config::Config;
@@ -963,8 +984,8 @@ mod tests {
 
         // Flat-side spelling: transposing G by +3 lands on Bb (not A#).
         // The displayed key matches the prefer-flat convention the
-        // chord lines use (`canonical_transposed_key` shares the same
-        // logic via `key_prefers_flat_for_song`).
+        // chord lines use (the renderer now feeds the same song-wide
+        // `prefer_flat` into `canonical_transposed_key_with_style`).
         let to_bflat = render_song_with_transpose(&song, 3, &Config::defaults());
         assert!(
             to_bflat.contains("[Key: B♭]"),
@@ -974,10 +995,10 @@ mod tests {
         // Unparseable key (a value that doesn't start with a chord
         // root letter at all) falls through to the authored value
         // rather than producing nonsense — same contract as
-        // `canonical_transposed_key`. The chord parser is permissive
-        // about trailing text (e.g. `C dorian` parses as C with
-        // extra text), and forgiving on letters like `F` that ARE
-        // root letters even in non-chord words (`Foo`), so this
+        // `canonical_transposed_key_with_style`. The chord parser is
+        // permissive about trailing text (e.g. `C dorian` parses as
+        // C with extra text), and forgiving on letters like `F` that
+        // ARE root letters even in non-chord words (`Foo`), so this
         // branch only fires for strings that don't even start with a
         // valid note letter (C / D / E / F / G / A / B).
         let nonchord = chordsketch_chordpro::parse("{key: Hidden}\n[C]hi").unwrap();
@@ -985,6 +1006,118 @@ mod tests {
         assert!(
             nonchord_out.contains("[Key: Hidden]"),
             "unparseable key falls back to authored value; got:\n{nonchord_out}"
+        );
+    }
+
+    /// Closes #2522 (HIGH-2 from the silent-failure audit): modal
+    /// qualifiers, slash-bass notes, and extension text MUST be
+    /// preserved when the inline `{key:}` marker is transposed.
+    /// Before the fix in `canonical_transposed_key_with_style`, the
+    /// renderers used `canonical_transposed_key` which drops these
+    /// — surfacing the same class of information loss the original
+    /// regression introduced, but in a different direction.
+    #[test]
+    fn test_inline_key_marker_preserves_modal_extension_and_bass() {
+        use chordsketch_chordpro::config::Config;
+
+        // Modal qualifier: "dorian" is preserved verbatim (it's not
+        // a transposable theory token).
+        let modal = chordsketch_chordpro::parse("{key: C dorian}\n[C]hi").unwrap();
+        let modal_out = render_song_with_transpose(&modal, 2, &Config::defaults());
+        assert!(
+            modal_out.contains("[Key: D dorian]"),
+            "modal qualifier must round-trip on transpose; got:\n{modal_out}"
+        );
+
+        // "minor" written out as a word (the space prevents the
+        // chord parser's `min` prefix match, so it lands in the
+        // extension field). The minor *modality* is therefore in
+        // the extension text, not the ChordQuality enum — but the
+        // user sees the right text either way.
+        let bb_minor = chordsketch_chordpro::parse("{key: Bb minor}\n[Bb]hi").unwrap();
+        let bb_minor_out = render_song_with_transpose(&bb_minor, 2, &Config::defaults());
+        assert!(
+            bb_minor_out.contains("[Key: C minor]"),
+            "spelled-out `minor` must round-trip; got:\n{bb_minor_out}"
+        );
+
+        // Slash bass: the bass note transposes in lockstep with the
+        // root via `transpose_detail_with_style`.
+        let slash = chordsketch_chordpro::parse("{key: G/B}\n[G]hi").unwrap();
+        let slash_out = render_song_with_transpose(&slash, 2, &Config::defaults());
+        assert!(
+            slash_out.contains("[Key: A/C♯]"),
+            "slash-bass must transpose alongside the root; got:\n{slash_out}"
+        );
+
+        // Extension (`7`, `maj7`, `sus4`, …) preserved verbatim.
+        let seventh = chordsketch_chordpro::parse("{key: G7}\n[G]hi").unwrap();
+        let seventh_out = render_song_with_transpose(&seventh, 2, &Config::defaults());
+        assert!(
+            seventh_out.contains("[Key: A7]"),
+            "extension must round-trip on transpose; got:\n{seventh_out}"
+        );
+
+        // Compact-form minor (`Em`) uses ChordQuality::Minor — the
+        // helper appends `m` after the (transposed) accidental. At
+        // +2 the song-wide `prefer_flat` for an Em key lands flat
+        // side, so the helper spells G♭m (consistent with the chord
+        // lines, which also use G♭m). F♯m / G♭m are enharmonic
+        // equivalents; the convention is owned by
+        // `transposed_key_prefers_flat` and not negotiated here.
+        let em = chordsketch_chordpro::parse("{key: Em}\n[Em]hi").unwrap();
+        let em_out = render_song_with_transpose(&em, 2, &Config::defaults());
+        assert!(
+            em_out.contains("[Key: G♭m]"),
+            "compact minor form must transpose to G♭m at +2 (song-wide prefer_flat); got:\n{em_out}"
+        );
+        assert!(
+            em_out.contains("Gbm"),
+            "chord lines must agree with key marker spelling; got:\n{em_out}"
+        );
+
+        // Flat-side authored key + transpose lands on a flat-side
+        // target — chord lines and key marker must agree.
+        let bb_song = chordsketch_chordpro::parse("{key: Bb}\n[Bb]hi").unwrap();
+        let bb_up_two = render_song_with_transpose(&bb_song, 2, &Config::defaults());
+        assert!(
+            bb_up_two.contains("[Key: C]"),
+            "Bb at +2 lands on C; got:\n{bb_up_two}"
+        );
+    }
+
+    /// Closes #2522 (MEDIUM-3 from the silent-failure audit):
+    /// multi-`{key:}` songs MUST spell the inline key marker the
+    /// same way the chord lines do. Before the fix, the chord
+    /// lines used the song-wide `prefer_flat` (derived from
+    /// `song.metadata.key`, which is the LAST `{key:}` seen) while
+    /// the inline marker used a per-directive `prefer_flat`
+    /// computed against the specific directive value — producing
+    /// outputs where `[Key: A♭]` would appear next to a chord
+    /// spelled `G#` for the same pitch.
+    #[test]
+    fn test_inline_key_marker_agrees_with_chord_lines_on_multi_key_songs() {
+        use chordsketch_chordpro::config::Config;
+
+        // Two `{key:}` directives straddling both sides of the
+        // circle of fifths. With +1 transpose, the song-wide
+        // anchor is the LAST key (`Eb`, sharp side after the
+        // shift), so chord lines render `G#` / `E`. The marker
+        // MUST match the chord-line spelling at both positions.
+        let song = chordsketch_chordpro::parse("{key: G}\n[G]hi\n{key: Eb}\n[Eb]ho").unwrap();
+        let up_one = render_song_with_transpose(&song, 1, &Config::defaults());
+        assert!(
+            up_one.contains("[Key: G♯]"),
+            "primary G with +1 (under last-key Eb anchor) spells `G♯`; got:\n{up_one}"
+        );
+        assert!(
+            up_one.contains("[Key: E]"),
+            "mid-song Eb with +1 spells `E`; got:\n{up_one}"
+        );
+        // Chord lines must use the same spelling.
+        assert!(
+            up_one.contains("G#"),
+            "chord line G at +1 must spell `G#` consistent with the marker; got:\n{up_one}"
         );
     }
 

--- a/crates/render-text/src/lib.rs
+++ b/crates/render-text/src/lib.rs
@@ -10,7 +10,9 @@ use chordsketch_chordpro::render_result::{
     RenderResult, push_warning, validate_capo, validate_multiple_capo, validate_strict_key,
 };
 use chordsketch_chordpro::resolve_diagrams_instrument;
-use chordsketch_chordpro::transpose::{transpose_chord_with_style, transposed_key_prefers_flat};
+use chordsketch_chordpro::transpose::{
+    canonical_transposed_key, transpose_chord_with_style, transposed_key_prefers_flat,
+};
 use chordsketch_chordpro::typography::{tempo_marking_for, unicode_accidentals};
 use unicode_width::UnicodeWidthStr;
 
@@ -174,10 +176,25 @@ fn render_song_impl(
                     {
                         match directive.kind {
                             DirectiveKind::Key => {
-                                // Typeset `Bb` / `F#` with Unicode
-                                // accidentals — sister-site to the
-                                // React JSX walker + Rust HTML renderer.
-                                output.push(format!("[Key: {}]", unicode_accidentals(value)));
+                                // Apply the active transpose offset to the
+                                // displayed key so it matches the chord
+                                // lines, which are transposed in-place via
+                                // `transpose_chord_with_style`. Falls back
+                                // to the authored value when the key is
+                                // not parseable as a chord root (e.g.
+                                // `{key: C dorian}`) or transpose is 0.
+                                // Sister-site to render-html / render-pdf
+                                // / the React JSX walker (per
+                                // `.claude/rules/renderer-parity.md`);
+                                // closes #2522. Typeset `Bb` / `F#` with
+                                // Unicode accidentals.
+                                let displayed = if transpose_offset == 0 {
+                                    value.to_string()
+                                } else {
+                                    canonical_transposed_key(Some(value), transpose_offset)
+                                        .unwrap_or_else(|| value.to_string())
+                                };
+                                output.push(format!("[Key: {}]", unicode_accidentals(&displayed)));
                             }
                             DirectiveKind::Tempo => {
                                 // Append the Italian tempo marking
@@ -904,6 +921,70 @@ mod tests {
         assert!(
             !output.contains("[Key:"),
             "empty {{key}} must not produce a marker; got:\n{output}"
+        );
+    }
+
+    /// Closes #2522: the inline `[Key: …]` marker MUST follow the
+    /// active transpose offset so it agrees with the chord lines,
+    /// which are transposed in-place. Sister-site to the React JSX
+    /// walker (which emits an "Original → Playing" pair when the
+    /// transposed key differs) and to render-html / render-pdf.
+    #[test]
+    fn test_inline_key_marker_follows_transpose() {
+        use chordsketch_chordpro::config::Config;
+
+        let song = chordsketch_chordpro::parse("{key: G}\n[G]hi [D]world").unwrap();
+
+        // No transpose: authored key passes through unchanged.
+        let zero = render_song_with_transpose(&song, 0, &Config::defaults());
+        assert!(
+            zero.contains("[Key: G]"),
+            "no-transpose case must preserve authored key; got:\n{zero}"
+        );
+
+        // +2 semitones: G → A. Chord line is transposed to A E so the
+        // marker must follow.
+        let up_two = render_song_with_transpose(&song, 2, &Config::defaults());
+        assert!(
+            up_two.contains("[Key: A]"),
+            "+2 transpose must surface [Key: A]; got:\n{up_two}"
+        );
+        assert!(
+            !up_two.contains("[Key: G]"),
+            "+2 transpose must NOT leave [Key: G] in output; got:\n{up_two}"
+        );
+
+        // -3 semitones: G → E. Same invariant in the opposite direction.
+        let down_three = render_song_with_transpose(&song, -3, &Config::defaults());
+        assert!(
+            down_three.contains("[Key: E]"),
+            "-3 transpose must surface [Key: E]; got:\n{down_three}"
+        );
+
+        // Flat-side spelling: transposing G by +3 lands on Bb (not A#).
+        // The displayed key matches the prefer-flat convention the
+        // chord lines use (`canonical_transposed_key` shares the same
+        // logic via `key_prefers_flat_for_song`).
+        let to_bflat = render_song_with_transpose(&song, 3, &Config::defaults());
+        assert!(
+            to_bflat.contains("[Key: B♭]"),
+            "+3 transpose must surface flat-side [Key: B♭]; got:\n{to_bflat}"
+        );
+
+        // Unparseable key (a value that doesn't start with a chord
+        // root letter at all) falls through to the authored value
+        // rather than producing nonsense — same contract as
+        // `canonical_transposed_key`. The chord parser is permissive
+        // about trailing text (e.g. `C dorian` parses as C with
+        // extra text), and forgiving on letters like `F` that ARE
+        // root letters even in non-chord words (`Foo`), so this
+        // branch only fires for strings that don't even start with a
+        // valid note letter (C / D / E / F / G / A / B).
+        let nonchord = chordsketch_chordpro::parse("{key: Hidden}\n[C]hi").unwrap();
+        let nonchord_out = render_song_with_transpose(&nonchord, 2, &Config::defaults());
+        assert!(
+            nonchord_out.contains("[Key: Hidden]"),
+            "unparseable key falls back to authored value; got:\n{nonchord_out}"
         );
     }
 


### PR DESCRIPTION
## Summary

v0.5.1 candidate. Closes #2522.

Across all three Rust renderers (text / HTML / PDF), the inline
`Key:` marker now follows the active `--transpose` offset so it
agrees with the chord lines — which are transposed in-place. Before
this fix, `chordsketch --transpose=2` against `{key: G}` emitted
`[Key: G]` next to chord lines pitched in A, surfacing as the
v0.5.0-blocking `Test action (*)` CI failures on every PR since the
v0.5.0 tag was pushed.

The follow-on commit (`d703dfd`) upgraded the renderer from the simpler
`canonical_transposed_key` helper to `canonical_transposed_key_with_style`,
which preserves modal qualifiers (`{key: C dorian}` ↦ `D dorian`),
extensions (`{key: G7}` ↦ `A7`), spelled-out minor, and slash-bass
(`{key: G/B}` ↦ `A/C♯`), and uses the same song-wide `prefer_flat`
the chord lines use — closing the silent-failure validation-parity gap
from the first revision.

Sister-site: the React JSX walker already handles the **primary** `{key}`
via its "Original → Playing" key-pair design (per ADR-0017) and is
unchanged.

## Why this is the fundamental fix

Two alternative shapes were considered:

  - **(b) Test-side mitigation**: change `github-action-ci.yml`'s
    `grep -qw 'G'` to skip directive lines. Ships immediately but
    leaves end-user output wrong — anyone reading the rendered
    preview would still see `[Key: G]` alongside transposed chord
    lines.
  - **(a) Renderer fix (this PR)**: route the key value through
    `canonical_transposed_key_with_style` at render time. The displayed key
    matches the chord lines; the test passes incidentally because
    the previously-untransposed `[Key: G]` header was the only G
    leaking through.

(a) was chosen — the bug is in the renderers, not the test.

## Test plan

- [x] `cargo test -p chordsketch-render-text -p chordsketch-render-html -p chordsketch-render-pdf` — 587 passed (was 584; +3 new tests).
- [x] Empirical: `chordsketch --transpose=2` on
      `packages/github-action/fixtures/simple.cho` emits `[Key: A]`
      with no standalone `G` in the rendered output (verified
      manually).
- [ ] CI: `Test action (*)` 4 platforms should turn green without
      touching the smoke logic — the smoke's `grep -qw 'G'` now
      finds nothing because `[Key: G]` no longer appears in
      transposed output.

## Sister-site audit

- render-text, render-html, render-pdf: all updated to `canonical_transposed_key_with_style`.
- React JSX walker: primary `{key}` already correct via "Original → Playing" pair. Unchanged.

## Deferred

- **React walker mid-song `{key}` parity**: Mid-song `{key:}` changes in the React JSX walker still emit the authored (pre-transpose) single chip because the host-supplied `transposedKey` carries only the primary key's offset. This is a pre-existing walker limitation unrelated to the regression in #2522; the Rust renderers' new `canonical_transposed_key_with_style` behaviour is now ahead of the walker on this dimension. No issue tracker yet — the gap is noted in CHANGELOG and will be addressed as a follow-up to renderer-parity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
