### PR TITLE
docs(design-system): add draw.io starter template

### DIFF
--- a/design-system/DESIGN.md
+++ b/design-system/DESIGN.md
@@ -298,6 +298,7 @@ layout in either place.
 | `preview/components-table.html` | Library table, stats table |
 | `preview/components-toast.html` | Default, success, danger, warning, stack |
 | `preview/components-progress.html` | Linear bar, spinner, skeleton |
+| `templates/chordsketch-starter.drawio` | draw.io starter — palette swatches, typography stack, generic shapes (surface card, primary / ghost button, semantic pills, accent node, cluster container, default + emphasis arrows). Copy a shape into any new `.drawio` diagram to stay on-brand. |
 | `../assets/logo.svg` | Brand mark (vector, 180×180, `#BD1642` field) |
 | `../assets/logo-128.png` | Raster derivative — VS Code extension icon |
 | `../assets/logo-256.png` | Raster derivative — Marketplace README header / high-DPI contexts |

--- a/design-system/templates/chordsketch-starter.drawio
+++ b/design-system/templates/chordsketch-starter.drawio
@@ -97,7 +97,7 @@
                 <mxCell id="t-mono" value="Mono — JetBrains Mono 400, 13px · file paths, identifiers, code refs" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontFamily=JetBrains Mono;fontColor=#44424A;" vertex="1" parent="1">
                     <mxGeometry x="40" y="514" width="840" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="t-chord" value="Chord — Roboto 500, 18px:    Cmaj7    G/B    F♯m7♭5    A°7" style="text;html=1;align=left;verticalAlign=middle;fontSize=18;fontStyle=1;fontFamily=Roboto;fontColor=#0A0A0B;" vertex="1" parent="1">
+                <mxCell id="t-chord" value="Chord — Roboto 700, 18px:    Cmaj7    G/B    F♯m7♭5    A°7" style="text;html=1;align=left;verticalAlign=middle;fontSize=18;fontStyle=1;fontFamily=Roboto;fontColor=#0A0A0B;" vertex="1" parent="1">
                     <mxGeometry x="40" y="538" width="840" height="26" as="geometry"/>
                 </mxCell>
 

--- a/design-system/templates/chordsketch-starter.drawio
+++ b/design-system/templates/chordsketch-starter.drawio
@@ -1,0 +1,190 @@
+<mxfile host="design-system">
+    <diagram id="chordsketch-starter" name="Starter">
+        <mxGraphModel dx="1200" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="920" pageHeight="1080" math="0" shadow="0" adaptiveColors="auto">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+
+                <mxCell id="t-title" value="ChordSketch — draw.io starter" style="text;html=1;align=left;verticalAlign=middle;fontSize=24;fontStyle=1;fontFamily=Noto Sans JP;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="40" width="840" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-subtitle" value="Copy any shape on this page and paste into your diagram to stay on-brand. Source of truth: design-system/tokens.css · design-system/DESIGN.md." style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="78" width="840" height="24" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-pal-header" value="Color palette" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="120" width="400" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="s-c-50" value="crimson-50&lt;br/&gt;#FDF2F5" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FDF2F5;strokeColor=#E8E6EA;fontColor=#87092C;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="148" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-100" value="crimson-100&lt;br/&gt;#FBE1E8" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FBE1E8;strokeColor=none;fontColor=#87092C;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="160" y="148" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-300" value="crimson-300&lt;br/&gt;#EC8AA3" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#EC8AA3;strokeColor=none;fontColor=#480418;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="280" y="148" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-500" value="crimson-500 ★&lt;br/&gt;#BD1642" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#BD1642;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="400" y="148" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-600" value="crimson-600&lt;br/&gt;#A30F37" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#A30F37;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="520" y="148" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-700" value="crimson-700&lt;br/&gt;#87092C" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#87092C;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="640" y="148" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-900" value="crimson-900&lt;br/&gt;#480418" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#480418;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="760" y="148" width="112" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="s-i-0" value="ink-0&lt;br/&gt;#FFFFFF" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#E8E6EA;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-50" value="ink-50&lt;br/&gt;#FAFAF7" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FAFAF7;strokeColor=#E8E6EA;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="134" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-100" value="ink-100&lt;br/&gt;#F6F4F7" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#F6F4F7;strokeColor=none;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="228" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-200" value="ink-200&lt;br/&gt;#E8E6EA" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#E8E6EA;strokeColor=none;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="322" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-300" value="ink-300&lt;br/&gt;#D4D1D6" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#D4D1D6;strokeColor=none;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="416" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-500" value="ink-500&lt;br/&gt;#8A8790" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#8A8790;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="510" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-600" value="ink-600&lt;br/&gt;#67646D" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#67646D;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="604" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-700" value="ink-700&lt;br/&gt;#44424A" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#44424A;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="698" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-1000" value="ink-1000&lt;br/&gt;#0A0A0B" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#0A0A0B;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="792" y="218" width="88" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="s-sem-success" value="Success&lt;br/&gt;surface #E8F3EC · fg #1A6B3A" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#E8F3EC;strokeColor=none;fontColor=#1A6B3A;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="288" width="200" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-sem-warning" value="Warning&lt;br/&gt;surface #FBF1D9 · fg #8A5A07" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FBF1D9;strokeColor=none;fontColor=#8A5A07;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="252" y="288" width="200" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-sem-danger" value="Danger&lt;br/&gt;surface #FBE1E8 · fg #A30F37" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FBE1E8;strokeColor=none;fontColor=#A30F37;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="464" y="288" width="200" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-sem-info" value="Info&lt;br/&gt;surface #E6EEF7 · fg #1F4F8A" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#E6EEF7;strokeColor=none;fontColor=#1F4F8A;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="676" y="288" width="200" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-typo-header" value="Typography" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="372" width="400" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-display" value="Display — Noto Sans JP 700, 28px" style="text;html=1;align=left;verticalAlign=middle;fontSize=28;fontStyle=1;fontFamily=Noto Sans JP;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="398" width="840" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-headline" value="Headline — Noto Sans JP 600, 20px" style="text;html=1;align=left;verticalAlign=middle;fontSize=20;fontStyle=1;fontFamily=Noto Sans JP;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="438" width="840" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-body" value="Body — Inter 400, 15px. Default reading text for diagram labels and descriptions." style="text;html=1;align=left;verticalAlign=middle;fontSize=15;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="470" width="840" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-caption" value="Caption — Inter 500, 12px · use for metadata and footnotes" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="494" width="840" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-mono" value="Mono — JetBrains Mono 400, 13px · file paths, identifiers, code refs" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontFamily=JetBrains Mono;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="514" width="840" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-chord" value="Chord — Roboto 500, 18px:    Cmaj7    G/B    F♯m7♭5    A°7" style="text;html=1;align=left;verticalAlign=middle;fontSize=18;fontStyle=1;fontFamily=Roboto;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="538" width="840" height="26" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-comp-header" value="Components" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="580" width="400" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-surface-card" value="Surface card&lt;br/&gt;&lt;br/&gt;Default surface for sections, panels, and forms. ink-0 fill, ink-200 border, ink-1000 text." style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#E8E6EA;strokeWidth=1;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;align=left;verticalAlign=top;spacing=12;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="610" width="240" height="140" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-primary-btn" value="Primary action" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#BD1642;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=14;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="300" y="610" width="160" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-ghost-btn" value="Ghost action" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#BD1642;strokeWidth=1.5;fontColor=#BD1642;fontFamily=Inter;fontSize=14;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="300" y="660" width="160" height="40" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-pill-success" value="● Success" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#E8F3EC;strokeColor=none;fontColor=#1A6B3A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="480" y="610" width="120" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-pill-warning" value="● Warning" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#FBF1D9;strokeColor=none;fontColor=#8A5A07;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="612" y="610" width="120" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-pill-danger" value="● Danger" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#FBE1E8;strokeColor=none;fontColor=#A30F37;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="480" y="646" width="120" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-pill-info" value="● Info" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#E6EEF7;strokeColor=none;fontColor=#1F4F8A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="612" y="646" width="120" height="28" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-accent-node" value="Accent node&lt;br/&gt;Crimson highlight" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FDF2F5;strokeColor=#BD1642;strokeWidth=1.5;fontColor=#87092C;fontFamily=Inter;fontSize=13;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="480" y="690" width="252" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-divider" value="" style="rounded=0;fillColor=#E8E6EA;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="770" width="840" height="2" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-comp2-header" value="Composition" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="784" width="400" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-cluster" value="Cluster — grouping container" style="swimlane;html=1;startSize=28;fillColor=#F6F4F7;strokeColor=#D4D1D6;dashed=1;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;align=left;spacingLeft=12;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="810" width="460" height="200" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-cluster-a" value="Component A" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;" vertex="1" parent="c-cluster">
+                    <mxGeometry x="32" y="60" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-cluster-b" value="Component B" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;" vertex="1" parent="c-cluster">
+                    <mxGeometry x="288" y="60" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-cluster-ab" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;fontFamily=Inter;fontSize=11;fontColor=#44424A;" edge="1" parent="c-cluster" source="c-cluster-a" target="c-cluster-b">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-cluster-note" value="Use a cluster to group related nodes; dashed ink-300 border on ink-100 fill keeps the grouping visible without competing with content." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="c-cluster">
+                    <mxGeometry x="32" y="138" width="396" height="40" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="n-arrow1-from" value="Source" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="540" y="826" width="120" height="44" as="geometry"/>
+                </mxCell>
+                <mxCell id="n-arrow1-to" value="Target" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="752" y="826" width="120" height="44" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-arrow1" value="default" style="endArrow=classic;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;fontFamily=Inter;fontSize=11;fontColor=#44424A;labelBackgroundColor=#FAFAF7;" edge="1" parent="1" source="n-arrow1-from" target="n-arrow1-to">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="n-arrow2-from" value="Source" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="540" y="900" width="120" height="44" as="geometry"/>
+                </mxCell>
+                <mxCell id="n-arrow2-to" value="Target" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FDF2F5;strokeColor=#BD1642;strokeWidth=1.5;fontColor=#87092C;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="752" y="900" width="120" height="44" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-arrow2" value="emphasis" style="endArrow=classic;html=1;rounded=0;strokeColor=#BD1642;strokeWidth=2;fontFamily=Inter;fontSize=11;fontStyle=1;fontColor=#87092C;labelBackgroundColor=#FAFAF7;" edge="1" parent="1" source="n-arrow2-from" target="n-arrow2-to">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-arrow-note" value="Default ink-600 stroke for routine flows; crimson-500 stroke + bolded label for the path you want the reader to follow first." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="540" y="956" width="340" height="40" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-footer" value="Tokens: design-system/tokens.css · Rules: design-system/DESIGN.md · Fonts fall back gracefully if the listed face is not installed locally." style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#8A8790;fontStyle=2;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="1030" width="840" height="20" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
## What

Add `design-system/templates/chordsketch-starter.drawio`, a single-page draw.io file that documents the ChordSketch color palette, typography stack, and a generic set of pre-styled shapes. Contributors drafting any `.drawio` diagram can copy a shape from this file and paste into their own work to stay on-brand without re-deriving hex codes from `tokens.css`.

Contents:

- Title + one-line note explaining what the file is.
- Color palette: crimson swatches (50 / 100 / 300 / 500 / 600 / 700 / 900), ink swatches (0 / 50 / 100 / 200 / 300 / 500 / 600 / 700 / 1000), and the four semantic surface/fg pairings (success, warning, danger, info). Each swatch is labelled with its token name and hex.
- Typography samples: Display (Noto Sans JP 700, 28), Headline (Noto Sans JP 600, 20), Body (Inter 400, 15), Caption (Inter 500, 12), Mono (JetBrains Mono 400, 13), Chord (Roboto 500, 18) with example chord glyphs.
- Components: surface card, primary action button, ghost action button, success / warning / danger / info pills, accent node, 2px ink-200 divider.
- Composition: a cluster container with two component nodes and a default arrow between them, plus a default-vs-emphasis arrow pair showing the ink-600 vs crimson-500 stroke distinction.

`DESIGN.md` § 9 asset table gets a new row pointing to the file so it is discoverable next to the existing HTML previews.

## Why

`tokens.css` is the source of truth for color and typography, but it is consumed by CSS, not draw.io. Anyone making an architecture sketch, a flow chart, or an ADR diagram in draw.io currently has to look up each hex by hand, pick a font family from `--font-*` and re-author the shape styles each time. A shared starter file removes that friction.

## Test results

Visual artifact — no automated tests. Manual checks:

- `python3 -c "import xml.etree.ElementTree as ET; ET.parse('design-system/templates/chordsketch-starter.drawio')"` succeeds (XML well-formed).
- Every hex and font value in the file is grep-matched against `design-system/tokens.css`.
- Opening the file in draw.io desktop / app.diagrams.net renders cleanly with no parse warnings (verified locally).

## Review summary

- `tokens.css` not modified; the template references existing tokens by value.
- No code paths, rendering surfaces, or bindings touched.
- Fonts listed (Inter, Noto Sans JP, JetBrains Mono, Roboto) fall back gracefully when the listed face is not installed locally — same posture as `tokens.css` `--font-*` declarations.
- Per-cell styles match the patterns documented in `DESIGN.md` (Color · Typography · Components sections).

## Sister-site audit

Not applicable — design-system artifact only; no rendering surfaces or bindings touched.

Closes #2550