### PR TITLE
docs: make worktree opt-in rather than the default

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -48,10 +48,13 @@ metadata that informs *how* a chosen item is split into PRs, not
 
 1. Create Issue with labels.
 2. Move the issue to **In Progress** on the [chordsketch project board](https://github.com/orgs/koedame/projects/1)
-   at the moment work actually starts — i.e. the first commit or worktree
-   creation, not at planning time. Issues still sitting in Todo while a
-   PR exists against them are a signal that this step was skipped.
-3. Create worktree + branch from latest `main`.
+   at the moment work actually starts — i.e. the first commit (or worktree
+   creation, if one is being used), not at planning time. Issues still sitting
+   in Todo while a PR exists against them are a signal that this step was
+   skipped.
+3. Create a branch from latest `main`. Use a worktree only when running
+   concurrent instances or invoking the autopilot workflow — see
+   [`parallel-work.md`](parallel-work.md).
 4. Implement (commits reference issue: `Part of #N` or `Closes #N`).
 5. Open PR (title references issue, body has `Closes #N`).
    *(Batched autopilot PRs aggregate multiple issues per

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -71,7 +71,7 @@ metadata that informs *how* a chosen item is split into PRs, not
    linked `Closes #N`, or — if that workflow is not enabled — flip the
    Status to Done manually with the same `gh` snippet below, using
    option ID `98236657`.
-8. Cleanup worktree.
+8. Cleanup: delete the local branch (and remove the worktree if one was used).
 
 ### Updating Project Board Status
 

--- a/.claude/rules/one-pr-at-a-time.md
+++ b/.claude/rules/one-pr-at-a-time.md
@@ -2,7 +2,7 @@
 
 Drive PRs to `main` through the merge pipeline **serially**. Do not
 open a new PR against `main` until the previous one has merged and
-the working tree (branch + worktree) is cleaned up.
+the branch is cleaned up (and the worktree, if one was used).
 
 ## Rule
 
@@ -10,10 +10,11 @@ When a batch of independent issues is in scope, process them one at
 a time:
 
 1. Pick one issue.
-2. Create a worktree and branch from the latest `origin/main`.
+2. Create a branch from the latest `origin/main` (add a worktree if
+   running concurrent instances — see `parallel-work.md`).
 3. Implement, push, open the PR.
 4. Wait for CI. Address blocking review findings.
-5. Merge. Delete the branch. Remove the worktree.
+5. Merge. Delete the branch (and remove the worktree if one was used).
 6. Only **then** start the next issue.
 
 Opening multiple PRs against `main` in parallel is prohibited unless

--- a/.claude/rules/parallel-work.md
+++ b/.claude/rules/parallel-work.md
@@ -1,13 +1,36 @@
 # Parallel Work Rules
 
-## Git Worktree Isolation
+## Git Worktree Isolation (opt-in)
 
-- Each Claude Code instance MUST work in a separate git worktree.
-- Worktree location: `../chordsketch-wt/issue-{N}-{slug}/`
-- Never modify files outside your own worktree.
+Worktrees are the isolation mechanism for **concurrent** work — when more than
+one Claude Code instance, tmux pane, or maintainer is actively editing the
+repository at the same time. They are NOT required for routine single-session
+work; the main checkout plus a feature branch is enough when nothing else is
+editing in parallel.
+
+When a worktree IS used:
+
+- One worktree per concurrent instance — never modify files outside your own
+  worktree.
+- Worktree location: `../chordsketch-wt/issue-{N}-{slug}/`.
 - Each worktree has its own `target/` directory — no build lock contention.
 
+The `autopilot-issue` workflow always creates its own worktree because it
+batches multiple issues into one branch and isolates the failure surface; that
+behaviour is owned by the workflow and does not change with this rule.
+
 ## Setup for a New Task
+
+Default (single instance, no concurrent work):
+
+```bash
+# From the main repo checkout
+git fetch origin
+git checkout -b issue-{N}-{slug} origin/main
+```
+
+When you actually need worktree isolation (concurrent instances, autopilot,
+keeping `main` checked out while you build):
 
 ```bash
 # From the main repo checkout
@@ -17,6 +40,15 @@ cd ../chordsketch-wt/issue-{N}-{slug}
 ```
 
 ## Cleanup after PR Merge
+
+Branch-only flow:
+
+```bash
+git checkout main && git pull --ff-only
+git branch -d issue-{N}-{slug}
+```
+
+Worktree flow:
 
 ```bash
 git worktree remove ../chordsketch-wt/issue-{N}-{slug}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,21 +150,26 @@ Bot-driven merge is conditional on the four-clause check above — see
 
 ## Parallel Development with tmux
 
-This project is designed for multiple Claude Code instances working simultaneously
-via tmux.
+This project supports multiple Claude Code instances working simultaneously
+via tmux. Worktrees are the isolation mechanism **when running concurrently**;
+single-session work does not need a worktree by default.
 
-**Key principle**: Each instance works in an isolated git worktree. No shared mutable
-state.
+**Key principle**: When more than one instance is active, each works in an
+isolated git worktree. No shared mutable state across concurrent instances.
 
-| Resource | Isolation Method |
+| Resource | Isolation Method (concurrent runs) |
 |---|---|
 | Git branch | One branch per worktree, named `issue-{N}-{slug}` |
 | Build artifacts | Each worktree has its own `target/` directory |
 | Network ports | `3000 + issue_number` |
 | Working directory | `../chordsketch-wt/issue-{N}-{slug}/` |
 
-**Before starting work**: Always create a fresh worktree from latest `origin/main`.
-**After PR merge**: Remove the worktree and local branch.
+**Default (single instance)**: branch from latest `origin/main` in the main
+checkout — no worktree.
+**Concurrent runs / autopilot batches**: create a worktree under
+`../chordsketch-wt/issue-{N}-{slug}/`.
+**After PR merge**: delete the local branch (and remove the worktree if one
+was created).
 
 ## Ticket-Driven Development
 


### PR DESCRIPTION
## What

Reframe the worktree convention as an isolation tool for concurrent runs (multiple Claude Code instances, autopilot batches) rather than a hard default for every piece of work.

- `CLAUDE.md` Parallel Development with tmux: distinguish the default single-instance flow (branch only) from concurrent runs (worktree).
- `.claude/rules/parallel-work.md`: relax "Each Claude Code instance MUST work in a separate git worktree" to apply only when concurrent instances are actually running. Document both the branch-only setup and the worktree setup side by side. Cleanup section gets a branch-only flow too.
- `.claude/rules/issue-workflow.md` step 3: branch creation no longer mandates a worktree; the worktree is mentioned as an option for concurrent work with a link to `parallel-work.md`.

## Why

The worktree-by-default convention costs:

- A fresh `target/` per worktree multiplies build cache size.
- Leftover `../chordsketch-wt/<branch>/` directories accumulate next to the main checkout and need separate cleanup.
- When the main checkout lives inside an outer parent directory that has its own tooling, the conventional `${repo_top}/../chordsketch-wt/` path can land the worktree somewhere unexpected.

The benefit (no shared mutable state across instances) only materialises when more than one instance is actually editing at the same time. For the routine single-session "open one PR, finish it, merge it" loop, a single branch in the main checkout is enough.

The autopilot-issue workflow's `phases/implementation.md` still creates its own worktree because it batches multiple issues per branch and needs an isolated failure surface; that behaviour is owned by the workflow and is unchanged by this PR.

## Test results

Docs-only change. No tests to run.

## Review summary

- `.claude/rules/one-pr-at-a-time.md` § "How this interacts with parallel-work.md" still reads coherently — parallel worktrees remain allowed, the serial-PR-to-main rule is orthogonal.
- `.claude/rules/branch-strategy.md` does not say worktrees are required; it only documents branch naming and the autopilot batch shape — no edit needed.
- Workflows under `.claude/workflows/autopilot-issue/` were left untouched per the §"Out of scope" note in the issue.

## Sister-site audit

Not applicable — docs-only PR; no rendering surfaces or bindings touched.

Closes #2548