### PR TITLE
fix(grid): tokeniser hangs on bare `:` not followed by `|`

### DIFF
--- a/crates/chordpro/src/grid.rs
+++ b/crates/chordpro/src/grid.rs
@@ -400,17 +400,23 @@ pub fn tokenize_grid_line(input: &str) -> Vec<GridToken> {
         }
         if i == start {
             // Head byte is a terminator the dispatch above did
-            // not consume. The widened terminator set + the
-            // named-branch dispatch must agree; if a future PR
-            // adds a terminator without adding a named branch,
-            // the debug assertion below fires in tests so the
-            // bug class from issue #2556 (no-progress infinite
-            // loop) can never silently regress.
+            // not consume. Drop it and advance so the outer
+            // loop makes progress.
+            //
+            // The assertion is a postcondition invariant: the
+            // inner `while` exits with zero progress only when
+            // `is_dialect_terminator(bytes[i])` is already true
+            // (that is the loop exit condition). It fires if a
+            // future refactor decouples the while condition from
+            // `is_dialect_terminator`. Regression protection for
+            // the "new terminator without a dispatch branch"
+            // scenario (issue #2556 class) comes from the LCG
+            // property test.
             //
             // Sister-site: same guard in `tokenizeGridLine`.
             debug_assert!(
                 is_dialect_terminator(bytes[i]),
-                "tokenize_grid_line no-progress guard reached on non-terminator byte {:?}",
+                "tokenize_grid_line no-progress guard: non-terminator byte {:?} must not reach this branch",
                 bytes[i] as char
             );
             i += 1;

--- a/crates/chordpro/src/grid.rs
+++ b/crates/chordpro/src/grid.rs
@@ -283,6 +283,33 @@ pub struct GridRow {
     pub trailing_comment: Option<String>,
 }
 
+/// Single source of truth for cell-text terminator bytes.
+///
+/// The cell-text fallback in [`tokenize_grid_line`] reads a
+/// run of bytes that are NOT in this set. The dispatch above
+/// it MUST handle every byte in this set with a named branch
+/// that advances the cursor unconditionally; otherwise the
+/// outer loop would pin on a head terminator nobody consumed
+/// (the bug fixed in issue #2556).
+///
+/// `b':'` is in the set because it is the head of the `:|` /
+/// `:|:` repeat-end markers; a bare `:` not followed by `|` is
+/// dialect garbage that the cell-text path drops via the
+/// no-progress guard at the end of [`tokenize_grid_line`].
+/// `b'\n'` / `b'\r'` are deliberately absent — grid rows are
+/// already line-split upstream.
+///
+/// Sister-site: `DIALECT_TERMINATORS` in
+/// `packages/react/src/chordpro-jsx.tsx`. The two sets MUST
+/// remain in lockstep so the four rendering surfaces consume
+/// equivalent token streams.
+const DIALECT_TERMINATORS: &[u8] = b" \t|:";
+
+#[inline]
+fn is_dialect_terminator(b: u8) -> bool {
+    DIALECT_TERMINATORS.contains(&b)
+}
+
 /// Tokenise a grid row into `[GridToken]`.
 ///
 /// Sister-site to `tokenizeGridLine` in
@@ -365,20 +392,27 @@ pub fn tokenize_grid_line(input: &str) -> Vec<GridToken> {
             i += 1;
             continue;
         }
-        // Read a cell token — any contiguous run of
-        // non-whitespace / non-bar / non-colon characters.
-        // Chord brackets `[X]` are unwrapped.
+        // Cell-text fallback: read a run of non-terminator
+        // bytes. Chord brackets `[X]` are unwrapped below.
         let start = i;
-        while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'|' | b':') {
+        while i < bytes.len() && !is_dialect_terminator(bytes[i]) {
             i += 1;
         }
         if i == start {
-            // The head byte is itself a terminator that no named
-            // branch above consumed — today only a bare `:` not
-            // followed by `|`. Drop it and advance so the outer
-            // loop cannot pin on the same offset and hang.
-            // Sister-site to the same guard in `tokenizeGridLine`
-            // (packages/react/src/chordpro-jsx.tsx).
+            // Head byte is a terminator the dispatch above did
+            // not consume. The widened terminator set + the
+            // named-branch dispatch must agree; if a future PR
+            // adds a terminator without adding a named branch,
+            // the debug assertion below fires in tests so the
+            // bug class from issue #2556 (no-progress infinite
+            // loop) can never silently regress.
+            //
+            // Sister-site: same guard in `tokenizeGridLine`.
+            debug_assert!(
+                is_dialect_terminator(bytes[i]),
+                "tokenize_grid_line no-progress guard reached on non-terminator byte {:?}",
+                bytes[i] as char
+            );
             i += 1;
             continue;
         }
@@ -771,29 +805,23 @@ mod tests {
         assert_eq!(row.kind, GridRowKind::Chord);
     }
 
-    // Regression tests for the no-progress branch in the cell-text
-    // reader (issue #2556). A bare `:` not followed by `|` used to
-    // hang the tokeniser because the cell-read terminator set
-    // includes `:` itself — `start == i`, nothing pushed, the
-    // outer loop pinned on the same offset. The guard added in
-    // the same commit advances `i` by one in that branch; these
-    // tests pin the contract so the regression cannot return, and
-    // are sister-site to the same cases in
-    // `packages/react/tests/chordpro-jsx-helpers.test.ts`.
+    // Regression tests for #2556 — sister-site to the same
+    // cases in `packages/react/tests/chordpro-jsx-helpers.test.ts`.
+    // See the production guard in `tokenize_grid_line` for the
+    // mechanism; these tests pin the user-observable contract.
     #[test]
     fn tokenize_trailing_bare_colon_terminates() {
         // Mid-edit state captured from the kitchen-sink sample.
-        // Pre-fix this input hung the renderer.
+        // Pre-fix `tokenize_grid_line` spun without forward
+        // progress on the trailing `:`.
         let toks = tokenize_grid_line("|: C7 . | %  . :|: G7 . | %  . :");
         let non_space: Vec<&GridToken> = toks
             .iter()
             .filter(|t| !matches!(t, GridToken::Space))
             .collect();
-        // Stray trailing `:` is dropped; the rest is a valid
-        // token stream ending at the last continuation.
-        // `GridToken: PartialEq` — compare directly so that a
-        // future regression swapping `RepeatBoth` for `Single`
-        // (etc.) is caught here rather than silently passing.
+        // `GridToken: PartialEq` — direct comparison catches a
+        // future regression that swaps `RepeatBoth` for `Single`
+        // (which a discriminant-only check would silently miss).
         assert_eq!(
             non_space,
             vec![
@@ -819,10 +847,16 @@ mod tests {
     }
 
     #[test]
+    fn tokenize_run_of_colons_terminates() {
+        // Drives the no-progress guard through multiple
+        // iterations. A discriminant-only check on the first
+        // colon would pass even if a future regression reverted
+        // the unconditional `i += 1`.
+        assert!(tokenize_grid_line(":::::::").is_empty());
+    }
+
+    #[test]
     fn tokenize_colon_between_cells_is_dropped() {
-        // `C : D` — the orphan colon between cells is dialect
-        // garbage. The tokeniser must skip it and still surface
-        // the two cells on either side.
         let toks = tokenize_grid_line("C : D");
         let cells: Vec<&Vec<String>> = toks
             .iter()
@@ -834,5 +868,45 @@ mod tests {
         assert_eq!(cells.len(), 2);
         assert_eq!(cells[0], &vec!["C".to_string()]);
         assert_eq!(cells[1], &vec!["D".to_string()]);
+    }
+
+    #[test]
+    fn tokenize_grid_line_terminates_for_arbitrary_ascii_input() {
+        // Property check: the outer loop must terminate for any
+        // input drawn from the dispatch alphabet, regardless of
+        // ordering. Generated deterministically (no rand dep)
+        // from a small LCG so the corpus survives across runs.
+        // A regression that reintroduces the no-progress shape
+        // would hang one of the cases here under the test
+        // runner's per-test timeout.
+        let alphabet = b"|:.%~ \t[]nstC7G:1234ABs";
+        let mut state: u32 = 0xC0FFEE;
+        for _ in 0..256 {
+            let mut s = String::new();
+            let len = (state as usize) % 48;
+            for _ in 0..len {
+                state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+                let idx = (state >> 16) as usize % alphabet.len();
+                s.push(alphabet[idx] as char);
+            }
+            // Just calling tokenize_grid_line is enough — if it
+            // doesn't return, the test runner kills the harness.
+            let _ = tokenize_grid_line(&s);
+        }
+    }
+
+    #[test]
+    fn classify_row_with_trailing_bare_colon_demotes_to_row_comment() {
+        // The cell-text guard drops the trailing `:`, after which
+        // the row's last barline is the `|` before `% .`. The
+        // engraving classifier therefore demotes the orphan
+        // `% .` to a `trailing_comment` because the row no longer
+        // has a closing barline. This is intentional mid-edit
+        // behaviour — pinning it at the parse layer so a future
+        // change to `classify_grid_row` that re-promotes the
+        // percent back to a body cell fails here rather than
+        // silently rewriting three golden snapshots.
+        let row = classify_grid_row("|: G7 . | %  . :");
+        assert_eq!(row.trailing_comment.as_deref(), Some("% ."));
     }
 }

--- a/crates/chordpro/src/grid.rs
+++ b/crates/chordpro/src/grid.rs
@@ -785,28 +785,30 @@ mod tests {
         // Mid-edit state captured from the kitchen-sink sample.
         // Pre-fix this input hung the renderer.
         let toks = tokenize_grid_line("|: C7 . | %  . :|: G7 . | %  . :");
-        let kinds: Vec<std::mem::Discriminant<GridToken>> = toks
+        let non_space: Vec<&GridToken> = toks
             .iter()
             .filter(|t| !matches!(t, GridToken::Space))
-            .map(std::mem::discriminant)
             .collect();
         // Stray trailing `:` is dropped; the rest is a valid
         // token stream ending at the last continuation.
+        // `GridToken: PartialEq` — compare directly so that a
+        // future regression swapping `RepeatBoth` for `Single`
+        // (etc.) is caught here rather than silently passing.
         assert_eq!(
-            kinds,
+            non_space,
             vec![
-                std::mem::discriminant(&GridToken::Barline(GridBarline::RepeatStart)),
-                std::mem::discriminant(&GridToken::Cell(vec!["C7".into()])),
-                std::mem::discriminant(&GridToken::Continuation),
-                std::mem::discriminant(&GridToken::Barline(GridBarline::Single)),
-                std::mem::discriminant(&GridToken::Percent1),
-                std::mem::discriminant(&GridToken::Continuation),
-                std::mem::discriminant(&GridToken::Barline(GridBarline::RepeatBoth)),
-                std::mem::discriminant(&GridToken::Cell(vec!["G7".into()])),
-                std::mem::discriminant(&GridToken::Continuation),
-                std::mem::discriminant(&GridToken::Barline(GridBarline::Single)),
-                std::mem::discriminant(&GridToken::Percent1),
-                std::mem::discriminant(&GridToken::Continuation),
+                &GridToken::Barline(GridBarline::RepeatStart),
+                &GridToken::Cell(vec!["C7".into()]),
+                &GridToken::Continuation,
+                &GridToken::Barline(GridBarline::Single),
+                &GridToken::Percent1,
+                &GridToken::Continuation,
+                &GridToken::Barline(GridBarline::RepeatBoth),
+                &GridToken::Cell(vec!["G7".into()]),
+                &GridToken::Continuation,
+                &GridToken::Barline(GridBarline::Single),
+                &GridToken::Percent1,
+                &GridToken::Continuation,
             ]
         );
     }

--- a/crates/chordpro/src/grid.rs
+++ b/crates/chordpro/src/grid.rs
@@ -372,6 +372,16 @@ pub fn tokenize_grid_line(input: &str) -> Vec<GridToken> {
         while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'|' | b':') {
             i += 1;
         }
+        if i == start {
+            // The head byte is itself a terminator that no named
+            // branch above consumed — today only a bare `:` not
+            // followed by `|`. Drop it and advance so the outer
+            // loop cannot pin on the same offset and hang.
+            // Sister-site to the same guard in `tokenizeGridLine`
+            // (packages/react/src/chordpro-jsx.tsx).
+            i += 1;
+            continue;
+        }
         let mut raw = &input[start..i];
         if raw.starts_with('[') && raw.ends_with(']') && raw.len() >= 2 {
             raw = &raw[1..raw.len() - 1];
@@ -759,5 +769,68 @@ mod tests {
     fn classify_row_chord_when_not_strum() {
         let row = classify_grid_row("| G7 . . . |");
         assert_eq!(row.kind, GridRowKind::Chord);
+    }
+
+    // Regression tests for the no-progress branch in the cell-text
+    // reader (issue #2556). A bare `:` not followed by `|` used to
+    // hang the tokeniser because the cell-read terminator set
+    // includes `:` itself — `start == i`, nothing pushed, the
+    // outer loop pinned on the same offset. The guard added in
+    // the same commit advances `i` by one in that branch; these
+    // tests pin the contract so the regression cannot return, and
+    // are sister-site to the same cases in
+    // `packages/react/tests/chordpro-jsx-helpers.test.ts`.
+    #[test]
+    fn tokenize_trailing_bare_colon_terminates() {
+        // Mid-edit state captured from the kitchen-sink sample.
+        // Pre-fix this input hung the renderer.
+        let toks = tokenize_grid_line("|: C7 . | %  . :|: G7 . | %  . :");
+        let kinds: Vec<std::mem::Discriminant<GridToken>> = toks
+            .iter()
+            .filter(|t| !matches!(t, GridToken::Space))
+            .map(std::mem::discriminant)
+            .collect();
+        // Stray trailing `:` is dropped; the rest is a valid
+        // token stream ending at the last continuation.
+        assert_eq!(
+            kinds,
+            vec![
+                std::mem::discriminant(&GridToken::Barline(GridBarline::RepeatStart)),
+                std::mem::discriminant(&GridToken::Cell(vec!["C7".into()])),
+                std::mem::discriminant(&GridToken::Continuation),
+                std::mem::discriminant(&GridToken::Barline(GridBarline::Single)),
+                std::mem::discriminant(&GridToken::Percent1),
+                std::mem::discriminant(&GridToken::Continuation),
+                std::mem::discriminant(&GridToken::Barline(GridBarline::RepeatBoth)),
+                std::mem::discriminant(&GridToken::Cell(vec!["G7".into()])),
+                std::mem::discriminant(&GridToken::Continuation),
+                std::mem::discriminant(&GridToken::Barline(GridBarline::Single)),
+                std::mem::discriminant(&GridToken::Percent1),
+                std::mem::discriminant(&GridToken::Continuation),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_lone_colon_drops_to_no_tokens() {
+        assert!(tokenize_grid_line(":").is_empty());
+    }
+
+    #[test]
+    fn tokenize_colon_between_cells_is_dropped() {
+        // `C : D` — the orphan colon between cells is dialect
+        // garbage. The tokeniser must skip it and still surface
+        // the two cells on either side.
+        let toks = tokenize_grid_line("C : D");
+        let cells: Vec<&Vec<String>> = toks
+            .iter()
+            .filter_map(|t| match t {
+                GridToken::Cell(n) => Some(n),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0], &vec!["C".to_string()]);
+        assert_eq!(cells[1], &vec!["D".to_string()]);
     }
 }

--- a/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Grid Lone Colon</title>
+<style>
+body { font-family: "Noto Sans JP", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-size: 1rem; line-height: 1.6875; color: #0A0A0B; max-width: 720px; margin: 2em auto; padding: 0 1em; }
+h1 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 1.875rem; letter-spacing: -0.02em; color: #0A0A0B; margin-bottom: 0.2em; }
+h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-weight: 400; font-size: 1rem; color: #67646D; margin-top: 0; }
+.meta { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.8125rem; color: #67646D; margin: 0 0 0.4em; font-feature-settings: "tnum" 1; }
+.song-header > .meta:last-of-type { margin-bottom: 1.5em; }
+.meta--attribution { font-family: "Inter", system-ui, sans-serif; font-size: 1rem; color: #4A4750; margin: 0.1em 0; }
+.meta--attribution-secondary { font-size: 0.8125rem; color: #8A8790; margin-bottom: 0.8em; }
+.meta__label { color: #8A8790; font-weight: 400; }
+.meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
+.meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
+.meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline__label { color: #8A8790; font-weight: 500; }
+.meta-inline__value { color: #0A0A0B; font-weight: 600; }
+.meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }
+.meta-inline .music-glyph { display: inline-flex; align-items: center; flex-shrink: 0; color: #0A0A0B; height: 1.1em; }
+.meta-inline svg.music-glyph { height: 1.1em; width: auto; display: block; }
+.meta-inline span.music-glyph--time { font-size: 0.85em; }
+.music-glyph { display: inline-block; flex-shrink: 0; vertical-align: middle; color: #1A1718; }
+.music-glyph--time { display: inline-flex; flex-direction: column; align-items: center; justify-content: center; line-height: 1; font-family: "Source Serif Pro", serif; font-weight: 700; font-size: 1.1em; letter-spacing: 0; }
+.music-glyph--time__num, .music-glyph--time__den { display: block; line-height: 0.9; font-feature-settings: "tnum" 1; }
+.music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
+.music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
+@keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
+.chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
+.chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }
+.lyrics { font-family: "Noto Sans JP", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 400; font-size: 1.125rem; white-space: pre; }
+.empty-line { height: 1em; }
+section { margin: 1em 0; }
+section > .section-label, .chorus-recall > .section-label { font-family: "Inter", system-ui, -apple-system, sans-serif; font-weight: 600; font-size: 0.75rem; color: #67646D; margin: 0 0 0.5em; line-height: 1.4; }
+.comment { font-family: "Inter", system-ui, -apple-system, sans-serif; font-style: italic; color: #8A8790; margin: 0.3em 0; }
+.comment-box { border: 1px solid #D4D1D6; border-radius: 4px; padding: 0.2em 0.5em; display: block; width: fit-content; margin: 0.3em 0; }
+.comment.comment--highlight { background-color: #FFF3A3; color: #1A1718; font-style: normal; font-weight: 600; padding: 0.15em 0.4em; border-radius: 3px; display: block; width: fit-content; }
+.comment.comment--highlight mark { background: none; color: inherit; }
+section.tab .lyrics, section.grid .lyrics, section.abc .lyrics, section.ly .lyrics, section.textblock .lyrics { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.875rem; font-feature-settings: "tnum" 1; }
+.chorus-recall { margin: 1em 0; }
+img { max-width: 100%; height: auto; }
+.chord-diagrams-grid { display: flex; flex-wrap: wrap; gap: 0.5em; margin: 0.5em 0; }
+.chord-diagram-container { display: inline-block; vertical-align: top; }
+.chord-diagram { display: block; }
+.grid-line { display: flex; align-items: stretch; margin: 0.35em 0; min-height: 2.4em; font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 600; font-size: 1rem; line-height: 1.4; color: #1A1718; }
+.grid-bar { flex: 1 1 0; display: flex; align-items: center; padding: 0.2em 0.4em; min-width: 3em; }
+.grid-beat { flex: 1 1 0; display: flex; align-items: center; justify-content: flex-start; min-width: 0; }
+.grid-chord { color: #BD1642; }
+.grid-no-chord { color: #67646D; font-style: italic; font-weight: 500; }
+.grid-barline { display: inline-flex; align-items: stretch; align-self: stretch; gap: 1.5px; flex-shrink: 0; }
+.grid-barline:not([class*='--']) { width: 1.5px; background-color: #1A1718; }
+.grid-barline__line { display: inline-block; width: 1.5px; background-color: #1A1718; }
+.grid-barline__line--thick { width: 3.5px; }
+.grid-barline__dots { display: inline-flex; flex-direction: column; justify-content: center; gap: 0.18em; padding: 0 2.5px; }
+.grid-barline__dots > span { width: 3px; height: 3px; border-radius: 50%; background-color: #1A1718; display: inline-block; }
+.grid-volta { position: relative; display: inline-flex; align-items: stretch; flex-shrink: 0; }
+.grid-volta .grid-barline__line { background-color: #1A1718; }
+.grid-volta__bracket { position: absolute; top: -0.1em; left: 0; display: flex; flex-direction: column; align-items: flex-start; justify-content: flex-start; }
+.grid-volta__cap { display: block; width: 1.5em; height: 1.5px; background-color: #1A1718; }
+.grid-volta__label { display: inline-block; margin-left: 0.15em; font-size: 0.7em; font-weight: 600; color: #1A1718; line-height: 1; padding-top: 0.1em; }
+.grid-row__label { display: inline-flex; align-items: center; flex-shrink: 0; padding-right: 0.6em; font-weight: 700; color: #44424A; text-transform: uppercase; font-size: 0.85em; letter-spacing: 0.04em; min-width: 2em; }
+.grid-row__comment { display: inline-flex; align-items: center; flex-shrink: 0; padding-left: 0.6em; font-style: italic; font-weight: 500; font-size: 0.85em; color: #67646D; }
+.grid-percent { font-weight: 700; font-size: 0.9em; color: #44424A; }
+.grid-beat--percent1, .grid-beat--percent2 { justify-content: center; }
+.grid-chord__sep { display: inline-block; margin: 0 0.15em; color: #8A8790; font-weight: 400; font-size: 0.85em; }
+.grid-beat--multi { gap: 0; }
+.grid-line--strum { margin-top: -0.4em; min-height: 1.6em; font-size: 0.85em; color: #67646D; }
+.grid-strum { font-weight: 600; }
+.grid-strum__glyph { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+.grid-strum--up { color: #BD1642; }
+.grid-strum--down { color: #1A1718; }
+.grid-strum--up-accent, .grid-strum--down-accent { font-weight: 700; }
+.grid-strum--anticipated { font-style: italic; }
+.grid-strum--custom { color: #67646D; font-style: italic; }
+.sr-only { position: absolute; clip: rect(0,0,0,0); width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; white-space: nowrap; border: 0; }
+</style>
+</head>
+<body>
+<article class="song">
+<header class="song-header">
+<h1>Grid Lone Colon</h1>
+</header>
+<div class="empty-line" aria-hidden="true"></div>
+<section class="grid">
+<h3 class="section-label">Grid</h3>
+<div class="grid-line"></div>
+</section>
+</article>
+</body>
+</html>

--- a/crates/render-html/tests/fixtures/grid-lone-colon/input.cho
+++ b/crates/render-html/tests/fixtures/grid-lone-colon/input.cho
@@ -1,0 +1,5 @@
+{title: Grid Lone Colon}
+
+{start_of_grid}
+:
+{end_of_grid}

--- a/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Grid Trailing Colon</title>
+<style>
+body { font-family: "Noto Sans JP", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-size: 1rem; line-height: 1.6875; color: #0A0A0B; max-width: 720px; margin: 2em auto; padding: 0 1em; }
+h1 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 1.875rem; letter-spacing: -0.02em; color: #0A0A0B; margin-bottom: 0.2em; }
+h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-weight: 400; font-size: 1rem; color: #67646D; margin-top: 0; }
+.meta { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.8125rem; color: #67646D; margin: 0 0 0.4em; font-feature-settings: "tnum" 1; }
+.song-header > .meta:last-of-type { margin-bottom: 1.5em; }
+.meta--attribution { font-family: "Inter", system-ui, sans-serif; font-size: 1rem; color: #4A4750; margin: 0.1em 0; }
+.meta--attribution-secondary { font-size: 0.8125rem; color: #8A8790; margin-bottom: 0.8em; }
+.meta__label { color: #8A8790; font-weight: 400; }
+.meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
+.meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
+.meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline__label { color: #8A8790; font-weight: 500; }
+.meta-inline__value { color: #0A0A0B; font-weight: 600; }
+.meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }
+.meta-inline .music-glyph { display: inline-flex; align-items: center; flex-shrink: 0; color: #0A0A0B; height: 1.1em; }
+.meta-inline svg.music-glyph { height: 1.1em; width: auto; display: block; }
+.meta-inline span.music-glyph--time { font-size: 0.85em; }
+.music-glyph { display: inline-block; flex-shrink: 0; vertical-align: middle; color: #1A1718; }
+.music-glyph--time { display: inline-flex; flex-direction: column; align-items: center; justify-content: center; line-height: 1; font-family: "Source Serif Pro", serif; font-weight: 700; font-size: 1.1em; letter-spacing: 0; }
+.music-glyph--time__num, .music-glyph--time__den { display: block; line-height: 0.9; font-feature-settings: "tnum" 1; }
+.music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
+.music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
+@keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
+.chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
+.chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }
+.lyrics { font-family: "Noto Sans JP", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 400; font-size: 1.125rem; white-space: pre; }
+.empty-line { height: 1em; }
+section { margin: 1em 0; }
+section > .section-label, .chorus-recall > .section-label { font-family: "Inter", system-ui, -apple-system, sans-serif; font-weight: 600; font-size: 0.75rem; color: #67646D; margin: 0 0 0.5em; line-height: 1.4; }
+.comment { font-family: "Inter", system-ui, -apple-system, sans-serif; font-style: italic; color: #8A8790; margin: 0.3em 0; }
+.comment-box { border: 1px solid #D4D1D6; border-radius: 4px; padding: 0.2em 0.5em; display: block; width: fit-content; margin: 0.3em 0; }
+.comment.comment--highlight { background-color: #FFF3A3; color: #1A1718; font-style: normal; font-weight: 600; padding: 0.15em 0.4em; border-radius: 3px; display: block; width: fit-content; }
+.comment.comment--highlight mark { background: none; color: inherit; }
+section.tab .lyrics, section.grid .lyrics, section.abc .lyrics, section.ly .lyrics, section.textblock .lyrics { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.875rem; font-feature-settings: "tnum" 1; }
+.chorus-recall { margin: 1em 0; }
+img { max-width: 100%; height: auto; }
+.chord-diagrams-grid { display: flex; flex-wrap: wrap; gap: 0.5em; margin: 0.5em 0; }
+.chord-diagram-container { display: inline-block; vertical-align: top; }
+.chord-diagram { display: block; }
+.grid-line { display: flex; align-items: stretch; margin: 0.35em 0; min-height: 2.4em; font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 600; font-size: 1rem; line-height: 1.4; color: #1A1718; }
+.grid-bar { flex: 1 1 0; display: flex; align-items: center; padding: 0.2em 0.4em; min-width: 3em; }
+.grid-beat { flex: 1 1 0; display: flex; align-items: center; justify-content: flex-start; min-width: 0; }
+.grid-chord { color: #BD1642; }
+.grid-no-chord { color: #67646D; font-style: italic; font-weight: 500; }
+.grid-barline { display: inline-flex; align-items: stretch; align-self: stretch; gap: 1.5px; flex-shrink: 0; }
+.grid-barline:not([class*='--']) { width: 1.5px; background-color: #1A1718; }
+.grid-barline__line { display: inline-block; width: 1.5px; background-color: #1A1718; }
+.grid-barline__line--thick { width: 3.5px; }
+.grid-barline__dots { display: inline-flex; flex-direction: column; justify-content: center; gap: 0.18em; padding: 0 2.5px; }
+.grid-barline__dots > span { width: 3px; height: 3px; border-radius: 50%; background-color: #1A1718; display: inline-block; }
+.grid-volta { position: relative; display: inline-flex; align-items: stretch; flex-shrink: 0; }
+.grid-volta .grid-barline__line { background-color: #1A1718; }
+.grid-volta__bracket { position: absolute; top: -0.1em; left: 0; display: flex; flex-direction: column; align-items: flex-start; justify-content: flex-start; }
+.grid-volta__cap { display: block; width: 1.5em; height: 1.5px; background-color: #1A1718; }
+.grid-volta__label { display: inline-block; margin-left: 0.15em; font-size: 0.7em; font-weight: 600; color: #1A1718; line-height: 1; padding-top: 0.1em; }
+.grid-row__label { display: inline-flex; align-items: center; flex-shrink: 0; padding-right: 0.6em; font-weight: 700; color: #44424A; text-transform: uppercase; font-size: 0.85em; letter-spacing: 0.04em; min-width: 2em; }
+.grid-row__comment { display: inline-flex; align-items: center; flex-shrink: 0; padding-left: 0.6em; font-style: italic; font-weight: 500; font-size: 0.85em; color: #67646D; }
+.grid-percent { font-weight: 700; font-size: 0.9em; color: #44424A; }
+.grid-beat--percent1, .grid-beat--percent2 { justify-content: center; }
+.grid-chord__sep { display: inline-block; margin: 0 0.15em; color: #8A8790; font-weight: 400; font-size: 0.85em; }
+.grid-beat--multi { gap: 0; }
+.grid-line--strum { margin-top: -0.4em; min-height: 1.6em; font-size: 0.85em; color: #67646D; }
+.grid-strum { font-weight: 600; }
+.grid-strum__glyph { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+.grid-strum--up { color: #BD1642; }
+.grid-strum--down { color: #1A1718; }
+.grid-strum--up-accent, .grid-strum--down-accent { font-weight: 700; }
+.grid-strum--anticipated { font-style: italic; }
+.grid-strum--custom { color: #67646D; font-style: italic; }
+.sr-only { position: absolute; clip: rect(0,0,0,0); width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; white-space: nowrap; border: 0; }
+</style>
+</head>
+<body>
+<article class="song">
+<header class="song-header">
+<h1>Grid Trailing Colon</h1>
+</header>
+<div class="empty-line" aria-hidden="true"></div>
+<section class="grid">
+<h3 class="section-label">Grid</h3>
+<div class="grid-line"><span class="grid-barline grid-barline--repeat-start" aria-label="repeat start"><span class="grid-barline__line grid-barline__line--thick"></span><span class="grid-barline__line"></span><span class="grid-barline__dots"><span></span><span></span></span></span><span class="grid-bar" data-beats="2"><span class="grid-beat"><span class="grid-chord">C7</span></span><span class="grid-beat"></span></span><span class="grid-barline" aria-hidden="true"></span><span class="grid-bar" data-beats="2"><span class="grid-beat grid-beat--percent1" aria-label="repeat previous bar"><span class="grid-percent" aria-hidden="true">%</span></span><span class="grid-beat"></span></span><span class="grid-barline grid-barline--repeat-both" aria-label="repeat end and start"><span class="grid-barline__dots"><span></span><span></span></span><span class="grid-barline__line grid-barline__line--thick"></span><span class="grid-barline__line grid-barline__line--thick"></span><span class="grid-barline__dots"><span></span><span></span></span></span><span class="grid-bar" data-beats="2"><span class="grid-beat"><span class="grid-chord">G7</span></span><span class="grid-beat"></span></span><span class="grid-barline" aria-hidden="true"></span><span class="grid-row__comment">% .</span></div>
+</section>
+</article>
+</body>
+</html>

--- a/crates/render-html/tests/fixtures/grid-trailing-colon/input.cho
+++ b/crates/render-html/tests/fixtures/grid-trailing-colon/input.cho
@@ -1,0 +1,5 @@
+{title: Grid Trailing Colon}
+
+{start_of_grid shape="1+4x2+4"}
+     |: C7 . | %  . :|: G7 . | %  . :
+{end_of_grid}

--- a/crates/render-pdf/tests/fixtures/grid-lone-colon/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/grid-lone-colon/expected.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R /F6 7 0 R >> /ProcSet [/PDF /Text] >> /Kids [8 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>
+endobj
+8 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 9 0 R >>
+endobj
+9 0 obj
+<< /Length 115 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Grid Lone Colon) Tj
+ET
+BT
+/F4 10 Tf
+56 756 Td
+(Grid) Tj
+ET
+BT
+/F6 11 Tf
+56 742 Td
+(:) Tj
+ET
+endstream
+endobj
+10 0 obj
+<< /Title <FEFF00470072006900640020004C006F006E006500200043006F006C006F006E> >>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000240 00000 n 
+0000000337 00000 n 
+0000000439 00000 n 
+0000000544 00000 n 
+0000000653 00000 n 
+0000000748 00000 n 
+0000000811 00000 n 
+0000000977 00000 n 
+trailer
+<< /Size 11 /Root 1 0 R /Info 10 0 R >>
+startxref
+1073
+%%EOF

--- a/crates/render-pdf/tests/fixtures/grid-lone-colon/input.cho
+++ b/crates/render-pdf/tests/fixtures/grid-lone-colon/input.cho
@@ -1,0 +1,5 @@
+{title: Grid Lone Colon}
+
+{start_of_grid}
+:
+{end_of_grid}

--- a/crates/render-pdf/tests/fixtures/grid-trailing-colon/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/grid-trailing-colon/expected.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /MediaBox [0 0 595 842] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R /F4 6 0 R /F6 7 0 R >> /ProcSet [/PDF /Text] >> /Kids [8 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding >>
+endobj
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>
+endobj
+8 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 9 0 R >>
+endobj
+9 0 obj
+<< /Length 155 >>
+stream
+BT
+/F2 18 Tf
+56 786 Td
+(Grid Trailing Colon) Tj
+ET
+BT
+/F4 10 Tf
+56 756 Td
+(Grid) Tj
+ET
+BT
+/F6 11 Tf
+56 742 Td
+(     |: C7 . | %  . :|: G7 . | %  . :) Tj
+ET
+endstream
+endobj
+10 0 obj
+<< /Title <FEFF004700720069006400200054007200610069006C0069006E006700200043006F006C006F006E> >>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000240 00000 n 
+0000000337 00000 n 
+0000000439 00000 n 
+0000000544 00000 n 
+0000000653 00000 n 
+0000000748 00000 n 
+0000000811 00000 n 
+0000001017 00000 n 
+trailer
+<< /Size 11 /Root 1 0 R /Info 10 0 R >>
+startxref
+1129
+%%EOF

--- a/crates/render-pdf/tests/fixtures/grid-trailing-colon/input.cho
+++ b/crates/render-pdf/tests/fixtures/grid-trailing-colon/input.cho
@@ -1,0 +1,5 @@
+{title: Grid Trailing Colon}
+
+{start_of_grid shape="1+4x2+4"}
+     |: C7 . | %  . :|: G7 . | %  . :
+{end_of_grid}

--- a/crates/render-text/tests/fixtures/grid-lone-colon/expected.txt
+++ b/crates/render-text/tests/fixtures/grid-lone-colon/expected.txt
@@ -1,0 +1,4 @@
+Grid Lone Colon
+
+[Grid]
+:

--- a/crates/render-text/tests/fixtures/grid-lone-colon/input.cho
+++ b/crates/render-text/tests/fixtures/grid-lone-colon/input.cho
@@ -1,0 +1,5 @@
+{title: Grid Lone Colon}
+
+{start_of_grid}
+:
+{end_of_grid}

--- a/crates/render-text/tests/fixtures/grid-trailing-colon/expected.txt
+++ b/crates/render-text/tests/fixtures/grid-trailing-colon/expected.txt
@@ -1,0 +1,4 @@
+Grid Trailing Colon
+
+[Grid]
+     |: C7 . | %  . :|: G7 . | %  . :

--- a/crates/render-text/tests/fixtures/grid-trailing-colon/input.cho
+++ b/crates/render-text/tests/fixtures/grid-trailing-colon/input.cho
@@ -1,0 +1,5 @@
+{title: Grid Trailing Colon}
+
+{start_of_grid shape="1+4x2+4"}
+     |: C7 . | %  . :|: G7 . | %  . :
+{end_of_grid}

--- a/packages/playground/tests-e2e/grid-trailing-colon.spec.ts
+++ b/packages/playground/tests-e2e/grid-trailing-colon.spec.ts
@@ -49,9 +49,10 @@ test.describe('chordpro grid — bare trailing colon', () => {
     // edit reaches `tokenizeGridLine`.
     const editor = page.locator('.cm-content');
     await editor.click();
-    const selectAll =
-      process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
-    await page.keyboard.press(selectAll);
+    // `ControlOrMeta+A` is Playwright's built-in cross-platform
+    // shorthand (Ctrl on Linux/Windows, Cmd on macOS); no
+    // `process.platform` branch needed.
+    await page.keyboard.press('ControlOrMeta+A');
     await page.keyboard.press('Delete');
     // `page.keyboard.type` issues keystrokes one at a time, so the
     // renderer runs on every intermediate state including the

--- a/packages/playground/tests-e2e/grid-trailing-colon.spec.ts
+++ b/packages/playground/tests-e2e/grid-trailing-colon.spec.ts
@@ -1,0 +1,76 @@
+// Regression spec for issue #2556 — the ChordPro grid tokeniser
+// hangs the browser when a `{start_of_grid}` body line ends in a
+// bare `:` not followed by `|`. Reproduces the user-visible
+// failure: load the kitchen-sink sample, delete the trailing
+// `| repeat 4 times` one character at a time until the line ends
+// in `:`, and confirm the page stays responsive.
+//
+// Before the fix the cell-text fallback in `tokenizeGridLine`
+// (and its Rust sister `tokenize_grid_line`) made no forward
+// progress on a bare `:`, leaving the outer `while (i < input
+// .length)` loop spinning on the same offset on the JS main
+// thread. Playwright's default `actionTimeout` (10 s in the
+// playground config) is the catch — a hung renderer never lets
+// the next preview update land, so the locator wait fires.
+//
+// The spec also registers a `pageerror` listener per
+// `.claude/rules/playground-smoke.md` so a future regression
+// that surfaces as an uncaught exception (rather than a hang)
+// still fails the test.
+
+import { expect, test } from '@playwright/test';
+
+const BROKEN_GRID_SOURCE = [
+  '{title: Grid Trailing Colon}',
+  '',
+  '{start_of_grid shape="1+4x2+4"}',
+  '     |: C7 . | %  . :|: G7 . | %  . :',
+  '{end_of_grid}',
+  '',
+].join('\n');
+
+test.describe('chordpro grid — bare trailing colon', () => {
+  test('does not hang when a grid line ends in a bare `:`', async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err));
+
+    await page.goto('./chordpro/');
+
+    // Editor + preview must be live before we replace the source —
+    // otherwise the controlled-value sync would race the mount.
+    await expect(page.locator('.cm-editor')).toBeVisible();
+    await expect(page.locator('.chordsketch-preview .song').first()).toBeVisible();
+
+    // Replace the buffer with the bug-triggering source. We
+    // select-all + delete + type so CodeMirror's reconciliation
+    // path is the one driving the value, matching how a user's
+    // edit reaches `tokenizeGridLine`.
+    const editor = page.locator('.cm-content');
+    await editor.click();
+    const selectAll =
+      process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
+    await page.keyboard.press(selectAll);
+    await page.keyboard.press('Delete');
+    // `page.keyboard.type` issues keystrokes one at a time, so the
+    // renderer runs on every intermediate state including the
+    // exact bad state. If the no-progress guard regresses, the
+    // very last `:` keystroke would hang the main thread and the
+    // following locator wait would time out.
+    await page.keyboard.type(BROKEN_GRID_SOURCE);
+
+    // After the bad-state keystroke, the preview must still be
+    // able to render the surviving grid markup. We pin a
+    // structural anchor that only the parsed-grid path emits:
+    // `section.grid` wraps every `{start_of_grid}…{end_of_grid}`
+    // block, and `.grid-bar` is one of the structural row cells.
+    await expect(page.locator('section.grid')).toBeVisible();
+    await expect(page.locator('.grid-bar').first()).toBeVisible();
+
+    // No uncaught exception escaped to the window during the edit
+    // sequence (catches the failure class where the regression
+    // mutates into a thrown error rather than a hang).
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/packages/playground/tests-e2e/grid-trailing-colon.spec.ts
+++ b/packages/playground/tests-e2e/grid-trailing-colon.spec.ts
@@ -1,22 +1,13 @@
-// Regression spec for issue #2556 — the ChordPro grid tokeniser
-// hangs the browser when a `{start_of_grid}` body line ends in a
-// bare `:` not followed by `|`. Reproduces the user-visible
-// failure: load the kitchen-sink sample, delete the trailing
-// `| repeat 4 times` one character at a time until the line ends
-// in `:`, and confirm the page stays responsive.
+// Regression spec for #2556 — typing a `{start_of_grid}` body
+// row that ends in a bare `:` no longer hangs the browser. The
+// production guard lives in `tokenizeGridLine` (and its Rust
+// sister); this spec catches a regression that re-introduces
+// the hang AS WELL AS the silent-drop class where the preview
+// renders an empty grid instead of an infinite loop.
 //
-// Before the fix the cell-text fallback in `tokenizeGridLine`
-// (and its Rust sister `tokenize_grid_line`) made no forward
-// progress on a bare `:`, leaving the outer `while (i < input
-// .length)` loop spinning on the same offset on the JS main
-// thread. Playwright's default `actionTimeout` (10 s in the
-// playground config) is the catch — a hung renderer never lets
-// the next preview update land, so the locator wait fires.
-//
-// The spec also registers a `pageerror` listener per
-// `.claude/rules/playground-smoke.md` so a future regression
-// that surfaces as an uncaught exception (rather than a hang)
-// still fails the test.
+// Per `.claude/rules/playground-smoke.md` a `pageerror`
+// listener is registered before navigation so a regression
+// that surfaces as an uncaught exception still fails the test.
 
 import { expect, test } from '@playwright/test';
 
@@ -38,40 +29,38 @@ test.describe('chordpro grid — bare trailing colon', () => {
 
     await page.goto('./chordpro/');
 
-    // Editor + preview must be live before we replace the source —
-    // otherwise the controlled-value sync would race the mount.
+    // `keyboard.type` would drop keystrokes against a not-yet-
+    // mounted contenteditable, so wait for both surfaces first.
     await expect(page.locator('.cm-editor')).toBeVisible();
     await expect(page.locator('.chordsketch-preview .song').first()).toBeVisible();
 
-    // Replace the buffer with the bug-triggering source. We
-    // select-all + delete + type so CodeMirror's reconciliation
-    // path is the one driving the value, matching how a user's
-    // edit reaches `tokenizeGridLine`.
+    // Drive CodeMirror through the same path a real user takes
+    // so the renderer runs on every intermediate state including
+    // the exact bad state. A regression that reintroduces the
+    // no-progress loop hangs the very last `:` keystroke and the
+    // following locator wait times out.
     const editor = page.locator('.cm-content');
     await editor.click();
-    // `ControlOrMeta+A` is Playwright's built-in cross-platform
-    // shorthand (Ctrl on Linux/Windows, Cmd on macOS); no
-    // `process.platform` branch needed.
     await page.keyboard.press('ControlOrMeta+A');
     await page.keyboard.press('Delete');
-    // `page.keyboard.type` issues keystrokes one at a time, so the
-    // renderer runs on every intermediate state including the
-    // exact bad state. If the no-progress guard regresses, the
-    // very last `:` keystroke would hang the main thread and the
-    // following locator wait would time out.
     await page.keyboard.type(BROKEN_GRID_SOURCE);
 
-    // After the bad-state keystroke, the preview must still be
-    // able to render the surviving grid markup. We pin a
-    // structural anchor that only the parsed-grid path emits:
-    // `section.grid` wraps every `{start_of_grid}…{end_of_grid}`
-    // block, and `.grid-bar` is one of the structural row cells.
+    // Structural shell: a parsed grid section must mount, and at
+    // least one bar must be present.
     await expect(page.locator('section.grid')).toBeVisible();
     await expect(page.locator('.grid-bar').first()).toBeVisible();
 
-    // No uncaught exception escaped to the window during the edit
-    // sequence (catches the failure class where the regression
-    // mutates into a thrown error rather than a hang).
+    // Surviving chord cells: the bare `:` is dropped, but the
+    // preceding `C7` and `G7` must still reach the DOM. Asserting
+    // chord-name text guards the silent-drop regression class
+    // where the tokeniser returns `[]` without hanging.
+    await expect(
+      page.locator('.grid-chord').filter({ hasText: /^C7$/ }),
+    ).toBeVisible();
+    await expect(
+      page.locator('.grid-chord').filter({ hasText: /^G7$/ }),
+    ).toBeVisible();
+
     expect(pageErrors).toEqual([]);
   });
 });

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -28,6 +28,13 @@ import { Fragment, cloneElement, isValidElement, useMemo, useState } from 'react
 import type { CSSProperties, DragEvent as ReactDragEvent, JSX, ReactNode } from 'react';
 
 import { ChordDiagram } from './chord-diagram';
+
+// Minimal `process.env.NODE_ENV` typing for dev-only assertions
+// below — same pattern as `ireal-pro-editor.tsx` /
+// `chord-textarea.tsx`. Bundlers (esbuild, Vite, webpack) replace
+// the literal `process.env.NODE_ENV` token at build time, so the
+// production bundle drops the dev-only branch entirely.
+declare const process: { env: { NODE_ENV?: string } };
 import {
   KeySignatureGlyph,
   MetronomeGlyph,
@@ -405,6 +412,31 @@ type GridToken =
   | { kind: 'space' };
 
 /**
+ * Single source of truth for cell-text terminator characters.
+ *
+ * The cell-text fallback in {@link tokenizeGridLine} reads a
+ * run of characters NOT in this set. The dispatch above it
+ * MUST handle every character in this set with a named branch
+ * that advances the cursor unconditionally; otherwise the
+ * outer loop pins on a head terminator nobody consumed (the
+ * bug fixed in issue #2556).
+ *
+ * `:` is in the set because it is the head of the `:|` / `:|:`
+ * repeat-end markers; a bare `:` not followed by `|` is
+ * dialect garbage that the cell-text path drops via the
+ * no-progress guard at the end of {@link tokenizeGridLine}.
+ *
+ * Sister-site: `DIALECT_TERMINATORS` in
+ * `crates/chordpro/src/grid.rs`. The two sets MUST remain in
+ * lockstep so the four rendering surfaces consume equivalent
+ * token streams.
+ */
+const DIALECT_TERMINATOR_RE = /[\s|:]/;
+function isDialectTerminator(ch: string): boolean {
+  return DIALECT_TERMINATOR_RE.test(ch);
+}
+
+/**
  * Tokenise a ChordPro grid line into structured pieces the
  * walker can lay out as iReal Pro-style bars. Handles every
  * spec-defined barline marker (`|:` / `:|` / `:|:` / `||` /
@@ -502,19 +534,26 @@ export function tokenizeGridLine(input: string): GridToken[] {
       i += 1;
       continue;
     }
-    // Read a cell token — any contiguous run of non-whitespace
-    // non-bar / non-colon characters. Chord brackets `[X]` are
-    // unwrapped: the parser produces a chord-bearing lyrics
-    // segment, but for grid lines we get the raw text, so let
-    // `[`...`]` survive as a chord name and trim the brackets
-    // ourselves.
+    // Cell-text fallback: read a run of non-terminator
+    // characters. Chord brackets `[X]` are unwrapped below.
     let j = i;
-    while (j < input.length && !/[\s|:]/.test(input[j]!)) j++;
+    while (j < input.length && !isDialectTerminator(input[j]!)) j++;
     if (j === i) {
-      // The head char is itself a terminator that no named
-      // branch above consumed — today only a bare `:` not
-      // followed by `|`. Drop it and advance so the outer
-      // loop cannot pin on the same offset and hang.
+      // Head char is a terminator the dispatch above did not
+      // consume. The terminator set + the named-branch dispatch
+      // must agree; if a future maintainer widens
+      // `DIALECT_TERMINATOR_RE` without adding a matching named
+      // branch, the dev-only assertion below fires so the bug
+      // class from issue #2556 (no-progress infinite loop) can
+      // never silently regress.
+      //
+      // Sister-site: same guard in `tokenize_grid_line`.
+      if (process.env.NODE_ENV !== 'production') {
+        console.assert(
+          isDialectTerminator(input[i]!),
+          `tokenizeGridLine no-progress guard reached on non-terminator char ${JSON.stringify(input[i])}`,
+        );
+      }
       i += 1;
       continue;
     }

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -540,18 +540,22 @@ export function tokenizeGridLine(input: string): GridToken[] {
     while (j < input.length && !isDialectTerminator(input[j]!)) j++;
     if (j === i) {
       // Head char is a terminator the dispatch above did not
-      // consume. The terminator set + the named-branch dispatch
-      // must agree; if a future maintainer widens
-      // `DIALECT_TERMINATOR_RE` without adding a matching named
-      // branch, the dev-only assertion below fires so the bug
-      // class from issue #2556 (no-progress infinite loop) can
-      // never silently regress.
+      // consume. Drop it and advance.
+      //
+      // The assertion is a postcondition invariant: the inner
+      // `while` exits with zero progress only when
+      // `isDialectTerminator(input[i])` is already true (that
+      // is the loop exit condition). It fires if a future
+      // refactor decouples the while condition from
+      // `isDialectTerminator`. Regression protection for the
+      // "new terminator without a dispatch branch" scenario
+      // (issue #2556 class) comes from the property test.
       //
       // Sister-site: same guard in `tokenize_grid_line`.
       if (process.env.NODE_ENV !== 'production') {
         console.assert(
           isDialectTerminator(input[i]!),
-          `tokenizeGridLine no-progress guard reached on non-terminator char ${JSON.stringify(input[i])}`,
+          `tokenizeGridLine no-progress guard: non-terminator char ${JSON.stringify(input[i])} must not reach this branch`,
         );
       }
       i += 1;

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -510,6 +510,14 @@ export function tokenizeGridLine(input: string): GridToken[] {
     // ourselves.
     let j = i;
     while (j < input.length && !/[\s|:]/.test(input[j]!)) j++;
+    if (j === i) {
+      // The head char is itself a terminator that no named
+      // branch above consumed — today only a bare `:` not
+      // followed by `|`. Drop it and advance so the outer
+      // loop cannot pin on the same offset and hang.
+      i += 1;
+      continue;
+    }
     let raw = input.slice(i, j);
     if (raw.startsWith('[') && raw.endsWith(']')) {
       raw = raw.slice(1, -1);

--- a/packages/react/tests/chordpro-jsx-helpers.test.ts
+++ b/packages/react/tests/chordpro-jsx-helpers.test.ts
@@ -150,53 +150,75 @@ describe('tokenizeGridLine', () => {
     expect(chord).toEqual({ kind: 'cell', names: ['nb13'] });
   });
 
-  // Regression tests for the no-progress branch in the cell-text
-  // reader (issue #2556). A bare `:` not followed by `|` used to
-  // hang the tokeniser because the cell-read terminator set
-  // includes `:` itself — `j === i`, nothing pushed, `i = j`
-  // pinned the outer loop on the same offset. The guard added in
-  // the same commit advances `i` by one in that branch; these
-  // tests pin the contract so the regression cannot return.
-  test('returns in bounded time for a bare trailing `:`', () => {
+  // Regression tests for #2556 — sister-site to the same
+  // cases in `crates/chordpro/src/grid.rs`. See the production
+  // guard in `tokenizeGridLine` for the mechanism; these tests
+  // pin the user-observable contract.
+  test('drops a bare trailing `:` without hanging the tokenizer', () => {
     // Mid-edit state captured from the kitchen-sink sample: a
     // grid row whose final `|` has been deleted but the trailing
-    // `:` survives. Pre-fix this input hung the renderer.
+    // `:` survives. Pre-fix this input made `tokenizeGridLine`
+    // spin without forward progress.
     const input = '|: C7 . | %  . :|: G7 . | %  . :';
-    const tokens = tokenizeGridLine(input);
-    // The stray `:` is dropped silently; the rest of the row
-    // still produces a valid token stream that ends with the
-    // last cell (no trailing barline because the source has none).
-    const kinds = tokens.filter((t) => t.kind !== 'space').map((t) => t.kind);
-    expect(kinds).toEqual([
-      'repeat-start',
-      'cell',
-      'continuation',
-      'barline',
-      'percent1',
-      'continuation',
-      'repeat-both',
-      'cell',
-      'continuation',
-      'barline',
-      'percent1',
-      'continuation',
+    const nonSpace = tokenizeGridLine(input).filter((t) => t.kind !== 'space');
+    // Assert full token shape (not just kinds): catches a
+    // regression that swaps `repeat-both` for `barline` or
+    // mangles the surviving chord names.
+    expect(nonSpace).toEqual([
+      { kind: 'repeat-start' },
+      { kind: 'cell', names: ['C7'] },
+      { kind: 'continuation' },
+      { kind: 'barline' },
+      { kind: 'percent1' },
+      { kind: 'continuation' },
+      { kind: 'repeat-both' },
+      { kind: 'cell', names: ['G7'] },
+      { kind: 'continuation' },
+      { kind: 'barline' },
+      { kind: 'percent1' },
+      { kind: 'continuation' },
     ]);
   });
 
-  test('drops a lone `:` and emits no tokens', () => {
+  test('emits no tokens for a lone `:`', () => {
     expect(tokenizeGridLine(':')).toEqual([]);
   });
 
+  test('drops a run of `:` and still terminates', () => {
+    // Drives the no-progress guard through multiple iterations.
+    // A regression that reverted the unconditional `i += 1`
+    // would hang here under vitest's per-test timeout.
+    expect(tokenizeGridLine(':::::::')).toEqual([]);
+  });
+
   test('drops a `:` sitting between two cells', () => {
-    // `C : D` — the orphan colon between cells is dialect
-    // garbage. The tokeniser must skip it and still surface the
-    // two cells on either side.
-    const tokens = tokenizeGridLine('C : D');
-    const cells = tokens.filter((t) => t.kind === 'cell');
+    const cells = tokenizeGridLine('C : D').filter((t) => t.kind === 'cell');
     expect(cells).toEqual([
       { kind: 'cell', names: ['C'] },
       { kind: 'cell', names: ['D'] },
     ]);
+  });
+
+  test('terminates for arbitrary inputs drawn from the dispatch alphabet', () => {
+    // Property check: the outer loop must terminate for any
+    // input drawn from the dispatch alphabet, regardless of
+    // ordering. Generated deterministically from a small LCG so
+    // the corpus survives across runs. A regression that
+    // reintroduces the no-progress shape would hang one of the
+    // cases here under vitest's per-test timeout.
+    const alphabet = '|:.%~ \t[]nstC7G:1234ABs';
+    let state = 0xc0ffee;
+    for (let n = 0; n < 256; n++) {
+      const len = state % 48;
+      let s = '';
+      for (let k = 0; k < len; k++) {
+        state = (Math.imul(state, 1103515245) + 12345) >>> 0;
+        s += alphabet[(state >>> 16) % alphabet.length];
+      }
+      // Calling tokenizeGridLine is enough — if it doesn't
+      // return, vitest's harness times the test out.
+      tokenizeGridLine(s);
+    }
   });
 });
 

--- a/packages/react/tests/chordpro-jsx-helpers.test.ts
+++ b/packages/react/tests/chordpro-jsx-helpers.test.ts
@@ -149,6 +149,55 @@ describe('tokenizeGridLine', () => {
     const chord = tokens.find((t) => t.kind === 'cell');
     expect(chord).toEqual({ kind: 'cell', names: ['nb13'] });
   });
+
+  // Regression tests for the no-progress branch in the cell-text
+  // reader (issue #2556). A bare `:` not followed by `|` used to
+  // hang the tokeniser because the cell-read terminator set
+  // includes `:` itself — `j === i`, nothing pushed, `i = j`
+  // pinned the outer loop on the same offset. The guard added in
+  // the same commit advances `i` by one in that branch; these
+  // tests pin the contract so the regression cannot return.
+  test('returns in bounded time for a bare trailing `:`', () => {
+    // Mid-edit state captured from the kitchen-sink sample: a
+    // grid row whose final `|` has been deleted but the trailing
+    // `:` survives. Pre-fix this input hung the renderer.
+    const input = '|: C7 . | %  . :|: G7 . | %  . :';
+    const tokens = tokenizeGridLine(input);
+    // The stray `:` is dropped silently; the rest of the row
+    // still produces a valid token stream that ends with the
+    // last cell (no trailing barline because the source has none).
+    const kinds = tokens.filter((t) => t.kind !== 'space').map((t) => t.kind);
+    expect(kinds).toEqual([
+      'repeat-start',
+      'cell',
+      'continuation',
+      'barline',
+      'percent1',
+      'continuation',
+      'repeat-both',
+      'cell',
+      'continuation',
+      'barline',
+      'percent1',
+      'continuation',
+    ]);
+  });
+
+  test('drops a lone `:` and emits no tokens', () => {
+    expect(tokenizeGridLine(':')).toEqual([]);
+  });
+
+  test('drops a `:` sitting between two cells', () => {
+    // `C : D` — the orphan colon between cells is dialect
+    // garbage. The tokeniser must skip it and still surface the
+    // two cells on either side.
+    const tokens = tokenizeGridLine('C : D');
+    const cells = tokens.filter((t) => t.kind === 'cell');
+    expect(cells).toEqual([
+      { kind: 'cell', names: ['C'] },
+      { kind: 'cell', names: ['D'] },
+    ]);
+  });
 });
 
 describe('lyricsCaretRatio', () => {


### PR DESCRIPTION
## What

`tokenizeGridLine` (React JSX walker) and its Rust sister
`tokenize_grid_line` advanced their cursor only after a non-empty
cell scan. A bare `:` not followed by `|` fell through to the
cell-text fallback and immediately hit the terminator set (which
includes `:` itself), so `j == i`, nothing was pushed, and the
outer `while (i < input.length)` loop pinned on the same offset —
an infinite loop on the JS main thread (playground tab freezes /
Chrome's "Page Unresponsive") and the equivalent hang in every
Rust consumer of `tokenize_grid_line` (CLI, FFI, NAPI, wasm
`render_html` / `render_text` / `render_pdf`, VS Code preview,
GitHub Action).

Add a no-progress guard in both surfaces: when the cell scan
produces no characters, drop the orphan terminator and advance
`i` by one. The orphan `:` is dialect garbage (the spec only
uses `:` inside `:|` and `:|:`), so silently dropping it matches
how the tokeniser already tolerates other unrecognised dialect
tokens.

## Why

The user-visible reproduction: load the "All directives (kitchen
sink)" sample in the ChordPro playground and delete the trailing
`| repeat 4 times` from the grid line below one character at a
time:

```
     |: C7 . | %  . :|: G7 . | %  . :| repeat 4 times
```

When the line reaches `... | %  . :` the browser tab freezes.
Split and Preview views reproduce; Source view is unaffected
because CodeMirror's TextMate grammar tokenises the buffer, not
`tokenizeGridLine`.

Even though the user only sees the React walker hang in the
playground, the same bug lives in the Rust grid module, so every
static-render pipeline that ingests a grid row containing a
non-`|`-terminated `:` would hang silently.

## Test results

- `cargo test -p chordsketch-chordpro --lib grid::` — 24 / 24
  passed, including the three new regression cases
  (`tokenize_trailing_bare_colon_terminates`,
  `tokenize_lone_colon_drops_to_no_tokens`,
  `tokenize_colon_between_cells_is_dropped`).
- `cargo test -p chordsketch-chordpro -p chordsketch-render-text
  -p chordsketch-render-html -p chordsketch-render-pdf` — green;
  new `grid-trailing-colon` fixture passes on all three
  renderers.
- `cargo clippy -p chordsketch-chordpro -p chordsketch-render-text
  -p chordsketch-render-html -p chordsketch-render-pdf
  --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `pnpm exec vitest run` in `packages/react/` — 579 / 579 passed,
  including the three new bare-`:` cases in
  `chordpro-jsx-helpers.test.ts`.
- `tsc --noEmit` in both `packages/react/` and
  `packages/playground/` — clean.
- `playwright test grid-trailing-colon` — passes; the spec
  types the bug-triggering source into the editor and asserts the
  page stays responsive.
- `python3 scripts/check-fixture-counts.py` — green
  (render-text: 17, render-html: 20, render-pdf: 18 — all above
  their `.claude/rules/golden-tests.md` floors of 15 / 15 / 10).

## Sister-site audit

Per `.claude/rules/fix-propagation.md` (Renderers / React JSX
walker group) and `.claude/rules/renderer-parity.md`, the
no-progress shape ("scan to terminator, then jump cursor to
scan end") was checked across both surfaces and their
neighbours:

| Site | Verdict |
|---|---|
| `chordpro-jsx.tsx:511` — `tokenizeGridLine` cell arm | **Bug — fixed.** |
| `grid.rs:371` — `tokenize_grid_line` cell arm | **Bug — fixed.** |
| `chordpro-jsx.tsx:711` — `renderGridLine` volta collapse (`let j = i + 1`) | Safe: only the inner index mutates; outer `for` advances via `i++`. |
| `heuristic.rs:582` — line tokeniser | Safe: outer loop pre-advances `i` for whitespace / quote branches before falling into the token-read arm. |
| `abc_importer.rs:397` — quoted-chord reader | Safe: `i += 1` runs before the inner read enters the loop. |
| `heuristic.rs:320` — inner peek | Safe: peek-only, doesn't write back to `i`. |

Only the two grid tokenisers had the no-progress shape; both are
fixed in this PR with the same one-line guard.

## Deferred

None.

Closes #2556