### PR TITLE
docs(design-system): add draw.io starter templates with intent variants

### DIFF
--- a/design-system/DESIGN.md
+++ b/design-system/DESIGN.md
@@ -298,6 +298,8 @@ layout in either place.
 | `preview/components-table.html` | Library table, stats table |
 | `preview/components-toast.html` | Default, success, danger, warning, stack |
 | `preview/components-progress.html` | Linear bar, spinner, skeleton |
+| `templates/chordsketch-starter.drawio` | draw.io starter — palette swatches, typography stack, surface card, accent node, divider, cluster. Button row is split by intent (primary / ghost / danger / secondary); pill row is one per semantic surface (success / warning / danger / info); connection-intent specimens show default / primary / warning / info. Pick the variant that matches the role and the colour is correct by construction. |
+| `templates/chordsketch-system-starter.drawio` | draw.io system-diagram starter — service / library / binding / consumer / host / external component shapes, infrastructure shapes (database, file, cache, queue, registry, actor), boundary clusters (internal solid / external dashed), and connection styles split into neutral connectors (sync / async / dependency) and data-flow intent variants (primary / warning / danger / info). Plus a worked example using each style in one sketch. |
 | `../assets/logo.svg` | Brand mark (vector, 180×180, `#BD1642` field) |
 | `../assets/logo-128.png` | Raster derivative — VS Code extension icon |
 | `../assets/logo-256.png` | Raster derivative — Marketplace README header / high-DPI contexts |

--- a/design-system/templates/chordsketch-starter.drawio
+++ b/design-system/templates/chordsketch-starter.drawio
@@ -1,0 +1,228 @@
+<mxfile host="design-system">
+    <diagram id="chordsketch-starter" name="Starter">
+        <mxGraphModel dx="1200" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="920" pageHeight="1200" math="0" shadow="0" adaptiveColors="auto">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+
+                <mxCell id="t-title" value="ChordSketch — draw.io starter" style="text;html=1;align=left;verticalAlign=middle;fontSize=24;fontStyle=1;fontFamily=Noto Sans JP;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="40" width="840" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-subtitle" value="Pick a variant by semantic intent (primary / ghost / danger / success / warning / info) — picking the right intent gives the right color automatically, no per-cell hex editing. Source of truth: design-system/tokens.css · DESIGN.md." style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="78" width="840" height="36" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-pal-header" value="Color palette" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="128" width="400" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="s-c-50" value="crimson-50&lt;br/&gt;#FDF2F5" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FDF2F5;strokeColor=#E8E6EA;fontColor=#87092C;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="156" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-100" value="crimson-100&lt;br/&gt;#FBE1E8" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FBE1E8;strokeColor=none;fontColor=#87092C;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="160" y="156" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-300" value="crimson-300&lt;br/&gt;#EC8AA3" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#EC8AA3;strokeColor=none;fontColor=#480418;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="280" y="156" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-500" value="crimson-500 ★&lt;br/&gt;#BD1642" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#BD1642;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="400" y="156" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-600" value="crimson-600&lt;br/&gt;#A30F37" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#A30F37;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="520" y="156" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-700" value="crimson-700&lt;br/&gt;#87092C" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#87092C;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="640" y="156" width="112" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-c-900" value="crimson-900&lt;br/&gt;#480418" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#480418;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="760" y="156" width="112" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="s-i-0" value="ink-0&lt;br/&gt;#FFFFFF" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#E8E6EA;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-50" value="ink-50&lt;br/&gt;#FAFAF7" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FAFAF7;strokeColor=#E8E6EA;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="134" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-100" value="ink-100&lt;br/&gt;#F6F4F7" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#F6F4F7;strokeColor=none;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="228" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-200" value="ink-200&lt;br/&gt;#E8E6EA" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#E8E6EA;strokeColor=none;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="322" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-300" value="ink-300&lt;br/&gt;#D4D1D6" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#D4D1D6;strokeColor=none;fontColor=#0A0A0B;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="416" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-500" value="ink-500&lt;br/&gt;#8A8790" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#8A8790;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="510" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-600" value="ink-600&lt;br/&gt;#67646D" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#67646D;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="604" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-700" value="ink-700&lt;br/&gt;#44424A" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#44424A;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="698" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-i-1000" value="ink-1000&lt;br/&gt;#0A0A0B" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#0A0A0B;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="792" y="226" width="88" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="s-sem-success" value="success&lt;br/&gt;surface #E8F3EC · fg #1A6B3A" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#E8F3EC;strokeColor=none;fontColor=#1A6B3A;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="296" width="200" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-sem-warning" value="warning&lt;br/&gt;surface #FBF1D9 · fg #8A5A07" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FBF1D9;strokeColor=none;fontColor=#8A5A07;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="252" y="296" width="200" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-sem-danger" value="danger&lt;br/&gt;surface #FBE1E8 · fg #A30F37" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FBE1E8;strokeColor=none;fontColor=#A30F37;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="464" y="296" width="200" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s-sem-info" value="info&lt;br/&gt;surface #E6EEF7 · fg #1F4F8A" style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#E6EEF7;strokeColor=none;fontColor=#1F4F8A;fontFamily=Inter;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="676" y="296" width="200" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-typo-header" value="Typography" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="380" width="400" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-display" value="Display — Noto Sans JP 700, 28px" style="text;html=1;align=left;verticalAlign=middle;fontSize=28;fontStyle=1;fontFamily=Noto Sans JP;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="406" width="840" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-headline" value="Headline — Noto Sans JP 600, 20px" style="text;html=1;align=left;verticalAlign=middle;fontSize=20;fontStyle=1;fontFamily=Noto Sans JP;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="446" width="840" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-body" value="Body — Inter 400, 15px. Default reading text for diagram labels and descriptions." style="text;html=1;align=left;verticalAlign=middle;fontSize=15;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="478" width="840" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-caption" value="Caption — Inter 500, 12px · use for metadata and footnotes" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="502" width="840" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-mono" value="Mono — JetBrains Mono 400, 13px · file paths, identifiers, code refs" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontFamily=JetBrains Mono;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="522" width="840" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-chord" value="Chord — Roboto 500, 18px:    Cmaj7    G/B    F♯m7♭5    A°7" style="text;html=1;align=left;verticalAlign=middle;fontSize=18;fontStyle=1;fontFamily=Roboto;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="546" width="840" height="26" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-button-header" value="Buttons — pick the intent variant" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="592" width="600" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-btn-primary" value="Primary" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#BD1642;strokeColor=none;fontColor=#FFFFFF;fontFamily=Inter;fontSize=14;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="620" width="124" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-btn-ghost" value="Ghost" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#BD1642;strokeWidth=1.5;fontColor=#BD1642;fontFamily=Inter;fontSize=14;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="176" y="620" width="124" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-btn-danger" value="Danger" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FBE1E8;strokeColor=#A30F37;strokeWidth=1.5;fontColor=#A30F37;fontFamily=Inter;fontSize=14;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="312" y="620" width="124" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-btn-secondary" value="Secondary" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F6F4F7;strokeColor=#D4D1D6;strokeWidth=1;fontColor=#44424A;fontFamily=Inter;fontSize=14;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="448" y="620" width="124" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-btn-note" value="Variants per DESIGN.md § 6: primary / ghost / danger / secondary." style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="592" y="620" width="288" height="40" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-pill-header" value="Status pills — one per semantic surface" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="678" width="600" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-pill-success" value="● Success" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#E8F3EC;strokeColor=none;fontColor=#1A6B3A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="706" width="124" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-pill-warning" value="● Warning" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#FBF1D9;strokeColor=none;fontColor=#8A5A07;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="176" y="706" width="124" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-pill-danger" value="● Danger" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#FBE1E8;strokeColor=none;fontColor=#A30F37;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="312" y="706" width="124" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-pill-info" value="● Info" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#E6EEF7;strokeColor=none;fontColor=#1F4F8A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="448" y="706" width="124" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-pill-note" value="Match the pill colour to the semantic intent (success / warning / danger / info) — never recolour by hand." style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="592" y="706" width="288" height="40" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-surf-header" value="Surface card &amp; accent" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="752" width="600" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-surface-card" value="Surface card&lt;br/&gt;&lt;br/&gt;Default surface for sections, panels, and forms. ink-0 fill, ink-200 border, ink-1000 text." style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#E8E6EA;strokeWidth=1;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;align=left;verticalAlign=top;spacing=12;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="780" width="260" height="120" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-accent-node" value="Accent node&lt;br/&gt;&lt;br/&gt;Crimson is the only accent (DESIGN.md § 2.1). For non-primary highlights, use the matching semantic pill or a labeled border colour." style="rounded=1;arcSize=8;whiteSpace=wrap;html=1;fillColor=#FDF2F5;strokeColor=#BD1642;strokeWidth=1.5;fontColor=#87092C;fontFamily=Inter;fontSize=12;align=left;verticalAlign=top;spacing=12;" vertex="1" parent="1">
+                    <mxGeometry x="320" y="780" width="260" height="120" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-divider-label" value="Divider (ink-200, 2px)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="600" y="780" width="280" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-divider" value="" style="rounded=0;fillColor=#E8E6EA;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="600" y="802" width="280" height="2" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-comp-header" value="Composition — cluster + connection intents" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="916" width="600" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="c-cluster" value="Cluster — grouping container" style="swimlane;html=1;startSize=28;fillColor=#F6F4F7;strokeColor=#D4D1D6;dashed=1;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;align=left;spacingLeft=12;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="942" width="440" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-cluster-a" value="Component A" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;" vertex="1" parent="c-cluster">
+                    <mxGeometry x="32" y="50" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="c-cluster-b" value="Component B" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;" vertex="1" parent="c-cluster">
+                    <mxGeometry x="268" y="50" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-cluster-ab" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;fontFamily=Inter;fontSize=11;fontColor=#44424A;" edge="1" parent="c-cluster" source="c-cluster-a" target="c-cluster-b">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-cluster-note" value="Use a cluster to group related nodes; dashed ink-300 border on ink-100 fill keeps grouping visible without competing with content." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="c-cluster">
+                    <mxGeometry x="32" y="120" width="376" height="40" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-arrow-header" value="Connection intents" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="500" y="942" width="200" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-default-line" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="500" y="978" as="sourcePoint"/>
+                        <mxPoint x="640" y="978" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-default-lbl" value="default — neutral flow (ink-600)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="650" y="966" width="230" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-primary-line" value="" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#BD1642;strokeWidth=2.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="500" y="1010" as="sourcePoint"/>
+                        <mxPoint x="640" y="1010" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-primary-lbl" value="primary — the path you want read first (crimson-500)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Inter;fontColor=#87092C;" vertex="1" parent="1">
+                    <mxGeometry x="650" y="998" width="230" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-warning-line" value="" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#8A5A07;strokeWidth=2.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="500" y="1042" as="sourcePoint"/>
+                        <mxPoint x="640" y="1042" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-warning-lbl" value="warning — caution path (warning-fg #8A5A07)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Inter;fontColor=#8A5A07;" vertex="1" parent="1">
+                    <mxGeometry x="650" y="1030" width="230" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-info-line" value="" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#1F4F8A;strokeWidth=2.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="500" y="1074" as="sourcePoint"/>
+                        <mxPoint x="640" y="1074" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-info-lbl" value="info — informational hint (info-fg #1F4F8A)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Inter;fontColor=#1F4F8A;" vertex="1" parent="1">
+                    <mxGeometry x="650" y="1062" width="230" height="24" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-retheme-header" value="Retheming an existing diagram" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="1136" width="600" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-retheme-body" value="If you already used a primary variant and now want a warning variant: open the .drawio in draw.io → Extras → Edit Diagram → find/replace the source hex (e.g. #BD1642 → #8A5A07) in the raw XML. The variants above show every design-system-compliant target colour." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="1158" width="840" height="36" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/design-system/templates/chordsketch-system-starter.drawio
+++ b/design-system/templates/chordsketch-system-starter.drawio
@@ -1,0 +1,219 @@
+<mxfile host="design-system">
+    <diagram id="chordsketch-system-starter" name="System diagram">
+        <mxGraphModel dx="1200" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="920" pageHeight="1200" math="0" shadow="0" adaptiveColors="auto">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+
+                <mxCell id="t-title" value="ChordSketch — draw.io system-diagram starter" style="text;html=1;align=left;verticalAlign=middle;fontSize=24;fontStyle=1;fontFamily=Noto Sans JP;fontColor=#0A0A0B;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="40" width="840" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-subtitle" value="Drop-in shapes for architecture sketches. Connection styles are split into neutral connectors (sync / async / dep — one each) and data-flow intent variants (primary / warning / danger / info) so you pick the right intent up front. Pair with chordsketch-starter.drawio." style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="78" width="840" height="36" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-comp-header" value="Component shapes" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="128" width="400" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="sh-service" value="Service&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;CLI, daemon&lt;/font&gt;" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;strokeWidth=1;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="156" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-crate" value="Library / crate&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;chordsketch-chordpro&lt;/font&gt;" style="shape=cube;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;size=10;" vertex="1" parent="1">
+                    <mxGeometry x="180" y="156" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-binding" value="Binding&lt;br/&gt;&lt;font color=&quot;#87092C&quot; style=&quot;font-weight:normal&quot;&gt;@chordsketch/wasm&lt;/font&gt;" style="shape=cube;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;whiteSpace=wrap;html=1;fillColor=#FDF2F5;strokeColor=#BD1642;fontColor=#87092C;fontFamily=Inter;fontSize=12;fontStyle=1;size=10;" vertex="1" parent="1">
+                    <mxGeometry x="320" y="156" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-consumer" value="Consumer pkg&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;npm / PyPI / Maven&lt;/font&gt;" style="shape=folder;whiteSpace=wrap;html=1;tabWidth=46;tabHeight=14;tabPosition=left;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="460" y="156" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-host" value="Host app&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;playground / VS Code&lt;/font&gt;" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FAFAF7;strokeColor=#D4D1D6;strokeWidth=1.5;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="600" y="156" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-external" value="External system&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;3rd-party API&lt;/font&gt;" style="shape=cloud;whiteSpace=wrap;html=1;fillColor=#F6F4F7;strokeColor=#8A8790;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="740" y="156" width="140" height="80" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-data-header" value="Data &amp; infrastructure shapes" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="266" width="400" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="sh-db" value="Database&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;SQLite, Postgres…&lt;/font&gt;" style="shape=cylinder3;boundedLbl=1;backgroundOutline=1;size=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="294" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-file" value="File / artifact&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;.cho · .pdf · .json&lt;/font&gt;" style="shape=document;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="180" y="294" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-cache" value="Cache&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;in-memory · CDN&lt;/font&gt;" style="rounded=1;arcSize=50;whiteSpace=wrap;html=1;fillColor=#FAFAF7;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="320" y="294" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-queue" value="Queue / stream&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;async hand-off&lt;/font&gt;" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fillColor=#FAFAF7;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="460" y="294" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-registry" value="Registry&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;crates.io · npm · GHCR&lt;/font&gt;" style="shape=folder;whiteSpace=wrap;html=1;tabWidth=46;tabHeight=14;tabPosition=left;fillColor=#F6F4F7;strokeColor=#8A8790;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="600" y="294" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="sh-actor" value="Actor / user" style="shape=umlActor;whiteSpace=wrap;html=1;fillColor=#67646D;strokeColor=#67646D;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;verticalLabelPosition=bottom;verticalAlign=top;labelPosition=center;" vertex="1" parent="1">
+                    <mxGeometry x="788" y="294" width="44" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-bound-header" value="Boundary clusters" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="404" width="400" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="cluster-internal" value="Internal boundary" style="swimlane;html=1;startSize=28;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;align=left;spacingLeft=12;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="434" width="400" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="cluster-internal-child" value="Internal service&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;solid ink-300 border on ink-0&lt;/font&gt;" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;strokeWidth=1.5;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="cluster-internal">
+                    <mxGeometry x="24" y="44" width="180" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="cluster-internal-note" value="Components owned by ChordSketch. Solid border + ink-0 fill." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="cluster-internal">
+                    <mxGeometry x="220" y="44" width="160" height="80" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="cluster-external" value="External / 3rd-party boundary" style="swimlane;html=1;startSize=28;fillColor=#FAFAF7;strokeColor=#8A8790;dashed=1;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;align=left;spacingLeft=12;" vertex="1" parent="1">
+                    <mxGeometry x="460" y="434" width="420" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="cluster-external-child" value="External service&lt;br/&gt;&lt;font color=&quot;#67646D&quot; style=&quot;font-weight:normal&quot;&gt;dashed ink-500 border on ink-50&lt;/font&gt;" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FAFAF7;strokeColor=#8A8790;strokeWidth=1.5;dashed=1;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="cluster-external">
+                    <mxGeometry x="24" y="44" width="180" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="cluster-external-note" value="Anything outside ChordSketch's control — registries, browsers, OS APIs, SaaS. Dashed border + ink-50 fill." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="cluster-external">
+                    <mxGeometry x="220" y="44" width="180" height="80" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-conn-neutral-header" value="Connection styles — neutral connectors" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="592" width="600" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-sync" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="40" y="628" as="sourcePoint"/>
+                        <mxPoint x="180" y="628" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-sync-lbl" value="sync — HTTP / RPC / function call" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="194" y="616" width="246" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-async" value="" style="endArrow=open;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;dashed=1;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="40" y="664" as="sourcePoint"/>
+                        <mxPoint x="180" y="664" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-async-lbl" value="async — queue / webhook / fire-and-forget" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="194" y="652" width="246" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-dep" value="" style="endArrow=open;html=1;rounded=0;strokeColor=#8A8790;strokeWidth=1;dashed=1;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="40" y="700" as="sourcePoint"/>
+                        <mxPoint x="180" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-dep-lbl" value="dep — A uses / depends on B" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=2;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="194" y="688" width="246" height="24" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-conn-intent-header" value="Data-flow intent variants — pick the semantic" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="460" y="592" width="400" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-data-primary" value="" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#BD1642;strokeWidth=2.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="460" y="628" as="sourcePoint"/>
+                        <mxPoint x="600" y="628" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-data-primary-lbl" value="primary — the path you want read first (crimson-500)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Inter;fontColor=#87092C;" vertex="1" parent="1">
+                    <mxGeometry x="614" y="616" width="266" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-data-warning" value="" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#8A5A07;strokeWidth=2.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="460" y="664" as="sourcePoint"/>
+                        <mxPoint x="600" y="664" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-data-warning-lbl" value="warning — caution / unsaved (warning-fg #8A5A07)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Inter;fontColor=#8A5A07;" vertex="1" parent="1">
+                    <mxGeometry x="614" y="652" width="266" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-data-danger" value="" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#A30F37;strokeWidth=2.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="460" y="700" as="sourcePoint"/>
+                        <mxPoint x="600" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-data-danger-lbl" value="danger — failure / destructive (danger-fg #A30F37)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Inter;fontColor=#A30F37;" vertex="1" parent="1">
+                    <mxGeometry x="614" y="688" width="266" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="ar-data-info" value="" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#1F4F8A;strokeWidth=2.5;" edge="1" parent="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="460" y="736" as="sourcePoint"/>
+                        <mxPoint x="600" y="736" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ar-data-info-lbl" value="info — informational hint (info-fg #1F4F8A)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Inter;fontColor=#1F4F8A;" vertex="1" parent="1">
+                    <mxGeometry x="614" y="724" width="266" height="24" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-ex-header" value="Example sketch — actor reaches the wasm binding through the playground host" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="788" width="840" height="20" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="ex-actor" value="Musician" style="shape=umlActor;whiteSpace=wrap;html=1;fillColor=#67646D;strokeColor=#67646D;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;verticalLabelPosition=bottom;verticalAlign=top;labelPosition=center;" vertex="1" parent="1">
+                    <mxGeometry x="68" y="850" width="44" height="60" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="ex-cluster-internal" value="ChordSketch (internal)" style="swimlane;html=1;startSize=28;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;align=left;spacingLeft=12;" vertex="1" parent="1">
+                    <mxGeometry x="180" y="820" width="380" height="220" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-host" value="Playground host" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#FAFAF7;strokeColor=#D4D1D6;strokeWidth=1.5;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="ex-cluster-internal">
+                    <mxGeometry x="24" y="48" width="160" height="44" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-binding" value="@chordsketch/wasm" style="shape=cube;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;whiteSpace=wrap;html=1;fillColor=#FDF2F5;strokeColor=#BD1642;fontColor=#87092C;fontFamily=Inter;fontSize=12;fontStyle=1;size=10;" vertex="1" parent="ex-cluster-internal">
+                    <mxGeometry x="24" y="112" width="160" height="64" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-crate" value="chordsketch-chordpro" style="shape=cube;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D4D1D6;fontColor=#0A0A0B;fontFamily=Inter;fontSize=12;fontStyle=1;size=10;" vertex="1" parent="ex-cluster-internal">
+                    <mxGeometry x="216" y="112" width="140" height="64" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="ex-cluster-external" value="Registries (external)" style="swimlane;html=1;startSize=28;fillColor=#FAFAF7;strokeColor=#8A8790;dashed=1;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;align=left;spacingLeft=12;" vertex="1" parent="1">
+                    <mxGeometry x="600" y="820" width="280" height="220" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-reg-crates" value="crates.io" style="shape=folder;whiteSpace=wrap;html=1;tabWidth=46;tabHeight=14;tabPosition=left;fillColor=#F6F4F7;strokeColor=#8A8790;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="ex-cluster-external">
+                    <mxGeometry x="24" y="48" width="116" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-reg-npm" value="npm" style="shape=folder;whiteSpace=wrap;html=1;tabWidth=46;tabHeight=14;tabPosition=left;fillColor=#F6F4F7;strokeColor=#8A8790;fontColor=#44424A;fontFamily=Inter;fontSize=12;fontStyle=1;" vertex="1" parent="ex-cluster-external">
+                    <mxGeometry x="148" y="48" width="108" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-reg-note" value="chordpro publishes to crates.io; the wasm binding publishes to npm." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="ex-cluster-external">
+                    <mxGeometry x="24" y="112" width="232" height="80" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="ex-edge-actor-host" value="opens" style="endArrow=classic;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;fontFamily=Inter;fontSize=11;fontColor=#44424A;labelBackgroundColor=#FAFAF7;exitX=1;exitY=0.5;entryX=0;entryY=0.5;" edge="1" parent="1" source="ex-actor" target="ex-host">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-edge-host-binding" value="" style="endArrow=open;html=1;rounded=0;strokeColor=#8A8790;strokeWidth=1;dashed=1;fontFamily=Inter;fontSize=11;fontColor=#67646D;fontStyle=2;exitX=0.5;exitY=1;entryX=0.5;entryY=0;" edge="1" parent="ex-cluster-internal" source="ex-host" target="ex-binding">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-edge-binding-crate" value="calls" style="endArrow=classic;html=1;rounded=0;strokeColor=#67646D;strokeWidth=1.5;fontFamily=Inter;fontSize=11;fontColor=#44424A;labelBackgroundColor=#FFFFFF;exitX=1;exitY=0.5;entryX=0;entryY=0.5;" edge="1" parent="ex-cluster-internal" source="ex-binding" target="ex-crate">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-edge-crate-registry" value="published" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#BD1642;strokeWidth=2.5;fontFamily=Inter;fontSize=11;fontStyle=1;fontColor=#87092C;labelBackgroundColor=#FAFAF7;" edge="1" parent="1" source="ex-crate" target="ex-reg-crates">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="ex-edge-binding-npm" value="published" style="endArrow=classicThin;html=1;rounded=0;strokeColor=#BD1642;strokeWidth=2.5;fontFamily=Inter;fontSize=11;fontStyle=1;fontColor=#87092C;labelBackgroundColor=#FFFFFF;" edge="1" parent="1" source="ex-binding" target="ex-reg-npm">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-retheme-header" value="Retheming an existing diagram" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontFamily=Inter;fontColor=#44424A;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="1064" width="600" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="t-retheme-body" value="To swap one intent for another after the fact: open the .drawio in draw.io → Extras → Edit Diagram → find/replace the source hex in the raw XML (e.g. data-primary #BD1642 → data-warning #8A5A07). The intent variants above show every design-system-compliant target colour." style="text;html=1;align=left;verticalAlign=top;fontSize=11;fontFamily=Inter;fontColor=#67646D;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="1086" width="840" height="48" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="t-footer" value="Tokens: design-system/tokens.css · Rules: design-system/DESIGN.md · Built-in draw.io shapes only (cube, cylinder3, cloud, document, hexagon, folder, umlActor)." style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontFamily=Inter;fontColor=#8A8790;fontStyle=2;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="1158" width="840" height="20" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
## What

Add two `.drawio` starter templates under `design-system/templates/`:

- `chordsketch-starter.drawio` — palette swatches, typography stack, surface card, accent node, divider, cluster, plus a Buttons row (primary / ghost / danger / secondary), a Pills row (success / warning / danger / info), and a Connection-intent row (default / primary / warning / info).
- `chordsketch-system-starter.drawio` — service / library / binding / consumer / host / external component shapes, infrastructure shapes (database, file, cache, queue, registry, actor), boundary clusters (internal solid / external dashed), neutral connectors (sync / async / dep), data-flow intent variants (primary / warning / danger / info), and a worked example.

Both files document the retheming workflow in the footer (Extras → Edit Diagram → find/replace in raw XML).

Add two rows to `DESIGN.md` § 9 asset table.

## Why

Without templates, anyone drafting an architecture sketch or a flow chart in draw.io picks hex codes by hand and re-authors shape styles each time. A previous iteration of these templates (closed PR #2551) shipped a single primary/crimson variant per shape, which surfaced a follow-up concern: when the desired semantic intent later changes (e.g. "this arrow should be a warning, not a primary path"), per-cell editing is needed to retheme.

These templates address that by **fronting the semantic axis**: each shape that takes an intent (Buttons, Pills, Connection-intent arrows) is shown as a row of variants — primary / warning / success / danger / info — so picking the right variant from the start gives the right colour by construction. Switching after the fact still requires Find/Replace in the raw XML, but the file footer documents the workflow and the variants name every design-system-compliant target colour explicitly.

Closes #2550 (the original starter ask) and #2552 (the system-diagram ask) — both share the same intent-variant approach and the same asset-table row block, so they ship together.

## Test results

Visual artifacts — no automated tests. Manual checks:

- `python3 -c "import xml.etree.ElementTree as ET; ET.parse('design-system/templates/chordsketch-starter.drawio'); ET.parse('design-system/templates/chordsketch-system-starter.drawio')"` succeeds (XML well-formed).
- Every hex in both files matches a value in `design-system/tokens.css` (crimson tokens, ink tokens, semantic surface/fg pairs).
- Both files use only built-in draw.io shapes (`cube`, `cylinder3`, `cloud`, `document`, `hexagon`, `folder`, `umlActor`) so no custom shape libraries are needed.
- Opening each in draw.io desktop / app.diagrams.net renders cleanly with no parse warnings (verified locally).

## Review summary

- `tokens.css` not modified; templates reference existing tokens by value.
- No code paths, rendering surfaces, or bindings touched.
- Fonts listed (Inter, Noto Sans JP, JetBrains Mono, Roboto) fall back gracefully when the listed face is not installed locally — same posture as `tokens.css` `--font-*` declarations.
- DESIGN.md § 9 row wording highlights the intent-variant structure so readers know what to expect when they open the files.

## Sister-site audit

Not applicable — design-system artifacts only; no rendering surfaces or bindings touched.

Closes #2550
Closes #2552