### PR TITLE
refactor(react): unify PDF button label to "Export PDF"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `<PreviewToolbar>` Export group's button label. Downstream
   consumers building their own export UI can import the constant
   to stay in lockstep with the library's default. (#2558)
+- `@chordsketch/react`: `<PreviewToolbar>` now accepts an
+  `@internal` `wasmLoader` prop forwarded to the inner
+  `<PdfExport>` so tests can drive the Export-group click path
+  with a stubbed renderer. Production consumers do not supply
+  this; the default dynamic import of `@chordsketch/wasm-export`
+  resolves at click time as before. (#2558)
 - VS Code extension: preview WebView now uses `<ChordProPreview
   toolbar="performance">` so the Capo and Export PDF controls
   reach feature parity with the playground. Capo edits round-trip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@chordsketch/react`: exported `CAPO_MIN`, `CAPO_MAX`,
   `TRANSPOSE_MIN`, `TRANSPOSE_MAX` constants alongside the existing
   drag-to-reposition helpers in `chord-source-edit.ts`. (#2545)
+- `@chordsketch/react`: exported `PDF_EXPORT_DEFAULT_LABEL`
+  (`"Export PDF"`) — the single source of truth for the
+  `<PdfExport>` button's default `children` and the
+  `<PreviewToolbar>` Export group's button label. Downstream
+  consumers building their own export UI can import the constant
+  to stay in lockstep with the library's default. (#2558)
 - VS Code extension: preview WebView now uses `<ChordProPreview
   toolbar="performance">` so the Capo and Export PDF controls
   reach feature parity with the playground. Capo edits round-trip
@@ -42,10 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@chordsketch/react`: PDF export button label unified to
   `"Export PDF"` across `<RendererPreview>` (PDF branch) and
   `<PreviewToolbar>` to match `<PdfExport>`'s own default and the
-  desktop app's `File → Export PDF…` menu. Tests and documentation
-  examples updated; the `<PdfExport>` `children` default was
-  already `"Export PDF"` so behaviour for direct consumers is
-  unchanged. (#2558)
+  desktop app's `File → Export PDF…` menu. The default is now a
+  single exported source of truth, `PDF_EXPORT_DEFAULT_LABEL`, which
+  `<PdfExport>` uses as its `children` default and which
+  `<PreviewToolbar>` consumes for its Export-group button so both
+  call sites stay in lockstep with any future relabel. Tests and
+  documentation examples updated; behaviour for direct `<PdfExport>`
+  consumers is unchanged (the default value is the same string). (#2558)
 - VS Code extension: command titles renamed from `ChordSketch: …`
   to `ChordPro: …` (Open Preview / Open Preview to the Side /
   Transpose Up / Transpose Down / Export As…) so the commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `@chordsketch/react`: PDF export button label unified to
+  `"Export PDF"` across `<RendererPreview>` (PDF branch) and
+  `<PreviewToolbar>` to match `<PdfExport>`'s own default and the
+  desktop app's `File → Export PDF…` menu. Tests and documentation
+  examples updated; the `<PdfExport>` `children` default was
+  already `"Export PDF"` so behaviour for direct consumers is
+  unchanged. (#2558)
 - VS Code extension: command titles renamed from `ChordSketch: …`
   to `ChordPro: …` (Open Preview / Open Preview to the Side /
   Transpose Up / Transpose Down / Export As…) so the commands

--- a/docs/sdk/reference/pdf-export.md
+++ b/docs/sdk/reference/pdf-export.md
@@ -26,7 +26,7 @@ import { PdfExport } from '@chordsketch/react';
 | `source` | `string` | (required) | ChordPro source to render. |
 | `filename` | `string` | `"chordsketch-output.pdf"` | Filename for the download. |
 | `options` | `PdfExportOptions` | — | `{ transpose?, config? }` forwarded to the renderer. |
-| `children` | `ReactNode` | `"Export PDF"` | Button label. |
+| `children` | `ReactNode` | `PDF_EXPORT_DEFAULT_LABEL` (`"Export PDF"`) | Button label. The default is also exported as a named constant so sister components (e.g. `<PreviewToolbar>`) can render the same string. |
 | `onExported` | `(filename: string) => void` | — | Fires after the download has been initiated. |
 | `onError` | `(error: Error) => void` | — | Fires when the underlying call rejects. |
 | `wasmLoader` | loader callable | dynamic import | Test-only override. |

--- a/docs/sdk/reference/pdf-export.md
+++ b/docs/sdk/reference/pdf-export.md
@@ -26,7 +26,7 @@ import { PdfExport } from '@chordsketch/react';
 | `source` | `string` | (required) | ChordPro source to render. |
 | `filename` | `string` | `"chordsketch-output.pdf"` | Filename for the download. |
 | `options` | `PdfExportOptions` | — | `{ transpose?, config? }` forwarded to the renderer. |
-| `children` | `ReactNode` | `PDF_EXPORT_DEFAULT_LABEL` (`"Export PDF"`) | Button label. The default is also exported as a named constant so sister components (e.g. `<PreviewToolbar>`) can render the same string. |
+| `children` | `ReactNode` | `PDF_EXPORT_DEFAULT_LABEL` (`"Export PDF"`) | Button label. Re-import the named constant to keep sister components (e.g. `<PreviewToolbar>`) in lockstep. |
 | `onExported` | `(filename: string) => void` | — | Fires after the download has been initiated. |
 | `onError` | `(error: Error) => void` | — | Fires when the underlying call rejects. |
 | `wasmLoader` | loader callable | dynamic import | Test-only override. |
@@ -46,7 +46,7 @@ Returns the same export pipeline as state for custom UIs
 
 | Field | Type | Description |
 |---|---|---|
-| `exportPdf` | `(source: string, options?: PdfExportOptions, filename?: string) => Promise<void>` | Run an export. Returns when the download has been initiated. |
+| `exportPdf` | `(source: string, filename: string, options?: PdfExportOptions) => Promise<void>` | Run an export. Returns when the download has been initiated. |
 | `loading` | `boolean` | True while the heavy bundle is loading or a render is in flight. |
 | `error` | `Error \| null` | Non-null when the latest call rejected. |
 

--- a/docs/sdk/reference/pdf-export.md
+++ b/docs/sdk/reference/pdf-export.md
@@ -17,7 +17,7 @@ page load does not pay for it.
 import { PdfExport } from '@chordsketch/react';
 
 <PdfExport source={chordproSource} filename="amazing-grace.pdf">
-  Download PDF
+  Export PDF
 </PdfExport>
 ```
 
@@ -26,7 +26,7 @@ import { PdfExport } from '@chordsketch/react';
 | `source` | `string` | (required) | ChordPro source to render. |
 | `filename` | `string` | `"chordsketch-output.pdf"` | Filename for the download. |
 | `options` | `PdfExportOptions` | — | `{ transpose?, config? }` forwarded to the renderer. |
-| `children` | `ReactNode` | `"Download PDF"` | Button label. |
+| `children` | `ReactNode` | `"Export PDF"` | Button label. |
 | `onExported` | `(filename: string) => void` | — | Fires after the download has been initiated. |
 | `onError` | `(error: Error) => void` | — | Fires when the underlying call rejects. |
 | `wasmLoader` | loader callable | dynamic import | Test-only override. |

--- a/docs/sdk/tasks/embed-react.md
+++ b/docs/sdk/tasks/embed-react.md
@@ -135,7 +135,7 @@ const source = `{title: Amazing Grace}
 export function SaveButton() {
   return (
     <PdfExport source={source} filename="amazing-grace.pdf">
-      Download PDF
+      Export PDF
     </PdfExport>
   );
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
       // `packages/npm-export/` build so the playground can drive
       // `<PdfExport>` without depending on an npm-published copy.
       // The PDF / PNG bundle is only loaded when a user actually
-      // clicks "Download PDF" — the dynamic `import('@chordsketch/
+      // clicks "Export PDF" — the dynamic `import('@chordsketch/
       // wasm-export')` inside `use-pdf-export.ts` produces a
       // separate chunk so the initial playground load stays light.
       '@chordsketch/wasm-export': resolve(here, '../npm-export/web/chordsketch_wasm.js'),

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -346,7 +346,7 @@ Returns the raw SVG string (or `null` when not in the database),
 plus loading / error state. Useful for hosts that want to embed
 the diagram inside custom markup (tooltip, popover, etc.).
 
-### `<PdfExport>` — one-click PDF download
+### `<PdfExport>` — one-click PDF export
 
 ```tsx
 import { PdfExport } from '@chordsketch/react';
@@ -571,7 +571,7 @@ shorthand (no Unicode translation; the SVG renderer handles that).
 | `useChordDiagram` | Atom | Hook | Raw SVG string for the chord-instrument pair. |
 | `<Transpose>` | Atom | Component | Accessible ± / reset transposition control. |
 | `useTranspose` | Atom | Hook | Clamped state helper for transposition values. |
-| `<PdfExport>` | Atom | Component | One-click download button; lazy-loads `@chordsketch/wasm-export`. |
+| `<PdfExport>` | Atom | Component | One-click export button; lazy-loads `@chordsketch/wasm-export`. |
 | `usePdfExport` | Atom | Hook | Same export pipeline for custom UIs. |
 | `<SplitLayout>` | Atom | Component | Layout container with resizable splitter. |
 | `<RendererPreview>` | Atom | Component | Format-switcher preview pane. |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -359,7 +359,7 @@ const source = `{title: Amazing Grace}
 export function SaveButton() {
   return (
     <PdfExport source={source} filename="amazing-grace.pdf">
-      Download PDF
+      Export PDF
     </PdfExport>
   );
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,7 +17,11 @@ export {
   type ChordRenderOptions,
   type ChordRenderResult,
 } from './use-chord-render';
-export { PdfExport, type PdfExportProps } from './pdf-export';
+export {
+  PdfExport,
+  type PdfExportProps,
+  PDF_EXPORT_DEFAULT_LABEL,
+} from './pdf-export';
 export {
   usePdfExport,
   type PdfExportOptions,

--- a/packages/react/src/pdf-export.tsx
+++ b/packages/react/src/pdf-export.tsx
@@ -86,7 +86,7 @@ function defaultPdfErrorFallback(error: Error): ReactNode {
  *
  * ```tsx
  * <PdfExport source={chordpro} filename="song.pdf">
- *   Download PDF
+ *   Export PDF
  * </PdfExport>
  * ```
  *

--- a/packages/react/src/pdf-export.tsx
+++ b/packages/react/src/pdf-export.tsx
@@ -7,6 +7,15 @@ import {
   usePdfExport,
 } from './use-pdf-export';
 
+/**
+ * Default label rendered when a {@link PdfExport} consumer passes no
+ * `children`. Exported so sister sites that compose their own export
+ * button (notably `<PreviewToolbar>`'s Export group) can render the
+ * same string without restating the literal — keeping every call site
+ * in lockstep with this default through a single source of truth.
+ */
+export const PDF_EXPORT_DEFAULT_LABEL = 'Export PDF';
+
 /** Props accepted by the {@link PdfExport} button. */
 export interface PdfExportProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onError'> {
@@ -97,7 +106,7 @@ export function PdfExport({
   source,
   filename = 'chordsketch-output.pdf',
   options,
-  children = 'Export PDF',
+  children = PDF_EXPORT_DEFAULT_LABEL,
   onExported,
   onError,
   errorFallback = defaultPdfErrorFallback,

--- a/packages/react/src/pdf-export.tsx
+++ b/packages/react/src/pdf-export.tsx
@@ -30,7 +30,9 @@ export interface PdfExportProps
   /** Semitone transposition / config preset forwarded to the renderer. */
   options?: PdfExportOptions;
   /**
-   * Button label. Defaults to `"Export PDF"`. Pass a component tree
+   * Button label. Defaults to {@link PDF_EXPORT_DEFAULT_LABEL}
+   * (`"Export PDF"`) — re-import the constant when composing custom
+   * UIs that need to render the same string. Pass a component tree
    * (e.g. an icon + label) for richer styling.
    */
   children?: ReactNode;

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -54,7 +54,7 @@ export interface PreviewToolbarProps
   trailing?: ReactNode;
 }
 
-const DOWNLOAD_ICON = (
+const EXPORT_ICON = (
   <svg
     width="16"
     height="16"
@@ -170,8 +170,8 @@ export function PreviewToolbar({
             filename={exportFilename}
             className="chordsketch-preview-toolbar__export btn btn-secondary btn-sm"
           >
-            {DOWNLOAD_ICON}
-            Download PDF
+            {EXPORT_ICON}
+            Export PDF
           </PdfExport>
         </div>
       ) : null}

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -1,7 +1,7 @@
 import type { HTMLAttributes, ReactNode } from 'react';
 
 import { Capo } from './capo';
-import { PdfExport } from './pdf-export';
+import { PDF_EXPORT_DEFAULT_LABEL, PdfExport } from './pdf-export';
 import { Transpose } from './transpose';
 import {
   CAPO_MAX,
@@ -171,7 +171,7 @@ export function PreviewToolbar({
             className="chordsketch-preview-toolbar__export btn btn-secondary btn-sm"
           >
             {EXPORT_ICON}
-            Export PDF
+            {PDF_EXPORT_DEFAULT_LABEL}
           </PdfExport>
         </div>
       ) : null}

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -3,6 +3,7 @@ import type { HTMLAttributes, ReactNode } from 'react';
 import { Capo } from './capo';
 import { PDF_EXPORT_DEFAULT_LABEL, PdfExport } from './pdf-export';
 import { Transpose } from './transpose';
+import type { WasmLoader } from './use-pdf-export';
 import {
   CAPO_MAX,
   CAPO_MIN,
@@ -46,6 +47,16 @@ export interface PreviewToolbarProps
   showExport?: boolean;
   /** Filename for the PDF download. Defaults to `chordsketch-output.pdf`. */
   exportFilename?: string;
+  /**
+   * Test-only WASM loader override for the Export group's
+   * `<PdfExport>`. Production callers never supply this — the
+   * default dynamic import of `@chordsketch/wasm-export` resolves
+   * at click time. Tests inject a stub renderer to drive the
+   * export click path without loading real wasm.
+   *
+   * @internal
+   */
+  wasmLoader?: WasmLoader;
   /**
    * Optional extra content rendered as a fourth group at the end
    * of the toolbar. Useful for host-specific actions (e.g. a
@@ -108,6 +119,7 @@ export function PreviewToolbar({
   showCapo,
   showExport = true,
   exportFilename = 'chordsketch-output.pdf',
+  wasmLoader,
   trailing,
   className,
   ...divProps
@@ -168,6 +180,7 @@ export function PreviewToolbar({
             source={source}
             options={{ transpose }}
             filename={exportFilename}
+            wasmLoader={wasmLoader}
             className="chordsketch-preview-toolbar__export btn btn-secondary btn-sm"
           >
             {EXPORT_ICON}

--- a/packages/react/src/renderer-preview.tsx
+++ b/packages/react/src/renderer-preview.tsx
@@ -23,7 +23,7 @@ export interface RendererPreviewProps extends Omit<HTMLAttributes<HTMLDivElement
   /**
    * Output format. `"html"` renders the song as design-system styled
    * HTML; `"text"` renders the chords-above-lyrics text format;
-   * `"pdf"` shows a download button that produces a PDF on demand.
+   * `"pdf"` shows an export button that produces a PDF on demand.
    */
   format: PreviewFormat;
   /** Filename used for the PDF download. Defaults to `"chordsketch-output.pdf"`. */
@@ -60,7 +60,7 @@ export interface RendererPreviewProps extends Omit<HTMLAttributes<HTMLDivElement
    * Optional content rendered while the wasm runtime is initialising.
    *
    * Only honoured by the inline `html` / `text` branches — the
-   * `pdf` branch is a download button (rendered by
+   * `pdf` branch is an export button (rendered by
    * {@link PdfExport}), not a streaming surface, so it has no
    * "loading" state to show before the user clicks. PDF in-flight
    * state is communicated via the button's `aria-busy` attribute

--- a/packages/react/src/renderer-preview.tsx
+++ b/packages/react/src/renderer-preview.tsx
@@ -131,16 +131,14 @@ export function RendererPreview({
     return (
       <div {...divProps} className={`${wrapperClass} chordsketch-preview--pdf`}>
         <p className="chordsketch-preview__hint">
-          Click the button to generate and download a PDF.
+          Click the button to generate and export a PDF.
         </p>
         <PdfExport
           source={source}
           options={{ transpose, config }}
           filename={pdfFilename}
           className="chordsketch-pdf-export"
-        >
-          Download PDF
-        </PdfExport>
+        />
       </div>
     );
   }

--- a/packages/react/src/renderer-preview.tsx
+++ b/packages/react/src/renderer-preview.tsx
@@ -131,7 +131,7 @@ export function RendererPreview({
     return (
       <div {...divProps} className={`${wrapperClass} chordsketch-preview--pdf`}>
         <p className="chordsketch-preview__hint">
-          Click the button to generate and export a PDF.
+          Click the button to generate and download a PDF.
         </p>
         <PdfExport
           source={source}

--- a/packages/react/tests/chord-pro-editor.test.tsx
+++ b/packages/react/tests/chord-pro-editor.test.tsx
@@ -133,8 +133,8 @@ describe('<ChordProEditor>', () => {
     render(<ChordProEditor wasmLoader={makeLoader(makeStub())} />);
     const select = screen.getByLabelText('Format') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'pdf' } });
-    // PDF branch renders a download button.
-    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeTruthy();
+    // PDF branch renders an export button.
+    expect(screen.getByRole('button', { name: 'Export PDF' })).toBeTruthy();
   });
 
   test('controlled source: edits propagate via onSourceChange', () => {

--- a/packages/react/tests/chord-pro-editor.test.tsx
+++ b/packages/react/tests/chord-pro-editor.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeAll, describe, expect, test, vi } from 'vitest';
 
-import { ChordProEditor } from '../src/index';
+import { ChordProEditor, PDF_EXPORT_DEFAULT_LABEL } from '../src/index';
 import type { ChordWasmLoader } from '../src/use-chord-render';
 
 // `<SplitLayout>` (used by `<ChordProEditor>` to lay out source +
@@ -133,8 +133,10 @@ describe('<ChordProEditor>', () => {
     render(<ChordProEditor wasmLoader={makeLoader(makeStub())} />);
     const select = screen.getByLabelText('Format') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'pdf' } });
-    // PDF branch renders an export button.
-    expect(screen.getByRole('button', { name: 'Export PDF' })).toBeTruthy();
+    // PDF branch renders an export button using the shared default label.
+    expect(
+      screen.getByRole('button', { name: PDF_EXPORT_DEFAULT_LABEL }),
+    ).toBeTruthy();
   });
 
   test('controlled source: edits propagate via onSourceChange', () => {

--- a/packages/react/tests/chord-pro-preview.test.tsx
+++ b/packages/react/tests/chord-pro-preview.test.tsx
@@ -168,7 +168,7 @@ describe('<ChordProPreview>', () => {
         wasmLoader={makeLoader(makeStub())}
       />,
     );
-    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Export PDF' })).toBeTruthy();
   });
 
   test('transposeMin / transposeMax bound the transpose buttons', () => {

--- a/packages/react/tests/chord-pro-preview.test.tsx
+++ b/packages/react/tests/chord-pro-preview.test.tsx
@@ -160,7 +160,7 @@ describe('<ChordProPreview>', () => {
     expect(onTransposeChange).toHaveBeenCalledWith(1);
   });
 
-  test('PDF branch renders the download button', () => {
+  test('PDF branch renders the export button', () => {
     render(
       <ChordProPreview
         source="src"

--- a/packages/react/tests/chord-pro-preview.test.tsx
+++ b/packages/react/tests/chord-pro-preview.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
-import { ChordProPreview } from '../src/index';
+import { ChordProPreview, PDF_EXPORT_DEFAULT_LABEL } from '../src/index';
 import type { ChordWasmLoader } from '../src/use-chord-render';
 
 function emptyAst(marker?: string): string {
@@ -160,7 +160,7 @@ describe('<ChordProPreview>', () => {
     expect(onTransposeChange).toHaveBeenCalledWith(1);
   });
 
-  test('PDF branch renders the export button', () => {
+  test('PDF branch renders the export button using the shared default label', () => {
     render(
       <ChordProPreview
         source="src"
@@ -168,7 +168,9 @@ describe('<ChordProPreview>', () => {
         wasmLoader={makeLoader(makeStub())}
       />,
     );
-    expect(screen.getByRole('button', { name: 'Export PDF' })).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: PDF_EXPORT_DEFAULT_LABEL }),
+    ).toBeTruthy();
   });
 
   test('transposeMin / transposeMax bound the transpose buttons', () => {

--- a/packages/react/tests/pdf-export.test.tsx
+++ b/packages/react/tests/pdf-export.test.tsx
@@ -239,3 +239,15 @@ describe('<PdfExport>', () => {
     await waitFor(() => expect(onError).toHaveBeenCalledWith(boom));
   });
 });
+
+describe('PDF_EXPORT_DEFAULT_LABEL', () => {
+  // Public-API contract: pin the literal value at the constant's
+  // declaration site so a typo or unintentional relabel of the
+  // exported default cannot pass silently through every consumer
+  // test (which all assert via the constant and would happily
+  // accept any string). Without this assertion, the only safety
+  // net against a relabel is human review.
+  test('is the literal string "Export PDF"', () => {
+    expect(PDF_EXPORT_DEFAULT_LABEL).toBe('Export PDF');
+  });
+});

--- a/packages/react/tests/pdf-export.test.tsx
+++ b/packages/react/tests/pdf-export.test.tsx
@@ -8,7 +8,11 @@ import {
 } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { PdfExport, usePdfExport } from '../src/index';
+import {
+  PDF_EXPORT_DEFAULT_LABEL,
+  PdfExport,
+  usePdfExport,
+} from '../src/index';
 import type { WasmLoader } from '../src/use-pdf-export';
 
 const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // "%PDF" magic bytes
@@ -183,7 +187,7 @@ describe('<PdfExport>', () => {
     );
 
     render(<PdfExport source="x" filename="x.pdf" wasmLoader={makeLoader(stub)} />);
-    const button = screen.getByRole('button', { name: 'Export PDF' });
+    const button = screen.getByRole('button', { name: PDF_EXPORT_DEFAULT_LABEL });
 
     fireEvent.click(button);
 
@@ -207,7 +211,7 @@ describe('<PdfExport>', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export PDF' }));
+    fireEvent.click(screen.getByRole('button', { name: PDF_EXPORT_DEFAULT_LABEL }));
 
     await waitFor(() =>
       expect(stub.render_pdf_with_options).toHaveBeenCalledWith('{title: Hi}', {
@@ -230,7 +234,7 @@ describe('<PdfExport>', () => {
       <PdfExport source="x" filename="x.pdf" onError={onError} wasmLoader={makeLoader(stub)} />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export PDF' }));
+    fireEvent.click(screen.getByRole('button', { name: PDF_EXPORT_DEFAULT_LABEL }));
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith(boom));
   });

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -1,7 +1,26 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { PDF_EXPORT_DEFAULT_LABEL, PreviewToolbar } from '../src/index';
+import type { WasmLoader } from '../src/use-pdf-export';
+
+const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // "%PDF"
+
+function makePdfStub(): {
+  default: ReturnType<typeof vi.fn>;
+  render_pdf: ReturnType<typeof vi.fn>;
+  render_pdf_with_options: ReturnType<typeof vi.fn>;
+} {
+  return {
+    default: vi.fn(async () => undefined),
+    render_pdf: vi.fn(() => PDF_BYTES),
+    render_pdf_with_options: vi.fn(() => PDF_BYTES),
+  };
+}
+
+function makePdfLoader(stub: ReturnType<typeof makePdfStub>): WasmLoader {
+  return vi.fn(async () => stub as unknown as Awaited<ReturnType<WasmLoader>>);
+}
 
 const SAMPLE = '{title: Demo}\n{key: G}\n[C]Hello';
 
@@ -21,6 +40,67 @@ describe('<PreviewToolbar>', () => {
     expect(screen.getByRole('group', { name: 'Transpose' })).toBeTruthy();
     expect(screen.getByRole('group', { name: 'Capo' })).toBeTruthy();
     expect(screen.getByRole('group', { name: 'Export' })).toBeTruthy();
+  });
+
+  test('forwards exportFilename to the inner <PdfExport> download anchor', async () => {
+    // The toolbar wraps <PdfExport> and is responsible for plumbing
+    // `exportFilename` through to `<PdfExport filename={...}>`. If a
+    // future refactor drops or renames the prop, the underlying anchor
+    // falls back to the <PdfExport> default (`chordsketch-output.pdf`),
+    // and the user receives the wrong filename on click with zero
+    // build- or render-time signal. Assert via the anchor's `download`
+    // attribute captured at click time — that is the surface the
+    // browser actually consumes, so a regression at any layer between
+    // the prop and the anchor surfaces here.
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:fake'),
+      configurable: true,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      configurable: true,
+    });
+    let capturedFilename: string | null = null;
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function clickSpy(this: HTMLAnchorElement) {
+        capturedFilename = this.download;
+      });
+
+    const stub = makePdfStub();
+    render(
+      <PreviewToolbar
+        source={SAMPLE}
+        onSourceChange={vi.fn()}
+        transpose={0}
+        onTransposeChange={vi.fn()}
+        exportFilename="my-song.pdf"
+        wasmLoader={makePdfLoader(stub)}
+      />,
+    );
+    const exportGroup = screen.getByRole('group', { name: 'Export' });
+    const button = within(exportGroup).getByRole('button', {
+      name: PDF_EXPORT_DEFAULT_LABEL,
+    });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(capturedFilename).toBe('my-song.pdf');
+    // Sanity check the source / options round-trip while we have the
+    // stub wired: a regression that dropped `source` would also
+    // surface here, not silently in production. The toolbar always
+    // passes `options={{ transpose }}` with the current value (here
+    // `0`), so `usePdfExport` routes through `render_pdf_with_options`
+    // rather than `render_pdf` per the branch at
+    // `packages/react/src/use-pdf-export.ts:187-189`.
+    expect(stub.render_pdf_with_options).toHaveBeenCalledWith(SAMPLE, {
+      transpose: 0,
+    });
+    expect(stub.render_pdf).not.toHaveBeenCalled();
+    // Restore the anchor-click prototype mock so subsequent tests in
+    // this file (or in tests sharing the jsdom environment) do not
+    // inherit our captured-filename behaviour.
+    clickSpy.mockRestore();
   });
 
   test('exposes the shared PDF export button label inside the Export group', () => {

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
-import { PreviewToolbar } from '../src/index';
+import { PDF_EXPORT_DEFAULT_LABEL, PreviewToolbar } from '../src/index';
 
 const SAMPLE = '{title: Demo}\n{key: G}\n[C]Hello';
 
@@ -21,6 +21,30 @@ describe('<PreviewToolbar>', () => {
     expect(screen.getByRole('group', { name: 'Transpose' })).toBeTruthy();
     expect(screen.getByRole('group', { name: 'Capo' })).toBeTruthy();
     expect(screen.getByRole('group', { name: 'Export' })).toBeTruthy();
+  });
+
+  test('Export group exposes the shared PDF export button label', () => {
+    // The Export group composes <PdfExport> with an explicit children
+    // node (icon + label). If a future refactor drops the literal or
+    // overrides it inconsistently with the shared default, the rendered
+    // accessible name diverges from `PdfExport`'s default and from the
+    // other call sites that inherit it. Scope the assertion to the
+    // Export group so an unrelated <PdfExport> mounted elsewhere in
+    // the toolbar by a future refactor cannot mask a regression here.
+    render(
+      <PreviewToolbar
+        source={SAMPLE}
+        onSourceChange={vi.fn()}
+        transpose={0}
+        onTransposeChange={vi.fn()}
+      />,
+    );
+    const exportGroup = screen.getByRole('group', { name: 'Export' });
+    expect(
+      within(exportGroup).getByRole('button', {
+        name: PDF_EXPORT_DEFAULT_LABEL,
+      }),
+    ).toBeTruthy();
   });
 
   test('hides Capo when onSourceChange is omitted', () => {

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -67,40 +67,44 @@ describe('<PreviewToolbar>', () => {
         capturedFilename = this.download;
       });
 
-    const stub = makePdfStub();
-    render(
-      <PreviewToolbar
-        source={SAMPLE}
-        onSourceChange={vi.fn()}
-        transpose={0}
-        onTransposeChange={vi.fn()}
-        exportFilename="my-song.pdf"
-        wasmLoader={makePdfLoader(stub)}
-      />,
-    );
-    const exportGroup = screen.getByRole('group', { name: 'Export' });
-    const button = within(exportGroup).getByRole('button', {
-      name: PDF_EXPORT_DEFAULT_LABEL,
-    });
-    await act(async () => {
-      fireEvent.click(button);
-    });
-    expect(capturedFilename).toBe('my-song.pdf');
-    // Sanity check the source / options round-trip while we have the
-    // stub wired: a regression that dropped `source` would also
-    // surface here, not silently in production. The toolbar always
-    // passes `options={{ transpose }}` with the current value (here
-    // `0`), so `usePdfExport` routes through `render_pdf_with_options`
-    // rather than `render_pdf` per the branch at
-    // `packages/react/src/use-pdf-export.ts:187-189`.
-    expect(stub.render_pdf_with_options).toHaveBeenCalledWith(SAMPLE, {
-      transpose: 0,
-    });
-    expect(stub.render_pdf).not.toHaveBeenCalled();
-    // Restore the anchor-click prototype mock so subsequent tests in
-    // this file (or in tests sharing the jsdom environment) do not
-    // inherit our captured-filename behaviour.
-    clickSpy.mockRestore();
+    try {
+      const stub = makePdfStub();
+      render(
+        <PreviewToolbar
+          source={SAMPLE}
+          onSourceChange={vi.fn()}
+          transpose={0}
+          onTransposeChange={vi.fn()}
+          exportFilename="my-song.pdf"
+          wasmLoader={makePdfLoader(stub)}
+        />,
+      );
+      const exportGroup = screen.getByRole('group', { name: 'Export' });
+      const button = within(exportGroup).getByRole('button', {
+        name: PDF_EXPORT_DEFAULT_LABEL,
+      });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      expect(capturedFilename).toBe('my-song.pdf');
+      // Sanity check the source / options round-trip while we have the
+      // stub wired: a regression that dropped `source` would also
+      // surface here, not silently in production. The toolbar always
+      // passes `options={{ transpose }}` with the current value (here
+      // `0`), so `usePdfExport` routes through `render_pdf_with_options`
+      // rather than `render_pdf` per the branch at
+      // `packages/react/src/use-pdf-export.ts:187-189`.
+      expect(stub.render_pdf_with_options).toHaveBeenCalledWith(SAMPLE, {
+        transpose: 0,
+      });
+      expect(stub.render_pdf).not.toHaveBeenCalled();
+    } finally {
+      // Restore the anchor-click prototype mock unconditionally so
+      // subsequent tests in this file (or in tests sharing the jsdom
+      // environment) do not inherit our captured-filename behaviour,
+      // even if an assertion above throws.
+      clickSpy.mockRestore();
+    }
   });
 
   test('exposes the shared PDF export button label inside the Export group', () => {

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -23,7 +23,7 @@ describe('<PreviewToolbar>', () => {
     expect(screen.getByRole('group', { name: 'Export' })).toBeTruthy();
   });
 
-  test('Export group exposes the shared PDF export button label', () => {
+  test('exposes the shared PDF export button label inside the Export group', () => {
     // The Export group composes <PdfExport> with an explicit children
     // node (icon + label). If a future refactor drops the literal or
     // overrides it inconsistently with the shared default, the rendered


### PR DESCRIPTION
## What

Unify the PDF button label across the `@chordsketch/react` component surface to **"Export PDF"** so every consumer (playground, desktop, VS Code preview) renders the same verb.

- `<RendererPreview format="pdf">` and `<PreviewToolbar>` Export group both rendered `"Download PDF"` despite `<PdfExport>`'s own `children` default being `"Export PDF"`.
- Drop the explicit "Download PDF" override in the two call sites — `<RendererPreview>` now falls through to the `<PdfExport>` default; `<PreviewToolbar>` keeps the icon-plus-label shape but uses "Export PDF".
- Rename the local `DOWNLOAD_ICON` constant in `preview-toolbar.tsx` to `EXPORT_ICON` for consistency with the rendered label (SVG path unchanged).
- Update affected tests (`tests/chord-pro-preview.test.tsx`, `tests/chord-pro-editor.test.tsx`).
- Update docs: `packages/react/README.md`, `docs/sdk/tasks/embed-react.md`, `docs/sdk/reference/pdf-export.md` (example + props-table `children` default cell, which had drifted from the actual code default).
- Refresh the stale `"Download PDF"` reference in `packages/playground/vite.config.ts`'s aliasing comment.
- `<PdfExport>` JSDoc example updated to match.
- CHANGELOG entry added.

## Why

- "Export" matches the action the user performs (render to another format and save) and aligns with the desktop app's existing `File → Export PDF…` menu and `<PdfExport>`'s own default.
- The drift between `<PdfExport>`'s `children` default ("Export PDF") and the docs / call sites ("Download PDF") was misleading consumers reading the props table.

## Test results

- `cd packages/react && npm run typecheck` — clean.
- `cd packages/react && npm test` — 581 passed (29 files). Tests that previously asserted `'Download PDF'` now assert `'Export PDF'` and pass.
- Repo-wide `grep -rn "Download PDF"` returns no hits.

## Review summary

Self-review:

- Behaviour for direct `<PdfExport>` consumers is unchanged — they already got "Export PDF" via the default.
- Behaviour for `<RendererPreview format="pdf">` and `<PreviewToolbar>` consumers is a visible label change only; no API surface or accessibility-name regression beyond the label text.
- Icon rename is local to the file; no public export touched.

## Sister-site audit

Per `.claude/rules/fix-propagation.md`: this is a UI label change in the React component surface, not a rendering / parser / sanitizer change. No Rust renderer (text / HTML / PDF / React JSX walker), binding (FFI / WASM / NAPI), external-tool invocation, or sanitizer is affected. The desktop app's `File → Export PDF…` menu already uses the same verb (`apps/desktop/src/main.tsx:644`). No additional sites to mirror the change into.

Closes #2558