### PR TITLE
fix(react): tolerate resolved optional peer in use-pdf-export

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
+        "@types/node": "^25.9.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "jsdom": "^25.0.1",
@@ -1217,6 +1218,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2922,6 +2933,13 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,9 +54,9 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
+    "@chordsketch/wasm-export": "^0.5.0",
     "react": ">=18",
-    "react-dom": ">=18",
-    "@chordsketch/wasm-export": "^0.5.0"
+    "react-dom": ">=18"
   },
   "peerDependenciesMeta": {
     "@chordsketch/wasm-export": {
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
+    "@types/node": "^25.9.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "jsdom": "^25.0.1",

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -91,9 +91,10 @@ export type WasmLoader = () => Promise<PdfRenderer>;
 // is solved by the sibling shim declaration, so this site needs no
 // suppression directive. The `as Promise<PdfRenderer>` cast is
 // LOAD-BEARING: the shorthand ambient declaration types the module
-// as `any`, and without the cast that `any` would survive the
-// `await mod = loader()` below — silently dropping the narrow
-// surface contract `exportPdf` relies on.
+// as `any`, which TypeScript silently accepts via `WasmLoader`'s
+// return annotation. Without the cast the narrow `PdfRenderer`
+// surface contract is invisible at this definition site and could
+// be lost if `WasmLoader`'s return type is ever widened.
 const defaultLoader: WasmLoader = () =>
   import('@chordsketch/wasm-export') as Promise<PdfRenderer>;
 

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -88,9 +88,11 @@ export type WasmLoader = () => Promise<PdfRenderer>;
 
 // Lazy-load `@chordsketch/wasm-export` only when an export is
 // actually requested. The optional-peer resolution issue (#2539)
-// is solved by `wasm-export-shim.d.ts`, so this site needs no
-// suppression directive. The structural `Promise<PdfRenderer>`
-// cast pins the narrow subset `exportPdf` touches.
+// is solved by the sibling shim declaration, so this site needs no
+// suppression directive. The `as Promise<PdfRenderer>` cast is
+// LOAD-BEARING: without it the shorthand ambient declaration would
+// propagate `any` into `rendererPromiseRef` and silently lose the
+// narrow surface contract `exportPdf` relies on.
 const defaultLoader: WasmLoader = () =>
   import('@chordsketch/wasm-export') as Promise<PdfRenderer>;
 

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -87,14 +87,10 @@ export interface UsePdfExportResult {
 export type WasmLoader = () => Promise<PdfRenderer>;
 
 // Lazy-load `@chordsketch/wasm-export` only when an export is
-// actually requested. The optional-peer resolution problem (a
-// suppression directive here used to flip between dead and
-// load-bearing depending on whether the consumer's package
-// manager auto-installed the peer — see #2539) is solved
-// upstream by the ambient declaration in `wasm-export-shim.d.ts`,
-// so this site needs no directive. The structural
-// `Promise<PdfRenderer>` cast pins the narrow subset that
-// `usePdfExport` actually touches.
+// actually requested. The optional-peer resolution issue (#2539)
+// is solved by `wasm-export-shim.d.ts`, so this site needs no
+// suppression directive. The structural `Promise<PdfRenderer>`
+// cast pins the narrow subset `exportPdf` touches.
 const defaultLoader: WasmLoader = () =>
   import('@chordsketch/wasm-export') as Promise<PdfRenderer>;
 

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -86,18 +86,16 @@ export interface UsePdfExportResult {
  */
 export type WasmLoader = () => Promise<PdfRenderer>;
 
-// `@chordsketch/wasm-export` is declared in package.json as an
-// OPTIONAL peer dependency — consumers who use `<PdfExport>`
-// install it themselves; consumers who only use `<ChordSheet>`
-// don't pay the ~6 MB download. This means tsc may not be able to
-// resolve the module at build time (e.g., when the react package
-// is typechecked in CI before wasm-export is published / linked).
-// `@ts-expect-error` silences the resolution error while the
-// structural `Promise<PdfRenderer>` cast preserves the type-check
-// at the use site.
+// Lazy-load `@chordsketch/wasm-export` only when an export is
+// actually requested. The optional-peer resolution problem (a
+// suppression directive here used to flip between dead and
+// load-bearing depending on whether the consumer's package
+// manager auto-installed the peer — see #2539) is solved
+// upstream by the ambient declaration in `wasm-export-shim.d.ts`,
+// so this site needs no directive. The structural
+// `Promise<PdfRenderer>` cast pins the narrow subset that
+// `usePdfExport` actually touches.
 const defaultLoader: WasmLoader = () =>
-  // @ts-expect-error optional peer dep; see `peerDependenciesMeta` in package.json
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   import('@chordsketch/wasm-export') as Promise<PdfRenderer>;
 
 /**

--- a/packages/react/src/use-pdf-export.ts
+++ b/packages/react/src/use-pdf-export.ts
@@ -90,9 +90,10 @@ export type WasmLoader = () => Promise<PdfRenderer>;
 // actually requested. The optional-peer resolution issue (#2539)
 // is solved by the sibling shim declaration, so this site needs no
 // suppression directive. The `as Promise<PdfRenderer>` cast is
-// LOAD-BEARING: without it the shorthand ambient declaration would
-// propagate `any` into `rendererPromiseRef` and silently lose the
-// narrow surface contract `exportPdf` relies on.
+// LOAD-BEARING: the shorthand ambient declaration types the module
+// as `any`, and without the cast that `any` would survive the
+// `await mod = loader()` below — silently dropping the narrow
+// surface contract `exportPdf` relies on.
 const defaultLoader: WasmLoader = () =>
   import('@chordsketch/wasm-export') as Promise<PdfRenderer>;
 

--- a/packages/react/src/wasm-export-shim.d.ts
+++ b/packages/react/src/wasm-export-shim.d.ts
@@ -6,17 +6,15 @@
 // heavy WebAssembly download. The module may therefore be unresolved
 // at type-check time.
 //
-// Without this declaration the call site in `use-pdf-export.ts` would
-// need a suppression directive (#2539). Either choice misfires under
-// one of the two consumer states: `@ts-expect-error` becomes dead
+// Without this declaration the lazy-load call site would need a
+// suppression directive (#2539). Either choice misfires under one of
+// the two consumer resolution states: `@ts-expect-error` becomes dead
 // once the peer auto-resolves; `@ts-ignore` silently swallows every
 // other diagnostic on the same line. Declaring the module here lets
 // the call site stay directive-free and subject to all future TS
-// checks.
+// checks. The narrow `Promise<PdfRenderer>` cast at the call site
+// (see `use-pdf-export.ts`) keeps the surface contract explicit.
 //
-// The shorthand form (no body) yields `any`, so the real `.d.ts`
-// shipped by the optional peer — when installed in the consumer's
-// `node_modules` — supersedes this ambient without merge conflict.
-// The narrow `Promise<PdfRenderer>` cast at the lazy-load site pins
-// the subset `exportPdf` actually touches.
+// Body-less form yields `any`; the real `.d.ts` shipped by the
+// optional peer supersedes it when installed.
 declare module '@chordsketch/wasm-export';

--- a/packages/react/src/wasm-export-shim.d.ts
+++ b/packages/react/src/wasm-export-shim.d.ts
@@ -1,28 +1,22 @@
 // Ambient declaration for the OPTIONAL peer `@chordsketch/wasm-export`.
 //
-// `@chordsketch/wasm-export` is declared in `package.json` as an
-// optional peer dependency (`peerDependenciesMeta`): consumers who use
-// `<PdfExport>` install it themselves; consumers who only use
-// `<ChordSheet>` don't pay the heavy WebAssembly download. As a result
-// the module may or may not be resolvable when this package is
-// type-checked — `tsc` (and `tsup`'s DTS build, which the package's
-// `prepare` hook runs on `pnpm install`) sees a `TS2307 Cannot find
-// module` error in the unresolved case but a clean import in the
-// resolved case.
+// The peer carries `peerDependenciesMeta.optional: true` in
+// `package.json`: consumers who use `<PdfExport>` install it
+// themselves; consumers who only use `<ChordSheet>` don't pay the
+// heavy WebAssembly download. The module may therefore be unresolved
+// at type-check time.
 //
-// Suppressing the diagnostic with `@ts-expect-error` flips the failure
-// mode in the resolved case to `TS2578 Unused '@ts-expect-error'
-// directive` (#2539). Suppressing it with `@ts-ignore` silences not
-// only the resolution error but every future diagnostic on the same
-// line, including unrelated typos and cast mismatches.
+// Without this declaration the call site in `use-pdf-export.ts` would
+// need a suppression directive (#2539). Either choice misfires under
+// one of the two consumer states: `@ts-expect-error` becomes dead
+// once the peer auto-resolves; `@ts-ignore` silently swallows every
+// other diagnostic on the same line. Declaring the module here lets
+// the call site stay directive-free and subject to all future TS
+// checks.
 //
-// Declaring the module here makes resolution succeed in both states
-// without any suppression directive at the call site. When the
-// optional peer is installed alongside the consumer's build, that
-// package's own `.d.ts` (shipped by wasm-pack) is the source of truth
-// for the module's surface; this ambient declaration only takes over
-// when the resolver finds nothing else. The structural
-// `Promise<PdfRenderer>` cast at the lazy-load site (see
-// `use-pdf-export.ts`) is what pins the subset this package actually
-// touches — the ambient does not need to repeat that contract.
+// The shorthand form (no body) yields `any`, so the real `.d.ts`
+// shipped by the optional peer — when installed in the consumer's
+// `node_modules` — supersedes this ambient without merge conflict.
+// The narrow `Promise<PdfRenderer>` cast at the lazy-load site pins
+// the subset `exportPdf` actually touches.
 declare module '@chordsketch/wasm-export';

--- a/packages/react/src/wasm-export-shim.d.ts
+++ b/packages/react/src/wasm-export-shim.d.ts
@@ -1,0 +1,28 @@
+// Ambient declaration for the OPTIONAL peer `@chordsketch/wasm-export`.
+//
+// `@chordsketch/wasm-export` is declared in `package.json` as an
+// optional peer dependency (`peerDependenciesMeta`): consumers who use
+// `<PdfExport>` install it themselves; consumers who only use
+// `<ChordSheet>` don't pay the heavy WebAssembly download. As a result
+// the module may or may not be resolvable when this package is
+// type-checked — `tsc` (and `tsup`'s DTS build, which the package's
+// `prepare` hook runs on `pnpm install`) sees a `TS2307 Cannot find
+// module` error in the unresolved case but a clean import in the
+// resolved case.
+//
+// Suppressing the diagnostic with `@ts-expect-error` flips the failure
+// mode in the resolved case to `TS2578 Unused '@ts-expect-error'
+// directive` (#2539). Suppressing it with `@ts-ignore` silences not
+// only the resolution error but every future diagnostic on the same
+// line, including unrelated typos and cast mismatches.
+//
+// Declaring the module here makes resolution succeed in both states
+// without any suppression directive at the call site. When the
+// optional peer is installed alongside the consumer's build, that
+// package's own `.d.ts` (shipped by wasm-pack) is the source of truth
+// for the module's surface; this ambient declaration only takes over
+// when the resolver finds nothing else. The structural
+// `Promise<PdfRenderer>` cast at the lazy-load site (see
+// `use-pdf-export.ts`) is what pins the subset this package actually
+// touches — the ambient does not need to repeat that contract.
+declare module '@chordsketch/wasm-export';

--- a/packages/react/tests/use-pdf-export-optional-peer.test.ts
+++ b/packages/react/tests/use-pdf-export-optional-peer.test.ts
@@ -9,26 +9,26 @@ import { describe, expect, test } from 'vitest';
 // The bug: when the dynamic-import site for the optional peer
 // `@chordsketch/wasm-export` was guarded with a suppression directive
 // (`@ts-expect-error` / `@ts-ignore`), the directive's behaviour
-// flipped with the consumer's package manager. In the resolved case
-// `@ts-expect-error` became a dead directive and `tsup`'s DTS build
-// failed with `TS2578`, crashing the consumer's `pnpm install`
-// through the `prepare` hook. In the unresolved case `@ts-ignore`
-// silently swallowed unrelated diagnostics on the same line (typos
-// in the module specifier, cast mismatches, etc.) — the silent-
-// failure pattern called out by `.claude/rules/root-cause-fixes.md`.
+// flipped with the consumer's resolution state for the peer. In the
+// resolved case `@ts-expect-error` became a dead directive and the
+// package's DTS build failed, breaking the consumer's install through
+// the `prepare` hook. In the unresolved case `@ts-ignore` silently
+// swallowed unrelated diagnostics on the same line (typos in the
+// module specifier, cast mismatches, etc.) — the silent-failure
+// pattern called out by `.claude/rules/root-cause-fixes.md`.
 //
-// The root-cause fix replaces the directive with an ambient module
-// declaration (`src/wasm-export-shim.d.ts`) so resolution succeeds in
+// The fix replaces the directive with an ambient module declaration
+// (the optional-peer shim under `src/`) so resolution succeeds in
 // both states without any suppression at the call site. These tests
 // pin that contract from three angles:
 //
-//  1. positive — `src/use-pdf-export.ts` type-checks cleanly against
-//     the shim with NO node_modules instance of the peer present;
+//  1. positive — the source type-checks cleanly against the shim
+//     with NO node_modules instance of the peer present;
 //  2. negative control — without the shim (and with the real peer
 //     hidden), resolution genuinely fails (`TS2307`). Proves the
 //     shim is load-bearing rather than incidentally redundant;
 //  3. policy — the source must NOT reintroduce any suppression
-//     directive on the dynamic-import line.
+//     directive (`@ts-expect-error` / `@ts-ignore` / `@ts-nocheck`).
 
 const here = dirname(fileURLToPath(import.meta.url));
 const SOURCE_PATH = resolve(here, '../src/use-pdf-export.ts');
@@ -58,6 +58,12 @@ function loadCompilerOptions(): ts.CompilerOptions {
  * node_modules instance forces the resolver to rely on whatever
  * ambient declarations (shim or otherwise) are passed in via
  * `rootNames`.
+ *
+ * The filter assumes a conventional `node_modules` layout (npm /
+ * pnpm hoisted / pnpm `.pnpm/...` virtual store — all of which carry
+ * `node_modules` and the peer's package directory in the path). A
+ * Yarn PnP environment has no `node_modules` segment and would need
+ * a different strategy; CI for this repo does not exercise PnP.
  */
 function makeHost(
   options: ts.CompilerOptions,
@@ -117,9 +123,10 @@ describe('use-pdf-export optional-peer import resolution', () => {
     // A future contributor reintroducing `@ts-expect-error` would
     // recreate #2539 in any consumer environment where the peer
     // auto-resolves; `@ts-ignore` would silently swallow unrelated
-    // errors. Catch both by forbidding either directive in the file.
+    // errors; a file-scope `@ts-nocheck` would disable the entire
+    // file's type-checks and bypass even the shim. Catch all three
+    // by forbidding any `@ts-*` suppression directive in the file.
     const source = readFileSync(SOURCE_PATH, 'utf8');
-    expect(source).not.toMatch(/@ts-expect-error/);
-    expect(source).not.toMatch(/@ts-ignore/);
+    expect(source).not.toMatch(/@ts-(?:expect-error|ignore|nocheck)\b/);
   });
 });

--- a/packages/react/tests/use-pdf-export-optional-peer.test.ts
+++ b/packages/react/tests/use-pdf-export-optional-peer.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, test } from 'vitest';
+
+// Regression tests for #2539.
+//
+// The bug: when the dynamic-import site for the optional peer
+// `@chordsketch/wasm-export` was guarded with a suppression directive
+// (`@ts-expect-error` / `@ts-ignore`), the directive's behaviour
+// flipped with the consumer's package manager. In the resolved case
+// `@ts-expect-error` became a dead directive and `tsup`'s DTS build
+// failed with `TS2578`, crashing the consumer's `pnpm install`
+// through the `prepare` hook. In the unresolved case `@ts-ignore`
+// silently swallowed unrelated diagnostics on the same line (typos
+// in the module specifier, cast mismatches, etc.) — the silent-
+// failure pattern called out by `.claude/rules/root-cause-fixes.md`.
+//
+// The root-cause fix replaces the directive with an ambient module
+// declaration (`src/wasm-export-shim.d.ts`) so resolution succeeds in
+// both states without any suppression at the call site. These tests
+// pin that contract from three angles:
+//
+//  1. positive — `src/use-pdf-export.ts` type-checks cleanly against
+//     the shim with NO node_modules instance of the peer present;
+//  2. negative control — without the shim (and with the real peer
+//     hidden), resolution genuinely fails (`TS2307`). Proves the
+//     shim is load-bearing rather than incidentally redundant;
+//  3. policy — the source must NOT reintroduce any suppression
+//     directive on the dynamic-import line.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SOURCE_PATH = resolve(here, '../src/use-pdf-export.ts');
+const SHIM_PATH = resolve(here, '../src/wasm-export-shim.d.ts');
+const TSCONFIG_PATH = resolve(here, '../tsconfig.json');
+
+function loadCompilerOptions(): ts.CompilerOptions {
+  const configFile = ts.readConfigFile(TSCONFIG_PATH, ts.sys.readFile);
+  if (configFile.error !== undefined) {
+    throw new Error(
+      ts.flattenDiagnosticMessageText(configFile.error.messageText, '\n'),
+    );
+  }
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    dirname(TSCONFIG_PATH),
+  );
+  return { ...parsed.options, noEmit: true };
+}
+
+/**
+ * Build a compiler host that, when `hidePeer` is true, refuses to
+ * resolve any node_modules path containing `@chordsketch/wasm-export`.
+ * This keeps the negative-control test robust against a developer who
+ * happens to have the optional peer installed locally: hiding the
+ * node_modules instance forces the resolver to rely on whatever
+ * ambient declarations (shim or otherwise) are passed in via
+ * `rootNames`.
+ */
+function makeHost(
+  options: ts.CompilerOptions,
+  { hidePeer }: { hidePeer: boolean },
+): ts.CompilerHost {
+  const host = ts.createCompilerHost(options);
+  if (!hidePeer) return host;
+
+  const shouldHide = (path: string): boolean =>
+    path.includes('node_modules') && path.includes('@chordsketch/wasm-export');
+
+  const originalFileExists = host.fileExists.bind(host);
+  const originalReadFile = host.readFile.bind(host);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+
+  host.fileExists = (path) => (shouldHide(path) ? false : originalFileExists(path));
+  host.readFile = (path) => (shouldHide(path) ? undefined : originalReadFile(path));
+  host.getSourceFile = (path, languageVersion, onError, shouldCreateNewSourceFile) =>
+    shouldHide(path)
+      ? undefined
+      : originalGetSourceFile(path, languageVersion, onError, shouldCreateNewSourceFile);
+  return host;
+}
+
+function compileWithPeerHidden(rootNames: string[]): readonly ts.Diagnostic[] {
+  const options = loadCompilerOptions();
+  const host = makeHost(options, { hidePeer: true });
+  const program = ts.createProgram({ rootNames, options, host });
+  return ts.getPreEmitDiagnostics(program);
+}
+
+describe('use-pdf-export optional-peer import resolution', () => {
+  test('source typechecks cleanly when the shim is present and the peer is unresolved', () => {
+    const diagnostics = compileWithPeerHidden([SOURCE_PATH, SHIM_PATH]).map((d) =>
+      ts.flattenDiagnosticMessageText(d.messageText, '\n'),
+    );
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('source emits TS2307 for @chordsketch/wasm-export when the shim is absent and the peer is unresolved', () => {
+    // Negative control. Proves the shim is what unblocks resolution;
+    // hiding node_modules instances of the peer keeps this assertion
+    // robust to a developer who has the optional peer installed
+    // locally.
+    const diagnostics = compileWithPeerHidden([SOURCE_PATH]);
+    const ts2307 = diagnostics.filter(
+      (d) =>
+        d.code === 2307 &&
+        ts
+          .flattenDiagnosticMessageText(d.messageText, '\n')
+          .includes('@chordsketch/wasm-export'),
+    );
+    expect(ts2307).not.toHaveLength(0);
+  });
+
+  test('source does not suppress diagnostics on the dynamic import line', () => {
+    // A future contributor reintroducing `@ts-expect-error` would
+    // recreate #2539 in any consumer environment where the peer
+    // auto-resolves; `@ts-ignore` would silently swallow unrelated
+    // errors. Catch both by forbidding either directive in the file.
+    const source = readFileSync(SOURCE_PATH, 'utf8');
+    expect(source).not.toMatch(/@ts-expect-error/);
+    expect(source).not.toMatch(/@ts-ignore/);
+  });
+});


### PR DESCRIPTION
Closes #2539.

## What

`packages/react/src/use-pdf-export.ts` dynamically imports `@chordsketch/wasm-export`, which is declared as an OPTIONAL peer dependency. The site no longer needs a TypeScript suppression directive — an ambient module declaration shipped as `packages/react/src/wasm-export-shim.d.ts` makes resolution succeed regardless of whether the consumer's package manager auto-installed the peer.

- Add `src/wasm-export-shim.d.ts`: `declare module '@chordsketch/wasm-export';` (shorthand, untyped body). When the optional peer is installed in the consumer's `node_modules`, the real wasm-pack `.d.ts` supersedes the ambient without merge conflict. The narrow `Promise<PdfRenderer>` cast at the loader site still pins the subset `exportPdf` touches and is marked LOAD-BEARING.
- Remove `@ts-expect-error` and the accompanying `eslint-disable-next-line @typescript-eslint/consistent-type-imports` from `src/use-pdf-export.ts`. The dynamic-import line is now subject to every TS diagnostic.
- Add `tests/use-pdf-export-optional-peer.test.ts` with three assertions:
  1. **positive** — source + shim typechecks cleanly with the peer hidden from the test's compiler host;
  2. **negative control** — without the shim (and with the peer still hidden), `@chordsketch/wasm-export` fails to resolve with `TS2307`. Proves the shim is load-bearing rather than incidentally redundant;
  3. **policy** — the source must not contain `@ts-expect-error`, `@ts-ignore`, or `@ts-nocheck` anywhere. Reintroducing any of the three is the regression class the fix retires.
- Add `@types/node` as a devDep so the test can use `node:fs` / `node:path` / `node:url` without polluting the package's global type-check.

History is Red → Green → Refactor, with iter-2 and iter-3 polish:

| Commit  | Phase       | Summary                                                         |
|---------|-------------|-----------------------------------------------------------------|
| `c5b8b8d` | Red         | Adds the regression suite + `@types/node`. All assertions fail against the pre-fix source. |
| `7141efa` | Green       | Adds the shim, removes the directive, rewrites the loader-site comment. All assertions pass. |
| `7483b12` | Refactor #1 | Tightens both comment blocks (drops `tsup` / `prepare` narrative from the shim, halves the loader-site comment). |
| `3e56b77` | Refactor #2 | Iter-2 polish: tool-neutralises the test header, extends the policy regex to `@ts-nocheck`, documents the `node_modules`-layout assumption of `makeHost(hidePeer:true)`, marks the cast LOAD-BEARING, removes duplicated "pins the narrow subset" sentence, replaces hard-coded filename pin in the shim with a description. |
| `c077f2c` | Refactor #3 | Iter-3 NIT: corrects the LOAD-BEARING comment's propagation path (`any` survives `await loader()`, not the `useRef` slot). |

## Why

`@ts-expect-error` and `@ts-ignore` are both symptomatic fixes for the optional-peer resolution problem:

- `@ts-expect-error` becomes a dead directive (`TS2578`) the moment the peer resolves, and the consumer's `pnpm install` then dies inside the package's DTS build via the `prepare` hook (the #2539 failure).
- `@ts-ignore` papers over that specific case but silences every future diagnostic on the same line — a typo in the module specifier, a cast mismatch, or any new strict-mode lint goes through undetected. This is exactly the silent-failure pattern called out by `.claude/rules/root-cause-fixes.md`.

The root cause is that `tsc` has no declaration for `@chordsketch/wasm-export` when the consumer's resolution state for the peer is "absent". Supplying one in `src/` makes resolution succeed without any suppression at the call site. The shorthand form yields `any`, so the real `.d.ts` shipped by the optional peer continues to be the source of truth when it is installed.

## Test results

From `packages/react/`:

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 26 files / 514 tests pass (3 added).
- `npm run build` — `tsup` ESM + CJS + DTS builds all succeed.

The new test file was empirically validated against three states:

| State                                            | Test 1 (positive)                              | Test 2 (neg. ctrl) | Test 3 (policy) |
|--------------------------------------------------|------------------------------------------------|--------------------|-----------------|
| Pre-fix source, no shim                          | passes (incidentally — directive suppresses)   | fails              | fails           |
| Post-fix source + shim, peer absent              | passes                                         | passes             | passes          |
| Post-fix source + shim, peer present (simulated) | passes                                         | passes             | passes          |

The post-fix-with-peer-present case was simulated by writing a temporary `node_modules/@chordsketch/wasm-export/{package.json,index.d.ts,index.js}` mirroring the real wasm-pack output, then running `tsc --noEmit` + the vitest suite. Both stayed green, confirming the shim does not conflict with the real package types.

## Sister-site audit

Package-local to `@chordsketch/react`. The renderer-parity, sanitizer-parity, and bindings-parity sister-site groups (`render-text` / `render-html` / `render-pdf` / `chordpro-jsx`; `crates/ffi` / `crates/wasm` / `crates/napi`) carry no equivalent suppression directive on an optional-peer dynamic import. Verified via `git grep -n "@ts-expect-error\|@ts-ignore" -- packages crates apps syntaxes`; remaining matches sit in unrelated test mocks.

## Review summary

The PR went through three review iterations driven by five specialised reviewer agents (code-reviewer, silent-failure-hunter, comment-analyzer, pr-test-analyzer, project-rules audit against `.claude/rules/`):

| Iteration | Findings (severity-shaped)                                                                                                                                                                                                                                                                                                                                                              | Resolution                                                |
|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
| 1         | HIGH: `@ts-ignore` is itself a silent-failure construct (`.claude/rules/root-cause-fixes.md`). HIGH: `tests/raw-modules.d.ts` ambient leaked into prod typecheck. HIGH: pnpm version-pinned + tsup/prepare narrative would rot. HIGH: no negative-control test. MEDIUM: diagnostic filter `code === 2578` masked other classes. MEDIUM: source/test comment duplication. MEDIUM: missing "Review summary" PR section. | Drove the root-cause refactor in `7141efa`: ambient shim replaces both directives, the test grows to three assertions (positive / negative control / policy). |
| 2         | MEDIUM: test header still named `tsup` / `TS2578` / `pnpm` / `prepare`. LOW: policy regex missed `@ts-nocheck`. LOW: cast at loader site load-bearing through `any` without a marker. LOW: `makeHost(hidePeer:true)` filter assumed `node_modules` layout. LOW: shim re-stated general TS knowledge. LOW: shim ↔ source duplication. LOW: hard-coded filename pin in shim. NIT: "consumer's package manager" → "resolution state". | All eight resolved in `3e56b77`. |
| 3         | NIT (comment-analyzer): the LOAD-BEARING comment named `rendererPromiseRef` as the propagation site, but the ref is typed as `useRef<Promise<PdfRenderer> \| null>` and acts as a type barrier — `any` actually survives the `await loader()` step one frame deeper. | Resolved in `c077f2c`. |

All three iter-3 delta reviews (code-reviewer, silent-failure-hunter, comment-analyzer) returned READY FOR MERGE.

Every finding at every severity was resolved in this PR per `pr-workflow.md` step 4 — no follow-up issues were filed.

## Deferred

None. The earlier draft of this PR had a "Deferred" entry (a CI matrix cell installing the optional peer) that the shim approach made moot: resolution succeeds regardless of consumer-side peer presence, so the failure mode the matrix would have caught can no longer occur from this site.