### PR TITLE
fix(react): declare @chordsketch/wasm ambient to unblock workspace install

### DIFF
--- a/packages/react/src/use-chord-diagram.ts
+++ b/packages/react/src/use-chord-diagram.ts
@@ -77,14 +77,14 @@ export type ChordDiagramWasmLoader = () => Promise<DiagramRenderer>;
 // runtime contract; consumers that pass their own loader are
 // expected to satisfy it directly.
 //
-// Asymmetry note: the other dynamic `import('@chordsketch/wasm')`
-// sites in `src/` use a single `as Promise<T>` cast, which surfaces
-// a `TS2352` if the real wasm-pack declarations supersede the
-// ambient shim (`wasm-shim.d.ts`, #2540) with a shape incompatible
-// with `T`. The `unknown` step here erases shape conformance by
-// construction, so the cast at this site cannot carry the same
-// divergence-detection responsibility — that responsibility lives
-// in the runtime test against a stubbed renderer instead.
+// Asymmetry note: a single-step `as Promise<T>` cast on a dynamic
+// `import('@chordsketch/wasm')` would surface a `TS2352` if the
+// real wasm-pack declarations supersede the ambient shim
+// (`wasm-shim.d.ts`, #2540) with a shape incompatible with `T`.
+// The `unknown` step here erases shape conformance by construction,
+// so the cast at this site cannot carry that divergence-detection
+// responsibility — it lives in the runtime test against a stubbed
+// renderer instead.
 const defaultLoader: ChordDiagramWasmLoader = () =>
   import('@chordsketch/wasm') as unknown as Promise<DiagramRenderer>;
 

--- a/packages/react/src/use-chord-diagram.ts
+++ b/packages/react/src/use-chord-diagram.ts
@@ -76,6 +76,15 @@ export type ChordDiagramWasmLoader = () => Promise<DiagramRenderer>;
 // present at runtime. The `DiagramRenderer` shape models the
 // runtime contract; consumers that pass their own loader are
 // expected to satisfy it directly.
+//
+// Asymmetry note: the other dynamic `import('@chordsketch/wasm')`
+// sites in `src/` use a single `as Promise<T>` cast, which surfaces
+// a `TS2352` if the real wasm-pack declarations supersede the
+// ambient shim (`wasm-shim.d.ts`, #2540) with a shape incompatible
+// with `T`. The `unknown` step here erases shape conformance by
+// construction, so the cast at this site cannot carry the same
+// divergence-detection responsibility — that responsibility lives
+// in the runtime test against a stubbed renderer instead.
 const defaultLoader: ChordDiagramWasmLoader = () =>
   import('@chordsketch/wasm') as unknown as Promise<DiagramRenderer>;
 

--- a/packages/react/src/wasm-shim.d.ts
+++ b/packages/react/src/wasm-shim.d.ts
@@ -1,24 +1,17 @@
 // Ambient declaration for `@chordsketch/wasm`.
 //
-// `@chordsketch/wasm` exposes its public surface through wasm-pack-
-// generated declaration files at `web/chordsketch_wasm.d.ts` and
-// `node/chordsketch_wasm.d.ts`. Those files are build artefacts: a
-// fresh source checkout does not have them until `wasm-pack build`
-// runs against the `chordsketch-wasm` crate. Workspace consumers
-// (pnpm workspace, git submodule, workspace protocol) therefore
-// see a missing-types diagnostic at `pnpm install` time because
-// `@chordsketch/react`'s `prepare` script runs the DTS build before
-// the wasm-pack artefacts can be produced — the build that would
-// produce them is itself downstream of the failing install (#2540).
+// The package exposes its public surface through wasm-pack-generated
+// declaration files. Those files are build artefacts and do not exist
+// in a fresh source checkout, so a consumer whose resolution state for
+// the peer is "absent" cannot type-check any of the dynamic
+// `import('@chordsketch/wasm')` sites in `src/` (#2540).
 //
 // Declaring the module here lets resolution succeed without any
-// suppression directive at the seven dynamic-import sites in `src/`.
-// The shorthand form (no body) yields `any`; the real `.d.ts` shipped
-// by wasm-pack supersedes it when present in the consumer's
-// `node_modules`. Each call site casts to its own narrow interface
-// (`ChordRenderer`, `IrealParser`, etc.), so the per-site surface
-// contract remains explicit.
+// suppression directive at the call sites. The shorthand form (no
+// body) yields `any`; the real wasm-pack declarations supersede this
+// ambient when present in the consumer's `node_modules` or in any
+// equivalent workspace path.
 //
-// Sibling: `wasm-export-shim.d.ts` applies the same pattern to the
-// optional `@chordsketch/wasm-export` peer (#2539).
+// Sibling: the optional `@chordsketch/wasm-export` peer carries an
+// analogous ambient shim (#2539).
 declare module '@chordsketch/wasm';

--- a/packages/react/src/wasm-shim.d.ts
+++ b/packages/react/src/wasm-shim.d.ts
@@ -1,0 +1,24 @@
+// Ambient declaration for `@chordsketch/wasm`.
+//
+// `@chordsketch/wasm` exposes its public surface through wasm-pack-
+// generated declaration files at `web/chordsketch_wasm.d.ts` and
+// `node/chordsketch_wasm.d.ts`. Those files are build artefacts: a
+// fresh source checkout does not have them until `wasm-pack build`
+// runs against the `chordsketch-wasm` crate. Workspace consumers
+// (pnpm workspace, git submodule, workspace protocol) therefore
+// see a missing-types diagnostic at `pnpm install` time because
+// `@chordsketch/react`'s `prepare` script runs the DTS build before
+// the wasm-pack artefacts can be produced — the build that would
+// produce them is itself downstream of the failing install (#2540).
+//
+// Declaring the module here lets resolution succeed without any
+// suppression directive at the seven dynamic-import sites in `src/`.
+// The shorthand form (no body) yields `any`; the real `.d.ts` shipped
+// by wasm-pack supersedes it when present in the consumer's
+// `node_modules`. Each call site casts to its own narrow interface
+// (`ChordRenderer`, `IrealParser`, etc.), so the per-site surface
+// contract remains explicit.
+//
+// Sibling: `wasm-export-shim.d.ts` applies the same pattern to the
+// optional `@chordsketch/wasm-export` peer (#2539).
+declare module '@chordsketch/wasm';

--- a/packages/react/tests/wasm-shim-resolution.test.ts
+++ b/packages/react/tests/wasm-shim-resolution.test.ts
@@ -1,45 +1,34 @@
-import { readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, extname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { describe, expect, test } from 'vitest';
 
-// Regression tests for #2540.
+// Regression tests for #2540. See `src/wasm-shim.d.ts` for why the
+// ambient declaration exists. The tests pin its contract from three
+// angles:
 //
-// `@chordsketch/react`'s `prepare` script runs `tsup`'s DTS build,
-// which type-checks every dynamic `import('@chordsketch/wasm')` site
-// in `src/`. The runtime artefacts that ship `@chordsketch/wasm`'s
-// type declarations (`web/chordsketch_wasm.d.ts`, `node/chordsketch_wasm.d.ts`)
-// are wasm-pack output and do NOT exist in a fresh source checkout.
-// Workspace consumers therefore hit `TS7016` / `TS2307` at
-// `pnpm install` time because `prepare` cannot finish without those
-// declarations — and the build that would produce them is itself
-// downstream of the failing install.
-//
-// The fix declares `@chordsketch/wasm` as an ambient module in
-// `src/`, the same pattern `wasm-export-shim.d.ts` applies to the
-// optional `@chordsketch/wasm-export` peer (#2539). The shim only
-// kicks in when the real `.d.ts` files are absent; when they are
-// present (npm-registry install or post-wasm-pack workspace), the
-// real declarations supersede the ambient. These tests pin that
-// contract:
-//
-//  1. positive — `src/` type-checks cleanly when the shim is present
-//     and `node_modules/@chordsketch/wasm` instances are hidden;
-//  2. negative control — without the shim (and with the peer still
-//     hidden) the dynamic-import sites emit `TS7016` / `TS2307` for
-//     `@chordsketch/wasm`. Proves the shim is load-bearing;
-//  3. policy — `src/` does NOT carry a suppression directive on or
-//     near a `@chordsketch/wasm` import line. Reintroducing one would
-//     paper over the resolution problem in the same silent-failure
-//     style `.claude/rules/root-cause-fixes.md` calls out.
+//  1. positive — `src/` type-checks cleanly with the shim present
+//     and every other resolution path for `@chordsketch/wasm`
+//     hidden;
+//  2. negative control — without the shim (every other resolution
+//     path still hidden) every dynamic-import site emits a
+//     missing-types diagnostic. Proves the shim is load-bearing for
+//     the entire surface, not just one representative site;
+//  3. policy — no file in `src/` that imports `@chordsketch/wasm`
+//     carries a `@ts-(expect-error|ignore|nocheck)` directive.
+//     Reintroducing one would paper over the resolution problem in
+//     the same silent-failure style `.claude/rules/root-cause-fixes.md`
+//     calls out.
 
 const here = dirname(fileURLToPath(import.meta.url));
 const SRC_DIR = resolve(here, '../src');
 const SHIM_PATH = resolve(SRC_DIR, 'wasm-shim.d.ts');
 const TSCONFIG_PATH = resolve(here, '../tsconfig.json');
 
-const TS_EXTS = new Set(['.ts', '.tsx', '.d.ts']);
+const TS_EXTS = new Set(['.ts', '.tsx']);
+const WASM_IMPORT_RE = /import\(\s*['"]@chordsketch\/wasm['"]\s*\)/;
+const SUPPRESSION_RE = /@ts-(?:expect-error|ignore|nocheck)\b/;
 
 function collectSourceFiles(root: string): string[] {
   const out: string[] = [];
@@ -47,10 +36,10 @@ function collectSourceFiles(root: string): string[] {
     const full = join(root, name);
     if (statSync(full).isDirectory()) {
       out.push(...collectSourceFiles(full));
-    } else if (
-      TS_EXTS.has(extname(full)) ||
-      full.endsWith('.d.ts')
-    ) {
+    } else if (TS_EXTS.has(extname(full)) || full.endsWith('.d.ts')) {
+      // `extname('foo.d.ts')` returns '.ts' so the second clause is
+      // belt-and-braces against a future TS_EXTS change that drops
+      // '.ts'.
       out.push(full);
     }
   }
@@ -73,24 +62,30 @@ function loadCompilerOptions(): ts.CompilerOptions {
 }
 
 /**
- * Build a compiler host that refuses to resolve any node_modules
- * path containing `@chordsketch/wasm` (without matching
- * `@chordsketch/wasm-export`, which is a sibling module). Hiding the
- * real peer keeps the negative-control assertion robust against a
- * developer who has the wasm artefacts installed locally.
+ * Build a compiler host that refuses to resolve `@chordsketch/wasm`
+ * via any of the project's two primary resolution paths:
  *
- * Assumes a conventional `node_modules` layout (npm / pnpm hoisted /
- * pnpm `.pnpm/...` virtual store all include the segment). Yarn PnP
- * has no `node_modules` segment and would need a different strategy;
- * CI for this repo does not exercise PnP.
+ *   - `node_modules/@chordsketch/wasm/...` (npm-registry install,
+ *     pnpm hoisted, pnpm `.pnpm/...` virtual store)
+ *   - `packages/npm/...` (the workspace-relative path that
+ *     `tsconfig.json`'s `paths` mapping points at)
+ *
+ * Hiding both keeps the assertions accurate regardless of whether
+ * the developer has run `wasm-pack build` locally — without the
+ * `packages/npm/` filter, the positive test could silently pass via
+ * the real wasm-pack output rather than the shim. The sibling
+ * `@chordsketch/wasm-export` ambient is left in place so its own
+ * regression test (`tests/use-pdf-export-optional-peer.test.ts`)
+ * stays unaffected when run alongside this one.
  */
 function makeHost(options: ts.CompilerOptions): ts.CompilerHost {
   const host = ts.createCompilerHost(options);
 
   const shouldHide = (path: string): boolean => {
-    if (!path.includes('node_modules')) return false;
     if (path.includes('@chordsketch/wasm-export')) return false;
-    return path.includes('@chordsketch/wasm');
+    if (!path.includes('@chordsketch/wasm') && !path.includes('packages/npm/'))
+      return false;
+    return path.includes('node_modules') || path.includes('packages/npm/');
   };
 
   const originalFileExists = host.fileExists.bind(host);
@@ -109,6 +104,17 @@ function makeHost(options: ts.CompilerOptions): ts.CompilerHost {
 function compileSrc({ withShim }: { withShim: boolean }): readonly ts.Diagnostic[] {
   const options = loadCompilerOptions();
   const allFiles = collectSourceFiles(SRC_DIR);
+  // Fail loud if the shim was renamed without updating SHIM_PATH —
+  // otherwise the `withShim: false` filter would silently become a
+  // no-op and the negative control would degrade to a duplicate of
+  // the positive test.
+  if (!allFiles.includes(SHIM_PATH)) {
+    throw new Error(
+      `Test setup invariant: expected shim file at ${SHIM_PATH}. ` +
+        `Update SHIM_PATH if the shim was renamed; otherwise the ` +
+        `negative control degrades silently.`,
+    );
+  }
   const rootNames = withShim
     ? allFiles
     : allFiles.filter((p) => p !== SHIM_PATH);
@@ -118,22 +124,70 @@ function compileSrc({ withShim }: { withShim: boolean }): readonly ts.Diagnostic
 }
 
 describe('@chordsketch/wasm shim resolution', () => {
-  test('src typechecks cleanly when the shim is present and the peer is unresolved', () => {
+  test('src typechecks cleanly when the shim is present and every other peer-resolution path is hidden', () => {
+    // The positive test compiles the entire `src/` tree because the
+    // production failure (the package's pre-publish DTS build) also
+    // type-checks the whole tree. Any unrelated TS regression
+    // elsewhere in `src/` will fail this test with a noisy message —
+    // that is intentional: the contract is "src/ compiles", not
+    // "the import site compiles in isolation".
     const diagnostics = compileSrc({ withShim: true }).map((d) =>
       ts.flattenDiagnosticMessageText(d.messageText, '\n'),
     );
     expect(diagnostics).toEqual([]);
   });
 
-  test('src emits a missing-types diagnostic for @chordsketch/wasm when the shim is absent', () => {
-    // Negative control. Proves the shim is what unblocks resolution
-    // for every dynamic-import site, not some incidental fallback.
+  test('every src file dynamically importing @chordsketch/wasm emits a missing-types diagnostic when the shim is absent', () => {
+    // Negative control. The filter accepts TS2307 (no module found
+    // anywhere) AND TS7016 (declaration file missing for a JS
+    // module). Which code fires depends on whether the runtime
+    // bundle is present alongside the missing `.d.ts`; the test
+    // accepts either. A future wasm-pack change that shipped a stub
+    // `.d.ts` with incomplete exports would shift the diagnostic
+    // class (TS2305 / TS2339), in which case this test needs
+    // updating — that is intentional, the test pins the current
+    // failure mode.
     const diagnostics = compileSrc({ withShim: false });
     const wasmErrors = diagnostics.filter((d) => {
       if (d.code !== 7016 && d.code !== 2307) return false;
       const msg = ts.flattenDiagnosticMessageText(d.messageText, '\n');
       return msg.includes('@chordsketch/wasm') && !msg.includes('@chordsketch/wasm-export');
     });
-    expect(wasmErrors).not.toHaveLength(0);
+    const filesWithErrors = new Set(
+      wasmErrors.map((d) => d.file?.fileName).filter((n): n is string => Boolean(n)),
+    );
+    const expectedSites = collectSourceFiles(SRC_DIR).filter((p) => {
+      if (!TS_EXTS.has(extname(p))) return false;
+      if (p.endsWith('.d.ts')) return false;
+      const source = readFileSync(p, 'utf8');
+      return WASM_IMPORT_RE.test(source);
+    });
+    // Asserting "≥ every site that imports the module" pins the
+    // shim's claim that it unblocks the ENTIRE dynamic-import
+    // surface. A future refactor that drops some sites is welcome;
+    // a future refactor that drops the shim and silently leaves
+    // some sites failing is the regression class we want to catch.
+    expect(filesWithErrors.size).toBeGreaterThanOrEqual(expectedSites.length);
+  });
+
+  test('src files importing @chordsketch/wasm carry no suppression directive', () => {
+    // Sibling-test symmetry with #2541's wasm-export shim policy
+    // (`tests/use-pdf-export-optional-peer.test.ts`). A future
+    // contributor reintroducing `@ts-expect-error`,
+    // `@ts-ignore`, or `@ts-nocheck` near a `@chordsketch/wasm`
+    // import would recreate the silent-failure class
+    // `.claude/rules/root-cause-fixes.md` warns about — the
+    // directive would silently flip between dead and load-bearing
+    // depending on consumer resolution state. The shim's whole
+    // point is to make every such directive unnecessary.
+    const offending: string[] = [];
+    for (const path of collectSourceFiles(SRC_DIR)) {
+      if (!TS_EXTS.has(extname(path))) continue;
+      if (path.endsWith('.d.ts')) continue;
+      const source = readFileSync(path, 'utf8');
+      if (!WASM_IMPORT_RE.test(source)) continue;
+      if (SUPPRESSION_RE.test(source)) offending.push(path);
+    }
+    expect(offending).toEqual([]);
   });
 });

--- a/packages/react/tests/wasm-shim-resolution.test.ts
+++ b/packages/react/tests/wasm-shim-resolution.test.ts
@@ -149,13 +149,11 @@ function compileSrc({ withShim }: { withShim: boolean }): readonly ts.Diagnostic
 /**
  * Discover every `src/` source file that contains a dynamic
  * `import('@chordsketch/wasm')` call expression, including
- * variants the surface regex misses (template literals,
- * intermediate whitespace, multi-line). AST-based discovery is
- * brittle to fewer refactor classes than a literal-string regex —
- * see the silent-failure review on #2542 for the enumeration.
- *
- * Files that ONLY mention `@chordsketch/wasm` in comments or string
- * literals outside an `import(...)` call are excluded.
+ * template-literal arguments (`` import(`@chordsketch/wasm`) ``)
+ * that a literal-string regex would miss. AST discovery also
+ * excludes false positives the regex would otherwise hit — the
+ * shim's own header comment names the call-syntax exemplar, and a
+ * regex on file content would treat that as a real import site.
  */
 function discoverWasmImportSites(): string[] {
   const out: string[] = [];

--- a/packages/react/tests/wasm-shim-resolution.test.ts
+++ b/packages/react/tests/wasm-shim-resolution.test.ts
@@ -1,0 +1,139 @@
+import { readdirSync, statSync } from 'node:fs';
+import { dirname, extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, test } from 'vitest';
+
+// Regression tests for #2540.
+//
+// `@chordsketch/react`'s `prepare` script runs `tsup`'s DTS build,
+// which type-checks every dynamic `import('@chordsketch/wasm')` site
+// in `src/`. The runtime artefacts that ship `@chordsketch/wasm`'s
+// type declarations (`web/chordsketch_wasm.d.ts`, `node/chordsketch_wasm.d.ts`)
+// are wasm-pack output and do NOT exist in a fresh source checkout.
+// Workspace consumers therefore hit `TS7016` / `TS2307` at
+// `pnpm install` time because `prepare` cannot finish without those
+// declarations — and the build that would produce them is itself
+// downstream of the failing install.
+//
+// The fix declares `@chordsketch/wasm` as an ambient module in
+// `src/`, the same pattern `wasm-export-shim.d.ts` applies to the
+// optional `@chordsketch/wasm-export` peer (#2539). The shim only
+// kicks in when the real `.d.ts` files are absent; when they are
+// present (npm-registry install or post-wasm-pack workspace), the
+// real declarations supersede the ambient. These tests pin that
+// contract:
+//
+//  1. positive — `src/` type-checks cleanly when the shim is present
+//     and `node_modules/@chordsketch/wasm` instances are hidden;
+//  2. negative control — without the shim (and with the peer still
+//     hidden) the dynamic-import sites emit `TS7016` / `TS2307` for
+//     `@chordsketch/wasm`. Proves the shim is load-bearing;
+//  3. policy — `src/` does NOT carry a suppression directive on or
+//     near a `@chordsketch/wasm` import line. Reintroducing one would
+//     paper over the resolution problem in the same silent-failure
+//     style `.claude/rules/root-cause-fixes.md` calls out.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = resolve(here, '../src');
+const SHIM_PATH = resolve(SRC_DIR, 'wasm-shim.d.ts');
+const TSCONFIG_PATH = resolve(here, '../tsconfig.json');
+
+const TS_EXTS = new Set(['.ts', '.tsx', '.d.ts']);
+
+function collectSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(root)) {
+    const full = join(root, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectSourceFiles(full));
+    } else if (
+      TS_EXTS.has(extname(full)) ||
+      full.endsWith('.d.ts')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function loadCompilerOptions(): ts.CompilerOptions {
+  const configFile = ts.readConfigFile(TSCONFIG_PATH, ts.sys.readFile);
+  if (configFile.error !== undefined) {
+    throw new Error(
+      ts.flattenDiagnosticMessageText(configFile.error.messageText, '\n'),
+    );
+  }
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    dirname(TSCONFIG_PATH),
+  );
+  return { ...parsed.options, noEmit: true };
+}
+
+/**
+ * Build a compiler host that refuses to resolve any node_modules
+ * path containing `@chordsketch/wasm` (without matching
+ * `@chordsketch/wasm-export`, which is a sibling module). Hiding the
+ * real peer keeps the negative-control assertion robust against a
+ * developer who has the wasm artefacts installed locally.
+ *
+ * Assumes a conventional `node_modules` layout (npm / pnpm hoisted /
+ * pnpm `.pnpm/...` virtual store all include the segment). Yarn PnP
+ * has no `node_modules` segment and would need a different strategy;
+ * CI for this repo does not exercise PnP.
+ */
+function makeHost(options: ts.CompilerOptions): ts.CompilerHost {
+  const host = ts.createCompilerHost(options);
+
+  const shouldHide = (path: string): boolean => {
+    if (!path.includes('node_modules')) return false;
+    if (path.includes('@chordsketch/wasm-export')) return false;
+    return path.includes('@chordsketch/wasm');
+  };
+
+  const originalFileExists = host.fileExists.bind(host);
+  const originalReadFile = host.readFile.bind(host);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+
+  host.fileExists = (path) => (shouldHide(path) ? false : originalFileExists(path));
+  host.readFile = (path) => (shouldHide(path) ? undefined : originalReadFile(path));
+  host.getSourceFile = (path, languageVersion, onError, shouldCreateNewSourceFile) =>
+    shouldHide(path)
+      ? undefined
+      : originalGetSourceFile(path, languageVersion, onError, shouldCreateNewSourceFile);
+  return host;
+}
+
+function compileSrc({ withShim }: { withShim: boolean }): readonly ts.Diagnostic[] {
+  const options = loadCompilerOptions();
+  const allFiles = collectSourceFiles(SRC_DIR);
+  const rootNames = withShim
+    ? allFiles
+    : allFiles.filter((p) => p !== SHIM_PATH);
+  const host = makeHost(options);
+  const program = ts.createProgram({ rootNames, options, host });
+  return ts.getPreEmitDiagnostics(program);
+}
+
+describe('@chordsketch/wasm shim resolution', () => {
+  test('src typechecks cleanly when the shim is present and the peer is unresolved', () => {
+    const diagnostics = compileSrc({ withShim: true }).map((d) =>
+      ts.flattenDiagnosticMessageText(d.messageText, '\n'),
+    );
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('src emits a missing-types diagnostic for @chordsketch/wasm when the shim is absent', () => {
+    // Negative control. Proves the shim is what unblocks resolution
+    // for every dynamic-import site, not some incidental fallback.
+    const diagnostics = compileSrc({ withShim: false });
+    const wasmErrors = diagnostics.filter((d) => {
+      if (d.code !== 7016 && d.code !== 2307) return false;
+      const msg = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+      return msg.includes('@chordsketch/wasm') && !msg.includes('@chordsketch/wasm-export');
+    });
+    expect(wasmErrors).not.toHaveLength(0);
+  });
+});

--- a/packages/react/tests/wasm-shim-resolution.test.ts
+++ b/packages/react/tests/wasm-shim-resolution.test.ts
@@ -16,10 +16,11 @@ import { describe, expect, test } from 'vitest';
 //     missing-types diagnostic. Proves the shim is load-bearing for
 //     the entire surface, not just one representative site;
 //  3. policy — no file in `src/` that imports `@chordsketch/wasm`
-//     carries a `@ts-(expect-error|ignore|nocheck)` directive.
-//     Reintroducing one would paper over the resolution problem in
-//     the same silent-failure style `.claude/rules/root-cause-fixes.md`
-//     calls out.
+//     carries a suppression directive (`@ts-expect-error`,
+//     `@ts-ignore`, `@ts-nocheck`, or a triple-slash reference that
+//     bypasses the shim). Reintroducing one would paper over the
+//     resolution problem in the same silent-failure style
+//     `.claude/rules/root-cause-fixes.md` calls out.
 
 const here = dirname(fileURLToPath(import.meta.url));
 const SRC_DIR = resolve(here, '../src');
@@ -27,8 +28,14 @@ const SHIM_PATH = resolve(SRC_DIR, 'wasm-shim.d.ts');
 const TSCONFIG_PATH = resolve(here, '../tsconfig.json');
 
 const TS_EXTS = new Set(['.ts', '.tsx']);
-const WASM_IMPORT_RE = /import\(\s*['"]@chordsketch\/wasm['"]\s*\)/;
+const WASM_MODULE = '@chordsketch/wasm';
 const SUPPRESSION_RE = /@ts-(?:expect-error|ignore|nocheck)\b/;
+// Forbid only triple-slash directives that actively route around
+// the shim — pointing at the wasm-pack output or its module name.
+// Generic `/// <reference types="vite/client"/>` style references
+// remain allowed.
+const WASM_REFERENCE_RE =
+  /\/\/\/\s*<reference\s+(?:path|types)\s*=\s*['"][^'"]*(?:@chordsketch\/wasm|chordsketch_wasm)[^'"]*['"]/;
 
 function collectSourceFiles(root: string): string[] {
   const out: string[] = [];
@@ -67,7 +74,8 @@ function loadCompilerOptions(): ts.CompilerOptions {
  *
  *   - `node_modules/@chordsketch/wasm/...` (npm-registry install,
  *     pnpm hoisted, pnpm `.pnpm/...` virtual store)
- *   - `packages/npm/...` (the workspace-relative path that
+ *   - `packages/npm/{web,node}/chordsketch_wasm.*` (the
+ *     workspace-relative wasm-pack artefact path that
  *     `tsconfig.json`'s `paths` mapping points at)
  *
  * Hiding both keeps the assertions accurate regardless of whether
@@ -77,15 +85,25 @@ function loadCompilerOptions(): ts.CompilerOptions {
  * `@chordsketch/wasm-export` ambient is left in place so its own
  * regression test (`tests/use-pdf-export-optional-peer.test.ts`)
  * stays unaffected when run alongside this one.
+ *
+ * NOTE: the `packages/npm/` filter is keyed on the basename
+ * `chordsketch_wasm` (the wasm-pack output filename) so unrelated
+ * files under `packages/npm/` are not hidden. If `tsconfig.json`'s
+ * `paths` value ever changes to point elsewhere, update this filter
+ * — the comment in `tsconfig.json` next to `paths` flags it.
  */
 function makeHost(options: ts.CompilerOptions): ts.CompilerHost {
   const host = ts.createCompilerHost(options);
 
   const shouldHide = (path: string): boolean => {
     if (path.includes('@chordsketch/wasm-export')) return false;
-    if (!path.includes('@chordsketch/wasm') && !path.includes('packages/npm/'))
-      return false;
-    return path.includes('node_modules') || path.includes('packages/npm/');
+    if (path.includes('node_modules') && path.includes('@chordsketch/wasm')) {
+      return true;
+    }
+    if (path.includes('packages/npm/') && path.includes('chordsketch_wasm')) {
+      return true;
+    }
+    return false;
   };
 
   const originalFileExists = host.fileExists.bind(host);
@@ -115,12 +133,61 @@ function compileSrc({ withShim }: { withShim: boolean }): readonly ts.Diagnostic
         `negative control degrades silently.`,
     );
   }
+  // `ts.createProgram` with explicit `rootNames` builds the program
+  // from those roots and their transitive imports only — it does not
+  // re-walk `tsconfig.json`'s `include` globs. So filtering the shim
+  // out of `rootNames` is sufficient to keep its ambient declaration
+  // out of the program when `withShim: false`.
   const rootNames = withShim
     ? allFiles
     : allFiles.filter((p) => p !== SHIM_PATH);
   const host = makeHost(options);
   const program = ts.createProgram({ rootNames, options, host });
   return ts.getPreEmitDiagnostics(program);
+}
+
+/**
+ * Discover every `src/` source file that contains a dynamic
+ * `import('@chordsketch/wasm')` call expression, including
+ * variants the surface regex misses (template literals,
+ * intermediate whitespace, multi-line). AST-based discovery is
+ * brittle to fewer refactor classes than a literal-string regex —
+ * see the silent-failure review on #2542 for the enumeration.
+ *
+ * Files that ONLY mention `@chordsketch/wasm` in comments or string
+ * literals outside an `import(...)` call are excluded.
+ */
+function discoverWasmImportSites(): string[] {
+  const out: string[] = [];
+  for (const path of collectSourceFiles(SRC_DIR)) {
+    if (!TS_EXTS.has(extname(path))) continue;
+    if (path.endsWith('.d.ts')) continue;
+    const text = readFileSync(path, 'utf8');
+    const sf = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true);
+    if (containsWasmImport(sf)) out.push(path);
+  }
+  return out;
+}
+
+function containsWasmImport(sf: ts.SourceFile): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length >= 1
+    ) {
+      const arg = node.arguments[0];
+      if (ts.isStringLiteralLike(arg) && arg.text === WASM_MODULE) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return found;
 }
 
 describe('@chordsketch/wasm shim resolution', () => {
@@ -147,6 +214,13 @@ describe('@chordsketch/wasm shim resolution', () => {
     // class (TS2305 / TS2339), in which case this test needs
     // updating — that is intentional, the test pins the current
     // failure mode.
+    const expectedSites = discoverWasmImportSites();
+    // Guard against the silent regression where every site is
+    // refactored away or the discovery helper breaks — without this
+    // the `>=` assertion would pass vacuously with 0 errors against
+    // 0 expected sites.
+    expect(expectedSites.length).toBeGreaterThan(0);
+
     const diagnostics = compileSrc({ withShim: false });
     const wasmErrors = diagnostics.filter((d) => {
       if (d.code !== 7016 && d.code !== 2307) return false;
@@ -156,37 +230,33 @@ describe('@chordsketch/wasm shim resolution', () => {
     const filesWithErrors = new Set(
       wasmErrors.map((d) => d.file?.fileName).filter((n): n is string => Boolean(n)),
     );
-    const expectedSites = collectSourceFiles(SRC_DIR).filter((p) => {
-      if (!TS_EXTS.has(extname(p))) return false;
-      if (p.endsWith('.d.ts')) return false;
-      const source = readFileSync(p, 'utf8');
-      return WASM_IMPORT_RE.test(source);
-    });
     // Asserting "≥ every site that imports the module" pins the
-    // shim's claim that it unblocks the ENTIRE dynamic-import
+    // shim's claim that it unblocks the entire dynamic-import
     // surface. A future refactor that drops some sites is welcome;
     // a future refactor that drops the shim and silently leaves
     // some sites failing is the regression class we want to catch.
     expect(filesWithErrors.size).toBeGreaterThanOrEqual(expectedSites.length);
   });
 
-  test('src files importing @chordsketch/wasm carry no suppression directive', () => {
+  test('src files importing @chordsketch/wasm carry no suppression directive or wasm-targeting triple-slash reference', () => {
     // Sibling-test symmetry with #2541's wasm-export shim policy
     // (`tests/use-pdf-export-optional-peer.test.ts`). A future
-    // contributor reintroducing `@ts-expect-error`,
-    // `@ts-ignore`, or `@ts-nocheck` near a `@chordsketch/wasm`
-    // import would recreate the silent-failure class
-    // `.claude/rules/root-cause-fixes.md` warns about — the
+    // contributor reintroducing `@ts-expect-error`, `@ts-ignore`,
+    // `@ts-nocheck`, or a `/// <reference path="...wasm..."/>` near
+    // a `@chordsketch/wasm` import would recreate the silent-failure
+    // class `.claude/rules/root-cause-fixes.md` warns about — the
     // directive would silently flip between dead and load-bearing
     // depending on consumer resolution state. The shim's whole
     // point is to make every such directive unnecessary.
+    const sites = discoverWasmImportSites();
+    expect(sites.length).toBeGreaterThan(0);
+
     const offending: string[] = [];
-    for (const path of collectSourceFiles(SRC_DIR)) {
-      if (!TS_EXTS.has(extname(path))) continue;
-      if (path.endsWith('.d.ts')) continue;
+    for (const path of sites) {
       const source = readFileSync(path, 'utf8');
-      if (!WASM_IMPORT_RE.test(source)) continue;
-      if (SUPPRESSION_RE.test(source)) offending.push(path);
+      if (SUPPRESSION_RE.test(source) || WASM_REFERENCE_RE.test(source)) {
+        offending.push(path);
+      }
     }
     expect(offending).toEqual([]);
   });

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -13,6 +13,10 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "baseUrl": ".",
     "paths": {
+      // If this target changes, update `makeHost.shouldHide` in
+      // `tests/wasm-shim-resolution.test.ts` — the negative-control
+      // test hides this path to keep its assertions accurate when
+      // the wasm-pack artefacts exist locally.
       "@chordsketch/wasm": ["../npm/web/chordsketch_wasm"]
     }
   },


### PR DESCRIPTION
Closes #2540.

## What

`@chordsketch/react`'s `prepare` script runs the DTS build at `pnpm install` time for workspace / git / submodule consumers. The seven dynamic `import('@chordsketch/wasm')` sites in `src/` are resolved against wasm-pack-generated `.d.ts` files (`web/chordsketch_wasm.d.ts`, `node/chordsketch_wasm.d.ts`) that do not exist in a fresh source checkout — the build that would produce them is itself downstream of the failing install.

- Add `src/wasm-shim.d.ts` with `declare module '@chordsketch/wasm';` (shorthand, untyped body). Resolution now succeeds without the generated artefacts. When the real `.d.ts` is present in the consumer's `node_modules` (npm-registry install, or workspace install after `wasm-pack build` has run), the real declarations supersede the ambient — no merge conflict.
- Add `tests/wasm-shim-resolution.test.ts` with three assertions:
  1. **positive** — `src/` typechecks cleanly when the shim is present and every other resolution path for `@chordsketch/wasm` is hidden from the test's compiler host (both `node_modules/@chordsketch/wasm/...` AND the `packages/npm/.../chordsketch_wasm.*` workspace artefact path that `tsconfig.json`'s `paths` mapping points at);
  2. **negative control** — without the shim (with the same hide rules), the dynamic-import sites emit a missing-types diagnostic for `@chordsketch/wasm`. Asserts the count of distinct error-emitting files is ≥ the count of files containing an AST-detectable `import('@chordsketch/wasm')` call expression. Proves the shim is load-bearing for the entire dynamic-import surface;
  3. **policy** — no file in `src/` that imports `@chordsketch/wasm` carries a suppression directive (`@ts-expect-error`, `@ts-ignore`, `@ts-nocheck`) or a triple-slash reference (`/// <reference path|types="...wasm..."/>`) that would route around the shim.

Also documents the pre-existing `use-chord-diagram.ts:80` two-step cast (`as unknown as Promise<DiagramRenderer>`) as an asymmetry against the other six dynamic-import sites: its `unknown` step erases shape conformance, so it cannot carry the divergence-detection responsibility the single-step casts now carry against the real wasm-pack declarations.

History is Red → Green with three polish iterations driven by the parallel review loop:

| Commit  | Phase       | Summary                                                                                                                                                                                                                                                                                                       |
|---------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `c8faccd` | Red         | Adds the regression suite + `@types/node`. Positive assertion fails against the pre-fix source with seven "Cannot find module '@chordsketch/wasm'" diagnostics (one per dynamic-import site).                                                                                                                |
| `9745fff` | Green       | Adds `src/wasm-shim.d.ts`. Positive turns green; negative control stays green because the host's hide filter still excludes the node_modules instance.                                                                                                                                                       |
| `d60d1da` | Refactor #1 | Iter-1 polish: tool-neutralises the shim and test headers (drops `tsup` / `prepare` / `pnpm` narrative); deduplicates the shim ↔ test header overlap; extends `makeHost.shouldHide` to also exclude the `packages/npm/` workspace path; tightens negative control from `≥ 1 error` to `≥ every import site`; adds the policy assertion; adds an invariant guard that throws if the shim file is renamed without updating `SHIM_PATH`; drops the rotting "CI does not exercise PnP" sentence; filters `.d.ts` out of the policy / discovery loops. |
| `56da76b` | Refactor #2 | Iter-1 finding F: notes the `use-chord-diagram.ts` cast asymmetry next to the existing comment so a future reader does not infer the same divergence-guard property as the other six sites.                                                                                                                  |
| `70bfbb7` | Refactor #3 | Iter-2 polish: tightens `shouldHide` to require `chordsketch_wasm` substring (so unrelated `packages/npm/` content is not hidden); switches import-site discovery from regex to TypeScript AST walker (covers template-literal arguments + future refactor classes); extends the policy to reject triple-slash references that target the wasm artefacts; adds vacuous-pass guards in both tests; adds a cross-reference comment in `tsconfig.json` next to the `paths` entry; weakens the `use-chord-diagram.ts` cast-asymmetry comment to drop the rotting "other sites use single cast" quantification. |
| `fef3baa` | Refactor #4 | Iter-3 NIT: corrects the `discoverWasmImportSites` docstring's overclaim about what the literal-string regex missed (only template-literal arguments and the false-positive case from the shim's own example comment were genuine misses; intermediate whitespace and multi-line formatting were already handled). |

## Why

The issue listed three fix paths in order of preference:

1. Guard `prepare` on `dist/` existence.
2. Decouple DTS from runtime wasm artefacts via type stubs.
3. Document a pre-install step + `preprepare` failing fast.

Option 1 lets workspace consumers escape the failure with `--ignore-scripts` and a manual pre-build, but the first install still fails — the chicken-and-egg remains, just sidesteppable. Option 2 is the root-cause fix per `.claude/rules/root-cause-fixes.md`: TypeScript no longer needs the generated artefacts to resolve types, so the first install just works. The same pattern was used for `@chordsketch/wasm-export` in #2539, and the shorthand `declare module 'X';` is exactly the fix TypeScript itself suggests in the `TS7016` diagnostic.

Each dynamic-import site continues to cast to its own narrow interface (`ChordRenderer`, `IrealParser`, `DiagramRenderer`, etc.), so the per-site surface contract stays explicit — and (post-shim) single-step `as Promise<T>` casts surface a `TS2352` if the real wasm-pack declarations later supersede the ambient with an incompatible shape.

## Test results

From `packages/react/`:

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 27 files / 517 tests pass (3 added).
- `npm run build` — `tsup` ESM + CJS + DTS builds all succeed.

The shim was empirically validated against both consumer states by manipulating `node_modules`:

| State                                                    | `tsc --noEmit` | New tests | All tests |
|----------------------------------------------------------|----------------|-----------|-----------|
| Workspace (shim only, peer artefacts absent)             | clean          | 3/3 pass  | 517/517 pass |
| npm-registry (shim + real wasm-pack `.d.ts` reinstalled) | clean          | 3/3 pass  | 517/517 pass |

## Sister-site audit

`@chordsketch/wasm-export` carries the equivalent shim already (`src/wasm-export-shim.d.ts`, landed in #2539). `git grep -n "import('@chordsketch/" -- packages/react/src` confirms the two module specs are the only dynamic-import targets in this package; both are now shimmed.

The renderer-parity, sanitizer-parity, and bindings-parity sister-site groups carry no equivalent dynamic-import resolution surface. Package-local change.

## Review summary

Three full review iterations were driven in parallel by five specialised reviewer agents (code-reviewer, silent-failure-hunter, comment-analyzer, pr-test-analyzer, project-rules audit against `.claude/rules/`) plus the repo's auto-review bot. Convergence criterion: zero findings of any severity in the delta review.

| Iter | Findings (severity-shaped)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Resolution                                                |
|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
| 1    | MEDIUM × 3 (test header still pinned `tsup`/`prepare`/`pnpm`; shim/test comment duplication; missing policy assertion for sister-test symmetry with #2541); MEDIUM × 2 (`use-chord-diagram.ts` cast asymmetry undocumented; test hides only `node_modules`, not the `packages/npm/` workspace path); LOW × 5 (hard-coded filename pins, cast description without call-site pointer, makeHost CI assumption stale-prone, negative control too loose, missing precondition comments); NIT × 1 (redundant `.d.ts` check in collectSourceFiles).                                                                       | All resolved in `d60d1da` + `56da76b` (iter-1 polish + the asymmetry doc). |
| 2    | MEDIUM × 2 (`shouldHide` substring filter brittle vs `tsconfig.json` paths; `WASM_IMPORT_RE` literal-string regex misses realistic refactor classes — template literals, future multi-line/variable-spec forms); LOW × 4 (suppression policy misses triple-slash reference bypasses, vacuous-pass risk if discovery returned zero sites, `withShim:false` rootNames-filter assumption undocumented, "other sites use single cast" claim rot-prone).                                                                                                                                                          | All resolved in `70bfbb7` (iter-2 polish: tightened `shouldHide`, AST-based discovery, triple-slash policy extension, precondition guards, `tsconfig.json` cross-ref, weakened asymmetry quantifier). |
| 3    | NIT × 1 (`discoverWasmImportSites` docstring overclaims what the literal regex missed — only template-literal arguments + comment-false-positives were genuine misses).                                                                                                                                                                                                                                                                                                                                                                                                                                  | Resolved in `fef3baa`. |

The repo's auto-review bot ran two delta reviews against this branch's HEAD:
- `9745fff..56da76b` delta (iter-1 + use-chord-diagram doc): **No findings. Ready for human merge.**
- `56da76b..fef3baa` delta (iter-2 polish + iter-3 docstring fix): **No findings. Ready for human merge.**

Every finding at every severity was resolved in this PR per `pr-workflow.md` step 4 — no follow-up issues were filed.

## Deferred

None.