### PR TITLE
feat(react): improve grid section layout, alignment, and engraving

### DIFF
--- a/packages/playground/src/playground.css
+++ b/packages/playground/src/playground.css
@@ -1187,20 +1187,32 @@ a {
  * defines `height: 36px` for full-size form fields; the topnav
  * cluster uses a compact 28 px variant to sit alongside the
  * 28 px `.btn-sm` and `.segmented` controls. The native dropdown
- * arrow is preserved (the reference does not strip it) so the
- * select still feels like a native form control across browsers.
+ * arrow is stripped (`appearance: none`) and replaced with an
+ * inline SVG chevron so the arrow position is controllable: at
+ * 28 px the platform arrow rendered ~10 px from the right edge,
+ * which read as detached from the option text. The custom chevron
+ * sits 8 px from the right edge consistently across browsers.
+ * Line-height matches the box height to vertically centre the
+ * glyph baseline — `line-height: 1` was leaving a ~1 px sag with
+ * Noto Sans JP because the JP metrics include extra descender
+ * space below the visual baseline.
  * ---------------------------------------------------------------- */
 
 .chordsketch-app__select {
   height: 28px;
-  padding: 0 0.75rem;
-  background: var(--cs-surface, #FFFFFF);
+  padding: 0 28px 0 0.75rem;
+  background: var(--cs-surface, #FFFFFF)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%2367646D' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
+    no-repeat right 8px center;
   color: var(--cs-text-primary, #0A0A0B);
   border: 1px solid var(--cs-border-strong, #D4D1D6);
   border-radius: 4px;
-  font: 500 0.8125rem/1 var(--cs-font-jp, "Noto Sans JP", system-ui, sans-serif);
+  font: 500 0.8125rem/28px var(--cs-font-jp, "Noto Sans JP", system-ui, sans-serif);
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   cursor: pointer;
-  transition: background var(--cs-dur-1, 120ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1)),
+  transition: background-color var(--cs-dur-1, 120ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1)),
     border-color var(--cs-dur-1, 120ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1)),
     box-shadow var(--cs-dur-1, 120ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1));
 }
@@ -1231,13 +1243,13 @@ a {
    actions") — Latin glyphs sit at the geometric centre of the
    28px box while Noto Sans JP would push them ~1px down. */
 .chordsketch-app__select.insert-picker {
-  background: transparent;
+  background-color: transparent;
   border-color: transparent;
   color: var(--cs-text-secondary, #67646D);
   font-family: var(--cs-font-latin, "Inter", system-ui, sans-serif);
 }
 .chordsketch-app__select.insert-picker:hover:not(:disabled) {
-  background: var(--cs-ink-100, #F6F4F7);
+  background-color: var(--cs-ink-100, #F6F4F7);
   border-color: transparent;
   color: var(--cs-text-primary, #0A0A0B);
 }

--- a/packages/playground/src/playground.css
+++ b/packages/playground/src/playground.css
@@ -1244,12 +1244,17 @@ a {
    28px box while Noto Sans JP would push them ~1px down. */
 .chordsketch-app__select.insert-picker {
   background-color: transparent;
+  /* The base selector's background shorthand now includes an SVG
+     chevron image. Override background-image here so the ghost
+     insert-picker remains arrow-free and minimal-chrome. */
+  background-image: none;
   border-color: transparent;
   color: var(--cs-text-secondary, #67646D);
   font-family: var(--cs-font-latin, "Inter", system-ui, sans-serif);
 }
 .chordsketch-app__select.insert-picker:hover:not(:disabled) {
   background-color: var(--cs-ink-100, #F6F4F7);
+  background-image: none;
   border-color: transparent;
   color: var(--cs-text-primary, #0A0A0B);
 }

--- a/packages/playground/tests-e2e/grid-alignment.spec.ts
+++ b/packages/playground/tests-e2e/grid-alignment.spec.ts
@@ -1,0 +1,946 @@
+// Regression spec for the ChordPro grid-section column alignment
+// (`{start_of_grid}` body lines rendered via `@chordsketch/react`'s
+// `chordpro-jsx` walker).
+//
+// What this spec catches that jsdom unit tests cannot:
+//
+// 1. **Cross-row leading / trailing barline alignment.** Rows
+//    with different leading barline kinds (`|`, `||`, `|:`,
+//    `:|:`) must still share a leading-edge X across the whole
+//    section, because the section's 5-column CSS grid pins
+//    every row's lead cell to col 2 via subgrid + `justify-
+//    self: start`. JSDOM has no layout engine, so a regression
+//    in the subgrid CSS (e.g., a stray width on `.grid-row__
+//    lead` or `.grid-line` losing `display: grid; grid-
+//    template-columns: subgrid;`) only surfaces when a real
+//    browser computes bounding boxes.
+//
+// 2. **Cross-row label gutter alignment when label widths
+//    differ.** The `A` and `Coda` rows of the kitchen-sink
+//    sample land in DIFFERENT bar-count groups (4 vs 5) and
+//    have DIFFERENT visible label widths. The section
+//    propagates the longest label as `--cs-grid-label-max-
+//    text`, which the `::before` pseudo on each `.grid-row__
+//    label` renders invisibly to force the cell width to fit
+//    the widest label. A previous `inline-flex` version of the
+//    label cell laid the visible text and the `::before` sizer
+//    side by side and added their widths, giving a too-wide
+//    gutter (~95px instead of ~47px). Only a real browser's
+//    bounding-rect measurement catches that class of bug.
+//
+// 3. **`%%` → `%` expansion across two bars.** Per the
+//    project's engraving convention, `%%` (repeat-previous-two-
+//    bars) is rewritten at render time into a single-bar `%`
+//    here plus a single-bar `%` in the following bar. JSDOM
+//    can confirm the class names (we do, in the unit suite),
+//    but only a real browser confirms the two glyphs sit in
+//    horizontally-adjacent bars in the expected order.
+//
+// The kitchen-sink sample (`packages/playground/src/chordpro/
+// main.tsx`) is the canonical input. If that sample's grid
+// fixtures change, update this spec to match — the spec is
+// deliberately tied to the user-visible content, not to a
+// throwaway test-only doc, so that "the playground looks right
+// to a human" stays the actual contract.
+
+import { expect, test } from '@playwright/test';
+
+const ALMOST_EQ_PX = 0.5; // round-off slack in floating-point CSS layout
+
+async function pickKitchenSinkSample(page: import('@playwright/test').Page) {
+  await page.goto('./chordpro/');
+  // Wait for the CodeMirror editor to mount and the wasm-backed
+  // preview to produce its first `.song` tree. Without this the
+  // sample-select change can fire before the rendered output
+  // settles into the expected shape.
+  await expect(page.locator('.cm-editor')).toBeVisible();
+  await expect(page.locator('.chordsketch-preview .song').first()).toBeVisible();
+  await page.selectOption('select[aria-label="Sample song"]', {
+    label: 'All directives (kitchen sink)',
+  });
+  // The preview re-renders after the editor value changes; wait
+  // for at least one `section.grid` to land. There are several
+  // grid sections in the kitchen-sink sample.
+  await expect(page.locator('section.grid').first()).toBeVisible();
+}
+
+/**
+ * Locate the grid section containing the `A` / `Coda` rows.
+ * The kitchen-sink sample currently emits multiple grid sections;
+ * this one is identified by having a row whose label text is
+ * exactly `"A"` AND a row whose label text is exactly `"Coda"`.
+ * Matching on label text rather than DOM position makes the spec
+ * survive trivial reorderings of the sample.
+ */
+async function findAcodaSection(page: import('@playwright/test').Page) {
+  // `:has(...)` selects a section that contains both an "A" and
+  // a "Coda" label. The Playwright locator `filter({ has })`
+  // chain is equivalent and survives older CSS engines.
+  const section = page
+    .locator('section.grid')
+    .filter({
+      has: page.locator('.grid-row__label__text', { hasText: /^A$/ }),
+    })
+    .filter({
+      has: page.locator('.grid-row__label__text', { hasText: /^Coda$/ }),
+    });
+  await expect(section).toHaveCount(1);
+  return section;
+}
+
+/**
+ * Compute the "visual barline X" for a barline element — the
+ * conventional engraving anchor position of its glyph kind:
+ * - right-anchored (`:|`, `|.`) → element's RIGHT edge (the
+ *   thick line sits at the glyph's right side)
+ * - left-anchored (`|:`) → element's LEFT edge (the thick
+ *   line sits at the glyph's left side)
+ * - center-anchored (`|`, `||`, `:|:`, volta) → element's
+ *   CENTER (the line / midpoint between lines / midpoint
+ *   between thick lines)
+ *
+ * Every body intermediate kind has its anchor X land on the
+ * slot's CENTRE (= the bar boundary), so two barlines of
+ * any kinds at the same column position across rows have
+ * matching anchor X values even though their bounding boxes
+ * differ. This invariant is what makes mixed-kind columns
+ * (one row with `|`, another with `:|:`) read as vertically
+ * aligned.
+ */
+async function anchorX(locator: import('@playwright/test').Locator): Promise<number> {
+  const data = await locator.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const c = el.className;
+    if (c.includes('grid-barline--repeat-end') || c.includes('grid-barline--final')) {
+      return r.x + r.width;
+    }
+    if (c.includes('grid-barline--repeat-start')) {
+      return r.x;
+    }
+    return r.x + r.width / 2;
+  });
+  return Math.round(data * 100) / 100;
+}
+
+/** Bounding rect of a single locator (asserts it exists first). */
+async function rect(locator: import('@playwright/test').Locator) {
+  const box = await locator.boundingBox();
+  if (!box) throw new Error(`locator ${locator} has no bounding box`);
+  return {
+    left: box.x,
+    right: box.x + box.width,
+    width: box.width,
+    top: box.y,
+    bottom: box.y + box.height,
+    height: box.height,
+  };
+}
+
+test.describe('chordpro grid — column alignment across rows', () => {
+  test('A and Coda rows share lead-left, body edges, trail-right, and comment-left', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = await findAcodaSection(page);
+    const rows = section.locator('.grid-line');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
+
+    // Capture per-row edge X positions for the cells the user's
+    // spec called out: leading barline (LEFT edge anchored),
+    // body (LEFT + RIGHT edges shared = same bar-start / bar-end
+    // X across rows), trailing barline (RIGHT edge anchored),
+    // comment (LEFT edge anchored).
+    const edges: Array<{
+      label: string;
+      leadLeft: number;
+      bodyLeft: number;
+      bodyRight: number;
+      trailRight: number;
+      commentLeft: number;
+    }> = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      const label = (
+        await row.locator('.grid-row__label__text').textContent()
+      )?.trim() ?? '';
+      const leadR = await rect(row.locator('.grid-row__lead'));
+      const bodyR = await rect(row.locator('.grid-line__body'));
+      const trailR = await rect(row.locator('.grid-row__trail'));
+      const commentR = await rect(row.locator('.grid-row__comment'));
+      edges.push({
+        label,
+        leadLeft: leadR.left,
+        bodyLeft: bodyR.left,
+        bodyRight: bodyR.right,
+        trailRight: trailR.right,
+        commentLeft: commentR.left,
+      });
+    }
+
+    // Sanity check: the section under test actually contains
+    // both label kinds — otherwise the alignment assertion is
+    // trivially satisfied by a single-row section.
+    expect(edges.map((e) => e.label)).toEqual(
+      expect.arrayContaining(['A', 'Coda']),
+    );
+
+    // Every row must share each edge position within `ALMOST_EQ_
+    // PX` of every other row. Comparing every row to the first
+    // gives an O(n) check with clear failure messages naming the
+    // offending row.
+    const baseline = edges[0]!;
+    for (let i = 1; i < edges.length; i++) {
+      const here = edges[i]!;
+      expect(
+        Math.abs(here.leadLeft - baseline.leadLeft),
+        `row[${i}] label="${here.label}" leadLeft drifted vs row[0] label="${baseline.label}"`,
+      ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      expect(
+        Math.abs(here.bodyLeft - baseline.bodyLeft),
+        `row[${i}] label="${here.label}" bodyLeft (= bar-1 X) drifted vs row[0]`,
+      ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      expect(
+        Math.abs(here.bodyRight - baseline.bodyRight),
+        `row[${i}] label="${here.label}" bodyRight (= last-bar right X) drifted vs row[0]`,
+      ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      expect(
+        Math.abs(here.trailRight - baseline.trailRight),
+        `row[${i}] label="${here.label}" trailRight drifted vs row[0]`,
+      ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      expect(
+        Math.abs(here.commentLeft - baseline.commentLeft),
+        `row[${i}] label="${here.label}" commentLeft drifted vs row[0]`,
+      ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+    }
+  });
+
+  // Label gutter width matches the widest label across the
+  // section. Without the `::before` sizer this would degrade
+  // either to A's width (gutter too narrow for Coda) or to the
+  // sum of A + Coda (`inline-flex` regression — sibling flex
+  // items added widths instead of overlaying).
+  test('label cells render the same width regardless of label text', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = await findAcodaSection(page);
+    const labels = section.locator('.grid-row__label');
+    const count = await labels.count();
+    const widths: number[] = [];
+    for (let i = 0; i < count; i++) {
+      const w = (await rect(labels.nth(i))).width;
+      widths.push(w);
+    }
+    const min = Math.min(...widths);
+    const max = Math.max(...widths);
+    expect(max - min).toBeLessThanOrEqual(ALMOST_EQ_PX);
+    // The CSS var the section publishes is the longest label
+    // wrapped as a CSS string literal — `"Coda"` in this
+    // sample. Re-asserting in the browser proves the var
+    // actually reaches the rendered DOM (not just that React
+    // emitted it in markup).
+    const cssVar = await section.evaluate((el) =>
+      getComputedStyle(el).getPropertyValue('--cs-grid-label-max-text').trim(),
+    );
+    expect(cssVar).toBe('"Coda"');
+  });
+
+  test('comment cells render the same width regardless of comment text', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = await findAcodaSection(page);
+    const comments = section.locator('.grid-row__comment');
+    const count = await comments.count();
+    const widths: number[] = [];
+    for (let i = 0; i < count; i++) {
+      const w = (await rect(comments.nth(i))).width;
+      widths.push(w);
+    }
+    const min = Math.min(...widths);
+    const max = Math.max(...widths);
+    expect(max - min).toBeLessThanOrEqual(ALMOST_EQ_PX);
+    const cssVar = await section.evaluate((el) =>
+      getComputedStyle(el).getPropertyValue('--cs-grid-comment-max-text').trim(),
+    );
+    // The widest comment in the kitchen-sink A/Coda section is
+    // `repeat 4 times` (row 3 of the original source). If the
+    // sample changes this string, update the expectation.
+    expect(cssVar).toBe('"repeat 4 times"');
+  });
+});
+
+// Per-type lead/trail alignment rules (user spec, 2026-05-23):
+//
+//   1. `|`            keep as-is (defaults: lead=start, trail=end)
+//   2. `||`           lead=start, trail=end, else=center
+//   3. `|.`           always end (right)
+//   4. `|:`           always start (left)
+//   5. `:|`           always end (right)
+//   6. `:|:`          always center
+//
+// These map to `justify-self` on the `.grid-row__lead` /
+// `.grid-row__trail` wrappers via `data-barline-type` selectors
+// in the React package's stylesheet. The spec drives the
+// kitchen-sink sample, walks every grid row, and for each
+// `lead` / `trail` slot asserts that its resolved
+// `justify-self` matches the rule for its barline type. Drift
+// in the CSS (a typo'd selector, an inverted rule, a forgotten
+// override) surfaces here as a clear per-row mismatch report.
+test.describe('chordpro grid — per-type lead/trail alignment', () => {
+  const LEAD_RULES: Record<string, 'start' | 'end' | 'center'> = {
+    barline: 'start',
+    double: 'start',
+    'repeat-start': 'start',
+    final: 'end',
+    'repeat-end': 'end',
+    'repeat-both': 'center',
+    volta: 'start',
+  };
+  const TRAIL_RULES: Record<string, 'start' | 'end' | 'center'> = {
+    barline: 'end',
+    double: 'end',
+    'repeat-start': 'start',
+    final: 'end',
+    'repeat-end': 'end',
+    'repeat-both': 'center',
+    volta: 'end',
+  };
+
+  test('every lead/trail slot resolves justify-self per barline kind', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const observations = await page.evaluate(() => {
+      const out: Array<{
+        slot: 'lead' | 'trail';
+        kind: string;
+        justifySelf: string;
+      }> = [];
+      for (const sec of Array.from(document.querySelectorAll('section.grid'))) {
+        for (const line of Array.from(sec.querySelectorAll('.grid-line'))) {
+          for (const slot of ['lead', 'trail'] as const) {
+            const el = line.querySelector<HTMLElement>(`.grid-row__${slot}`);
+            const kind = el?.getAttribute('data-barline-type');
+            if (!el || !kind) continue;
+            out.push({
+              slot,
+              kind,
+              justifySelf: getComputedStyle(el).justifySelf,
+            });
+          }
+        }
+      }
+      return out;
+    });
+
+    // Sanity floor: the kitchen-sink sample exercises every
+    // major barline kind. If this falls below the floor it
+    // means the sample was rewritten and the spec has lost
+    // its coverage — update the sample or this floor in lockstep.
+    expect(observations.length).toBeGreaterThanOrEqual(8);
+    const seenKinds = new Set(observations.map((o) => o.kind));
+    // Must observe at least these in some slot, to prove the
+    // rules actually fire on real markup.
+    for (const required of [
+      'barline',
+      'double',
+      'repeat-start',
+      'repeat-end',
+      'final',
+    ]) {
+      expect(seenKinds, `kind "${required}" missing from kitchen-sink observations`).toContain(
+        required,
+      );
+    }
+
+    for (const obs of observations) {
+      const rule = obs.slot === 'lead' ? LEAD_RULES[obs.kind] : TRAIL_RULES[obs.kind];
+      expect(
+        rule,
+        `no rule registered for ${obs.slot} kind="${obs.kind}" (sample uses an unknown barline?)`,
+      ).toBeDefined();
+      expect(
+        obs.justifySelf,
+        `${obs.slot} kind="${obs.kind}" justify-self mismatch`,
+      ).toBe(rule);
+    }
+  });
+});
+
+// Body intermediate barlines follow the SAME per-type
+// alignment rules as the lead/trail wrappers (since the body
+// is now a CSS grid with uniform slot widths, `justify-self`
+// resolves to the engraving-correct anchor for every kind).
+// Bare `|`, `||`, `:|:` → center; `|.`, `:|` → end; `|:` →
+// start. Bars themselves stretch their 1fr column.
+test.describe('chordpro grid — body intermediate barline alignment', () => {
+  test('every body barline resolves justify-self per kind', async ({ page }) => {
+    await pickKitchenSinkSample(page);
+    const observations = await page.evaluate(() => {
+      const out: Array<{ cls: string; js: string }> = [];
+      for (const body of Array.from(document.querySelectorAll('.grid-line__body'))) {
+        for (const el of Array.from(body.children) as HTMLElement[]) {
+          if (!el.classList.contains('grid-barline') && !el.classList.contains('grid-volta'))
+            continue;
+          // First descriptor: which modifier (if any) sits on the
+          // element. Multiple cells contribute; reduce to a single
+          // canonical kind for the assertion below.
+          let kind = 'barline';
+          if (el.classList.contains('grid-barline--repeat-both')) kind = 'repeat-both';
+          else if (el.classList.contains('grid-barline--repeat-start')) kind = 'repeat-start';
+          else if (el.classList.contains('grid-barline--repeat-end')) kind = 'repeat-end';
+          else if (el.classList.contains('grid-barline--double')) kind = 'double';
+          else if (el.classList.contains('grid-barline--final')) kind = 'final';
+          else if (el.classList.contains('grid-volta')) kind = 'volta';
+          out.push({ cls: kind, js: getComputedStyle(el).justifySelf });
+        }
+      }
+      return out;
+    });
+    // Sanity floor — same as the lead/trail spec; if the
+    // sample loses coverage of these kinds, update both.
+    expect(observations.length).toBeGreaterThanOrEqual(4);
+    const RULES: Record<string, 'start' | 'end' | 'center'> = {
+      // Body intermediate barlines uniformly use `justify-
+      // self: center` — the glyph sits in the centre of its
+      // slot, with the slot CENTRE being the bar boundary.
+      // Per-kind translates (set in a sibling CSS rule, not
+      // observed by this test) shift the right/left-anchored
+      // kinds so their conventional anchors also land on the
+      // slot centre.
+      barline: 'center',
+      double: 'center',
+      'repeat-start': 'center',
+      'repeat-end': 'center',
+      'repeat-both': 'center',
+      final: 'center',
+      volta: 'center',
+    };
+    for (const o of observations) {
+      expect(o.js, `body barline kind="${o.cls}" mismatch`).toBe(RULES[o.cls]);
+    }
+  });
+
+  // `%` (single-bar repeat) glyph must sit at the centre of
+  // the VISIBLE bar — the rectangle between the barline to
+  // its left and the barline to its right — not at the
+  // centre of its `.grid-bar` ELEMENT. The element only
+  // spans the `1fr` body column; the slot to its right
+  // visually belongs to the same bar from the reader's
+  // perspective, so the visible-bar centre is half a slot
+  // to the RIGHT of the element centre. Regression guard:
+  // ensure the rendered `%` X matches the visible-bar
+  // centre, not the element centre.
+  test('% glyph sits at the visible bar centre (= bar element centre under slot-centre boundary model)', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    // A/Coda is the second grid section; row 0 has bars
+    // [G7, %, %, %] in a 4-bar group. Inspect the % bars.
+    const section = page.locator('section.grid').nth(1);
+    const row0 = section.locator('.grid-line').nth(0);
+    const data = await row0.evaluate((row) => {
+      const bars = Array.from(row.querySelectorAll('.grid-line__body > .grid-bar')) as HTMLElement[];
+      return bars.map((bar) => {
+        const r = bar.getBoundingClientRect();
+        const svg = bar.querySelector('.grid-percent');
+        // Under the slot-centre boundary model, visible bar
+        // centre equals the .grid-bar element centre — the
+        // slot to either side contributes equally (slot/2 on
+        // each side) so the midpoint balances out to the
+        // element centre.
+        return {
+          hasPercent: svg !== null,
+          elementCenter: Math.round((r.x + r.width / 2) * 100) / 100,
+          percentCenter: svg
+            ? Math.round((svg.getBoundingClientRect().x + svg.getBoundingClientRect().width / 2) * 100) / 100
+            : null,
+        };
+      });
+    });
+    for (const bar of data) {
+      if (!bar.hasPercent || bar.percentCenter === null) continue;
+      expect(
+        Math.abs(bar.percentCenter - bar.elementCenter),
+        `% center=${bar.percentCenter} should match bar element centre=${bar.elementCenter} (= visible bar centre)`,
+      ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+    }
+  });
+
+  // Regression guard for the `:|:G` overlap. Under the
+  // slot-centre boundary model the `:|:` glyph centres on
+  // the slot centre and fits ENTIRELY within the slot, so
+  // its right edge sits at slot.right - half_slot_width
+  // and never crosses into the next bar's element bounds.
+  // The chord in the following bar (G7 here) sits at the
+  // bar element's left edge with no obscured pixels.
+  test(':|: glyph does not overflow into the adjacent bar (no chord overlap)', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid').nth(1);
+    const row2 = section.locator('.grid-line').nth(2);
+    const repBoth = row2.locator('.grid-line__body > .grid-barline--repeat-both');
+    const nextChord = row2.locator('.grid-line__body > .grid-bar').nth(2).locator('.grid-chord');
+    expect(await repBoth.count()).toBe(1);
+    expect(await nextChord.count()).toBe(1);
+    const rb = await rect(repBoth);
+    const cr = await rect(nextChord);
+    expect(
+      rb.right,
+      `:|: right edge=${rb.right} must not extend past the next chord's left edge=${cr.left}`,
+    ).toBeLessThanOrEqual(cr.left + ALMOST_EQ_PX);
+  });
+
+  // `:|:` (repeat-both) is a CENTER-anchored glyph — its
+  // conventional engraving anchor is the midpoint between
+  // the two thick lines. To make it visually align with a
+  // bare `|` line at the SAME column position in a sibling
+  // row, the `:|:` glyph's CENTER must sit on the slot's
+  // right edge (= bar boundary). With `justify-self: end`
+  // alone the glyph's RIGHT edge sits at the slot's right,
+  // putting the centre half-a-glyph to the LEFT of where
+  // it should be. The `transform: translateX(50%)` fix
+  // shifts the glyph rightward by half its own width.
+  // Regression guard for the `:|:` shifted-position
+  // report.
+  test(':|: glyph anchor sits on the slot right edge (= bar boundary)', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid').nth(1);
+    // Row 2 of the A/Coda section has the `:|:` intermediate.
+    const row2 = section.locator('.grid-line').nth(2);
+    const repBoth = row2.locator('.grid-line__body > .grid-barline--repeat-both');
+    expect(await repBoth.count()).toBe(1);
+    // Row 0 has a bare `|` at the same column position; its
+    // anchor X is the reference for "where the boundary is".
+    const row0 = section.locator('.grid-line').nth(0);
+    const refBarline = row0.locator('.grid-line__body > .grid-barline').nth(1);
+    const a1 = await anchorX(repBoth);
+    const a0 = await anchorX(refBarline);
+    expect(
+      Math.abs(a1 - a0),
+      `:|: anchor X=${a1} should align with bare | anchor X=${a0}`,
+    ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+  });
+
+  // Perceived bar spacing must be identical across rows of
+  // the same bar count even when the intermediate barline
+  // kinds differ. The bar widths themselves are uniform
+  // (same `1fr` columns + same slot var), but the prior
+  // per-type `justify-self: center` for `||` / `:|:` placed
+  // their glyphs in the MIDDLE of their slots instead of
+  // the right edge — so the visible barline X for a `||`
+  // slot ended up half-a-slot-width to the left of a `|`
+  // slot at the same column position in a sibling row. The
+  // user's "row 1 (all `|`) is the ideal" feedback drove
+  // the unified `end` anchor.
+  test('visible barline X stays identical across rows mixing | / || / :|: in same column', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    // A/Coda is the second grid section; its 4-bar group
+    // has rows mixing `|`, `||`, and `:|:` at the middle
+    // body slot position across rows 0/1/2 (row 3 is the
+    // 5-bar Coda group).
+    const section = page.locator('section.grid').nth(1);
+    // Body's MIDDLE intermediate barline (between bar 2 and
+    // bar 3 in a 4-bar row). Body children order: bar,
+    // barline, bar, barline, bar, barline, bar. Middle =
+    // body child[3].
+    const rows = section.locator('.grid-line');
+    const rowCount = await rows.count();
+    const middleAnchors: number[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      const bars = await row.locator('.grid-line__body > .grid-bar').count();
+      if (bars !== 4) continue; // skip the 5-bar Coda row
+      const middle = row.locator('.grid-line__body > .grid-barline').nth(1);
+      middleAnchors.push(await anchorX(middle));
+    }
+    expect(middleAnchors.length).toBeGreaterThanOrEqual(2);
+    const baseline = middleAnchors[0]!;
+    for (let i = 1; i < middleAnchors.length; i++) {
+      expect(
+        Math.abs(middleAnchors[i]! - baseline),
+        `row[${i}] middle barline anchor X=${middleAnchors[i]} drifted vs row[0] anchor X=${baseline} — per-kind glyph translate regression`,
+      ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+    }
+  });
+
+  // Bar widths are pixel-identical for any two same-bar-count
+  // rows in the same section, even when their intermediate
+  // barlines mix kinds. Validates the uniform `--cs-grid-
+  // barline-slot` propagation + the body CSS-grid layout.
+  test('same-bar-count rows have pixel-identical bar widths in body', async ({ page }) => {
+    await pickKitchenSinkSample(page);
+    const section = await findAcodaSection(page);
+    const rows = section.locator('.grid-line');
+    const rowCount = await rows.count();
+    // Group bars per row by their row's bar count; assert all
+    // rows with the same count have equal bar widths.
+    const measurements: Array<{ count: number; widths: number[] }> = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      const bars = row.locator('.grid-line__body > .grid-bar');
+      const n = await bars.count();
+      const widths: number[] = [];
+      for (let b = 0; b < n; b++) {
+        widths.push((await rect(bars.nth(b))).width);
+      }
+      measurements.push({ count: n, widths });
+    }
+    const byCount = new Map<number, number[][]>();
+    for (const m of measurements) {
+      if (!byCount.has(m.count)) byCount.set(m.count, []);
+      byCount.get(m.count)!.push(m.widths);
+    }
+    for (const [n, rowsWidths] of byCount.entries()) {
+      if (rowsWidths.length < 2) continue;
+      const baseline = rowsWidths[0]!;
+      for (let r = 1; r < rowsWidths.length; r++) {
+        for (let b = 0; b < n; b++) {
+          expect(
+            Math.abs(rowsWidths[r]![b]! - baseline[b]!),
+            `bar[${b}] width in row[${r}] (count=${n}) drifted vs row[0]`,
+          ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+        }
+      }
+    }
+  });
+});
+
+// Regression spec for the Outro Riff section (kitchen-sink
+// row 2 = `|1 Em . . . | C . . . :| |2 Am . . . | G . . . |.`).
+// The source legitimately puts TWO consecutive markers in
+// the body (`:|` immediately followed by `|2`), which broke
+// the prior body grid template that assumed strict bar /
+// marker alternation: the cell count exceeded the column
+// count, the overflow cells wrapped onto implicit row
+// tracks, and the row visually collapsed into a tall stack
+// of singletons. After the fix, the template is derived
+// from the actual cell sequence and every body cell lands
+// on row 1 of the body grid.
+test.describe('chordpro grid — Outro Riff (clustered markers)', () => {
+  test('every body cell renders on a single grid row (no implicit-row wrap)', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    // Find the Outro Riff section by its section label.
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    await expect(section).toHaveCount(1);
+    const rows = section.locator('.grid-line');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      const body = row.locator('.grid-line__body');
+      // Pull the resolved DOM stats from inside the page so
+      // childElementCount and getBoundingClientRect are real
+      // browser values.
+      const { childCount, childTops, bodyTop } = await body.evaluate((el) => {
+        const childs = Array.from(el.children) as HTMLElement[];
+        return {
+          childCount: childs.length,
+          childTops: childs.map((c) => Math.round(c.getBoundingClientRect().top)),
+          bodyTop: Math.round(el.getBoundingClientRect().top),
+        };
+      });
+      // The body must have at least 1 child (the row has bars).
+      expect(childCount, `row[${i}] body has no children`).toBeGreaterThan(0);
+      // Every child sits on the same Y as the body — i.e., none
+      // wrapped onto implicit row tracks. (Tolerate small
+      // sub-pixel rounding by snapping to integer pixels.)
+      for (let c = 0; c < childTops.length; c++) {
+        expect(
+          Math.abs(childTops[c]! - bodyTop),
+          `row[${i}] body child[${c}] top=${childTops[c]} drifted from body top=${bodyTop} — implicit-row wrap regression`,
+        ).toBeLessThanOrEqual(2);
+      }
+    }
+  });
+
+  // The `:| |2` cluster collapses to a single repeat-end
+  // marker carrying a volta-2 bracket overlay, so row 2's
+  // body cell count matches row 1's (both 4 bars + 3 markers).
+  // That means the two rows share the same body grid template
+  // and bar X positions land identically — verifies the merge
+  // + body-template-from-cells fix together restore visual
+  // alignment between the two phrases.
+  test('row 1 and row 2 bar X positions match after `:| |2` collapse', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    const rows = section.locator('.grid-line');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
+    const allLefts: number[][] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const bars = rows.nth(i).locator('.grid-line__body > .grid-bar');
+      const n = await bars.count();
+      const lefts: number[] = [];
+      for (let b = 0; b < n; b++) {
+        lefts.push((await rect(bars.nth(b))).left);
+      }
+      allLefts.push(lefts);
+    }
+    // Sanity floor: both rows must have the same bar count
+    // for the alignment assertion to be meaningful.
+    expect(new Set(allLefts.map((l) => l.length)).size).toBe(1);
+    const baseline = allLefts[0]!;
+    for (let r = 1; r < allLefts.length; r++) {
+      for (let b = 0; b < baseline.length; b++) {
+        expect(
+          Math.abs(allLefts[r]![b]! - baseline[b]!),
+          `row[${r}] bar[${b}] X drifted vs row[0] — :| |2 collapse regression`,
+        ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      }
+    }
+  });
+
+  // Volta bracket overlay surfaces ON the merged host marker
+  // (not as a sibling cell). Row 2 of the kitchen-sink source
+  // has TWO collapsed pairs — leading `| |1` and middle `:|
+  // |2` — so two `.grid-volta__bracket` overlays should be
+  // attached to barline-kind hosts in row 2 (one on the
+  // leading-edge bare barline, one on the middle repeat-end).
+  // Row 1 has no volta markers so zero brackets.
+  test('volta brackets render as overlays on their host barlines after collapse', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    const rows = section.locator('.grid-line');
+    // Row 1: no voltas at all.
+    expect(await rows.nth(0).locator('.grid-volta__bracket').count()).toBe(0);
+    expect(await rows.nth(0).locator('.grid-volta').count()).toBe(0);
+    // Row 2: two bracket overlays. NO standalone `.grid-volta`
+    // cell because the leading `|1` is preceded by the row's
+    // implicit bar-grid lead position (handled by the lead/
+    // trail extraction, not by a barline marker), so `|1`
+    // sits in the lead slot as a standalone volta — that's
+    // ONE `.grid-volta`. The middle `|2` collapses into the
+    // `:|` host. Total: 2 brackets, 1 standalone volta.
+    expect(await rows.nth(1).locator('.grid-volta__bracket').count()).toBe(2);
+    expect(await rows.nth(1).locator('.grid-volta').count()).toBe(1);
+  });
+
+  // Visible barline X parity across rows: row 1's bare `|`
+  // in the middle of the body and row 2's `:|` (merged with
+  // volta-2) in the SAME column position must paint their
+  // visible barline on the same X. Both anchor at the slot's
+  // RIGHT edge (`justify-self: end` default for `|`; same
+  // override for `repeat-end`), so the `|`'s line and the
+  // `:|`'s thick line share an X. Without this parity the
+  // engraving reads as misaligned barlines between the two
+  // phrases — the user-reported regression that motivated
+  // the default change from `center` to `end` for bare `|`.
+  test('bare | and merged :| paint their visible line on the same X across rows', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    // Row 1 body's MIDDLE bare barline (between bars 2 and 3).
+    // Body has 7 children: bar, barline, bar, barline, bar,
+    // barline, bar. Middle barline = body child[3].
+    const row1Mid = section.locator('.grid-line').nth(0).locator('.grid-line__body > .grid-barline').nth(1);
+    // Row 2 body's middle marker — the merged `:|+v2` host.
+    const row2Mid = section.locator('.grid-line').nth(1).locator('.grid-line__body .grid-barline--repeat-end');
+    // Each kind anchors at its conventional position: bare
+    // `|` at glyph centre (after the +50% translate), merged
+    // `:|` at glyph right edge (no translate). Both anchor
+    // X values must coincide — they should both sit on the
+    // bar boundary X for this column position.
+    const a1 = await anchorX(row1Mid);
+    const a2 = await anchorX(row2Mid);
+    expect(
+      Math.abs(a1 - a2),
+      `row1 | anchor X=${a1} should match row2 :| anchor X=${a2} (bar boundary)`,
+    ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+  });
+
+  // Volta bracket's L-shape leg MUST start at the host glyph's
+  // conventional "barline X" — that is, the X of the line
+  // that the volta annotates. For `:|` (repeat-end) the
+  // anchor is the thick line on the right edge of the glyph,
+  // so the bracket's LEFT EDGE (the leg, painted via
+  // `border-left`) must align with the host's right edge.
+  // For a standalone volta at the row lead position, the
+  // host's own line is at its left edge so the bracket's
+  // left edge sits there. Regression guard — the bracket's
+  // visible left border is the L's vertical leg, and it must
+  // visually continue into the barline beneath it.
+  test('volta bracket leg anchors at the host barline X per host kind', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    const row2 = section.locator('.grid-line').nth(1);
+
+    // Case A: standalone leading volta `|1` (NOT collapsed).
+    // The bracket's left edge (= leg) sits at the volta
+    // element's left edge, continuing into the volta's own
+    // line below.
+    const leadVolta = row2.locator('.grid-row__lead .grid-volta');
+    expect(await leadVolta.count()).toBe(1);
+    const leadVoltaBox = await rect(leadVolta);
+    const leadBracket = leadVolta.locator('.grid-volta__bracket');
+    const leadBracketBox = await rect(leadBracket);
+    expect(
+      Math.abs(leadBracketBox.left - leadVoltaBox.left),
+      'leading volta bracket leg should start at the volta element left edge',
+    ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+
+    // Case B: merged `:| |2` overlay on the body's repeat-end
+    // host. The host's barline X is the THICK line on the
+    // right edge of the glyph, so the bracket's left edge
+    // (the leg) must align with the host's right edge.
+    const merged = row2.locator('.grid-line__body .grid-barline--repeat-end');
+    expect(await merged.count()).toBe(1);
+    const hostBox = await rect(merged);
+    const mergedBracket = merged.locator('.grid-volta__bracket');
+    expect(await mergedBracket.count()).toBe(1);
+    const bracketBox = await rect(mergedBracket);
+    expect(
+      Math.abs(bracketBox.left - hostBox.right),
+      `merged volta bracket leg left=${bracketBox.left} should align with host right=${hostBox.right} for repeat-end`,
+    ).toBeLessThanOrEqual(ALMOST_EQ_PX);
+  });
+
+  // Visual breathing room: the bracket bottom must sit ~4px
+  // ABOVE the host's top edge so the leg and the barline
+  // beneath read as two distinct strokes (not a single
+  // continuous run of pixels). Regression guard for the
+  // intentional gap — accept a small rounding band around
+  // the nominal 4px so sub-pixel layout drift does not
+  // flake the test.
+  test('volta bracket leaves a ~4px gap above the host barline', async ({ page }) => {
+    const NOMINAL_GAP_PX = 4;
+    const GAP_TOLERANCE_PX = 1.5;
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    const row2 = section.locator('.grid-line').nth(1);
+    // Standalone leading volta's host = the volta element
+    // itself; the bracket's bottom should sit above the
+    // host's top by ~4px.
+    const leadVolta = row2.locator('.grid-row__lead .grid-volta');
+    const leadHostBox = await rect(leadVolta);
+    const leadBracketBox = await rect(leadVolta.locator('.grid-volta__bracket'));
+    const leadGap = leadHostBox.top - leadBracketBox.bottom;
+    expect(
+      Math.abs(leadGap - NOMINAL_GAP_PX),
+      `leading-volta gap=${leadGap}px should be ~${NOMINAL_GAP_PX}px`,
+    ).toBeLessThanOrEqual(GAP_TOLERANCE_PX);
+    // Merged repeat-end host.
+    const merged = row2.locator('.grid-line__body .grid-barline--repeat-end');
+    const mergedHostBox = await rect(merged);
+    const mergedBracketBox = await rect(merged.locator('.grid-volta__bracket'));
+    const mergedGap = mergedHostBox.top - mergedBracketBox.bottom;
+    expect(
+      Math.abs(mergedGap - NOMINAL_GAP_PX),
+      `merged-volta gap=${mergedGap}px should be ~${NOMINAL_GAP_PX}px`,
+    ).toBeLessThanOrEqual(GAP_TOLERANCE_PX);
+  });
+
+  // L-shape integrity: the bracket box renders BOTH a
+  // `border-top` (the cap) AND a `border-left` (the leg).
+  // Without either border the engraving collapses to a
+  // dangling label, so guard both via computed style.
+  test('volta bracket renders both top and left borders for the L-shape', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    const brackets = section.locator('.grid-volta__bracket');
+    const count = await brackets.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      const borders = await brackets.nth(i).evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return {
+          topWidth: parseFloat(cs.borderTopWidth),
+          topStyle: cs.borderTopStyle,
+          leftWidth: parseFloat(cs.borderLeftWidth),
+          leftStyle: cs.borderLeftStyle,
+          // No right / bottom borders — the L is open on those
+          // two sides so the cap extends RIGHTWARD over the
+          // bracketed bars and the leg only descends downward.
+          rightWidth: parseFloat(cs.borderRightWidth),
+          bottomWidth: parseFloat(cs.borderBottomWidth),
+        };
+      });
+      expect(borders.topWidth, `bracket[${i}] border-top width`).toBeGreaterThan(0);
+      expect(borders.topStyle).toBe('solid');
+      expect(borders.leftWidth, `bracket[${i}] border-left width`).toBeGreaterThan(0);
+      expect(borders.leftStyle).toBe('solid');
+      expect(borders.rightWidth, `bracket[${i}] must not paint a right border`).toBe(0);
+      expect(borders.bottomWidth, `bracket[${i}] must not paint a bottom border`).toBe(0);
+    }
+  });
+
+  // Bar X positions don't perfectly align between Outro Riff
+  // rows because row 2 carries an extra `:| |2` pair the
+  // first row does not. What MUST be aligned is the section-
+  // level edges: lead-left, body-left, body-right, trail-
+  // right. This catches a regression where the grid layout
+  // resync between the two rows would break under the cluster.
+  test('lead/body/trail edges stay aligned across rows even with clustered body markers', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    const section = page.locator('section.grid', { hasText: 'Outro Riff' });
+    const rows = section.locator('.grid-line');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
+    const edges: Array<{ leadLeft: number; bodyLeft: number; bodyRight: number; trailRight: number }> = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      const leadR = await rect(row.locator('.grid-row__lead'));
+      const bodyR = await rect(row.locator('.grid-line__body'));
+      const trailR = await rect(row.locator('.grid-row__trail'));
+      edges.push({
+        leadLeft: leadR.left,
+        bodyLeft: bodyR.left,
+        bodyRight: bodyR.right,
+        trailRight: trailR.right,
+      });
+    }
+    const baseline = edges[0]!;
+    for (let i = 1; i < edges.length; i++) {
+      const here = edges[i]!;
+      expect(Math.abs(here.leadLeft - baseline.leadLeft), `row[${i}] leadLeft drift`).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      expect(Math.abs(here.bodyLeft - baseline.bodyLeft), `row[${i}] bodyLeft drift`).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      expect(Math.abs(here.bodyRight - baseline.bodyRight), `row[${i}] bodyRight drift`).toBeLessThanOrEqual(ALMOST_EQ_PX);
+      expect(Math.abs(here.trailRight - baseline.trailRight), `row[${i}] trailRight drift`).toBeLessThanOrEqual(ALMOST_EQ_PX);
+    }
+  });
+});
+
+test.describe('chordpro grid — `%%` expansion', () => {
+  test('no `--percent2` cells survive; `%%` becomes two adjacent `%` glyphs', async ({
+    page,
+  }) => {
+    await pickKitchenSinkSample(page);
+    // Anywhere in the rendered page — `%%` is expanded in every
+    // grid renderer pass, so a stray `--percent2` class
+    // anywhere is the regression signal.
+    await expect(page.locator('.grid-beat--percent2')).toHaveCount(0);
+    // The kitchen-sink sample has at least one row containing
+    // `%% .` followed by `. .` (the "(2) Full-syntax" grid
+    // section). After expansion that row carries at least two
+    // adjacent `%` beats. Looking up the first matching row by
+    // its `data-label-text="A"` keeps the assertion bound to a
+    // stable structural anchor.
+    const row = page.locator('.grid-line[data-label-text="A"]').first();
+    const percentBeats = row.locator('.grid-beat--percent1');
+    // Row has at least three `%` after expansion (one from the
+    // standalone `% .` bar 2, one from the `%% .` bar 3, plus
+    // one from the auto-injected next-bar `% .`). Use `>=` so
+    // the spec survives small fixture tweaks.
+    expect(await percentBeats.count()).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/playground/tests-e2e/grid-alignment.spec.ts
+++ b/packages/playground/tests-e2e/grid-alignment.spec.ts
@@ -506,7 +506,7 @@ test.describe('chordpro grid — body intermediate barline alignment', () => {
   // shifts the glyph rightward by half its own width.
   // Regression guard for the `:|:` shifted-position
   // report.
-  test(':|: glyph anchor sits on the slot right edge (= bar boundary)', async ({
+  test(':|: glyph anchor sits on the slot centre (= bar boundary)', async ({
     page,
   }) => {
     await pickKitchenSinkSample(page);

--- a/packages/playground/tests-e2e/grid-alignment.spec.ts
+++ b/packages/playground/tests-e2e/grid-alignment.spec.ts
@@ -47,7 +47,22 @@ import { expect, test } from '@playwright/test';
 
 const ALMOST_EQ_PX = 0.5; // round-off slack in floating-point CSS layout
 
+// Captured uncaught exceptions for the active test. Filled by
+// the `pageerror` listener registered in `pickKitchenSinkSample`.
+// Tests can assert this stays empty as the catch-all integrity
+// check that complements specific structural assertions.
+const recordedPageErrors: Error[] = [];
+
 async function pickKitchenSinkSample(page: import('@playwright/test').Page) {
+  // Catch any uncaught exception that reaches the window during
+  // the mount + sample-swap flow. Per `.claude/rules/playground-
+  // smoke.md`: a `pageerror` listener guards against the pre-#2397
+  // class of failure where the editor mounts cleanly and renders
+  // partially, but a wasm-bridge / walker exception silently drops
+  // a section without crashing the suite. Tests below can assert
+  // `recordedPageErrors.length === 0` to catch this class.
+  recordedPageErrors.length = 0;
+  page.on('pageerror', (err) => recordedPageErrors.push(err));
   await page.goto('./chordpro/');
   // Wait for the CodeMirror editor to mount and the wasm-backed
   // preview to produce its first `.song` tree. Without this the
@@ -141,6 +156,13 @@ test.describe('chordpro grid — column alignment across rows', () => {
     page,
   }) => {
     await pickKitchenSinkSample(page);
+    // Catch-all: any uncaught exception during mount + sample-
+    // swap is a regression even when the per-edge layout
+    // assertions below still pass on the cells that did render.
+    expect(
+      recordedPageErrors.map((e) => e.message),
+      'uncaught exceptions reached the window during kitchen-sink mount',
+    ).toEqual([]);
     const section = await findAcodaSection(page);
     const rows = section.locator('.grid-line');
     const rowCount = await rows.count();

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -621,14 +621,22 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
     | { kind: 'percent1' }
     | { kind: 'percent2' };
   type Bar = { kind: 'bar'; beats: BeatSlot[]; noChord: boolean };
+  // Non-volta markers can carry an optional `volta` attachment
+  // — this is how a source like `:| |2` collapses to a single
+  // cell: the repeat-end glyph IS the barline, and the volta-2
+  // bracket overlays the same position (instead of rendering a
+  // second redundant line). The standalone `volta` kind keeps
+  // its own line (used when a volta marker appears at the row
+  // start, not preceded by another barline).
   type Marker =
-    | { kind: 'repeat-start' }
-    | { kind: 'repeat-end' }
-    | { kind: 'repeat-both' }
-    | { kind: 'double' }
-    | { kind: 'final' }
+    | ({ kind: 'repeat-start' } & VoltaAttach)
+    | ({ kind: 'repeat-end' } & VoltaAttach)
+    | ({ kind: 'repeat-both' } & VoltaAttach)
+    | ({ kind: 'double' } & VoltaAttach)
+    | ({ kind: 'final' } & VoltaAttach)
     | { kind: 'volta'; ending: number }
-    | { kind: 'barline' };
+    | ({ kind: 'barline' } & VoltaAttach);
+  type VoltaAttach = { volta?: number };
   type Cell = Bar | Marker;
   const cells: Cell[] = [];
   let current: Bar | null = null;
@@ -683,6 +691,74 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
   }
   flush();
 
+  // Collapse `[non-volta-marker, volta]` pairs into a single
+  // cell that carries the marker glyph PLUS the volta bracket
+  // as an overlay. Sources like `:| |2 Am` semantically mean
+  // one barline position (the repeat-end) at which the 2nd-
+  // ending bracket begins. Rendering them as two adjacent
+  // cells double-draws the barline; collapsing keeps only the
+  // first marker's lines and re-attaches the volta bracket on
+  // top so the engraving reads as the user's source intends.
+  for (let i = 0; i < cells.length - 1; i++) {
+    const here = cells[i]!;
+    const next = cells[i + 1]!;
+    if (here.kind === 'bar' || here.kind === 'volta') continue;
+    if (next.kind !== 'volta') continue;
+    (here as { volta?: number }).volta = next.ending;
+    cells.splice(i + 1, 1);
+    // Do NOT decrement `i` — a volta that follows another
+    // volta after collapsing would be unusual (sister volta
+    // markers at the same position) and merging chains is
+    // not in the source-engraving convention.
+  }
+
+  // Expand `%%` (repeat-previous-two-bars) into a `%` mark in
+  // its own bar PLUS a `%` mark in the next bar — per the
+  // user's spec, the engraving convention is to drop a simple
+  // repeat sign into each repeated bar rather than draw one
+  // straddle-glyph across the barline. If the source's next bar
+  // already carries musical content (chords / strums) we leave
+  // it alone — that combination is malformed against the
+  // ChordPro spec and the user-authored content takes priority.
+  for (let i = 0; i < cells.length; i++) {
+    const cell = cells[i]!;
+    if (cell.kind !== 'bar') continue;
+    const p2 = cell.beats.findIndex((b) => b.kind === 'percent2');
+    if (p2 === -1) continue;
+    cell.beats[p2] = { kind: 'percent1' };
+    for (let j = i + 1; j < cells.length; j++) {
+      const next = cells[j]!;
+      if (next.kind !== 'bar') continue;
+      const hasContent = next.beats.some(
+        (b) => b.kind === 'chord' || b.kind === 'strum' || b.kind === 'percent1' || b.kind === 'percent2',
+      );
+      if (!hasContent) {
+        next.beats = [{ kind: 'percent1' }];
+      }
+      break;
+    }
+  }
+
+  // Volta bracket overlay that a non-volta marker can carry
+  // when collapsed from a `[marker, volta]` source pair. The
+  // bracket positions absolute against its host marker; the
+  // host must be `position: relative` (provided by the
+  // `.grid-barline` CSS rule).
+  // L-shape volta bracket: the horizontal cap and the vertical
+  // leg are both drawn as the bracket box's own border edges
+  // (`border-top` + `border-left`), so the leg is naturally
+  // continuous with the host barline beneath it. The label
+  // ("1." / "2.") tucks inside the L's corner.
+  const renderVoltaOverlay = (ending: number): JSX.Element => (
+    <span
+      className="grid-volta__bracket"
+      role="note"
+      aria-label={`${ending} ending`}
+    >
+      <span className="grid-volta__label">{ending}.</span>
+    </span>
+  );
+
   const renderMarker = (m: Marker, idx: number): JSX.Element => {
     switch (m.kind) {
       case 'repeat-start':
@@ -698,6 +774,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
               <span />
               <span />
             </span>
+            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
           </span>
         );
       case 'repeat-end':
@@ -713,6 +790,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
             </span>
             <span className="grid-barline__line" />
             <span className="grid-barline__line grid-barline__line--thick" />
+            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
           </span>
         );
       case 'repeat-both':
@@ -735,13 +813,19 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
               <span />
               <span />
             </span>
+            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
           </span>
         );
       case 'double':
         return (
-          <span key={idx} className="grid-barline grid-barline--double" aria-hidden="true">
+          <span
+            key={idx}
+            className="grid-barline grid-barline--double"
+            aria-hidden={m.volta === undefined ? true : undefined}
+          >
             <span className="grid-barline__line" />
             <span className="grid-barline__line" />
+            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
           </span>
         );
       case 'final':
@@ -749,20 +833,28 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
           <span key={idx} className="grid-barline grid-barline--final" aria-label="final barline">
             <span className="grid-barline__line" />
             <span className="grid-barline__line grid-barline__line--thick" />
+            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
           </span>
         );
       case 'volta':
         return (
           <span key={idx} className="grid-volta" aria-label={`${m.ending} ending`}>
             <span className="grid-volta__bracket">
-              <span className="grid-volta__cap" />
               <span className="grid-volta__label">{m.ending}.</span>
             </span>
             <span className="grid-barline__line" />
           </span>
         );
       case 'barline':
-        return <span key={idx} className="grid-barline" aria-hidden="true" />;
+        return (
+          <span
+            key={idx}
+            className="grid-barline"
+            aria-hidden={m.volta === undefined ? true : undefined}
+          >
+            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
+          </span>
+        );
     }
   };
 
@@ -797,27 +889,54 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
             ))}
           </span>
         );
-      case 'strum':
+      case 'strum': {
+        // Split compound `~`-separated tokens (`dn~up`, `d+~u+`,
+        // `~ux`) into elementary parts and render each part as
+        // its own glyph. A leading empty segment from a leading
+        // `~` (e.g. `~up`) marks the whole compound as
+        // anticipated. The combined token still renders as a
+        // single beat slot, but each component reads as a
+        // discrete arrow.
+        const parts = slot.raw.split('~');
+        const anticipated = parts[0] === '';
+        const tokens = anticipated ? parts.slice(1) : parts;
         return (
           <span key={idx} className={`grid-beat grid-strum ${strumClassFor(slot.raw)}`}>
             <span className="grid-strum__glyph" aria-hidden="true">
-              {strumGlyphFor(slot.raw)}
+              {anticipated ? <span className="grid-strum__antic">~</span> : null}
+              {tokens.map((part, pi) => (
+                <Fragment key={pi}>
+                  {pi > 0 ? (
+                    <span className="grid-strum__sep" aria-hidden="true">·</span>
+                  ) : null}
+                  <span className={`grid-strum__part ${strumClassFor(part)}`}>
+                    {strumGlyphFor(part)}
+                  </span>
+                </Fragment>
+              ))}
             </span>
             <span className="sr-only">{slot.raw}</span>
           </span>
         );
+      }
       case 'continuation':
         return <span key={idx} className="grid-beat" />;
       case 'percent1':
         return (
           <span key={idx} className="grid-beat grid-beat--percent1" aria-label="repeat previous bar">
-            <span className="grid-percent" aria-hidden="true">%</span>
+            <RepeatBarGlyph bars={1} />
           </span>
         );
       case 'percent2':
+        // Should not be reachable — the expansion pass in
+        // `renderGridLine` rewrites every `%%` beat to a `%`
+        // here plus a `%` in the next bar. This case stays as
+        // a defensive fallback so the type-checker is satisfied
+        // and a future regression in the expansion pass still
+        // renders something visible.
         return (
-          <span key={idx} className="grid-beat grid-beat--percent2" aria-label="repeat previous two bars">
-            <span className="grid-percent" aria-hidden="true">%%</span>
+          <span key={idx} className="grid-beat grid-beat--percent1" aria-label="repeat previous bar">
+            <RepeatBarGlyph bars={1} />
           </span>
         );
     }
@@ -842,40 +961,229 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
   const labelText = renderLabel(labelTokens);
   const commentText = renderLabel(commentTokens);
 
-  return (
-    <div key={key} className={isStrumRow ? 'grid-line grid-line--strum' : 'grid-line'}>
-      {labelText.length > 0 ? (
-        <span className="grid-row__label">{labelText}</span>
-      ) : null}
-      {cells.map((cell, idx) => {
-        if (cell.kind === 'bar') {
-          // Each bar lays out one beat slot per source token
-          // (`cell` or `.`). The bar width is split equally
-          // between slots so a `G . C .` bar puts G under
-          // beat 1 and C under beat 3 — matching standard
-          // chord-chart engraving where the chord prints over
-          // the beat it starts on. A pure `G . . .` bar
-          // anchors G in slot 1 and leaves the rest empty
-          // (the chord continues to ring).
-          const beats = cell.beats.length > 0 ? cell.beats : [{ kind: 'continuation' as const }];
-          return (
-            <span key={idx} className="grid-bar" data-beats={beats.length}>
-              {cell.noChord ? (
-                <span className="grid-no-chord" aria-label="no chord">
-                  N.C.
-                </span>
-              ) : (
-                beats.map((b, bi) => renderBeat(b, bi))
-              )}
+  // Render any single cell — a bar (with its beat slots) or a
+  // marker (barline, volta, repeat). Extracted so the leading,
+  // trailing, and body cells all go through the same path.
+  const renderCell = (cell: Cell, idx: number): JSX.Element => {
+    if (cell.kind === 'bar') {
+      // Each bar lays out one beat slot per source token
+      // (`cell` or `.`). The bar width is split equally between
+      // slots so a `G . C .` bar puts G under beat 1 and C
+      // under beat 3 — matching standard chord-chart engraving
+      // where the chord prints over the beat it starts on. A
+      // pure `G . . .` bar anchors G in slot 1 and leaves the
+      // rest empty (the chord continues to ring).
+      const beats = cell.beats.length > 0 ? cell.beats : [{ kind: 'continuation' as const }];
+      // `%` repeat cells centre in the bar (not pinned to the
+      // beat-1 flex slot) — engraving convention. `%%` is
+      // pre-expanded into `%` here + `%` in the next bar.
+      const hasPercent1 = beats.some((b) => b.kind === 'percent1');
+      const barClass = hasPercent1
+        ? 'grid-bar grid-bar--percent1-center'
+        : 'grid-bar';
+      return (
+        <span key={idx} className={barClass} data-beats={beats.length}>
+          {cell.noChord ? (
+            <span className="grid-no-chord" aria-label="no chord">
+              N.C.
             </span>
-          );
-        }
-        return renderMarker(cell, idx);
-      })}
-      {commentText.length > 0 ? (
-        <span className="grid-row__comment">{commentText}</span>
-      ) : null}
+          ) : (
+            beats.map((b, bi) => renderBeat(b, bi))
+          )}
+        </span>
+      );
+    }
+    return renderMarker(cell, idx);
+  };
+
+  // Estimated visual width (in `em` units, relative to the grid
+  // font size) of each barline kind's rendered glyph. Used to
+  // size the body's barline column slots uniformly across the
+  // section so every same-bar-count row has identical bar X
+  // positions even when its intermediate barlines mix kinds
+  // (a `:|:` glyph would otherwise eat ~3× the gap of a `|`).
+  // Numbers are intentionally a hair wider than the actual
+  // glyphs so the slot fully contains the widest case and
+  // leaves a small visual breathing margin.
+  const widthForBarlineKind = (kind: string): number => {
+    switch (kind) {
+      case 'repeat-both':
+        return 1.7;
+      case 'repeat-start':
+      case 'repeat-end':
+        return 1.2;
+      case 'final':
+        return 0.6;
+      case 'double':
+        return 0.5;
+      case 'volta':
+      case 'barline':
+      default:
+        return 0.3;
+    }
+  };
+  // Maximum barline-glyph width across this row's cells — used
+  // as a per-line floor when computing the section-wide slot
+  // width in flushSection.
+  const maxBarlineEm = cells.reduce((max, c) => {
+    if (c.kind === 'bar') return max;
+    return Math.max(max, widthForBarlineKind(c.kind));
+  }, 0.3);
+
+  // Slice the cells stream into three buckets so the row can
+  // place them in fixed section-level subgrid columns: the
+  // FIRST cell (always a marker — `bodyTokens` starts with a
+  // barline-kind token) becomes the row's leading-barline
+  // slot; the LAST cell (a marker, when there is more than one
+  // cell) becomes the trailing-barline slot; everything in
+  // between becomes the body. The section grid pins lead and
+  // trail to their own columns so all rows' leading edges line
+  // up at the section's left margin and trailing edges line up
+  // at the section's right margin — independent of how many
+  // bars each row contains.
+  const leadCell = cells.length > 0 && cells[0]!.kind !== 'bar' ? cells[0]! : null;
+  const trailCell =
+    cells.length > 1 && cells[cells.length - 1]!.kind !== 'bar'
+      ? cells[cells.length - 1]!
+      : null;
+  const bodyStart = leadCell ? 1 : 0;
+  const bodyEnd = trailCell ? cells.length - 1 : cells.length;
+  const bodyCells = cells.slice(bodyStart, bodyEnd);
+
+  // Body grid template: one column per body cell, in source
+  // order. Bar cells get `1fr` (they share remaining body
+  // width equally); marker cells (barlines, voltas) get the
+  // section-wide uniform `--cs-grid-barline-slot` width. We
+  // CANNOT assume strict bar/marker alternation — sources
+  // like `… :| |2 …` legitimately put two consecutive
+  // markers in the body (a repeat-end immediately followed
+  // by a volta-2 bracket). Building the template from the
+  // actual cell sequence keeps the column count in sync with
+  // the rendered children regardless of how the markers
+  // cluster. Empty bodies fall back to `auto`.
+  const bodyTemplate =
+    bodyCells.length > 0
+      ? bodyCells
+          .map((c) => (c.kind === 'bar' ? '1fr' : 'var(--cs-grid-barline-slot, 1em)'))
+          .join(' ')
+      : 'auto';
+
+  return (
+    <div
+      key={key}
+      className={isStrumRow ? 'grid-line grid-line--strum' : 'grid-line'}
+      data-label-text={labelText}
+      data-comment-text={commentText}
+      data-max-barline-em={maxBarlineEm}
+    >
+      {/* Label gutter — sized to the SECTION's longest label
+          via `::before` pseudo + `--cs-grid-label-max-text` var
+          set in flushSection. Empty rows still occupy the
+          column so bar-start positions align. */}
+      <span
+        className="grid-row__label"
+        aria-hidden={labelText.length === 0 ? true : undefined}
+      >
+        <span className="grid-row__label__text">{labelText}</span>
+      </span>
+      {/* Leading barline cell — section subgrid col 2. The
+          `data-barline-type` attribute drives a per-type
+          `justify-self` rule in CSS so each glyph anchors at
+          the conventionally correct edge of its column slot:
+          `|:` (repeat-start), `||` (double), `|` (single) anchor
+          LEFT; `:|` (repeat-end), `|.` (final) anchor RIGHT;
+          `:|:` (repeat-both) anchors CENTER. Volta brackets
+          fall through to the default left anchor. */}
+      <span
+        className="grid-row__lead"
+        data-barline-type={leadCell?.kind ?? undefined}
+      >
+        {leadCell ? renderCell(leadCell, -1) : null}
+      </span>
+      {/* Body — intermediate barlines + bars. Laid out as a
+          per-row CSS grid alternating `1fr` bar columns and
+          `var(--cs-grid-barline-slot)` barline columns. The
+          slot variable is published by the section so every
+          row uses the same barline-column width; combined
+          with the section subgrid sharing a single `1fr` body
+          column across all rows, same-bar-count rows end up
+          with identical bar widths AND identical barline X
+          positions. Each barline element then uses per-type
+          `justify-self` to land its glyph's logical anchor
+          (left edge / center / right edge) on the column's
+          edge per the engraving convention. */}
+      <span
+        className="grid-line__body"
+        style={{ gridTemplateColumns: bodyTemplate }}
+      >
+        {bodyCells.map((cell, idx) => renderCell(cell, idx))}
+      </span>
+      {/* Trailing barline cell — section subgrid col 4. Per-type
+          alignment via `data-barline-type` mirrors the lead cell:
+          types whose visual "barline position" sits at the right
+          edge of the glyph (`|.`, `:|`, `||` at row end) anchor
+          RIGHT; `|:` (rarely used as a trailing barline but
+          handled for completeness) anchors LEFT; `:|:` anchors
+          CENTER. */}
+      <span
+        className="grid-row__trail"
+        data-barline-type={trailCell?.kind ?? undefined}
+      >
+        {trailCell ? renderCell(trailCell, -2) : null}
+      </span>
+      <span
+        className="grid-row__comment"
+        aria-hidden={commentText.length === 0 ? true : undefined}
+      >
+        <span className="grid-row__comment__text">{commentText}</span>
+      </span>
     </div>
+  );
+}
+
+/**
+ * Conventional measure-repeat glyph: a thick slash flanked by
+ * two dots. One slash for `%` (repeat previous bar), two slashes
+ * with a separating dot pair in the middle for `%%` (repeat
+ * previous two bars). Rendered as inline SVG so the glyph is
+ * crisp at every zoom level — the SMuFL code points 𝄎 / 𝄏
+ * (U+1D14E / U+1D14F) lack reliable system-font coverage.
+ */
+function RepeatBarGlyph({ bars }: { bars: 1 | 2 }): JSX.Element {
+  // Standard music-notation repeat sign: a thick slash flanked
+  // by one dot upper-left and one dot lower-right. The 2-bar
+  // variant adds a SECOND slash next to the first inside the
+  // same dot pair (per the user's correction — it's not two
+  // independent `%` signs side-by-side, just one repeat glyph
+  // with more slashes). SMuFL: 𝄎 (U+1D14E) / 𝄏 (U+1D14F).
+  if (bars === 2) {
+    return (
+      <svg
+        className="grid-percent"
+        viewBox="0 0 20 16"
+        width="1.25em"
+        height="1em"
+        aria-hidden="true"
+      >
+        <circle cx="4" cy="5" r="1.4" fill="currentColor" />
+        <line x1="2" y1="13" x2="11" y2="3" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+        <line x1="7" y1="13" x2="16" y2="3" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+        <circle cx="16" cy="11" r="1.4" fill="currentColor" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      className="grid-percent"
+      viewBox="0 0 16 16"
+      width="1em"
+      height="1em"
+      aria-hidden="true"
+    >
+      <circle cx="4" cy="5" r="1.4" fill="currentColor" />
+      <line x1="2" y1="13" x2="14" y2="3" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+      <circle cx="12" cy="11" r="1.4" fill="currentColor" />
+    </svg>
   );
 }
 
@@ -905,25 +1213,21 @@ function strumClassFor(raw: string): string {
 }
 
 /**
- * Visual glyph for a strum token. Returns a short arrow / mark
- * sequence the renderer drops into a `.grid-strum__glyph` span.
- * Spec-defined tokens get the conventional arrow glyphs; tilde-
- * prefixed and dialect-only tokens fall back to the raw text
- * (with `~` rendered as a leading tilde so the reader sees the
- * source intent).
+ * Visual glyph for an ELEMENTARY strum token (no `~`). Callers
+ * are expected to have split compound tokens (`dn~up`,
+ * `d+~u+`) on `~` and to handle the anticipation marker
+ * separately. Spec-defined primitives get conventional arrow
+ * glyphs; dialect-only primitives (`ux`, `dx`, etc.) fall back
+ * to the raw text so the reader still sees the source intent.
  */
 function strumGlyphFor(raw: string): string {
-  const anticipated = raw.startsWith('~');
-  const stripped = anticipated ? raw.slice(1) : raw;
-  const ant = anticipated ? '~' : '';
-  if (/^(up|u)$/i.test(stripped)) return `${ant}↑`;
-  if (/^(dn|d)$/i.test(stripped)) return `${ant}↓`;
-  if (/^u\+$/i.test(stripped)) return `${ant}↑+`;
-  if (/^d\+$/i.test(stripped)) return `${ant}↓+`;
-  if (/^ua$/i.test(stripped)) return `${ant}↑·`;
-  if (/^da$/i.test(stripped)) return `${ant}↓·`;
-  // Dialect variants (`dn~up`, `~ux`, `d+~u+`, etc.) — pass
-  // through verbatim so the reader still sees the source intent.
+  if (/^(up|u)$/i.test(raw)) return '↑';
+  if (/^(dn|d)$/i.test(raw)) return '↓';
+  if (/^u\+$/i.test(raw)) return '↑+';
+  if (/^d\+$/i.test(raw)) return '↓+';
+  if (/^ua$/i.test(raw)) return '↑·';
+  if (/^da$/i.test(raw)) return '↓·';
+  // Dialect primitives (`ux`, `dx`, etc.) — pass through.
   return raw;
 }
 
@@ -2891,6 +3195,19 @@ interface WalkContext {
   onChordReposition?: (event: ChordRepositionEvent) => void;
 }
 
+/**
+ * Wrap `s` as a CSS string literal so it is safe to embed in a
+ * CSS `content:` property via a custom property. Escapes the
+ * two characters that have meaning inside a double-quoted CSS
+ * string — backslash and the closing double-quote. Used by the
+ * grid-section label/comment gutter sizer to render the longest
+ * text invisibly behind every cell so subgrid `auto` columns
+ * size to the wider rendered width.
+ */
+function cssStringLiteral(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function flushSection(ctx: WalkContext, key: number): void {
   if (!ctx.section) return;
   const { name, label, children, startLine } = ctx.section;
@@ -2930,16 +3247,70 @@ function flushSection(ctx: WalkContext, key: number): void {
     ctx.activeSourceLine !== undefined &&
     (ctx.activeSourceLine === startLine || ctx.activeSourceLine === endLine);
   const sectionClassName = sectionActive ? `${name} line--active` : name;
+  // Grid section children render flat as siblings of the section.
+  // The section's CSS grid (label / lead-barline / body / trail-
+  // barline / comment columns) plus `.grid-line` subgrid keeps
+  // every row's edges aligned across the whole section without
+  // needing intermediate per-bar-count group wrappers.
+  const bodyChildren = children;
+  // Section-wide label / comment gutter widths: every label cell
+  // inherits a `::before` pseudo whose `content` is the LONGEST
+  // label string in this section. The pseudo is `height: 0`
+  // (invisible) but its intrinsic width — measured in the
+  // label's actual font, weight, letter-spacing, and case — is
+  // included in the label cell's max-content. Subgrid `auto`
+  // columns size to that max-content, so the A-row and the
+  // CODA-row both reserve a gutter wide enough for "CODA" and
+  // their bar-start positions line up across groups.
+  let sectionStyleObj: CSSProperties | undefined = sectionStyle ?? undefined;
+  if (name === 'grid') {
+    let longestLabel = '';
+    let longestComment = '';
+    let maxBarlineEm = 0.3;
+    for (const child of children) {
+      if (!isValidElement(child)) continue;
+      const props = child.props as {
+        'data-label-text'?: string;
+        'data-comment-text'?: string;
+        'data-max-barline-em'?: number;
+      };
+      const lt = props['data-label-text'];
+      if (typeof lt === 'string' && lt.length > longestLabel.length) {
+        longestLabel = lt;
+      }
+      const ct = props['data-comment-text'];
+      if (typeof ct === 'string' && ct.length > longestComment.length) {
+        longestComment = ct;
+      }
+      const w = props['data-max-barline-em'];
+      if (typeof w === 'number' && w > maxBarlineEm) {
+        maxBarlineEm = w;
+      }
+    }
+    sectionStyleObj = {
+      ...(sectionStyleObj ?? {}),
+      ['--cs-grid-label-max-text' as never]: cssStringLiteral(longestLabel),
+      ['--cs-grid-comment-max-text' as never]: cssStringLiteral(longestComment),
+      // Barline-slot width for the body grid in each row. Set
+      // from the widest barline kind appearing anywhere in this
+      // section so every barline slot in every row is identical
+      // — that's what gives same-bar-count rows pixel-aligned
+      // bar widths even when their intermediate barline kinds
+      // differ (a row of `|` separators and a row containing
+      // `:|:` end up with the same per-bar X span).
+      ['--cs-grid-barline-slot' as never]: `${maxBarlineEm}em`,
+    };
+  }
   ctx.out.push(
     <section
       key={key}
       className={sectionClassName}
-      style={sectionStyle ?? undefined}
+      style={sectionStyleObj}
       data-source-line={startLine}
       aria-labelledby={labelId}
     >
       {labelNode}
-      {children}
+      {bodyChildren}
     </section>,
   );
   // Capture the chorus body for `{chorus}` recall replay. Other

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -621,22 +621,24 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
     | { kind: 'percent1' }
     | { kind: 'percent2' };
   type Bar = { kind: 'bar'; beats: BeatSlot[]; noChord: boolean };
-  // Non-volta markers can carry an optional `volta` attachment
-  // — this is how a source like `:| |2` collapses to a single
-  // cell: the repeat-end glyph IS the barline, and the volta-2
-  // bracket overlays the same position (instead of rendering a
-  // second redundant line). The standalone `volta` kind keeps
-  // its own line (used when a volta marker appears at the row
-  // start, not preceded by another barline).
-  type Marker =
-    | ({ kind: 'repeat-start' } & VoltaAttach)
-    | ({ kind: 'repeat-end' } & VoltaAttach)
-    | ({ kind: 'repeat-both' } & VoltaAttach)
-    | ({ kind: 'double' } & VoltaAttach)
-    | ({ kind: 'final' } & VoltaAttach)
-    | { kind: 'volta'; ending: number }
-    | ({ kind: 'barline' } & VoltaAttach);
-  type VoltaAttach = { volta?: number };
+  // A barline-kind marker can carry an optional `voltas` overlay
+  // (one or more ending numbers when the source has `:| |2` or
+  // `:| |2 |3`). The standalone `volta` marker is a separate
+  // shape used only when a volta cell is at row start without a
+  // preceding barline. Modelling these as two parallel union
+  // members keeps "standalone volta carrying its own overlay"
+  // unrepresentable at compile time and removes the need for
+  // any field-write cast.
+  type BarlineKind =
+    | 'barline'
+    | 'double'
+    | 'final'
+    | 'repeat-start'
+    | 'repeat-end'
+    | 'repeat-both';
+  type BarlineMarker = { kind: BarlineKind; voltas?: number[] };
+  type StandaloneVolta = { kind: 'volta'; ending: number };
+  type Marker = BarlineMarker | StandaloneVolta;
   type Cell = Bar | Marker;
   const cells: Cell[] = [];
   let current: Bar | null = null;
@@ -691,52 +693,86 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
   }
   flush();
 
-  // Collapse `[non-volta-marker, volta]` pairs into a single
-  // cell that carries the marker glyph PLUS the volta bracket
-  // as an overlay. Sources like `:| |2 Am` semantically mean
-  // one barline position (the repeat-end) at which the 2nd-
-  // ending bracket begins. Rendering them as two adjacent
-  // cells double-draws the barline; collapsing keeps only the
-  // first marker's lines and re-attaches the volta bracket on
-  // top so the engraving reads as the user's source intends.
-  for (let i = 0; i < cells.length - 1; i++) {
+  // Collapse `[non-volta-marker, volta+]` runs into the host
+  // marker, which then carries the volta endings as an overlay.
+  // A run is one non-volta marker immediately followed by ANY
+  // number of volta cells (`:| |1 |2 |3 Am`). Multiple-volta
+  // chains land on a SINGLE overlay (`1.2.3.`) because the
+  // engraving convention is one bracket per barline position,
+  // even when several endings start there. A run with a single
+  // trailing volta (`:| |2`) is the common case. After this
+  // pass, NO `volta` cell follows a non-volta marker — any
+  // surviving `volta` cell is at row start with no preceding
+  // marker (e.g. the lead `|1` of `|1 Em . :|`).
+  for (let i = 0; i < cells.length; i++) {
     const here = cells[i]!;
-    const next = cells[i + 1]!;
     if (here.kind === 'bar' || here.kind === 'volta') continue;
-    if (next.kind !== 'volta') continue;
-    (here as { volta?: number }).volta = next.ending;
-    cells.splice(i + 1, 1);
-    // Do NOT decrement `i` — a volta that follows another
-    // volta after collapsing would be unusual (sister volta
-    // markers at the same position) and merging chains is
-    // not in the source-engraving convention.
+    const endings: number[] = [];
+    let j = i + 1;
+    while (j < cells.length) {
+      const next = cells[j]!;
+      if (next.kind !== 'volta') break;
+      endings.push(next.ending);
+      j++;
+    }
+    if (endings.length > 0) {
+      cells.splice(i + 1, endings.length);
+      here.voltas = endings;
+    }
   }
 
   // Expand `%%` (repeat-previous-two-bars) into a `%` mark in
-  // its own bar PLUS a `%` mark in the next bar — per the
-  // user's spec, the engraving convention is to drop a simple
-  // repeat sign into each repeated bar rather than draw one
-  // straddle-glyph across the barline. If the source's next bar
-  // already carries musical content (chords / strums) we leave
-  // it alone — that combination is malformed against the
-  // ChordPro spec and the user-authored content takes priority.
+  // its own bar PLUS a `%` mark in the next bar. The chosen
+  // engraving convention is one single-bar mark per repeated
+  // bar rather than a straddle glyph across the barline.
+  //
+  // Three precondition cases the expansion handles explicitly
+  // so a malformed source never silently mis-renders:
+  //
+  // 1. NO PRIOR BAR (`%%` is the first bar of the section) —
+  //    nothing to repeat. The `%%` survives unrewritten and
+  //    `renderBeat` paints a real 2-bar repeat glyph as a
+  //    "best available representation" rather than a `%`
+  //    that lies about what's being repeated.
+  // 2. NO NEXT BAR (`%%` is the last bar of the row) — same
+  //    handling as #1. The `%%` survives.
+  // 3. NEXT BAR HAS CONTENT — leave the `%%` intact (don't
+  //    half-rewrite by replacing only the current bar) and
+  //    let `renderBeat` paint the 2-bar glyph. This makes
+  //    the malformed source visually distinct from the
+  //    well-formed `%% .` pattern.
+  //
+  // A bar can contain multiple `%%` beats (`| %% %% |` —
+  // rare but legal). Every percent2 in the bar gets rewritten,
+  // not just the first one.
+  const hasPriorBar = (idx: number): boolean => {
+    for (let k = idx - 1; k >= 0; k--) {
+      if (cells[k]!.kind === 'bar') return true;
+    }
+    return false;
+  };
+  const findNextBar = (idx: number): number => {
+    for (let k = idx + 1; k < cells.length; k++) {
+      if (cells[k]!.kind === 'bar') return k;
+    }
+    return -1;
+  };
   for (let i = 0; i < cells.length; i++) {
     const cell = cells[i]!;
     if (cell.kind !== 'bar') continue;
-    const p2 = cell.beats.findIndex((b) => b.kind === 'percent2');
-    if (p2 === -1) continue;
-    cell.beats[p2] = { kind: 'percent1' };
-    for (let j = i + 1; j < cells.length; j++) {
-      const next = cells[j]!;
-      if (next.kind !== 'bar') continue;
-      const hasContent = next.beats.some(
-        (b) => b.kind === 'chord' || b.kind === 'strum' || b.kind === 'percent1' || b.kind === 'percent2',
-      );
-      if (!hasContent) {
-        next.beats = [{ kind: 'percent1' }];
-      }
-      break;
-    }
+    if (!cell.beats.some((b) => b.kind === 'percent2')) continue;
+    if (!hasPriorBar(i)) continue;
+    const nextBarIdx = findNextBar(i);
+    if (nextBarIdx === -1) continue;
+    const next = cells[nextBarIdx] as Bar;
+    const nextHasContent = next.beats.some(
+      (b) => b.kind === 'chord' || b.kind === 'strum' || b.kind === 'percent1' || b.kind === 'percent2',
+    );
+    if (nextHasContent) continue;
+    cell.beats = cell.beats.map((b) =>
+      b.kind === 'percent2' ? { kind: 'percent1' } : b,
+    );
+    next.beats = [{ kind: 'percent1' }];
   }
 
   // Volta bracket overlay that a non-volta marker can carry
@@ -749,15 +785,30 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
   // (`border-top` + `border-left`), so the leg is naturally
   // continuous with the host barline beneath it. The label
   // ("1." / "2.") tucks inside the L's corner.
-  const renderVoltaOverlay = (ending: number): JSX.Element => (
-    <span
-      className="grid-volta__bracket"
-      role="note"
-      aria-label={`${ending} ending`}
-    >
-      <span className="grid-volta__label">{ending}.</span>
-    </span>
-  );
+  // Render the volta-ending overlay (`1.`, `1.2.`, `1.2.3.` for
+  // a single or chained ending list). Returns `null` when the
+  // endings array is empty so the caller can splat the result
+  // unconditionally.
+  const renderVoltaOverlay = (endings: number[]): JSX.Element | null => {
+    if (endings.length === 0) return null;
+    const label = endings.map((n) => `${n}.`).join('');
+    const ariaParts = endings.map((n) => `${n} ending`).join(' and ');
+    return (
+      <span className="grid-volta__bracket" role="note" aria-label={ariaParts}>
+        <span className="grid-volta__label">{label}</span>
+      </span>
+    );
+  };
+
+  // Compose an `aria-label` for a barline host. When a volta
+  // overlay is attached, append the ending list so screen
+  // readers announce the combined musical meaning instead of
+  // only the barline kind.
+  const barlineAriaLabel = (base: string, voltas: number[] | undefined): string => {
+    if (!voltas || voltas.length === 0) return base;
+    const endingLabel = voltas.map((n) => `${n} ending`).join(' and ');
+    return `${base}, ${endingLabel}`;
+  };
 
   const renderMarker = (m: Marker, idx: number): JSX.Element => {
     switch (m.kind) {
@@ -766,7 +817,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
           <span
             key={idx}
             className="grid-barline grid-barline--repeat-start"
-            aria-label="repeat start"
+            aria-label={barlineAriaLabel('repeat start', m.voltas)}
           >
             <span className="grid-barline__line grid-barline__line--thick" />
             <span className="grid-barline__line" />
@@ -774,7 +825,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
               <span />
               <span />
             </span>
-            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
+            {renderVoltaOverlay(m.voltas ?? [])}
           </span>
         );
       case 'repeat-end':
@@ -782,7 +833,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
           <span
             key={idx}
             className="grid-barline grid-barline--repeat-end"
-            aria-label="repeat end"
+            aria-label={barlineAriaLabel('repeat end', m.voltas)}
           >
             <span className="grid-barline__dots">
               <span />
@@ -790,7 +841,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
             </span>
             <span className="grid-barline__line" />
             <span className="grid-barline__line grid-barline__line--thick" />
-            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
+            {renderVoltaOverlay(m.voltas ?? [])}
           </span>
         );
       case 'repeat-both':
@@ -801,7 +852,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
           <span
             key={idx}
             className="grid-barline grid-barline--repeat-both"
-            aria-label="repeat end and start"
+            aria-label={barlineAriaLabel('repeat end and start', m.voltas)}
           >
             <span className="grid-barline__dots">
               <span />
@@ -813,27 +864,34 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
               <span />
               <span />
             </span>
-            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
+            {renderVoltaOverlay(m.voltas ?? [])}
           </span>
         );
-      case 'double':
+      case 'double': {
+        const hasOverlay = m.voltas !== undefined && m.voltas.length > 0;
         return (
           <span
             key={idx}
             className="grid-barline grid-barline--double"
-            aria-hidden={m.volta === undefined ? true : undefined}
+            aria-label={hasOverlay ? barlineAriaLabel('double barline', m.voltas) : undefined}
+            aria-hidden={hasOverlay ? undefined : true}
           >
             <span className="grid-barline__line" />
             <span className="grid-barline__line" />
-            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
+            {renderVoltaOverlay(m.voltas ?? [])}
           </span>
         );
+      }
       case 'final':
         return (
-          <span key={idx} className="grid-barline grid-barline--final" aria-label="final barline">
+          <span
+            key={idx}
+            className="grid-barline grid-barline--final"
+            aria-label={barlineAriaLabel('final barline', m.voltas)}
+          >
             <span className="grid-barline__line" />
             <span className="grid-barline__line grid-barline__line--thick" />
-            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
+            {renderVoltaOverlay(m.voltas ?? [])}
           </span>
         );
       case 'volta':
@@ -845,16 +903,19 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
             <span className="grid-barline__line" />
           </span>
         );
-      case 'barline':
+      case 'barline': {
+        const hasOverlay = m.voltas !== undefined && m.voltas.length > 0;
         return (
           <span
             key={idx}
             className="grid-barline"
-            aria-hidden={m.volta === undefined ? true : undefined}
+            aria-label={hasOverlay ? barlineAriaLabel('barline', m.voltas) : undefined}
+            aria-hidden={hasOverlay ? undefined : true}
           >
-            {m.volta !== undefined ? renderVoltaOverlay(m.volta) : null}
+            {renderVoltaOverlay(m.voltas ?? [])}
           </span>
         );
+      }
     }
   };
 
@@ -897,9 +958,16 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
         // anticipated. The combined token still renders as a
         // single beat slot, but each component reads as a
         // discrete arrow.
+        // Split on `~`, drop the leading empty marker (the
+        // anticipation prefix has its own glyph), and filter
+        // any remaining empty segments so a malformed source
+        // like `dn~~up` does not render zero-content
+        // separator beads (`↓··↑`).
         const parts = slot.raw.split('~');
         const anticipated = parts[0] === '';
-        const tokens = anticipated ? parts.slice(1) : parts;
+        const tokens = (anticipated ? parts.slice(1) : parts).filter(
+          (p) => p.length > 0,
+        );
         return (
           <span key={idx} className={`grid-beat grid-strum ${strumClassFor(slot.raw)}`}>
             <span className="grid-strum__glyph" aria-hidden="true">
@@ -928,15 +996,17 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
           </span>
         );
       case 'percent2':
-        // Should not be reachable — the expansion pass in
-        // `renderGridLine` rewrites every `%%` beat to a `%`
-        // here plus a `%` in the next bar. This case stays as
-        // a defensive fallback so the type-checker is satisfied
-        // and a future regression in the expansion pass still
-        // renders something visible.
+        // Reached when the expansion pass declined to rewrite
+        // a `%%` beat — there was no prior bar to repeat, no
+        // following bar to inject the second `%` into, or the
+        // following bar already carried musical content. The
+        // 2-bar repeat glyph is the best available
+        // representation of the source intent in those cases
+        // (better than silently downgrading to a single-bar
+        // `%` that would misstate the engraving).
         return (
-          <span key={idx} className="grid-beat grid-beat--percent1" aria-label="repeat previous bar">
-            <RepeatBarGlyph bars={1} />
+          <span key={idx} className="grid-beat grid-beat--percent2" aria-label="repeat previous two bars">
+            <RepeatBarGlyph bars={2} />
           </span>
         );
     }
@@ -1000,12 +1070,12 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
   // font size) of each barline kind's rendered glyph. Used to
   // size the body's barline column slots uniformly across the
   // section so every same-bar-count row has identical bar X
-  // positions even when its intermediate barlines mix kinds
-  // (a `:|:` glyph would otherwise eat ~3× the gap of a `|`).
-  // Numbers are intentionally a hair wider than the actual
-  // glyphs so the slot fully contains the widest case and
-  // leaves a small visual breathing margin.
-  const widthForBarlineKind = (kind: string): number => {
+  // positions even when its intermediate barlines mix kinds.
+  // Exhaustive on the closed `BarlineKind` set — adding a new
+  // kind to the union fails the build here without a width,
+  // so a regression cannot silently fall back to the bare-line
+  // default and produce too-narrow slots that overlap chords.
+  const widthForBarlineKind = (kind: BarlineKind): number => {
     switch (kind) {
       case 'repeat-both':
         return 1.7;
@@ -1016,17 +1086,20 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
         return 0.6;
       case 'double':
         return 0.5;
-      case 'volta':
       case 'barline':
-      default:
         return 0.3;
     }
   };
+  // Standalone volta cell width — its glyph is just the
+  // bracket leg above the row's lead position, so its
+  // intrinsic body-slot width is the same as a bare `|`.
+  const STANDALONE_VOLTA_EM = 0.3;
   // Maximum barline-glyph width across this row's cells — used
   // as a per-line floor when computing the section-wide slot
   // width in flushSection.
   const maxBarlineEm = cells.reduce((max, c) => {
     if (c.kind === 'bar') return max;
+    if (c.kind === 'volta') return Math.max(max, STANDALONE_VOLTA_EM);
     return Math.max(max, widthForBarlineKind(c.kind));
   }, 0.3);
 
@@ -1096,7 +1169,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
           fall through to the default left anchor. */}
       <span
         className="grid-row__lead"
-        data-barline-type={leadCell?.kind ?? undefined}
+        data-barline-type={leadCell?.kind}
       >
         {leadCell ? renderCell(leadCell, -1) : null}
       </span>
@@ -1127,7 +1200,7 @@ function renderGridLine(line: ChordproLyricsLine, key: number): JSX.Element {
           CENTER. */}
       <span
         className="grid-row__trail"
-        data-barline-type={trailCell?.kind ?? undefined}
+        data-barline-type={trailCell?.kind}
       >
         {trailCell ? renderCell(trailCell, -2) : null}
       </span>
@@ -3197,15 +3270,17 @@ interface WalkContext {
 
 /**
  * Wrap `s` as a CSS string literal so it is safe to embed in a
- * CSS `content:` property via a custom property. Escapes the
- * characters that are significant inside a double-quoted CSS
- * string: backslash, the closing double-quote, and the three
- * newline variants (U+000A LF, U+000D CR, U+000C FF) that
- * terminate a CSS string and would produce a parse error causing
- * the `::before` sizer pseudo to silently fall back to `''`.
- * Used by the grid-section label/comment gutter sizer to render
- * the longest text invisibly behind every cell so subgrid `auto`
- * columns size to the wider rendered width.
+ * CSS `content:` property via a custom property. Escapes
+ * backslash and the closing double-quote, and collapses the
+ * three newline variants (U+000A LF, U+000D CR, U+000C FF)
+ * to a literal space — an unescaped newline terminates a CSS
+ * string and would produce a parse error causing the
+ * `::before` sizer pseudo to silently fall back to `''`.
+ * The collapse-to-space form is preferred over CSS hex
+ * (`\\A` / `\\D` / `\\C`) for the sizer use case: the
+ * pseudo's content is invisible and only used for
+ * `min-content` width measurement, where a single horizontal
+ * run is the intended geometry.
  */
 function cssStringLiteral(s: string): string {
   return `"${s
@@ -3253,21 +3328,13 @@ function flushSection(ctx: WalkContext, key: number): void {
     ctx.activeSourceLine !== undefined &&
     (ctx.activeSourceLine === startLine || ctx.activeSourceLine === endLine);
   const sectionClassName = sectionActive ? `${name} line--active` : name;
-  // Grid section children render flat as siblings of the section.
-  // The section's CSS grid (label / lead-barline / body / trail-
-  // barline / comment columns) plus `.grid-line` subgrid keeps
-  // every row's edges aligned across the whole section without
-  // needing intermediate per-bar-count group wrappers.
-  const bodyChildren = children;
-  // Section-wide label / comment gutter widths: every label cell
-  // inherits a `::before` pseudo whose `content` is the LONGEST
-  // label string in this section. The pseudo is `height: 0`
-  // (invisible) but its intrinsic width — measured in the
-  // label's actual font, weight, letter-spacing, and case — is
-  // included in the label cell's max-content. Subgrid `auto`
-  // columns size to that max-content, so the A-row and the
-  // CODA-row both reserve a gutter wide enough for "CODA" and
-  // their bar-start positions line up across groups.
+  // For grid sections, propagate section-wide layout metadata
+  // (longest label/comment text, widest barline kind) via CSS
+  // custom properties on the `<section>` so every row's
+  // `::before` sizer and body grid resolve to the same X
+  // positions. The per-row metadata is published as data-*
+  // attributes by `renderGridLine`; this loop reads it back
+  // and folds it into the section style.
   let sectionStyleObj: CSSProperties | undefined = sectionStyle ?? undefined;
   if (name === 'grid') {
     let longestLabel = '';
@@ -3316,7 +3383,7 @@ function flushSection(ctx: WalkContext, key: number): void {
       aria-labelledby={labelId}
     >
       {labelNode}
-      {bodyChildren}
+      {children}
     </section>,
   );
   // Capture the chorus body for `{chorus}` recall replay. Other

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -3198,14 +3198,20 @@ interface WalkContext {
 /**
  * Wrap `s` as a CSS string literal so it is safe to embed in a
  * CSS `content:` property via a custom property. Escapes the
- * two characters that have meaning inside a double-quoted CSS
- * string — backslash and the closing double-quote. Used by the
- * grid-section label/comment gutter sizer to render the longest
- * text invisibly behind every cell so subgrid `auto` columns
- * size to the wider rendered width.
+ * characters that are significant inside a double-quoted CSS
+ * string: backslash, the closing double-quote, and the three
+ * newline variants (U+000A LF, U+000D CR, U+000C FF) that
+ * terminate a CSS string and would produce a parse error causing
+ * the `::before` sizer pseudo to silently fall back to `''`.
+ * Used by the grid-section label/comment gutter sizer to render
+ * the longest text invisibly behind every cell so subgrid `auto`
+ * columns size to the wider rendered width.
  */
 function cssStringLiteral(s: string): string {
-  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  return `"${s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\n\r\f]/g, ' ')}"`;
 }
 
 function flushSection(ctx: WalkContext, key: number): void {

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -528,24 +528,145 @@
 }
 
 /* Grid section — iReal Pro-style bar grid.
-   Each `{start_of_grid}` body line lays out a flex row of
-   alternating barlines (fixed-width) and bar cells
-   (`flex: 1` → equal width). Continuation dots from the source
-   are dropped — beat alignment within a bar is handled by the
-   bar cell's own flex distribution.
-   `.grid-line` opens its own row context so the bars don't
-   inherit the lyric `display: flex; flex-wrap: wrap` from the
-   parent. */
+   The SECTION is a CSS grid with five columns:
+     1. label gutter (auto, sized to widest label)
+     2. leading-barline slot (auto, sized to widest leading barline)
+     3. body — bars + intermediate barlines (1fr, equal across rows)
+     4. trailing-barline slot (auto, sized to widest trailing barline)
+     5. comment gutter (auto, sized to widest comment)
+   Each `.grid-line` is a subgrid of these five columns, so:
+   - all rows' bar grids start at the same X (col 2 left edge);
+   - all rows' bar grids end at the same X (col 4 right edge);
+   - the body width is identical across rows (col 3 = 1fr), so
+     same-bar-count rows naturally distribute bars to the same
+     positions even though different-count rows have different
+     bar widths within that shared body span. */
+.chordsketch-sheet__content section.grid {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto auto;
+  column-gap: 0;
+}
+.chordsketch-sheet__content section.grid > .section-label {
+  grid-column: 1 / -1;
+}
 .chordsketch-sheet__content .grid-line {
-  display: flex;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
   align-items: stretch;
+  position: relative;
   margin: 0.35em 0;
+  padding-top: 0.9em;
   min-height: 2.4em;
   font-family: var(--cs-font-chord, var(--cs-font-serif, 'Source Serif Pro', serif));
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.4;
   color: var(--cs-ink-900, #1a1718);
+}
+/* Leading-barline slot — section subgrid col 2. Default
+   `justify-self: start` anchors the glyph to the column's LEFT
+   edge so `||` and `|` rows share the same starting X. Per-
+   type overrides below align each glyph to the edge that the
+   engraving convention treats as the "barline position":
+   `|.` (final) and `:|` (repeat-end) anchor RIGHT (their
+   thick line carries the barline meaning); `:|:`
+   (repeat-end-and-start) anchors CENTER. The widest leading
+   barline in the section determines the column width via auto
+   sizing, so left/right/center within that column resolves
+   visibly to a per-type offset within a shared X range. */
+.chordsketch-sheet__content .grid-row__lead {
+  display: inline-flex;
+  align-items: stretch;
+  justify-self: start;
+}
+.chordsketch-sheet__content .grid-row__lead[data-barline-type='final'],
+.chordsketch-sheet__content .grid-row__lead[data-barline-type='repeat-end'] {
+  justify-self: end;
+}
+.chordsketch-sheet__content .grid-row__lead[data-barline-type='repeat-both'] {
+  justify-self: center;
+}
+
+/* Body — section subgrid col 3. A per-row CSS grid whose
+   columns alternate `1fr` (bars) and `var(--cs-grid-barline-
+   slot)` (intermediate barlines). The slot variable is set by
+   the section to the widest barline kind appearing anywhere
+   in this section, so every barline slot in every row is
+   identical. Combined with the section subgrid sharing one
+   `1fr` body width across all rows, same-bar-count rows end
+   up with pixel-identical bar widths regardless of how their
+   intermediate barlines mix. */
+.chordsketch-sheet__content .grid-line__body {
+  display: grid;
+  /* grid-template-columns set per-row via inline style */
+  align-items: stretch;
+  min-width: 0;
+}
+/* Per-type alignment for body intermediate barlines.
+
+   The bar boundary is the slot's CENTRE (not its right
+   edge). Each barline glyph is positioned so its
+   conventional engraving anchor lands exactly on the slot
+   centre — `justify-self: center` plus a per-kind translate
+   that compensates for where the anchor sits inside the
+   glyph's own bounding box:
+
+   - CENTER-anchored kinds (`|`, `||`, `:|:`, volta): anchor
+     is in the middle of the glyph. `justify-self: center`
+     puts the glyph centre on the slot centre — no translate
+     needed.
+
+   - RIGHT-anchored kinds (`:|`, `|.`): anchor is the THICK
+     line at the glyph's right edge. With `justify-self:
+     center` the glyph centre sits on the slot centre, so
+     the right edge sits half-a-glyph to the RIGHT of the
+     slot centre. `translateX(-50%)` shifts the whole glyph
+     leftward by half its own width so the right edge lands
+     on the slot centre.
+
+   - LEFT-anchored kinds (`|:` repeat-start): anchor is the
+     thick line at the glyph's LEFT edge. `translateX(50%)`
+     shifts the glyph rightward by half its width so the
+     left edge lands on the slot centre.
+
+   Result: the boundary X is identical across rows for any
+   mix of barline kinds. The bar ELEMENT centre also equals
+   the VISIBLE bar centre (boundary-to-boundary midpoint),
+   so a `%` glyph centred in its bar element is automatically
+   centred in the visible bar — no further offset needed.
+   Because each glyph sits ENTIRELY within its own slot, the
+   glyph never overflows into the adjacent bar's content
+   area — eliminating the `:|:G` overlap class of bug. */
+.chordsketch-sheet__content .grid-line__body > .grid-barline,
+.chordsketch-sheet__content .grid-line__body > .grid-volta {
+  justify-self: center;
+}
+.chordsketch-sheet__content .grid-line__body > .grid-barline--repeat-end,
+.chordsketch-sheet__content .grid-line__body > .grid-barline--final {
+  transform: translateX(-50%);
+}
+.chordsketch-sheet__content .grid-line__body > .grid-barline--repeat-start {
+  transform: translateX(50%);
+}
+
+/* Trailing-barline slot — section subgrid col 4. Default
+   `justify-self: end` anchors the glyph to the column's RIGHT
+   edge. Per-type overrides for the cases where the engraving
+   convention places the barline anchor elsewhere: `|:`
+   (repeat-start) anchors LEFT (rare as a trailing barline but
+   handled for completeness); `:|:` anchors CENTER. `|.`,
+   `:|`, and `||` at row end keep the default right anchor. */
+.chordsketch-sheet__content .grid-row__trail {
+  display: inline-flex;
+  align-items: stretch;
+  justify-self: end;
+}
+.chordsketch-sheet__content .grid-row__trail[data-barline-type='repeat-start'] {
+  justify-self: start;
+}
+.chordsketch-sheet__content .grid-row__trail[data-barline-type='repeat-both'] {
+  justify-self: center;
 }
 
 /* Bar cell — `flex: 1` so every bar in the row is the same
@@ -585,6 +706,12 @@
   align-self: stretch;
   gap: 1.5px;
   flex-shrink: 0;
+  /* Anchors an optional `.grid-volta__bracket` overlay when a
+     source like `:| |2` collapses the two markers into one
+     cell. Without `position: relative` the absolute-positioned
+     bracket escapes to the section ancestor and floats over
+     unrelated content. */
+  position: relative;
 }
 .chordsketch-sheet__content .grid-barline:not([class*='--']) {
   width: 1.5px;
@@ -625,57 +752,133 @@
   background-color: var(--cs-ink-900, #1a1718);
 }
 .chordsketch-sheet__content .grid-volta__bracket {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
   position: absolute;
-  top: -0.1em;
+  /* Lift the bracket above the bar so the `1.` / `2.` label
+     does not overlap the barline glyph beneath it. The parent
+     `.grid-line` reserves `padding-top` for this clearance.
+     The `4px` of extra lift opens a small gap between the
+     leg's bottom and the host barline's top — keeps the L
+     and the barline visually distinct rather than reading as
+     one continuous run of pixels.
+     `left` anchors the bracket to the host glyph's
+     conventional "barline X" — see per-host overrides below.
+     Default `0` matches the standalone `.grid-volta` host
+     (whose own line sits at the element's left edge). */
+  top: calc(-0.85em - 4px);
   left: 0;
+  /* L-shape: top edge = horizontal cap, left edge = vertical
+     leg. Both drawn as borders so the corner is a single
+     rendered intersection and the leg meets the barline
+     beneath without any gap or seam. */
+  border-top: 1.5px solid var(--cs-ink-900, #1a1718);
+  border-left: 1.5px solid var(--cs-ink-900, #1a1718);
+  box-sizing: border-box;
+  height: 0.85em;
+  min-width: 1em;
+  display: inline-flex;
+  align-items: flex-start;
+  padding: 0.08em 0.25em 0 0.25em;
+  pointer-events: none;
 }
-.chordsketch-sheet__content .grid-volta__cap {
-  display: block;
-  width: 1.5em;
-  height: 1.5px;
-  background-color: var(--cs-ink-900, #1a1718);
+/* When the bracket overlays a collapsed `[marker, volta]`
+   host (e.g. `:| |2` → repeat-end with volta-2 overlay), the
+   bracket cap must start at the HOST'S barline anchor — not
+   at the host element's left edge — so the cap visually
+   springs from the same X as the line the volta annotates.
+   For each barline kind that places its conventional anchor
+   somewhere other than the left edge of its glyph, anchor
+   the bracket accordingly:
+   - repeat-end / final → thick line at the RIGHT, anchor 100%
+   - repeat-both / double / single bare `|` → glyph centre, 50%
+   - repeat-start → thick line at the LEFT (default `0` works) */
+.chordsketch-sheet__content .grid-barline--repeat-end > .grid-volta__bracket,
+.chordsketch-sheet__content .grid-barline--final > .grid-volta__bracket {
+  left: 100%;
+}
+.chordsketch-sheet__content .grid-barline--repeat-both > .grid-volta__bracket,
+.chordsketch-sheet__content .grid-barline--double > .grid-volta__bracket,
+.chordsketch-sheet__content .grid-barline:not([class*='--']) > .grid-volta__bracket {
+  left: 50%;
 }
 .chordsketch-sheet__content .grid-volta__label {
   display: inline-block;
-  margin-left: 0.15em;
   font-size: 0.7em;
   font-weight: 600;
   color: var(--cs-ink-900, #1a1718);
   line-height: 1;
-  padding-top: 0.1em;
+  white-space: nowrap;
 }
 
 /* Row label (`A`, `Coda`, etc.) — a left-side tag for jazz
    lead-sheet style annotation. Not in the ChordPro spec but a
-   widely used dialect convention; render as a muted bold cap. */
+   widely used dialect convention; render as a muted bold cap.
+
+   The `::before` pseudo carries the SECTION's longest label
+   text (set as a CSS string in `--cs-grid-label-max-text` on
+   the `<section>` by flushSection). It is `height: 0` so the
+   visible row layout is unchanged, but its intrinsic width —
+   measured in this label's own font + size + weight + letter-
+   spacing + uppercase transform — counts toward the cell's
+   max-content. Subgrid `auto` columns size to max-content, so
+   every group's first column ends up the same width and an A
+   row aligns with a CODA row. `1ch` and similar abstract units
+   were too loose for uppercase + letter-spacing; only an actual
+   text measurement gives pixel-accurate alignment. */
 .chordsketch-sheet__content .grid-row__label {
-  display: inline-flex;
+  display: inline-grid;
+  /* One cell, one row. Both `::before` (the sizer) and
+     `.grid-row__label__text` (the visible content) explicitly
+     target `grid-area: 1 / 1`, so they OVERLAY instead of
+     stacking — that is what makes the cell width equal the
+     widest label without painting it twice. An earlier
+     `inline-flex` version laid the two as sibling flex items
+     and added their widths, giving a too-wide gutter. */
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
   align-items: center;
-  flex-shrink: 0;
   padding-right: 0.6em;
   font-weight: 700;
   color: var(--cs-ink-700, #44424a);
   text-transform: uppercase;
   font-size: 0.85em;
   letter-spacing: 0.04em;
-  min-width: 2em;
+}
+.chordsketch-sheet__content .grid-row__label::before {
+  content: var(--cs-grid-label-max-text, '');
+  grid-area: 1 / 1;
+  visibility: hidden;
+  white-space: pre;
+  pointer-events: none;
+}
+.chordsketch-sheet__content .grid-row__label__text {
+  grid-area: 1 / 1;
 }
 /* Trailing comment (`repeat 4 times`, etc.) — a right-side
-   annotation column. Italicised + smaller so it reads as a
-   performance instruction, not a chord. */
+   annotation column. Same `::before` sizer treatment as the
+   label (via `--cs-grid-comment-max-text`) so an empty row and
+   a `repeat 4 times` row reserve the same right gutter width.
+   Italicised + smaller so it reads as a performance
+   instruction, not a chord. */
 .chordsketch-sheet__content .grid-row__comment {
-  display: inline-flex;
+  display: inline-grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
   align-items: center;
-  flex-shrink: 0;
   padding-left: 0.6em;
   font-style: italic;
   font-weight: 500;
   font-size: 0.85em;
   color: var(--cs-ink-600, #67646d);
+}
+.chordsketch-sheet__content .grid-row__comment::before {
+  content: var(--cs-grid-comment-max-text, '');
+  grid-area: 1 / 1;
+  visibility: hidden;
+  white-space: pre;
+  pointer-events: none;
+}
+.chordsketch-sheet__content .grid-row__comment__text {
+  grid-area: 1 / 1;
 }
 
 /* Combined repeat-end + repeat-start barline (`:|:`). Renders
@@ -692,13 +895,31 @@
    typesetting trick reads as engraved music notation, but a
    simple `%` / `%%` glyph also works at this resolution). */
 .chordsketch-sheet__content .grid-percent {
-  font-weight: 700;
-  font-size: 0.9em;
   color: var(--cs-ink-700, #44424a);
+  display: inline-block;
+  vertical-align: middle;
 }
 .chordsketch-sheet__content .grid-beat--percent1,
 .chordsketch-sheet__content .grid-beat--percent2 {
   justify-content: center;
+}
+/* `%` centres in its bar (not pinned to the beat-1 flex slot).
+   With the slot-centre boundary model (see body barline
+   alignment above), the bar element's centre equals the
+   visible bar's centre — so a plain `translate(-50%, -50%)`
+   from `left: 50%; top: 50%` is sufficient. No extra
+   horizontal offset for slot width. `%%` is expanded into
+   two consecutive `%` cells at render time (one in the
+   current bar, one in the next), so there is no separate
+   2-bar engraving glyph. */
+.chordsketch-sheet__content .grid-bar--percent1-center {
+  position: relative;
+}
+.chordsketch-sheet__content .grid-bar--percent1-center .grid-beat--percent1 {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }
 
 /* Multi-chord cell separator — a thin tilde between two chord
@@ -731,6 +952,22 @@
 }
 .chordsketch-sheet__content .grid-strum__glyph {
   font-family: var(--cs-font-mono, ui-monospace, monospace);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.05em;
+}
+.chordsketch-sheet__content .grid-strum__antic {
+  font-style: italic;
+  color: var(--cs-ink-500, #8a8790);
+  margin-right: 0.1em;
+}
+.chordsketch-sheet__content .grid-strum__sep {
+  color: var(--cs-ink-400, #b6b1bd);
+  font-size: 0.7em;
+  padding: 0 0.05em;
+}
+.chordsketch-sheet__content .grid-strum__part {
+  display: inline-block;
 }
 .chordsketch-sheet__content .grid-strum--up {
   color: var(--cs-crimson-500, #bd1642);

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -637,7 +637,8 @@
    centred in the visible bar — no further offset needed.
    Because each glyph sits ENTIRELY within its own slot, the
    glyph never overflows into the adjacent bar's content
-   area — eliminating the `:|:G` overlap class of bug. */
+   area, so a barline glyph never paints over adjacent
+   chord text. */
 .chordsketch-sheet__content .grid-line__body > .grid-barline,
 .chordsketch-sheet__content .grid-line__body > .grid-volta {
   justify-self: center;

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -1519,10 +1519,13 @@ describe('renderChordproAst', () => {
   });
 
   // `%%` followed by a bar that already has a chord MUST NOT
-  // overwrite that chord — the source is malformed against the
-  // ChordPro spec ("%% repeats the previous two measures" implies
-  // the next bar should be empty), but the user-authored chord
-  // takes priority over the auto-expansion.
+  // overwrite that chord AND MUST NOT half-rewrite itself to a
+  // single `%` — half-rewriting would silently downgrade the
+  // "repeat previous TWO" semantics to "repeat previous ONE".
+  // Both bars stay intact: the `%%` falls through to the
+  // 2-bar repeat glyph (the best available representation when
+  // the expansion preconditions are not met), and the chord
+  // bar keeps its chord.
   test('grid `%%` does not overwrite a following bar that already has content', () => {
     const ast: ChordproSong = {
       metadata: EMPTY_META,
@@ -1542,8 +1545,10 @@ describe('renderChordproAst', () => {
       ],
     };
     const { container } = render(renderChordproAst(ast));
-    // Only the %% bar gets converted; bar 3 keeps its C chord.
-    expect(container.querySelectorAll('.grid-beat--percent1').length).toBe(1);
+    // `%%` survives as percent2 (rendered with 2-bar glyph),
+    // bar 3 keeps its C chord, and no half-rewrite to `%` happens.
+    expect(container.querySelectorAll('.grid-beat--percent2').length).toBe(1);
+    expect(container.querySelectorAll('.grid-beat--percent1').length).toBe(0);
     const chords = Array.from(container.querySelectorAll('.grid-chord')).map((c) => c.textContent);
     expect(chords).toEqual(['G', 'C']);
   });
@@ -1655,6 +1660,168 @@ describe('renderChordproAst', () => {
   // barline double-strike) and the volta-2 bracket landed
   // beside the repeat-end glyph instead of above the same
   // barline position.
+  // Edge case for `%%` (repeat-previous-two-bars) expansion.
+  // When the source has no PRIOR bar to repeat (first bar of
+  // section is `%%`), expansion must NOT silently rewrite the
+  // `%%` to a `%` (which would lie about "repeat previous
+  // bar" — there is no previous bar). The `%%` survives so
+  // `renderBeat` paints the real 2-bar repeat glyph as the
+  // best available representation of malformed input.
+  test('grid `%%` in the first bar of a section is left unexpanded (no prior bar to repeat)', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // No prior bar exists in the section before `%%`.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '| %% . | .  . |', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    // The %% survives as a percent2 beat (rendered with the
+    // 2-bar fallback glyph), and the following empty bar is
+    // NOT silently filled with a `%` — empty stays empty so
+    // the malformed source is visually distinct from the
+    // well-formed `%%` pattern.
+    expect(container.querySelectorAll('.grid-beat--percent2').length).toBe(1);
+    expect(container.querySelectorAll('.grid-beat--percent1').length).toBe(0);
+  });
+
+  // `%%` at the END of a row (no next bar to expand into) is
+  // similarly left unrewritten — silently rewriting `%%` to a
+  // single `%` would change the engraved meaning from
+  // "repeat previous TWO" to "repeat previous ONE".
+  test('grid `%%` with no following bar is left unexpanded', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // `%%` is the LAST bar of the row.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '| G . | C . | %% . |', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    expect(container.querySelectorAll('.grid-beat--percent2').length).toBe(1);
+    expect(container.querySelectorAll('.grid-beat--percent1').length).toBe(0);
+  });
+
+  // Multiple `%%` beats in a SINGLE bar (rare but legal source
+  // like `| %% %% . . |`) all get rewritten — not just the
+  // first occurrence. Pre-fix, `findIndex` only rewrote the
+  // first match, leaving subsequent `percent2` beats to fall
+  // through to the renderBeat "should not be reachable" arm.
+  test('grid expands every `%%` beat in a multi-%% bar (not just the first)', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // Prior bar `G` exists, next bar empty — every `%%`
+          // in bar 2 should rewrite to `%`.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '| G . | %% %% . . | .  . . . |', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    // Both `%%` in bar 2 rewrite to `%`, plus the next bar
+    // gets a `%` (one expansion run only — multiple `%%` in
+    // the same bar still target a single next-bar expansion).
+    expect(container.querySelectorAll('.grid-beat--percent2').length).toBe(0);
+    expect(container.querySelectorAll('.grid-beat--percent1').length).toBeGreaterThanOrEqual(3);
+  });
+
+  // Multi-volta chain `:| |2 |3 Am` collapses all volta cells
+  // onto the same host barline. The resulting overlay carries
+  // every ending in a single bracket (`2.3.`) — one bracket per
+  // barline position regardless of how many endings start
+  // there. Pre-fix, the second volta in the chain survived as
+  // a standalone `.grid-volta` cell, double-drawing the
+  // barline visually.
+  test('grid collapses chained voltas (`:| |2 |3`) into one overlay carrying every ending', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '|: G . | C . :| |2 |3 Am . | G . |.', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    // No standalone `.grid-volta` cell survives — both `|2`
+    // and `|3` collapse into the `:|` host's overlay.
+    expect(container.querySelectorAll('.grid-volta').length).toBe(0);
+    // The host carries a single bracket overlay whose label
+    // concatenates every ending (`2.3.`).
+    const bracket = container.querySelector('.grid-volta__bracket');
+    expect(bracket).not.toBeNull();
+    expect(bracket?.querySelector('.grid-volta__label')?.textContent).toBe('2.3.');
+  });
+
+  // Strum `~~` (consecutive tildes, possible source noise)
+  // must not render zero-content `.grid-strum__part` spans
+  // flanked by separator dots — the visible glyph would be a
+  // stray `··` with no corresponding source token.
+  test('grid strum row drops empty segments from `~~` consecutive-tilde tokens', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '|s dn~~up |', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    // `dn~~up` → split [dn, '', up] → empty filtered → 2 parts
+    // → 1 separator dot (between dn and up). No empty parts.
+    expect(container.querySelectorAll('.grid-strum__part').length).toBe(2);
+    expect(container.querySelectorAll('.grid-strum__sep').length).toBe(1);
+  });
+
   test('grid collapses [marker, volta] pairs into a single overlay-bearing cell', () => {
     const cases: Array<{
       source: string;

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -1411,8 +1411,16 @@ describe('renderChordproAst', () => {
     const { container } = render(renderChordproAst(ast));
     const gridLine = container.querySelector('.grid-line');
     expect(gridLine).not.toBeNull();
-    // Volta marker + final barline.
-    expect(gridLine?.querySelectorAll('.grid-volta').length).toBe(2);
+    // Two volta brackets surface in the row. The source has
+    // `| |1` (single barline + volta-1) and `:| |2` (repeat-
+    // end + volta-2); the marker-collapse pass merges each
+    // pair into a single cell whose host marker carries a
+    // `.grid-volta__bracket` overlay, so we count brackets
+    // rather than standalone `.grid-volta` cells. The
+    // standalone `.grid-volta` cell only appears when a volta
+    // marker is NOT preceded by another barline marker (e.g.
+    // a volta at the very start of a row).
+    expect(gridLine?.querySelectorAll('.grid-volta__bracket').length).toBe(2);
     expect(gridLine?.querySelector('.grid-barline--final')).not.toBeNull();
     // 8 bars (each chord lands in its own bar cell).
     expect(gridLine?.querySelectorAll('.grid-bar').length).toBe(8);
@@ -1478,9 +1486,44 @@ describe('renderChordproAst', () => {
     expect(container.querySelector('.grid-row__comment')?.textContent).toBe('repeat 4 times');
   });
 
-  // `%` / `%%` measure-repeat cells render as dedicated beat
-  // slots with `--percent1` / `--percent2` modifier classes.
-  test('grid measure-repeat markers `%` and `%%` render as percent beats', () => {
+  // `%` is a single-bar repeat. `%%` expands at render time
+  // into a `%` mark in its own bar AND a `%` mark in the
+  // following bar (when the following bar is empty / pure
+  // continuation) — the engraving convention chosen for this
+  // surface is to drop a single-bar mark into every repeated
+  // bar rather than draw one straddle-glyph across the
+  // barline. After expansion, no `--percent2` cells survive.
+  test('grid measure-repeat: `%` stays single-bar, `%%` expands to `%` in this bar and the next', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // Source: bar1=G, bar2=%, bar3=%%, bar4=empty (only continuations).
+          // After expansion: bar1=G, bar2=%, bar3=%, bar4=%.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '| G . | % . | %% . | .  . |', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    expect(container.querySelectorAll('.grid-beat--percent1').length).toBe(3);
+    expect(container.querySelectorAll('.grid-beat--percent2').length).toBe(0);
+  });
+
+  // `%%` followed by a bar that already has a chord MUST NOT
+  // overwrite that chord — the source is malformed against the
+  // ChordPro spec ("%% repeats the previous two measures" implies
+  // the next bar should be empty), but the user-authored chord
+  // takes priority over the auto-expansion.
+  test('grid `%%` does not overwrite a following bar that already has content', () => {
     const ast: ChordproSong = {
       metadata: EMPTY_META,
       lines: [
@@ -1490,7 +1533,7 @@ describe('renderChordproAst', () => {
         },
         {
           kind: 'lyrics',
-          value: { segments: [{ chord: null, text: '| G . | % . | %% . |', spans: [] }] },
+          value: { segments: [{ chord: null, text: '| G . | %% . | C . |', spans: [] }] },
         },
         {
           kind: 'directive',
@@ -1499,8 +1542,525 @@ describe('renderChordproAst', () => {
       ],
     };
     const { container } = render(renderChordproAst(ast));
+    // Only the %% bar gets converted; bar 3 keeps its C chord.
     expect(container.querySelectorAll('.grid-beat--percent1').length).toBe(1);
-    expect(container.querySelectorAll('.grid-beat--percent2').length).toBe(1);
+    const chords = Array.from(container.querySelectorAll('.grid-chord')).map((c) => c.textContent);
+    expect(chords).toEqual(['G', 'C']);
+  });
+
+  // Cross-group label alignment: when rows have DIFFERENT bar
+  // counts they land in different `.grid-line-group` blocks, but
+  // the section still propagates the LONGEST label / comment
+  // text via `--cs-grid-label-max-text` / `--cs-grid-comment-
+  // max-text`. Each `.grid-row__label` / `.grid-row__comment`
+  // uses that var as its `::before` pseudo content, forcing the
+  // cell to reserve the widest rendered width so an `A` row and
+  // a `CODA` row align their bar-start positions even though
+  // their groups are independent grids.
+  test('grid section emits CSS vars for widest label/comment across all rows', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // 4-bar row labelled `A`, no trailing comment.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: 'A | G . | C . | D . | G . |', spans: [] }] },
+        },
+        {
+          // 4-bar row, no label, trailing `repeat 4 times`.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '| C . | D . | G . | C . | repeat 4 times', spans: [] }] },
+        },
+        {
+          // 5-bar row labelled `CODA`, no trailing comment.
+          // Different bar count → separate `.grid-line-group`.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: 'CODA | D . | E . | F . | G . | C . |', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    const section = container.querySelector('section.grid') as HTMLElement | null;
+    expect(section).not.toBeNull();
+    // The CSS vars are quoted CSS string literals; the widest
+    // label is `"CODA"`, the widest comment is `"repeat 4 times"`.
+    expect(section?.style.getPropertyValue('--cs-grid-label-max-text')).toBe('"CODA"');
+    expect(section?.style.getPropertyValue('--cs-grid-comment-max-text')).toBe('"repeat 4 times"');
+  });
+
+  // Body grid template edge cases — the template must
+  // resolve cleanly for rows that have only one bar (no
+  // intermediate markers in body) AND for rows that have no
+  // body bars at all (degenerate sources). A regression that
+  // shipped an empty / mis-shaped template would crash CSS
+  // grid placement and stack cells vertically.
+  test('grid body template handles single-bar and empty-body edge cases', () => {
+    const makeAst = (text: string): ChordproSong => ({
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text, spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    });
+
+    // Single-bar row: lead `|`, bar(G), trail `|`. Body has
+    // just the one bar — template should be `1fr` (one column).
+    {
+      const { container, unmount } = render(renderChordproAst(makeAst('| G . |')));
+      const body = container.querySelector('.grid-line__body') as HTMLElement | null;
+      expect(body).not.toBeNull();
+      expect(body!.style.gridTemplateColumns).toBe('1fr');
+      expect(body!.childElementCount).toBe(1);
+      unmount();
+    }
+
+    // Degenerate row with only a single barline (no bars): the
+    // single `||` becomes lead, no trail, body is empty. Template
+    // falls back to `auto` so the grid still resolves.
+    {
+      const { container, unmount } = render(renderChordproAst(makeAst('||')));
+      const body = container.querySelector('.grid-line__body') as HTMLElement | null;
+      expect(body).not.toBeNull();
+      expect(body!.style.gridTemplateColumns).toBe('auto');
+      expect(body!.childElementCount).toBe(0);
+      unmount();
+    }
+  });
+
+  // Marker-collapse rule: when a non-volta marker is
+  // immediately followed by a volta marker in the source, the
+  // pair collapses to a single rendered cell. The host marker
+  // keeps its own glyph (repeat-end thick line, double-bar
+  // pair, etc.) and the volta-N bracket is overlaid on top
+  // via `.grid-volta__bracket`. Without this, the source
+  // `:| |2` rendered as TWO separate cells (a redundant
+  // barline double-strike) and the volta-2 bracket landed
+  // beside the repeat-end glyph instead of above the same
+  // barline position.
+  test('grid collapses [marker, volta] pairs into a single overlay-bearing cell', () => {
+    const cases: Array<{
+      source: string;
+      hostSelector: string;
+      hostLabel: string;
+      voltaText: string;
+      // Standalone `.grid-volta` cell count in the row body
+      // after collapse — must drop to zero when every volta
+      // was preceded by a barline marker.
+      remainingStandalone: number;
+    }> = [
+      // `| |1` — bare barline + volta-1.
+      {
+        source: '| G . | C . | |1 Em . | C . | |2 Am . | G . |.',
+        hostSelector: '.grid-barline:not([class*="--"])',
+        hostLabel: 'bare barline',
+        voltaText: '1.',
+        remainingStandalone: 0,
+      },
+      // `:| |2` — repeat-end + volta-2.
+      {
+        source: '|: G . | C . :| |2 Am . | G . |.',
+        hostSelector: '.grid-barline--repeat-end',
+        hostLabel: 'repeat-end',
+        voltaText: '2.',
+        remainingStandalone: 0,
+      },
+      // `:|: |3` — repeat-both + volta-3.
+      {
+        source: '|: G . | C . :|: |3 Am . | G . |.',
+        hostSelector: '.grid-barline--repeat-both',
+        hostLabel: 'repeat-both',
+        voltaText: '3.',
+        remainingStandalone: 0,
+      },
+      // `|| |2` — double + volta-2.
+      {
+        source: '|| G . | C . || |2 Am . | G . |.',
+        hostSelector: '.grid-barline--double',
+        hostLabel: 'double',
+        voltaText: '2.',
+        remainingStandalone: 0,
+      },
+      // Volta at row start has NO preceding marker, so it is
+      // NOT collapsed; it keeps its own `.grid-volta` cell.
+      {
+        source: '|1 Em . | C . |.',
+        hostSelector: '.grid-volta',
+        hostLabel: 'standalone volta at row start',
+        voltaText: '1.',
+        remainingStandalone: 1,
+      },
+    ];
+    for (const c of cases) {
+      const ast: ChordproSong = {
+        metadata: EMPTY_META,
+        lines: [
+          {
+            kind: 'directive',
+            value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+          },
+          {
+            kind: 'lyrics',
+            value: { segments: [{ chord: null, text: c.source, spans: [] }] },
+          },
+          {
+            kind: 'directive',
+            value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+          },
+        ],
+      };
+      const { container, unmount } = render(renderChordproAst(ast));
+      // Find the host marker carrying the bracket overlay.
+      const hostsWithBracket = Array.from(
+        container.querySelectorAll(c.hostSelector),
+      ).filter((el) => el.querySelector('.grid-volta__bracket'));
+      expect(
+        hostsWithBracket.length,
+        `expected one ${c.hostLabel} carrying the volta-overlay for source "${c.source}"`,
+      ).toBeGreaterThanOrEqual(1);
+      // The overlay's label text matches the volta number.
+      const labelText = hostsWithBracket[0]?.querySelector('.grid-volta__label')?.textContent;
+      expect(labelText).toBe(c.voltaText);
+      // Count any standalone `.grid-volta` cells that survived
+      // collapse — for non-leading voltas this must be zero.
+      const standaloneVoltas = container.querySelectorAll('.grid-volta').length;
+      expect(standaloneVoltas).toBe(c.remainingStandalone);
+      unmount();
+    }
+  });
+
+  // The body grid template must size one column per body cell
+  // (in source order) — bars get `1fr`, markers get the slot
+  // var. Sources like `|1 ... :| |2 ... |.` legitimately put
+  // two consecutive markers in the body (repeat-end followed
+  // by a volta-2 start). An earlier template that assumed
+  // strict bar/marker alternation gave too few columns and
+  // wrapped the overflow cells onto fake new rows, breaking
+  // the entire grid. Regression guard.
+  test('grid body template matches cell count when markers cluster', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // Mirrors the kitchen-sink "Outro Riff" row 2 source.
+          kind: 'lyrics',
+          value: {
+            segments: [
+              { chord: null, text: '|1 Em . . . | C . . . :| |2 Am . . . | G . . . |.', spans: [] },
+            ],
+          },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    const body = container.querySelector('.grid-line__body') as HTMLElement | null;
+    expect(body).not.toBeNull();
+    const template = body!.style.gridTemplateColumns;
+    // Body cell stream after lead `|1` and trail `|.` are
+    // extracted, AND after the marker-collapse pass merges
+    // `:| |2` into a single repeat-end marker carrying a
+    // volta-2 overlay: bar(Em), barline, bar(C), repeat-end+
+    // volta-2, bar(Am), barline, bar(G). That is 4 bars + 3
+    // markers = 7 columns. (Pre-collapse the cluster would
+    // have left 4 markers; the prior bar/marker alternation
+    // template assumption broke on EITHER count and the
+    // alternation rewrite handles both.)
+    expect((template.match(/\b1fr\b/g) ?? []).length).toBe(4);
+    expect((template.match(/var\(--cs-grid-barline-slot/g) ?? []).length).toBe(3);
+    // Same count of grid items as columns — no overflow onto
+    // implicit row tracks.
+    expect(body!.childElementCount).toBe(7);
+    // The middle marker MUST be the repeat-end glyph carrying
+    // the volta-2 bracket overlay (not a separate volta cell).
+    const repeatEnd = body!.querySelector('.grid-barline--repeat-end');
+    expect(repeatEnd).not.toBeNull();
+    expect(repeatEnd?.querySelector('.grid-volta__bracket')?.textContent).toContain('2.');
+    // No standalone `.grid-volta` survived in the body.
+    expect(body!.querySelectorAll('.grid-volta').length).toBe(0);
+  });
+
+  // Lead/trail wrappers carry `data-barline-type` so CSS can
+  // apply per-type `justify-self`:
+  // - `repeat-start` / `double` / `barline` / `volta` → left
+  //   (default `justify-self: start` on `.grid-row__lead`)
+  // - `final` / `repeat-end` → right
+  // - `repeat-both` → center
+  // The attribute is the contract — verify it surfaces with
+  // the parser's `kind` value for every barline marker type.
+  test('grid row exposes data-barline-type on lead/trail wrappers per barline kind', () => {
+    const cases: Array<{ source: string; leadKind: string; trailKind: string }> = [
+      // `|` (bare barline)
+      { source: '| G . | C . |', leadKind: 'barline', trailKind: 'barline' },
+      // `||` (double)
+      { source: '|| G . | C . ||', leadKind: 'double', trailKind: 'double' },
+      // `|.` (final) - typically trailing
+      { source: '| G . | C . |.', leadKind: 'barline', trailKind: 'final' },
+      // `|:` / `:|` (repeat-start / repeat-end)
+      { source: '|: G . | C . :|', leadKind: 'repeat-start', trailKind: 'repeat-end' },
+      // `:|:` (repeat-both) - rare as lead/trail but must round-trip
+      { source: ':|: G . | C . :|:', leadKind: 'repeat-both', trailKind: 'repeat-both' },
+    ];
+    for (const c of cases) {
+      const ast: ChordproSong = {
+        metadata: EMPTY_META,
+        lines: [
+          {
+            kind: 'directive',
+            value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+          },
+          {
+            kind: 'lyrics',
+            value: { segments: [{ chord: null, text: c.source, spans: [] }] },
+          },
+          {
+            kind: 'directive',
+            value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+          },
+        ],
+      };
+      const { container, unmount } = render(renderChordproAst(ast));
+      const lead = container.querySelector('.grid-row__lead');
+      const trail = container.querySelector('.grid-row__trail');
+      expect(
+        lead?.getAttribute('data-barline-type'),
+        `lead kind for source "${c.source}"`,
+      ).toBe(c.leadKind);
+      expect(
+        trail?.getAttribute('data-barline-type'),
+        `trail kind for source "${c.source}"`,
+      ).toBe(c.trailKind);
+      unmount();
+    }
+  });
+
+  // Section publishes `--cs-grid-barline-slot` in `em` units
+  // sized to the widest barline KIND that appears anywhere in
+  // the section. The body grid template in every row uses this
+  // var as the column width for marker cells, so all body
+  // slots resolve to the same pixel width regardless of which
+  // mix of barlines a particular row has. The em value is the
+  // table in `widthForBarlineKind` (chordpro-jsx.tsx) — bump
+  // both in lockstep.
+  test('grid section publishes --cs-grid-barline-slot em from widest barline kind', () => {
+    const cases: Array<{ source: string; expectedEm: number }> = [
+      // Only bare `|` → smallest slot.
+      { source: '| G . | C . |', expectedEm: 0.3 },
+      // Contains `||` → bumps to double width.
+      { source: '|| G . | C . ||', expectedEm: 0.5 },
+      // Contains `|.` → final width.
+      { source: '| G . | C . |.', expectedEm: 0.6 },
+      // Contains `|:` / `:|` → repeat width.
+      { source: '|: G . | C . :|', expectedEm: 1.2 },
+      // Contains `:|:` → widest.
+      { source: '|: G . | C . :|: D . :|', expectedEm: 1.7 },
+    ];
+    for (const c of cases) {
+      const ast: ChordproSong = {
+        metadata: EMPTY_META,
+        lines: [
+          {
+            kind: 'directive',
+            value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+          },
+          {
+            kind: 'lyrics',
+            value: { segments: [{ chord: null, text: c.source, spans: [] }] },
+          },
+          {
+            kind: 'directive',
+            value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+          },
+        ],
+      };
+      const { container, unmount } = render(renderChordproAst(ast));
+      const section = container.querySelector('section.grid') as HTMLElement | null;
+      expect(section).not.toBeNull();
+      // Inline style carries the var assignment; the value is
+      // `<em>em` so a string comparison is safe.
+      expect(
+        section?.style.getPropertyValue('--cs-grid-barline-slot'),
+        `slot var for source "${c.source}"`,
+      ).toBe(`${c.expectedEm}em`);
+      unmount();
+    }
+  });
+
+  // Each row tags its OWN widest barline-kind em value on the
+  // `.grid-line` wrapper. `flushSection` takes the max across
+  // children to derive `--cs-grid-barline-slot`. The per-row
+  // attribute is the contract — verify it for a row that has
+  // a mix of kinds.
+  test('grid row exposes data-max-barline-em equal to its widest barline kind', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // Mix of `|` (0.3), `:|` (1.2), and `|.` (0.6) — max is 1.2.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '| G . | C . :| D . |.', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    const line = container.querySelector('.grid-line') as HTMLElement | null;
+    expect(line?.getAttribute('data-max-barline-em')).toBe('1.2');
+  });
+
+  // Empty-label rows MUST still emit the `.grid-row__label`
+  // cell so that the section's subgrid label column reserves
+  // the same width for every row. Without this, an unlabelled
+  // row would skip column 1 of the row subgrid and shift its
+  // leading barline left by one column — visible regression
+  // when a labelled and an unlabelled row are siblings.
+  test('grid row emits .grid-row__label cell even when label text is empty', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // No leading text before the first barline = empty label.
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '| G . | C . |', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    const label = container.querySelector('.grid-row__label');
+    expect(label, 'label cell must exist even for empty label').not.toBeNull();
+    // Empty label is marked aria-hidden so AT does not announce
+    // a meaningless empty heading-like text node.
+    expect(label?.getAttribute('aria-hidden')).toBe('true');
+    expect(label?.textContent ?? '').toBe('');
+    // Same contract for the comment cell on a row with no
+    // trailing text — it must exist so the right gutter stays
+    // a reserved column.
+    const comment = container.querySelector('.grid-row__comment');
+    expect(comment).not.toBeNull();
+    expect(comment?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  // Strum row (a `s` token immediately after the opening
+  // barline) renders its compound `~`-separated tokens as
+  // individual arrow glyphs split by a visible separator. Per
+  // the user spec: `dn~up` is "down then up", not the literal
+  // string `dn~up`. The leading-`~` anticipation variant
+  // (`~up`) prefixes a faded `~` and renders the remaining
+  // glyph.
+  test('grid strum row splits ~-separated compound tokens into arrow glyphs', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          // `s` marks a strum row. `dn~up` = down then up;
+          // `~up` = anticipated up; `d+` = accented down.
+          kind: 'lyrics',
+          value: {
+            segments: [{ chord: null, text: '|s dn~up ~up d+ | d~u u~d ~d d+ |', spans: [] }],
+          },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    // Strum rows pick up the `grid-line--strum` modifier.
+    expect(container.querySelector('.grid-line--strum')).not.toBeNull();
+    // Compound tokens emit one `.grid-strum__part` per side of
+    // each `~`. Source has: `dn~up` (2 parts) + `~up` (1 part,
+    // leading-~ marks the whole token as anticipated) + `d+`
+    // (1 part) + `d~u` (2) + `u~d` (2) + `~d` (1) + `d+` (1).
+    // Total parts: 2+1+1+2+2+1+1 = 10.
+    expect(container.querySelectorAll('.grid-strum__part').length).toBe(10);
+    // Anticipation prefix appears for the 2 `~`-leading tokens.
+    expect(container.querySelectorAll('.grid-strum__antic').length).toBe(2);
+    // Visible separator `·` between parts of a compound token —
+    // one fewer than the part count within a compound. The
+    // compounds with >1 parts here: `dn~up` (1 sep), `d~u` (1),
+    // `u~d` (1). Total: 3 separators.
+    expect(container.querySelectorAll('.grid-strum__sep').length).toBe(3);
+  });
+
+  // Row structure for cross-section bar-edge alignment: each
+  // `.grid-line` carries dedicated `.grid-row__lead` and
+  // `.grid-row__trail` cells (the first / last barline of the
+  // row) outside the central `.grid-line__body`. The section's
+  // 5-column CSS grid pins lead to col 2 (left-anchored) and
+  // trail to col 4 (right-anchored), so every row's bar-grid
+  // starts and ends at the same X — independently of bar count
+  // or leading-barline kind (`|` / `||` / `|:`).
+  test('grid row separates leading and trailing barlines into their own cells', () => {
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'start_of_grid', value: null, kind: { tag: 'startOfGrid' }, selector: null },
+        },
+        {
+          kind: 'lyrics',
+          value: { segments: [{ chord: null, text: '|: G . | C . :|', spans: [] }] },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'end_of_grid', value: null, kind: { tag: 'endOfGrid' }, selector: null },
+        },
+      ],
+    };
+    const { container } = render(renderChordproAst(ast));
+    const lead = container.querySelector('.grid-row__lead');
+    const trail = container.querySelector('.grid-row__trail');
+    const body = container.querySelector('.grid-line__body');
+    expect(lead?.querySelector('.grid-barline--repeat-start')).not.toBeNull();
+    expect(trail?.querySelector('.grid-barline--repeat-end')).not.toBeNull();
+    // Body holds 2 bars + 1 intermediate barline (the middle `|`).
+    expect(body?.querySelectorAll('.grid-bar').length).toBe(2);
+    expect(body?.querySelectorAll('.grid-barline').length).toBe(1);
   });
 
   // Cell-internal `~` puts multiple chords in one beat slot


### PR DESCRIPTION
## What

Rework the `{start_of_grid}` rendering path in `@chordsketch/react`'s `chordpro-jsx` walker so bar boundaries, label / comment gutters, and barline glyphs line up consistently across rows within the same section regardless of how the source mixes bar counts and barline kinds.

### Layout

- **Section as 5-column subgrid** `auto auto 1fr auto auto` (label / lead barline / body / trail barline / comment). Every `.grid-line` is a `subgrid` of those columns so the lead-left, body-left, body-right, trail-right, and comment-left X positions match across every row in the section.
- **Per-row body grid** whose template is derived from the row's actual cell sequence — bars get `1fr`, markers get `var(--cs-grid-barline-slot)`. Clustered consecutive markers (e.g. `:| |2`, the Outro Riff row-2 case) now render without overflowing onto implicit row tracks.
- **Section-wide gutter sizing.** Every `.grid-row__label` / `.grid-row__comment` cell reserves the same width as the widest label / comment text in the section via a `::before` sizer driven by `--cs-grid-label-max-text` / `--cs-grid-comment-max-text` CSS variables on the `<section>`.

### Barline alignment (slot-centre boundary model)

Every barline glyph anchors on its slot's CENTRE (= the bar boundary):

| Anchor | Kinds | CSS |
|---|---|---|
| Centre of glyph | `\|`, `\|\|`, `:\|:`, volta | `justify-self: center` |
| Right edge of glyph (thick line) | `:\|`, `\|.` | `justify-self: center; transform: translateX(-50%)` |
| Left edge of glyph (thick line) | `\|:` | `justify-self: center; transform: translateX(50%)` |

Visible barlines align vertically across rows for any mix of kinds, and each glyph sits ENTIRELY within its own slot — no overflow into the adjacent bar's content area. Eliminates the `:|:G7` overlap class of bug.

### `%%` (repeat-previous-two-bars)

Pre-expanded into a `%` in its own bar plus a `%` in the next bar (when the next bar's beats are empty / continuation only). The per-bar single-bar mark replaces the prior straddle-glyph approach.

### Volta merge + L-shape bracket

- `[non-volta marker, volta]` source pairs (`| |1`, `:| |2`, etc.) collapse into ONE cell whose host barline carries the volta as an overlay — no double-drawn barline.
- The volta bracket is an L (`border-top` + `border-left` on `.grid-volta__bracket`); the leg meets the barline beneath with a deliberate ~4 px gap so the L and the line read as distinct strokes.
- Per-host CSS anchors the bracket leg at the host's conventional barline X (left / centre / right of the host element).

## Why

Multiple visual issues with `{start_of_grid}` rendering surfaced while exercising the kitchen-sink sample:

- Bars across rows in the same section did not line up.
- `A` and `Coda` labels (different lengths in different rows) misaligned the bar grid.
- `%%` rendered as a straddle glyph that read confusingly against per-bar engraving conventions.
- `:| |2` rendered as two adjacent barlines (double-stroke artefact).
- The volta bracket sat as a floating cap with no descender, so it visually disconnected from the barline beneath.
- `:|:` glyph overflowed into the chord text of the following bar (`:|:G7` overlap).
- Bare `|` and `:|` in the same column position painted at different X positions.

The slot-centre boundary model uniformly resolves these by making every barline kind's conventional anchor coincide on the same X.

## Test plan

- [x] `pnpm exec tsc --noEmit` in `packages/react/` and `packages/playground/` — both clean.
- [x] `npx vitest run` in `packages/react/` — 535 tests pass (18 new unit tests covering DOM structure, data attributes, `%%` expansion, marker / volta collapse, section CSS variables, per-row max barline width, body template for clustered markers, single-bar / empty-body edge cases, strum compound-token rendering).
- [x] `npx playwright test grid-alignment.spec.ts` in `packages/playground/` — 19 new specs measuring real-browser layout (section-wide edge alignment, per-kind `justify-self`, same-bar-count pixel-identical bar widths, Outro Riff cluster behaviour, `%%` expansion, `:|:` no-overlap with adjacent chord, visible barline X parity for mixed kinds).
- [x] Manual visual verification against the kitchen-sink sample's A/Coda and Outro Riff grid sections in a real browser (Cmd/Ctrl+Shift+R after build).

## Sister-site audit

This PR touches only the React JSX walker (`packages/react/src/chordpro-jsx.tsx`) and its CSS. The Rust `render-text` / `render-html` / `render-pdf` renderers are unchanged.

- `render-text`: line-based plain text — no concept of barline alignment or visual gutter sizing. No parity work needed.
- `render-html`: per [ADR-0017](https://github.com/koedame/chordsketch/blob/main/docs/adr/0017-react-renders-from-ast.md) the React JSX walker is the canonical HTML preview surface for the playground / desktop / VS Code preview; the Rust HTML renderer serves CLI / FFI / GitHub Action consumers that exercise a different output path without this CSS layout.
- `render-pdf`: page-based with its own layout algorithm; the React grid CSS does not apply.

`%%` expansion semantics and `[marker, volta]` collapse are presentation choices specific to the React surface for now. If a CLI / FFI consumer later reports a divergent rendering, follow-up parity work can be filed as separate issues.

## Deferred

None.

Closes #2546