### PR TITLE
Apply transpose to mid-song {key:} directives + backfill enharmonic minor key glyphs

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -3146,6 +3146,24 @@ mod tests {
     }
 
     #[test]
+    fn test_key_parseable_but_missing_from_table_emits_warning() {
+        // `{key: Fbm}` parses as a valid key name (root=F, flat
+        // accidental, minor suffix) but has no entry in the
+        // key-signature lookup table — it is enharmonically
+        // equivalent to Em, which `canonical_transposed_key` never
+        // produces, but a user can hand-write it. The renderer must
+        // emit a diagnostics warning rather than silently showing an
+        // empty staff glyph (#2526).
+        let song = chordsketch_chordpro::parse("{key: Fbm}\n[Em]Hi").unwrap();
+        let result = render_song_with_warnings(&song, 0, &Config::defaults());
+        assert!(
+            result.warnings.iter().any(|w| w.contains("Fbm")),
+            "expected a warning for parseable-but-missing key Fbm, got: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
     fn test_render_empty() {
         let song = chordsketch_chordpro::parse("").unwrap();
         let html = render_song(&song);

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -423,6 +423,29 @@ fn render_song_body_into(
                                     )
                                     .unwrap_or_else(|| value.to_string())
                                 };
+                                // Surface a warning when the
+                                // key string parses as a chord
+                                // root + accidental + optional
+                                // minor suffix but the
+                                // key-signature lookup table has
+                                // no entry. This is the silent
+                                // empty-staff failure mode
+                                // #2526 closed — the table-gap
+                                // case is observable now, modal
+                                // `{key: C dorian}` values (which
+                                // do not parse as a chord) stay
+                                // silent.
+                                if matches!(
+                                    music_glyphs::key_signature_for_with_diagnostics(&displayed),
+                                    music_glyphs::KeySignatureLookup::ParsedButMissing
+                                ) {
+                                    push_warning(
+                                        warnings,
+                                        format!(
+                                            "key signature lookup table missing entry for parseable key: {displayed}"
+                                        ),
+                                    );
+                                }
                                 html.push_str(&format!(
                                     "<span class=\"meta-inline meta-inline--key\">\
                                      {glyph}\

--- a/crates/render-html/src/music_glyphs.rs
+++ b/crates/render-html/src/music_glyphs.rs
@@ -29,6 +29,32 @@ pub enum KeySigType {
     Natural,
 }
 
+/// Diagnostic result of a key-signature lookup. Distinguishes the
+/// two failure modes so callers can emit a warning when a
+/// well-formed key-name parsed but missed the lookup table — a
+/// signal that the table has a gap and the glyph is silently
+/// blank.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeySignatureLookup {
+    /// The input parsed and the lookup table resolved to an
+    /// accidental count and direction.
+    Resolved(usize, KeySigType),
+    /// The input parsed as a key name (root in `A..=G`, optional
+    /// `b`/`#` accidental, optional minor suffix) but no lookup
+    /// table entry exists for the parsed `(root, accidental,
+    /// is_minor)` triple. The glyph caller should still render
+    /// an empty staff but SHOULD emit a warning so the table gap
+    /// is observable — the silent empty-staff render gave screen
+    /// readers and sighted users contradictory information (#2526).
+    ParsedButMissing,
+    /// The input did not parse as a key name at all (empty,
+    /// non-letter root, or unsupported suffix such as
+    /// `{key: C dorian}`). Callers fall back to the staff-only
+    /// glyph without a warning — modal `{key}` values are valid
+    /// ChordPro and not a table-gap signal.
+    Unparseable,
+}
+
 /// Order of sharps in a key signature, in their conventional
 /// treble-clef staff positions (`y` = half-line steps from the
 /// top staff line; 0 = top line, 1 = first space, …).
@@ -57,12 +83,30 @@ const FLAT_ORDER: &[(&str, f32)] = &[
 /// `{key}` value. Accepts both major (`G`, `Bb`, `F#`) and minor
 /// (`Em`, `E minor`, `f# min`) spellings; unicode ♯ / ♭ are
 /// normalised to ASCII. Returns `None` for an unparseable input
-/// so callers can render the marker without an icon.
+/// OR for a parseable key whose lookup table has no entry, so
+/// callers can render the marker without an icon. Callers that
+/// need to distinguish the two None cases (e.g. to emit a warning
+/// on a parseable-but-missing-from-table input) should use
+/// [`key_signature_for_with_diagnostics`].
 #[must_use]
 pub fn key_signature_for(key: &str) -> Option<(usize, KeySigType)> {
+    match key_signature_for_with_diagnostics(key) {
+        KeySignatureLookup::Resolved(count, kind) => Some((count, kind)),
+        KeySignatureLookup::ParsedButMissing | KeySignatureLookup::Unparseable => None,
+    }
+}
+
+/// Variant of [`key_signature_for`] that distinguishes a
+/// parseable-but-missing input from an unparseable one. Used by
+/// the HTML renderer to emit a warning when a key string that
+/// parses as a chord nonetheless has no lookup entry — a signal
+/// that the table has a silent gap rather than that the caller
+/// passed a modal `{key}` value (#2526).
+#[must_use]
+pub fn key_signature_for_with_diagnostics(key: &str) -> KeySignatureLookup {
     let trimmed = key.trim();
     if trimmed.is_empty() {
-        return None;
+        return KeySignatureLookup::Unparseable;
     }
     // Normalise unicode accidentals to ASCII so `F♯` and `F#`
     // hit the same table entry. NBSP / ideographic spaces fold
@@ -80,9 +124,12 @@ pub fn key_signature_for(key: &str) -> Option<(usize, KeySigType)> {
 
     // Parse `<root>[b|#]( m | min | minor)?` case-insensitively.
     let mut chars = ascii.chars();
-    let root = chars.next()?.to_ascii_uppercase();
+    let Some(root_ch) = chars.next() else {
+        return KeySignatureLookup::Unparseable;
+    };
+    let root = root_ch.to_ascii_uppercase();
     if !('A'..='G').contains(&root) {
-        return None;
+        return KeySignatureLookup::Unparseable;
     }
     let mut accidental = String::new();
     let rest: String = chars.collect();
@@ -97,7 +144,7 @@ pub fn key_signature_for(key: &str) -> Option<(usize, KeySigType)> {
     let suffix_trim = suffix.trim().to_ascii_lowercase();
     let is_minor = matches!(suffix_trim.as_str(), "m" | "min" | "minor");
     if !is_minor && !suffix_trim.is_empty() {
-        return None;
+        return KeySignatureLookup::Unparseable;
     }
 
     let note = format!("{root}{accidental}");
@@ -120,6 +167,15 @@ pub fn key_signature_for(key: &str) -> Option<(usize, KeySigType)> {
         ("Gb", (6, KeySigType::Flat)),
         ("Cb", (7, KeySigType::Flat)),
     ];
+    // Minor table includes Dbm / Gbm / Cbm as enharmonic
+    // aliases of C#m / F#m / Bm respectively — these spellings
+    // arise from `transposed_key_prefers_flat`-driven transpose
+    // landings (e.g. `{key: Am}` +4 with prefer-flat → `Dbm`,
+    // #2526). Conventional notation uses the sharp-side
+    // key signature for these (D-flat minor has no real signature;
+    // by convention the 4-sharp C-sharp minor signature is
+    // borrowed), so the staff glyph shows sharps even when chord
+    // lines spell flats.
     let minor: &[(&str, (usize, KeySigType))] = &[
         ("A", (0, KeySigType::Natural)),
         ("E", (1, KeySigType::Sharp)),
@@ -136,9 +192,15 @@ pub fn key_signature_for(key: &str) -> Option<(usize, KeySigType)> {
         ("Bb", (5, KeySigType::Flat)),
         ("Eb", (6, KeySigType::Flat)),
         ("Ab", (7, KeySigType::Flat)),
+        ("Cb", (2, KeySigType::Sharp)),
+        ("Gb", (3, KeySigType::Sharp)),
+        ("Db", (4, KeySigType::Sharp)),
     ];
     let table = if is_minor { minor } else { major };
-    table.iter().find(|(n, _)| *n == note).map(|(_, v)| *v)
+    match table.iter().find(|(n, _)| *n == note).map(|(_, v)| *v) {
+        Some((count, kind)) => KeySignatureLookup::Resolved(count, kind),
+        None => KeySignatureLookup::ParsedButMissing,
+    }
 }
 
 /// Emit an inline SVG mini key-signature glyph for the given
@@ -415,6 +477,70 @@ mod tests {
         assert_eq!(key_signature_for("Dm"), Some((1, KeySigType::Flat)));
         assert_eq!(key_signature_for("Cm"), Some((3, KeySigType::Flat)));
         assert_eq!(key_signature_for("F#m"), Some((3, KeySigType::Sharp)));
+    }
+
+    #[test]
+    fn key_signature_enharmonic_flat_side_minor_returns_sharp_side_count() {
+        // Dbm / Gbm / Cbm arise from `transposed_key_prefers_flat`
+        // landings (e.g. `{key: Am}` +4 → `Dbm`). They have no
+        // standalone key signature — by convention the staff
+        // glyph borrows the sharp-side enharmonic's signature
+        // (Dbm ↔ C#m = 4 sharps, Gbm ↔ F#m = 3 sharps,
+        // Cbm ↔ Bm = 2 sharps). Without these entries the glyph
+        // emitted an empty staff that contradicted the
+        // `aria-label="Key Dbm"` (#2526).
+        assert_eq!(key_signature_for("Dbm"), Some((4, KeySigType::Sharp)));
+        assert_eq!(key_signature_for("Gbm"), Some((3, KeySigType::Sharp)));
+        assert_eq!(key_signature_for("Cbm"), Some((2, KeySigType::Sharp)));
+        // Unicode ♭ variant routes through the same normalisation
+        // and lands on the same entry.
+        assert_eq!(key_signature_for("D♭m"), Some((4, KeySigType::Sharp)));
+    }
+
+    #[test]
+    fn key_signature_svg_enharmonic_minor_emits_sharp_accidentals() {
+        // Dbm uses the C#m signature (4 sharps) so the rendered
+        // SVG carries 4 `<g>` accidental groups, not an empty
+        // staff. Before #2526 the glyph for Dbm had zero `<g>`
+        // groups while still carrying `aria-label="Key Dbm"`,
+        // mismatching screen readers and sighted users.
+        let svg = key_signature_svg("Dbm");
+        assert_eq!(svg.matches("<g ").count(), 4);
+        assert!(svg.contains("Key Dbm"));
+        assert!(svg.contains("4 sharps"));
+    }
+
+    #[test]
+    fn key_signature_diagnostics_distinguishes_unparseable_from_table_gap() {
+        // Sanity: in-table entries report Resolved.
+        assert_eq!(
+            key_signature_for_with_diagnostics("A"),
+            KeySignatureLookup::Resolved(3, KeySigType::Sharp)
+        );
+        // Modal / non-key suffix => Unparseable (no warning).
+        assert_eq!(
+            key_signature_for_with_diagnostics("C dorian"),
+            KeySignatureLookup::Unparseable
+        );
+        assert_eq!(
+            key_signature_for_with_diagnostics(""),
+            KeySignatureLookup::Unparseable
+        );
+        assert_eq!(
+            key_signature_for_with_diagnostics("H"),
+            KeySignatureLookup::Unparseable
+        );
+        // Fbm parses as a key (root F, flat accidental, minor
+        // suffix) but no table entry exists — Fbm = 8 flats is
+        // outside the standard 0..=7 range and `transposed_key`
+        // canonicalises it to Em instead, so #2526's backfill
+        // intentionally does not include it. The diagnostics
+        // variant surfaces the table gap so the renderer can
+        // emit a warning instead of a silent empty-staff glyph.
+        assert_eq!(
+            key_signature_for_with_diagnostics("Fbm"),
+            KeySignatureLookup::ParsedButMissing
+        );
     }
 
     #[test]

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -777,6 +777,27 @@ struct ParseChordproResult {
     /// `do_parse_chordpro` for the source-of-truth computation.
     #[serde(rename = "transposedKey", skip_serializing_if = "Option::is_none")]
     transposed_key: Option<String>,
+    /// Map of `original {key:} directive value → transposed
+    /// value`, covering every `{key:}` directive in the song
+    /// (primary + mid-song). Present only when `transpose != 0`
+    /// AND at least one `{key:}` value parsed as a chord.
+    ///
+    /// Lets the React JSX walker render mid-song `{key:}` chips
+    /// with the canonically-transposed value too — without this
+    /// channel the walker only knew the song-primary's
+    /// transposition and fell back to the authored value for
+    /// every other directive, diverging from the Rust text /
+    /// HTML / PDF renderers (#2525).
+    ///
+    /// Entries where transpose is a no-op (e.g. modal `{key: C
+    /// dorian}` values that don't parse) are intentionally
+    /// omitted so the walker can treat presence-in-map as
+    /// "show the pair".
+    #[serde(
+        rename = "transposedKeyDirectives",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty"
+    )]
+    transposed_key_directives: std::collections::BTreeMap<String, String>,
 }
 
 /// Parse a ChordPro source string into an AST JSON document.
@@ -797,7 +818,7 @@ struct ParseChordproResult {
 #[wasm_bindgen(js_name = parseChordpro)]
 pub fn parse_chordpro(input: &str) -> Result<String, JsValue> {
     do_parse_chordpro(input, None)
-        .map(|(json, _, _)| json)
+        .map(|(json, _, _, _)| json)
         .map_err(|e| JsValue::from_str(&e))
 }
 
@@ -812,7 +833,7 @@ pub fn parse_chordpro(input: &str) -> Result<String, JsValue> {
 pub fn parse_chordpro_with_options(input: &str, options: JsValue) -> Result<String, JsValue> {
     let opts = deserialize_options(options)?;
     do_parse_chordpro(input, Some(&opts))
-        .map(|(json, _, _)| json)
+        .map(|(json, _, _, _)| json)
         .map_err(|e| JsValue::from_str(&e))
 }
 
@@ -834,12 +855,13 @@ pub fn parse_chordpro_with_options(input: &str, options: JsValue) -> Result<Stri
 #[must_use = "callers must handle parse errors"]
 #[wasm_bindgen(js_name = parseChordproWithWarnings)]
 pub fn parse_chordpro_with_warnings(input: &str) -> Result<JsValue, JsValue> {
-    let (ast, warnings, transposed_key) =
+    let (ast, warnings, transposed_key, transposed_key_directives) =
         do_parse_chordpro(input, None).map_err(|e| JsValue::from_str(&e))?;
     serde_wasm_bindgen::to_value(&ParseChordproResult {
         ast,
         warnings,
         transposed_key,
+        transposed_key_directives,
     })
     .map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -855,12 +877,13 @@ pub fn parse_chordpro_with_warnings_and_options(
     options: JsValue,
 ) -> Result<JsValue, JsValue> {
     let opts = deserialize_options(options)?;
-    let (ast, warnings, transposed_key) =
+    let (ast, warnings, transposed_key, transposed_key_directives) =
         do_parse_chordpro(input, Some(&opts)).map_err(|e| JsValue::from_str(&e))?;
     serde_wasm_bindgen::to_value(&ParseChordproResult {
         ast,
         warnings,
         transposed_key,
+        transposed_key_directives,
     })
     .map_err(|e| JsValue::from_str(&e.to_string()))
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -277,6 +277,28 @@ pub(crate) fn validate_inner(input: &str) -> Vec<ValidationErrorPayload> {
 
 // ---- ChordPro parse-to-AST binding -----------------------------
 
+/// Tuple returned by [`do_parse_chordpro`]. Carried as a type
+/// alias so callers do not trip clippy's `type_complexity` lint
+/// and so the React-binding plumbing in `bindings.rs` has a
+/// single source of truth for the shape.
+///
+/// Fields, in order:
+///
+/// - `String` — the AST JSON document.
+/// - `Vec<String>` — recoverable lenient-parser warnings.
+/// - `Option<String>` — transposed song-primary `{key}` value;
+///   `None` when transpose is zero or the primary key cannot be
+///   parsed.
+/// - `BTreeMap<String, String>` — per-directive transposed `{key}`
+///   map for every `{key:}` directive in the song (primary +
+///   mid-song), keyed by the authored value.
+pub(crate) type ParseChordproPayload = (
+    String,
+    Vec<String>,
+    Option<String>,
+    std::collections::BTreeMap<String, String>,
+);
+
 /// Run the ChordPro source → AST JSON pipeline; native helper used
 /// by the wasm wrapper and Rust unit tests. The pipeline:
 ///
@@ -294,8 +316,12 @@ pub(crate) fn validate_inner(input: &str) -> Vec<ValidationErrorPayload> {
 pub(crate) fn do_parse_chordpro(
     input: &str,
     options: Option<&RenderOptions>,
-) -> Result<(String, Vec<String>, Option<String>), String> {
+) -> Result<ParseChordproPayload, String> {
+    use chordsketch_chordpro::ast::{DirectiveKind, Line};
     use chordsketch_chordpro::json::ToJson;
+    use chordsketch_chordpro::transpose::{
+        canonical_transposed_key, canonical_transposed_key_with_style, transposed_key_prefers_flat,
+    };
 
     let parse_options = chordsketch_chordpro::ParseOptions::default();
     let parse_result = chordsketch_chordpro::parse_lenient_with_options(input, &parse_options);
@@ -325,13 +351,63 @@ pub(crate) fn do_parse_chordpro(
         // the song landed on. Returns `None` for unparseable
         // keys (e.g. `{key: C dorian}`) — the walker falls back
         // to showing the original key only in that case.
-        chordsketch_chordpro::transpose::canonical_transposed_key(
-            song.metadata.key.as_deref(),
-            transpose_steps,
-        )
+        canonical_transposed_key(song.metadata.key.as_deref(), transpose_steps)
     } else {
         None
     };
+
+    // Build a map of `original {key} value → transposed value`
+    // covering every `{key:}` directive in the song (primary +
+    // mid-song). This lets the React JSX walker (#2525) render
+    // every `{key:}` chip — not just the song-primary one —
+    // through the same canonical-spelling pipeline as the Rust
+    // text / HTML / PDF renderers, closing the four-way parity
+    // gap left by #2524.
+    //
+    // Uses the song-wide `prefer_flat` derived from
+    // `transposed_key_prefers_flat(metadata, transpose)`, so a
+    // mid-song `{key: D}` spells consistently with the chord
+    // lines (which all carry the same prefer-flat decision).
+    // Sister-site to the inline computations in
+    // `crates/render-{text,html,pdf}/src/lib.rs`.
+    //
+    // BTreeMap (instead of HashMap) keeps the serialised JSON
+    // key order deterministic across runs — useful for test
+    // snapshots and easier diffs.
+    let mut transposed_key_directives = std::collections::BTreeMap::<String, String>::new();
+    if transpose_steps != 0 {
+        let prefer_flat = transposed_key_prefers_flat(&song.metadata, transpose_steps);
+        for line in &song.lines {
+            let Line::Directive(directive) = line else {
+                continue;
+            };
+            if directive.kind != DirectiveKind::Key {
+                continue;
+            }
+            let Some(value) = directive
+                .value
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+            else {
+                continue;
+            };
+            if transposed_key_directives.contains_key(value) {
+                continue;
+            }
+            let Some(transposed) =
+                canonical_transposed_key_with_style(Some(value), transpose_steps, prefer_flat)
+            else {
+                continue;
+            };
+            // Skip entries where the transpose is a no-op so the
+            // walker can treat presence-in-map as "show the pair".
+            if transposed == value {
+                continue;
+            }
+            transposed_key_directives.insert(value.to_string(), transposed);
+        }
+    }
 
     // Apply transpose if requested. Mirrors the renderer entry
     // points which do this same step before rendering — keeps the
@@ -345,7 +421,12 @@ pub(crate) fn do_parse_chordpro(
         steps => chordsketch_chordpro::transpose::transpose(&song, steps),
     };
 
-    Ok((song.to_json_string(), warnings, transposed_key))
+    Ok((
+        song.to_json_string(),
+        warnings,
+        transposed_key,
+        transposed_key_directives,
+    ))
 }
 
 // ---- iReal Pro conversion bindings (#2067 Phase 1) ----
@@ -891,7 +972,7 @@ mod tests {
 
     #[test]
     fn test_parse_chordpro_emits_ast_json() {
-        let (json, warnings, _transposed_key) =
+        let (json, warnings, _transposed_key, _transposed_key_directives) =
             do_parse_chordpro("{title: My Song}\n[Am]Hello [G]world", None).unwrap();
         assert!(json.starts_with('{'), "expected JSON object, got: {json}");
         assert!(
@@ -915,7 +996,8 @@ mod tests {
             transpose: 2,
             config: None,
         };
-        let (json, _, _transposed_key) = do_parse_chordpro("[C]Hello", Some(&opts)).unwrap();
+        let (json, _, _transposed_key, _transposed_key_directives) =
+            do_parse_chordpro("[C]Hello", Some(&opts)).unwrap();
         // C transposed up 2 semitones lands on D.
         assert!(
             json.contains("\"name\":\"D\""),
@@ -929,7 +1011,8 @@ mod tests {
             transpose: 0,
             config: None,
         };
-        let (json, _, _transposed_key) = do_parse_chordpro("[C]Hello", Some(&opts)).unwrap();
+        let (json, _, _transposed_key, _transposed_key_directives) =
+            do_parse_chordpro("[C]Hello", Some(&opts)).unwrap();
         assert!(
             json.contains("\"name\":\"C\""),
             "transpose=0 must not alter chord names, got: {json}"
@@ -938,7 +1021,8 @@ mod tests {
 
     #[test]
     fn test_parse_chordpro_empty_input_returns_empty_song() {
-        let (json, warnings, _transposed_key) = do_parse_chordpro("", None).unwrap();
+        let (json, warnings, _transposed_key, _transposed_key_directives) =
+            do_parse_chordpro("", None).unwrap();
         assert!(
             json.contains("\"lines\":[]"),
             "empty input must yield an empty lines array, got: {json}"
@@ -956,7 +1040,7 @@ mod tests {
             transpose: 2,
             config: None,
         };
-        let (json, _warnings, transposed_key) =
+        let (json, _warnings, transposed_key, transposed_key_directives) =
             do_parse_chordpro("{key: G}\n[G]Hello", Some(&opts)).unwrap();
         assert!(
             json.contains("\"key\":\"G\""),
@@ -967,6 +1051,57 @@ mod tests {
             Some("A"),
             "transpose +2 from G should land on A"
         );
+        // The {key: G} directive appears in song.lines too, so the
+        // mid-song-key map (#2525) carries the same G→A mapping
+        // that the walker uses for the body chip.
+        assert_eq!(
+            transposed_key_directives.get("G").map(String::as_str),
+            Some("A"),
+            "{{key: G}} directive must surface in transposed_key_directives, got: {transposed_key_directives:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_chordpro_transposed_key_directives_covers_mid_song_keys() {
+        // The walker (#2525) needs the transposed value for every
+        // {key:} directive in the song, not just the primary, so
+        // mid-song key chips render with the canonical transposed
+        // spelling matching the Rust text / HTML / PDF surfaces.
+        let opts = RenderOptions {
+            transpose: 2,
+            config: None,
+        };
+        let (_json, _warnings, _transposed_key, transposed_key_directives) =
+            do_parse_chordpro("{key: G}\n[G]Hello\n{key: D}\n[D]world", Some(&opts)).unwrap();
+        // Both directives must surface: primary G→A and mid-song
+        // D→E. The walker keys lookups by directive value so each
+        // unique original maps to its transposed counterpart.
+        assert_eq!(
+            transposed_key_directives.get("G").map(String::as_str),
+            Some("A"),
+        );
+        assert_eq!(
+            transposed_key_directives.get("D").map(String::as_str),
+            Some("E"),
+        );
+    }
+
+    #[test]
+    fn test_parse_chordpro_transposed_key_directives_empty_when_transpose_zero() {
+        // transpose=0 means original and transposed are identical
+        // for every {key:} directive; emit an empty map so the
+        // serialised result drops the field entirely (via
+        // skip_serializing_if).
+        let opts = RenderOptions {
+            transpose: 0,
+            config: None,
+        };
+        let (_json, _warnings, _transposed_key, transposed_key_directives) =
+            do_parse_chordpro("{key: G}\n[G]Hello", Some(&opts)).unwrap();
+        assert!(
+            transposed_key_directives.is_empty(),
+            "transpose=0 must not emit any directive transpositions, got: {transposed_key_directives:?}"
+        );
     }
 
     #[test]
@@ -975,7 +1110,7 @@ mod tests {
             transpose: 0,
             config: None,
         };
-        let (_json, _warnings, transposed_key) =
+        let (_json, _warnings, transposed_key, _transposed_key_directives) =
             do_parse_chordpro("{key: G}\n[G]Hello", Some(&opts)).unwrap();
         assert!(
             transposed_key.is_none(),
@@ -996,7 +1131,7 @@ mod tests {
             transpose: 2,
             config: None,
         };
-        let (_json, _warnings, transposed_key) =
+        let (_json, _warnings, transposed_key, _transposed_key_directives) =
             do_parse_chordpro("{key: ???}", Some(&opts)).unwrap();
         assert!(
             transposed_key.is_none(),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1105,6 +1105,52 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_chordpro_transposed_key_directives_deduplicates_same_key() {
+        // The same {key:} value appearing more than once (e.g. an
+        // opening directive and a section repeat) must produce only
+        // one map entry — the transposed value is identical for both
+        // occurrences and the first wins. Exercises the
+        // `contains_key` deduplication branch in
+        // `do_parse_chordpro`.
+        let opts = RenderOptions {
+            transpose: 2,
+            config: None,
+        };
+        let (_json, _warnings, _transposed_key, transposed_key_directives) =
+            do_parse_chordpro("{key: G}\n[G]verse\n{key: G}\n[G]chorus", Some(&opts)).unwrap();
+        assert_eq!(
+            transposed_key_directives.len(),
+            1,
+            "duplicate {{key: G}} must not produce two map entries, got: {transposed_key_directives:?}"
+        );
+        assert_eq!(
+            transposed_key_directives.get("G").map(String::as_str),
+            Some("A"),
+            "{{key: G}} +2 must transpose to A, got: {transposed_key_directives:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_chordpro_transposed_key_directives_identity_at_octave() {
+        // transpose=+12 is an octave — the key lands on the same
+        // pitch class (C → C) so the identity-skip guard prevents
+        // the no-op entry from entering the map. The walker treats
+        // presence-in-map as "show the pair", so an identity entry
+        // would incorrectly trigger the pair display for unchanged
+        // keys.
+        let opts = RenderOptions {
+            transpose: 12,
+            config: None,
+        };
+        let (_json, _warnings, _transposed_key, transposed_key_directives) =
+            do_parse_chordpro("{key: C}\n[C]Hello", Some(&opts)).unwrap();
+        assert!(
+            transposed_key_directives.is_empty(),
+            "transpose+12 (identity) must not produce a map entry for C→C, got: {transposed_key_directives:?}"
+        );
+    }
+
+    #[test]
     fn test_parse_chordpro_transposed_key_null_when_transpose_zero() {
         let opts = RenderOptions {
             transpose: 0,
@@ -1131,11 +1177,18 @@ mod tests {
             transpose: 2,
             config: None,
         };
-        let (_json, _warnings, transposed_key, _transposed_key_directives) =
+        let (_json, _warnings, transposed_key, transposed_key_directives) =
             do_parse_chordpro("{key: ???}", Some(&opts)).unwrap();
         assert!(
             transposed_key.is_none(),
             "unparseable key must surface as `None` so the React surface can fall back, got: {transposed_key:?}"
+        );
+        // The directive-map loop must also skip non-note-letter
+        // values (the `canonical_transposed_key_with_style` → None
+        // branch), so the map stays empty for the same input.
+        assert!(
+            transposed_key_directives.is_empty(),
+            "unparseable key must not appear in transposed_key_directives, got: {transposed_key_directives:?}"
         );
     }
 

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -276,7 +276,7 @@ function ChordSheetAstBranch({
   caretLineLength: number | undefined;
   onChordReposition: ((event: ChordRepositionEvent) => void) | undefined;
 }): JSX.Element {
-  const { ast, loading, error, transposedKey } = useChordproAst(
+  const { ast, loading, error, transposedKey, transposedKeyDirectives } = useChordproAst(
     source,
     { transpose, config },
     wasmLoader,
@@ -304,6 +304,7 @@ function ChordSheetAstBranch({
       <div className="chordsketch-sheet__content">
         {renderChordproAst(ast, {
           transposedKey,
+          transposedKeyDirectives,
           chordDiagrams: chordDiagramsInstrument
             ? { instrument: chordDiagramsInstrument }
             : null,

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1922,6 +1922,23 @@ export interface RenderChordproAstOptions {
    */
   transposedKey?: string | null;
   /**
+   * Per-directive transposed-key map keyed by the authored
+   * `{key:}` directive value (e.g. `{ G: "A", D: "E" }` for a
+   * song with both directives transposed +2). Plumbed in from
+   * `useChordproAst`'s `transposedKeyDirectives`, which is
+   * sourced from the wasm `ParseChordproResult` (#2525).
+   *
+   * When present, the walker uses it for EVERY `{key:}`
+   * directive — primary AND mid-song — to emit a paired
+   * "Original → Playing" chip, achieving four-way parity with
+   * the Rust text / HTML / PDF renderers per
+   * `.claude/rules/renderer-parity.md`. When omitted, the walker
+   * falls back to the older `transposedKey`-only path that
+   * shows the pair for the primary directive only and leaves
+   * mid-song directives authored.
+   */
+  transposedKeyDirectives?: Record<string, string>;
+  /**
    * Append a chord-diagram grid showing each unique chord used in
    * the lyrics + each chord declared via `{define}`. Mirrors the
    * `<section class="chord-diagrams">` block
@@ -2843,8 +2860,27 @@ interface WalkContext {
    * paired "Written / Sounding" display matching the Perl
    * `key_print` / `key_sound` distinction. `null` when no
    * transposition is active or it lands on the same key.
+   *
+   * Retained as a back-compat path for hosts that supply only
+   * the primary `transposedKey` and not the full
+   * `transposedKeyDirectives` map; the body walker prefers the
+   * map when it has an entry for the directive's value (#2525).
    */
   soundingKey: string | null;
+  /**
+   * Per-directive transposed-key map keyed by the authored
+   * `{key:}` directive value (e.g. `{ G: "A", D: "E" }` for a
+   * song with both directives transposed +2). Sister-site to the
+   * Rust renderers' inline `canonical_transposed_key_with_style`
+   * calls per `{key:}` directive — without this channel the
+   * walker only knew the song-primary's transposition and fell
+   * back to the authored value for every other directive,
+   * diverging from the static-output renderers. The host
+   * supplies this map via
+   * `RenderChordproAstOptions.transposedKeyDirectives`; closes
+   * #2525.
+   */
+  transposedKeyDirectives: Record<string, string>;
   /**
    * Chord drag-and-drop callback (see
    * `RenderChordproAstOptions.onChordReposition`). When
@@ -3181,24 +3217,27 @@ function handleDirective(
   // the metronome).
   if (kind.tag === 'key' && directive.value && directive.value.trim().length > 0) {
     const keyName = directive.value.trim();
-    // When transposition is active AND this `{key}` directive
-    // matches the song-primary key (the one the host's
-    // `transposedKey` was computed against), render a paired
-    // "Original / Playing" display so the player can see both
-    // the source-authored key and the resulting capo / transposed
-    // key. "Original" / "Playing" reads more naturally for
-    // guitar-style chord sheets than the technically correct
-    // "Written" / "Sounding" pair (the latter trips up readers
-    // who haven't internalised the music-theory distinction).
-    //
-    // Mid-song `{key}` changes (and any `{key}` whose value
-    // doesn't match the primary) fall through to the single
-    // chip — the host's `transposedKey` only knows the primary
-    // key's transposition, so applying it blindly to a
-    // different `{key}` would be incorrect.
-    const showSounding =
-      ctx.soundingKey != null && ctx.primaryKey != null && keyName === ctx.primaryKey;
-    if (showSounding && ctx.soundingKey != null) {
+    // Resolve the sounding (transposed) value for this specific
+    // directive. Prefer the per-directive map (#2525) — it
+    // covers every `{key:}` directive in the song, primary and
+    // mid-song alike, computed via the same
+    // `canonical_transposed_key_with_style` +
+    // `transposed_key_prefers_flat` pair the Rust renderers use,
+    // so the four surfaces agree on the displayed transposed
+    // value. Fall back to the older `soundingKey` channel (which
+    // only knows the song-primary's transposition) for hosts
+    // that haven't been updated yet — that path's behaviour is
+    // unchanged: it pairs the primary `{key:}` only and leaves
+    // mid-song directives authored.
+    const mappedSounding = ctx.transposedKeyDirectives[keyName];
+    const soundingFromMap =
+      mappedSounding !== undefined && mappedSounding !== keyName ? mappedSounding : null;
+    const soundingFromPrimary =
+      ctx.soundingKey != null && ctx.primaryKey != null && keyName === ctx.primaryKey
+        ? ctx.soundingKey
+        : null;
+    const sounding = soundingFromMap ?? soundingFromPrimary;
+    if (sounding !== null) {
       pushElement(
         ctx,
         <span key={key} className="meta-inline meta-inline--key meta-inline--key-pair">
@@ -3211,11 +3250,9 @@ function handleDirective(
             →
           </span>
           <span className="meta-inline__group">
-            <KeySignatureGlyph keyName={ctx.soundingKey} className="meta-inline__glyph" />
+            <KeySignatureGlyph keyName={sounding} className="meta-inline__glyph" />
             <span className="meta-inline__label">Playing:</span>{' '}
-            <span className="meta-inline__value">
-              {unicodeAccidentals(ctx.soundingKey)}
-            </span>
+            <span className="meta-inline__value">{unicodeAccidentals(sounding)}</span>
           </span>
         </span>,
         key, // source-line for `line--active` decoration
@@ -3432,6 +3469,7 @@ export function renderChordproAst(
       options.transposedKey && options.transposedKey !== song.metadata.key
         ? options.transposedKey
         : null,
+    transposedKeyDirectives: options.transposedKeyDirectives ?? {},
     onChordReposition: options.onChordReposition,
   };
   // Emit header first so metadata lands above the body even when

--- a/packages/react/src/music-glyphs.tsx
+++ b/packages/react/src/music-glyphs.tsx
@@ -112,6 +112,14 @@ export function keySignatureFor(
     Gb: [6, 'flat'],
     Cb: [7, 'flat'],
   };
+  // Minor table includes Dbm / Gbm / Cbm as enharmonic aliases of
+  // C#m / F#m / Bm respectively — these spellings arise from
+  // `transposed_key_prefers_flat`-driven transpose landings (e.g.
+  // `{key: Am}` +4 with prefer-flat → `Dbm`, #2526). Conventional
+  // notation borrows the sharp-side key signature for them
+  // (D-flat minor has no real signature), so the staff glyph shows
+  // sharps even when chord lines spell flats. Sister-site to
+  // `crates/render-html/src/music_glyphs.rs`.
   const MINOR: Record<string, [number, 'sharp' | 'flat' | 'natural']> = {
     A: [0, 'natural'],
     E: [1, 'sharp'],
@@ -128,6 +136,9 @@ export function keySignatureFor(
     Bb: [5, 'flat'],
     Eb: [6, 'flat'],
     Ab: [7, 'flat'],
+    Cb: [2, 'sharp'],
+    Gb: [3, 'sharp'],
+    Db: [4, 'sharp'],
   };
   const table = isMinor ? MINOR : MAJOR;
   const note = `${root}${accidental}`;

--- a/packages/react/src/use-chordpro-ast.ts
+++ b/packages/react/src/use-chordpro-ast.ts
@@ -13,6 +13,7 @@ interface ChordproParser {
     ast: string;
     warnings: string[];
     transposedKey?: string;
+    transposedKeyDirectives?: Record<string, string>;
   };
   parseChordproWithWarningsAndOptions: (
     input: string,
@@ -21,6 +22,7 @@ interface ChordproParser {
     ast: string;
     warnings: string[];
     transposedKey?: string;
+    transposedKeyDirectives?: Record<string, string>;
   };
 }
 
@@ -84,6 +86,17 @@ export interface ChordproAstResult {
    * `ParseChordproResult` shape.
    */
   transposedKey: string | null;
+  /**
+   * Map of `original {key:} directive value → transposed value`
+   * covering every `{key:}` directive in the song (primary +
+   * mid-song). Empty when `transpose === 0` or no `{key:}`
+   * directive parsed as a chord. Mirrors the
+   * `transposedKeyDirectives` field on the wasm
+   * `ParseChordproResult` shape (#2525) — the walker uses it to
+   * render mid-song key chips with the canonical transposed
+   * spelling matching the Rust text / HTML / PDF surfaces.
+   */
+  transposedKeyDirectives: Record<string, string>;
 }
 
 /**
@@ -121,6 +134,9 @@ export function useChordproAst(
   const [error, setError] = useState<Error | null>(null);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [transposedKey, setTransposedKey] = useState<string | null>(null);
+  const [transposedKeyDirectives, setTransposedKeyDirectives] = useState<
+    Record<string, string>
+  >({});
   // Bumping `retryNonce` forces the effect to re-fire even when
   // (`source`, `transpose`, `config`) are unchanged — the hook
   // surface for consumers that hit a transient WASM-init failure
@@ -173,6 +189,7 @@ export function useChordproAst(
         setAst(parsed);
         setWarnings(result.warnings);
         setTransposedKey(result.transposedKey ?? null);
+        setTransposedKeyDirectives(result.transposedKeyDirectives ?? {});
         setError(null);
       } catch (e) {
         if (cancelled) return;
@@ -206,5 +223,13 @@ export function useChordproAst(
     setRetryNonce((n) => n + 1);
   }, []);
 
-  return { ast, loading, error, warnings, retry, transposedKey };
+  return {
+    ast,
+    loading,
+    error,
+    warnings,
+    retry,
+    transposedKey,
+    transposedKeyDirectives,
+  };
 }

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -1676,11 +1676,13 @@ describe('renderChordproAst', () => {
     }
   });
 
-  test('mid-song {key} that does not match the primary key stays single even under transpose', () => {
-    // Host's `transposedKey` is computed against the primary key
-    // (last `metadata.key`); applying it to an unrelated mid-song
-    // `{key}` would be incorrect, so those markers fall through to
-    // the single chip.
+  test('mid-song {key} falls back to single chip when only transposedKey is supplied (back-compat)', () => {
+    // Hosts that haven't been updated to thread
+    // `transposedKeyDirectives` still get the older behaviour:
+    // only the primary `{key:}` directive (the one whose value
+    // matches `metadata.key`) gets the pair display, mid-song
+    // directives stay authored. The map-based path supersedes
+    // this and is exercised by the next test.
     const ast: ChordproSong = {
       metadata: { ...EMPTY_META, key: 'D', keys: ['G', 'D'] },
       lines: [
@@ -1697,10 +1699,76 @@ describe('renderChordproAst', () => {
     const { container } = render(renderChordproAst(ast, { transposedKey: 'E' }));
     const markers = container.querySelectorAll('.meta-inline--key');
     expect(markers).toHaveLength(2);
-    // First `{key: G}` — not the primary, so single chip.
+    // First `{key: G}` — not the primary, no map → single chip.
     expect(markers[0]?.classList.contains('meta-inline--key-pair')).toBe(false);
     // Second `{key: D}` — primary, gets the Written + Sounding pair.
     expect(markers[1]?.classList.contains('meta-inline--key-pair')).toBe(true);
+  });
+
+  // #2525: mid-song `{key:}` directives now reach the same
+  // canonical transpose path the Rust renderers use, surfaced
+  // via the host's `transposedKeyDirectives` map. The walker
+  // emits an Original → Playing pair for every directive whose
+  // authored value appears in the map.
+  test('mid-song {key} renders Original → Playing pair when transposedKeyDirectives covers it', () => {
+    const ast: ChordproSong = {
+      metadata: { ...EMPTY_META, key: 'G', keys: ['G', 'D'] },
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'key', value: 'G', kind: { tag: 'key' }, selector: null },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'key', value: 'D', kind: { tag: 'key' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(
+      renderChordproAst(ast, {
+        transposedKey: 'A',
+        transposedKeyDirectives: { G: 'A', D: 'E' },
+      }),
+    );
+    const markers = container.querySelectorAll('.meta-inline--key');
+    expect(markers).toHaveLength(2);
+    // Primary `{key: G}` → Original G → Playing A.
+    expect(markers[0]?.classList.contains('meta-inline--key-pair')).toBe(true);
+    const primaryGroups = markers[0]?.querySelectorAll('.meta-inline__group');
+    expect(primaryGroups?.[0]?.querySelector('.meta-inline__value')?.textContent).toBe('G');
+    expect(primaryGroups?.[1]?.querySelector('.meta-inline__value')?.textContent).toBe('A');
+    // Mid-song `{key: D}` → Original D → Playing E (the bug
+    // #2525 closed — before the fix this was a single `Key: D`
+    // chip ignoring the transpose).
+    expect(markers[1]?.classList.contains('meta-inline--key-pair')).toBe(true);
+    const midGroups = markers[1]?.querySelectorAll('.meta-inline__group');
+    expect(midGroups?.[0]?.querySelector('.meta-inline__value')?.textContent).toBe('D');
+    expect(midGroups?.[1]?.querySelector('.meta-inline__value')?.textContent).toBe('E');
+  });
+
+  test('mid-song {key} stays single when transposedKeyDirectives entry equals the authored value', () => {
+    // Wasm already filters out no-op entries (transpose=0 or
+    // identity transpose), but the walker also guards in case a
+    // host hand-builds the map. Pair display only fires when
+    // original !== transposed.
+    const ast: ChordproSong = {
+      metadata: { ...EMPTY_META, key: 'G', keys: ['G'] },
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'key', value: 'G', kind: { tag: 'key' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(
+      renderChordproAst(ast, {
+        transposedKeyDirectives: { G: 'G' },
+      }),
+    );
+    expect(container.querySelector('.meta-inline--key-pair')).toBeNull();
+    expect(container.querySelector('.meta-inline--key .meta-inline__label')?.textContent).toBe(
+      'Key:',
+    );
   });
 
   test('extended metadata lands in tiered rows: attribution / params / supplementary / tags', () => {

--- a/packages/react/tests/music-glyphs.test.tsx
+++ b/packages/react/tests/music-glyphs.test.tsx
@@ -53,6 +53,25 @@ describe('keySignatureFor', () => {
     expect(sig?.type).toBe(type);
   });
 
+  // Dbm / Gbm / Cbm arise from `transposed_key_prefers_flat`
+  // landings (e.g. `{key: Am}` +4 with prefer-flat → `Dbm`,
+  // #2526). They have no standalone key signature — by convention
+  // the glyph borrows the sharp-side enharmonic's signature
+  // (Dbm ↔ C#m = 4 sharps, Gbm ↔ F#m = 3 sharps, Cbm ↔ Bm = 2
+  // sharps). Without these entries the glyph emitted an empty
+  // staff that contradicted `aria-label="Key Dbm"`.
+  test.each([
+    ['Dbm', 4, 'sharp'],
+    ['Gbm', 3, 'sharp'],
+    ['Cbm', 2, 'sharp'],
+    ['D♭m', 4, 'sharp'],
+  ])('enharmonic flat-side minor %s maps to %d %s', (input, count, type) => {
+    const sig = keySignatureFor(input);
+    expect(sig).not.toBeNull();
+    expect(sig?.count).toBe(count);
+    expect(sig?.type).toBe(type);
+  });
+
   test('accepts unicode ♯ / ♭ accidentals and lowercase trailing m', () => {
     expect(keySignatureFor('F♯')?.count).toBe(6);
     expect(keySignatureFor('B♭')?.count).toBe(2);
@@ -132,6 +151,17 @@ describe('<KeySignatureGlyph>', () => {
     const svg = container.querySelector('svg.music-glyph--key');
     expect(svg).not.toBeNull();
     expect(svg?.querySelectorAll('g').length).toBe(0);
+  });
+
+  test('Dbm renders 4 sharps via the enharmonic C#m signature (#2526)', () => {
+    // Before the gap was filled, Dbm rendered an empty staff
+    // (0 accidental groups) while the aria-label still announced
+    // "Key Dbm" — a silent visual + accessibility mismatch.
+    const { container } = render(<KeySignatureGlyph keyName="Dbm" />);
+    const svg = container.querySelector('svg.music-glyph--key');
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelectorAll('g').length).toBe(4);
+    expect(svg?.getAttribute('aria-label')).toBe('Key Dbm (4 sharps)');
   });
 
   test('aria-label spells out the key + accidental count for screen readers', () => {


### PR DESCRIPTION
## What

Two related `{key:}` parity gaps left behind by #2524:

- **#2526** — Lookup tables in `crates/render-html/src/music_glyphs.rs::key_signature_for` and the React sister-site `packages/react/src/music-glyphs.tsx::keySignatureFor` had no entries for `Dbm` / `Gbm` / `Cbm`, so the glyph caller emitted an SVG with `aria-label="Key Dbm"` over an empty staff. Filled the gap with the conventional borrowed-signature mapping (`Dbm` ↔ `C#m` = 4 sharps, `Gbm` ↔ `F#m` = 3 sharps, `Cbm` ↔ `Bm` = 2 sharps) on both sides, and exposed a diagnostics variant `key_signature_for_with_diagnostics` that the HTML renderer uses to emit a `push_warning` for any future parseable-but-missing input — silent table gaps are now observable instead of degrading to a blank glyph.

- **#2525** — `{key:}` directives now reach the React JSX walker with their per-directive transposed values, achieving four-way parity with the Rust text / HTML / PDF renderers. `do_parse_chordpro` collects a `BTreeMap<original, transposed>` covering every `{key:}` directive (primary + mid-song), keyed by the authored value and computed with `canonical_transposed_key_with_style` + `transposed_key_prefers_flat` so spellings match the chord lines' song-wide flat/sharp preference. The map is plumbed through `ParseChordproResult.transposedKeyDirectives`, `useChordproAst`'s return tuple, and `RenderChordproAstOptions` into a new `WalkContext` field. The walker's `{key:}` handler now emits the paired `Original → Playing` chip whenever the map has a non-identity entry for the directive's authored value, unifying the primary and mid-song paths. Hosts that haven't been updated to thread the map through fall back to the older `transposedKey`-only behaviour (primary-only pair display, mid-song stays authored) — no breaking change.

## Why

Per `.claude/rules/renderer-parity.md`, the four rendering surfaces must agree on the displayed transposed value for every directive. Before this PR a song with `{key: G}` ... `{key: D}` transposed +2 rendered:

| Surface              | Primary `{key: G}`         | Mid-song `{key: D}` |
| -------------------- | -------------------------- | ------------------- |
| Rust text / HTML / PDF | `Key: A`                 | `Key: E`            |
| React JSX walker     | `Original: G → Playing: A` | `Key: D` (authored) |

— the React walker's mid-song chip silently disagreed with the static-output Rust group. The `Dbm` / `Gbm` / `Cbm` glyph gap was the symmetric accessibility/visual failure on the glyph surface: aria-label said one thing, the rendered SVG said another.

## Test results

- `cargo fmt --check` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test` — full default-members workspace passes; new tests:
  - `key_signature_enharmonic_flat_side_minor_returns_sharp_side_count`
  - `key_signature_svg_enharmonic_minor_emits_sharp_accidentals`
  - `key_signature_diagnostics_distinguishes_unparseable_from_table_gap`
  - `test_parse_chordpro_transposed_key_directives_covers_mid_song_keys`
  - `test_parse_chordpro_transposed_key_directives_empty_when_transpose_zero`
- `packages/react`: `npx tsc --noEmit` clean; `npx vitest run` — 524 / 524 pass; new tests:
  - enharmonic flat-side minor cases in `tests/music-glyphs.test.tsx`
  - `Dbm renders 4 sharps via the enharmonic C#m signature (#2526)`
  - `mid-song {key} renders Original → Playing pair when transposedKeyDirectives covers it`
  - `mid-song {key} stays single when transposedKeyDirectives entry equals the authored value`

## Sister-site audit

- **Renderer parity** (text / HTML / PDF / React JSX walker): the static-output Rust trio already routes every `{key:}` directive through `canonical_transposed_key_with_style` (#2524); this PR adds the matching path to the React JSX walker via the per-directive map, closing the four-way gap. Glyph sister-site fix covers both the Rust `music_glyphs.rs` table and the React `music-glyphs.tsx` table together.
- **Bindings parity** (FFI / WASM / NAPI): only `crates/wasm` exposes a parse-to-AST surface (`parseChordproWithWarnings*`); the NAPI / FFI bindings expose render-only entry points and do not return AST JSON, so no change is needed there. The new `transposedKeyDirectives` field skips serialisation when empty, so existing consumers that ignore the field see no payload-shape change.
- **TS shim**: the inline `ChordproParser` interface in `use-chordpro-ast.ts` and the `RenderChordproAstOptions` interface both declare `transposedKeyDirectives?: Record<string, string>`; the ambient `@chordsketch/wasm` shim is `any`-typed and not affected.

## Deferred

None.

Closes #2525
Closes #2526