### PR TITLE
Permit scheduled unattended Dependabot review-and-merge

### DIFF
--- a/.claude/rules/branch-strategy.md
+++ b/.claude/rules/branch-strategy.md
@@ -39,3 +39,8 @@ single round implements every high-confidence eligible issue (capped at
   code-side fixes — and squash-merges the safe ones. See [ADR-0016](../../docs/adr/0016-dependabot-review-skill.md)
   for the policy rationale and [Pull Request Workflow](pr-workflow.md) §"Bot-driven
   merge: conditional permission" for the four-clause merge gate the skill operates under.
+- A **scheduled, maintainer-operated automation** may additionally perform the
+  same audit and squash-merge **patch/minor** Dependabot bumps without a
+  per-session human invocation, per [ADR-0024](../../docs/adr/0024-scheduled-dependabot-merge.md)
+  and [Pull Request Workflow](pr-workflow.md) §"Scheduled unattended Dependabot
+  merge". Major bumps and any non-`SAFE` audit verdict stay on the human path.

--- a/.claude/rules/branch-strategy.md
+++ b/.claude/rules/branch-strategy.md
@@ -39,8 +39,10 @@ single round implements every high-confidence eligible issue (capped at
   code-side fixes — and squash-merges the safe ones. See [ADR-0016](../../docs/adr/0016-dependabot-review-skill.md)
   for the policy rationale and [Pull Request Workflow](pr-workflow.md) §"Bot-driven
   merge: conditional permission" for the four-clause merge gate the skill operates under.
-- A **scheduled, maintainer-operated automation** may additionally perform the
-  same audit and squash-merge **patch/minor** Dependabot bumps without a
-  per-session human invocation, per [ADR-0024](../../docs/adr/0024-scheduled-dependabot-merge.md)
+- A **scheduled, maintainer-operated automation** may additionally run the same
+  audit-and-merge unattended (no per-session human invocation), for any bump
+  type including majors, per [ADR-0024](../../docs/adr/0024-scheduled-dependabot-merge.md)
   and [Pull Request Workflow](pr-workflow.md) §"Scheduled unattended Dependabot
-  merge". Major bumps and any non-`SAFE` audit verdict stay on the human path.
+  review-and-merge". The gate is the audit verdict (`SAFE`/`FIXED`) plus a green
+  full rollup, not the semver level; PRs the audit cannot clear
+  (`BLOCKED` / `NEEDS_REVIEW`) stay on the human path.

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -137,6 +137,11 @@ hold for a PR:
    the audit cannot clear (`BLOCKED` / `NEEDS_REVIEW`) is commented and
    left open for a human; it is never merged unattended.
 
+**Clause 3** (auto-review converged on HEAD) is satisfied by the
+automation's own audit pass — analogous to ADR-0016's mapping where the
+skill's audit cycle IS the converged review. Clauses 2 and 4 are
+unchanged and must be met verbatim.
+
 The semver level is not part of the gate — majors are handled the same
 way the attended skill handles them (read release notes, adapt the code,
 let the full matrix validate). The scheduled run is the maintainer's

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -112,35 +112,37 @@ why condition (4) is a direct squash and not a merge-queue enqueue.
 If any of (1)–(4) is not satisfied, post the "Ready for merge"
 comment and wait for the human merger.
 
-### Scheduled unattended Dependabot merge (ADR-0024)
+### Scheduled unattended Dependabot review-and-merge (ADR-0024)
 
 Clause 1 above ("explicit, current-session permission") is extended —
-**for Dependabot patch/minor bumps only** — by
+**for Dependabot PRs** — by
 [ADR-0024](../../docs/adr/0024-scheduled-dependabot-merge.md). A
-scheduled, maintainer-operated automation MAY squash-merge such a PR
-without a per-session human invocation when **all** of the following
-hold:
+scheduled, maintainer-operated automation MAY run the
+`/dependabot-review`-equivalent flow (audit, apply required code-side
+adaptation, squash-merge) without a per-session human invocation, for
+any bump type (patch, minor, or major), when **all** of the following
+hold for a PR:
 
-1. **Author is `dependabot[bot]`** and the bump is **patch or minor**
-   (never major — majors are commented and left for a human, preserving
-   ADR-0016's release-note-reading gate).
-2. **An automated audit returns `SAFE`** — diff confined to the
-   manifest/lockfile (cargo) or a single workflow `uses:` line
-   (github-actions), no GitHub Advisory Database hit against the new
-   version, and release notes between old and new showing no breaking or
-   undocumented behavioural change.
-3. **Full check rollup green** (clause 2 above, unchanged — required AND
-   non-required).
+1. **Author is `dependabot[bot]`.**
+2. **The audit clears the PR** with a `SAFE` verdict (no change needed)
+   or a `FIXED` verdict (the automation applied the required code-side
+   adaptation as commits on the Dependabot branch). The audit covers
+   diff sanity, GitHub Advisory Database exposure, and release notes
+   across every version between old and new.
+3. **Full check rollup green** on the final commit (clause 2 above,
+   unchanged — required AND non-required; for a `FIXED` PR, the rollup
+   *after* the adaptation commits).
 4. **Direct squash** (clause 4 above, unchanged).
-5. **The audit posts its verdict as a PR comment before merging.** A
-   PR that does not clear the audit (`BLOCKED` / `NEEDS_REVIEW`) is
-   commented and left open for a human; it is never merged unattended.
+5. **The audit posts its verdict as a PR comment before merging.** A PR
+   the audit cannot clear (`BLOCKED` / `NEEDS_REVIEW`) is commented and
+   left open for a human; it is never merged unattended.
 
-For this narrow class, the scheduled automation's configured run is the
-maintainer's standing authorization and replaces clause 1's per-session
-keystroke. This carve-out applies to nothing else: every non-Dependabot
-bot-initiated merge, and every Dependabot **major** bump, still requires
-explicit current-session permission per clause 1.
+The semver level is not part of the gate — majors are handled the same
+way the attended skill handles them (read release notes, adapt the code,
+let the full matrix validate). The scheduled run is the maintainer's
+standing authorization and replaces clause 1's per-session keystroke for
+Dependabot PRs. Every **non-Dependabot** bot-initiated merge still
+requires explicit current-session permission per clause 1.
 
 #### Historical rationale (superseded)
 

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -112,6 +112,36 @@ why condition (4) is a direct squash and not a merge-queue enqueue.
 If any of (1)–(4) is not satisfied, post the "Ready for merge"
 comment and wait for the human merger.
 
+### Scheduled unattended Dependabot merge (ADR-0024)
+
+Clause 1 above ("explicit, current-session permission") is extended —
+**for Dependabot patch/minor bumps only** — by
+[ADR-0024](../../docs/adr/0024-scheduled-dependabot-merge.md). A
+scheduled, maintainer-operated automation MAY squash-merge such a PR
+without a per-session human invocation when **all** of the following
+hold:
+
+1. **Author is `dependabot[bot]`** and the bump is **patch or minor**
+   (never major — majors are commented and left for a human, preserving
+   ADR-0016's release-note-reading gate).
+2. **An automated audit returns `SAFE`** — diff confined to the
+   manifest/lockfile (cargo) or a single workflow `uses:` line
+   (github-actions), no GitHub Advisory Database hit against the new
+   version, and release notes between old and new showing no breaking or
+   undocumented behavioural change.
+3. **Full check rollup green** (clause 2 above, unchanged — required AND
+   non-required).
+4. **Direct squash** (clause 4 above, unchanged).
+5. **The audit posts its verdict as a PR comment before merging.** A
+   PR that does not clear the audit (`BLOCKED` / `NEEDS_REVIEW`) is
+   commented and left open for a human; it is never merged unattended.
+
+For this narrow class, the scheduled automation's configured run is the
+maintainer's standing authorization and replaces clause 1's per-session
+keystroke. This carve-out applies to nothing else: every non-Dependabot
+bot-initiated merge, and every Dependabot **major** bump, still requires
+explicit current-session permission per clause 1.
+
 #### Historical rationale (superseded)
 
 A previous iteration of this workflow had bots run `gh pr merge --squash --auto` after

--- a/docs/adr/0013-conditional-bot-driven-merge.md
+++ b/docs/adr/0013-conditional-bot-driven-merge.md
@@ -1,6 +1,6 @@
 # 0013. Bot-driven merge is allowed under explicit session permission
 
-- **Status**: Accepted (condition 4 updated by ADR-0015 on 2026-05-03)
+- **Status**: Accepted (condition 4 updated by ADR-0015 on 2026-05-03; clause 1 extended for Dependabot patch/minor by ADR-0024 on 2026-05-25)
 - **Date**: 2026-04-29
 
 > **Update (2026-05-03):** Condition (4) below ("Merge queue path
@@ -12,6 +12,16 @@
 > for the active rule, see `.claude/rules/pr-workflow.md`
 > §"Bot-driven merge: conditional permission" and ADR-0015's
 > "Decision" section.
+
+> **Update (2026-05-25):** Condition (1) ("Explicit, current-session
+> permission") is extended — for **Dependabot patch/minor bumps
+> only** — by [ADR-0024](0024-scheduled-dependabot-merge.md). A
+> scheduled, maintainer-operated automation may squash-merge such PRs
+> without a per-session human invocation when the full five-condition
+> gate in ADR-0024 is satisfied. Every non-Dependabot bot-initiated
+> merge and every Dependabot major bump still requires explicit
+> current-session permission per condition (1). Conditions (2)–(4)
+> are unchanged.
 
 ## Context
 

--- a/docs/adr/0013-conditional-bot-driven-merge.md
+++ b/docs/adr/0013-conditional-bot-driven-merge.md
@@ -1,6 +1,6 @@
 # 0013. Bot-driven merge is allowed under explicit session permission
 
-- **Status**: Accepted (condition 4 updated by ADR-0015 on 2026-05-03; clause 1 extended for Dependabot patch/minor by ADR-0024 on 2026-05-25)
+- **Status**: Accepted (condition 4 updated by ADR-0015 on 2026-05-03; clause 1 extended for unattended Dependabot merge by ADR-0024 on 2026-05-25)
 - **Date**: 2026-04-29
 
 > **Update (2026-05-03):** Condition (4) below ("Merge queue path
@@ -14,14 +14,16 @@
 > "Decision" section.
 
 > **Update (2026-05-25):** Condition (1) ("Explicit, current-session
-> permission") is extended — for **Dependabot patch/minor bumps
-> only** — by [ADR-0024](0024-scheduled-dependabot-merge.md). A
-> scheduled, maintainer-operated automation may squash-merge such PRs
-> without a per-session human invocation when the full five-condition
-> gate in ADR-0024 is satisfied. Every non-Dependabot bot-initiated
-> merge and every Dependabot major bump still requires explicit
-> current-session permission per condition (1). Conditions (2)–(4)
-> are unchanged.
+> permission") is extended — for **Dependabot PRs of any bump type** —
+> by [ADR-0024](0024-scheduled-dependabot-merge.md). A scheduled,
+> maintainer-operated automation may run the `/dependabot-review`
+> audit-and-merge unattended (including applying code-side adaptation
+> for majors) when the full five-condition gate in ADR-0024 is
+> satisfied. The gate is the audit verdict (`SAFE`/`FIXED`) plus a green
+> full rollup, not the semver level; PRs the audit cannot clear stay on
+> the human path. Every non-Dependabot bot-initiated merge still
+> requires explicit current-session permission per condition (1).
+> Conditions (2)–(4) are unchanged.
 
 ## Context
 

--- a/docs/adr/0016-dependabot-review-skill.md
+++ b/docs/adr/0016-dependabot-review-skill.md
@@ -1,14 +1,16 @@
 # 0016. Dependabot review moves from a CI bot to a session skill; major bumps are no longer suppressed
 
-- **Status**: Accepted (unattended patch/minor merge added by ADR-0024 on 2026-05-25)
+- **Status**: Accepted (unattended scheduled run added by ADR-0024 on 2026-05-25)
 - **Date**: 2026-05-03
 
 > **Update (2026-05-25):** [ADR-0024](0024-scheduled-dependabot-merge.md) adds a
-> scheduled, maintainer-operated automation path for Dependabot **patch/minor**
-> bumps. For that narrow class, the automation's configured run replaces
-> condition-1's per-session keystroke when a five-condition gate is satisfied.
-> Major bumps continue to require a human invocation of `/dependabot-review`,
-> preserving this ADR's intent.
+> scheduled, maintainer-operated automation path that runs this skill's
+> audit-and-merge unattended, for Dependabot PRs of any bump type (the audit
+> reads release notes and applies code-side adaptation for majors exactly as the
+> attended skill does). The automation's configured run replaces condition-1's
+> per-session keystroke when the five-condition gate in ADR-0024 is satisfied;
+> the merge gate is the audit verdict plus a green full rollup, not the semver
+> level. PRs the audit cannot clear stay on the human path.
 
 ## Context
 

--- a/docs/adr/0016-dependabot-review-skill.md
+++ b/docs/adr/0016-dependabot-review-skill.md
@@ -1,7 +1,14 @@
 # 0016. Dependabot review moves from a CI bot to a session skill; major bumps are no longer suppressed
 
-- **Status**: Accepted
+- **Status**: Accepted (unattended patch/minor merge added by ADR-0024 on 2026-05-25)
 - **Date**: 2026-05-03
+
+> **Update (2026-05-25):** [ADR-0024](0024-scheduled-dependabot-merge.md) adds a
+> scheduled, maintainer-operated automation path for Dependabot **patch/minor**
+> bumps. For that narrow class, the automation's configured run replaces
+> condition-1's per-session keystroke when a five-condition gate is satisfied.
+> Major bumps continue to require a human invocation of `/dependabot-review`,
+> preserving this ADR's intent.
 
 ## Context
 

--- a/docs/adr/0024-scheduled-dependabot-merge.md
+++ b/docs/adr/0024-scheduled-dependabot-merge.md
@@ -1,7 +1,7 @@
 # 0024. Scheduled unattended Dependabot merge for patch/minor bumps
 
 - **Status**: Accepted
-- **Date**: 2026-05-26
+- **Date**: 2026-05-25
 
 ## Context
 

--- a/docs/adr/0024-scheduled-dependabot-merge.md
+++ b/docs/adr/0024-scheduled-dependabot-merge.md
@@ -1,0 +1,143 @@
+# 0024. Scheduled unattended Dependabot merge for patch/minor bumps
+
+- **Status**: Accepted
+- **Date**: 2026-05-26
+
+## Context
+
+[ADR-0013](0013-conditional-bot-driven-merge.md) permits a bot-initiated
+`gh pr merge --squash` only when four conditions hold, the first of which is
+**explicit, current-session human permission** — and it states plainly that
+"standing memory entries from earlier sessions do NOT count — the grant is
+per-session and explicit."
+
+[ADR-0016](0016-dependabot-review-skill.md) builds on that: it deletes the
+old CI auto-approval bot, un-suppresses major bumps so every update opens a
+PR, and introduces the `/dependabot-review` skill. Its condition-1 mapping is
+explicit — "the maintainer's invocation of `/dependabot-review` IS the
+per-session grant." The whole model assumes a human is present at merge time,
+invoking the skill by hand.
+
+That assumption is the bottleneck this ADR addresses. Dependabot opens a steady
+stream of patch and minor bumps (one PR per dependency per update type, weekly).
+For that risk class the audit signal is fully mechanisable:
+
+- the diff is confined to `Cargo.toml` / `Cargo.lock` (cargo) or a single
+  workflow `uses:` line (github-actions);
+- advisory exposure is checkable against the GitHub Advisory Database;
+- behavioural deltas are readable from the dependency's release notes;
+- and branch protection already runs the full matrix on every PR.
+
+Requiring a human to invoke a skill by hand for each of these — when nothing in
+the audit needs human judgement on a clean patch/minor result — is pure
+latency. Major bumps are different: ADR-0016 deliberately surfaced them as PRs
+precisely because their behavioural changes (e.g. `actions/checkout@v4 → @v5`
+changing default `fetch-depth`) can pass a green test suite while still
+altering behaviour, so a human reading the release notes remains the right
+gate for majors.
+
+## Decision
+
+A **scheduled, maintainer-operated automation** MAY squash-merge a Dependabot
+PR without a per-session human invocation when **all** of the following hold:
+
+1. **Author is `dependabot[bot]`.** No other author qualifies for unattended
+   merge under this ADR.
+2. **The bump is patch or minor**, not major. Major-version bumps are always
+   commented and left for a human merge (preserving ADR-0016's intent).
+3. **The automated audit returns a clean (`SAFE`) verdict** — diff sanity
+   (only the manifest/lockfile or a single `uses:` line), no GitHub Advisory
+   Database hit against the new version, and release notes between the old and
+   new version showing no breaking or undocumented behavioural change.
+4. **Full check rollup is green** — every check, required AND non-required, in
+   `pass` or `skipping` (ADR-0013 condition 2, unchanged).
+5. **The merge is a direct squash** (`gh pr merge <N> --squash`; ADR-0013
+   condition 4, unchanged).
+6. **The audit posts its verdict as a PR comment before merging**, so the
+   rationale is on the record. A PR that does not clear the audit
+   (`BLOCKED` / `NEEDS_REVIEW`) is commented and left open for a human; it is
+   never merged unattended.
+
+For this narrow class, the scheduled automation's configured run **is** the
+maintainer's standing authorization — it replaces ADR-0013 clause 1's
+per-session human invocation. ADR-0013 clause 1 continues to govern every
+**non-Dependabot** bot-initiated merge unchanged: those still require explicit,
+current-session permission. This ADR does not widen bot-merge authority beyond
+Dependabot patch/minor bumps.
+
+ADR-0013 condition 3 (auto-review converged on HEAD) is satisfied as in
+ADR-0016: the automation's own audit on the PR's latest commit is the converged
+review.
+
+## Rationale
+
+The per-session-permission rule in ADR-0013 exists to stop an AI assistant from
+merging on stale or assumed authority. The risk it guards against is a merge
+decision made without a human having recently decided to allow it. This ADR
+does not erode that guard for the general case — it carves out one narrow,
+low-risk, fully-auditable class and replaces "a human invoked the skill this
+session" with "the maintainer deliberately configured a recurring job to merge
+exactly this class, under a gate that is at least as strict as the manual one."
+
+The structural protection that actually keeps red checks off `main` —
+ADR-0013 condition 2, full-rollup-green — is retained verbatim. The advisory
+check, diff-sanity check, and verdict comment trail are all retained. The only
+thing removed is the human keystroke at merge time, for the class where that
+keystroke was rubber-stamping a mechanisable verdict.
+
+Excluding majors keeps the one case where human judgement still pays for itself
+(release-note reading for behavioural deltas) on the human path.
+
+## Consequences
+
+**Positive**
+
+- Routine patch/minor bumps merge without waiting for a hand-driven session.
+- The upgrade backlog stays small; security patches delivered as patch/minor
+  bumps land promptly.
+- Every unattended merge leaves a verdict comment, so the audit trail is
+  richer than a silent native auto-merge would be.
+
+**Negative / risks**
+
+- A malicious or buggy patch/minor release that ships clean release notes, has
+  no advisory filed yet, and passes the full check matrix could merge
+  unattended. Mitigations: the diff-sanity gate rejects anything beyond the
+  manifest/lockfile or single `uses:` line; the advisory check re-runs each
+  scheduled pass (a later-filed advisory blocks a not-yet-merged PR); and the
+  verdict comment makes the decision auditable after the fact.
+- The audit verdict is only as good as the automation producing it. A wrong
+  `SAFE` on a patch/minor merges without a human. This is the residual risk the
+  maintainer accepts for this class; majors and any non-`SAFE` verdict remain
+  on the human path.
+
+## Alternatives considered
+
+- **Status quo (human invokes `/dependabot-review`).** Rejected: it does not
+  scale to unattended operation, which is the entire point of this change. The
+  manual path remains available and is unchanged.
+- **GitHub-native Dependabot auto-merge.** Rejected: it merges on check status
+  alone, with no changelog/advisory audit and no verdict trail. This ADR's gate
+  is strictly stronger.
+- **Unattended auto-merge for all bumps including majors.** Rejected: majors
+  carry the behavioural-change risk ADR-0016 deliberately routed through a
+  human, and a green test suite does not rule that risk out.
+- **Restrict to patch only.** Considered. Minor bumps under semver are additive
+  and, combined with the full-rollup-green + advisory + changelog gate, carry
+  acceptable risk; including them captures most of the backlog-reduction
+  benefit. The maintainer may tighten to patch-only later if minor bumps prove
+  troublesome — that would be a follow-up ADR.
+
+## References
+
+- [ADR-0013](0013-conditional-bot-driven-merge.md) — the four-clause
+  bot-merge gate this ADR adapts clause 1 of, for Dependabot patch/minor only.
+- [ADR-0015](0015-disable-github-merge-queue.md) — why condition 4 is a direct
+  squash, not a merge-queue enqueue.
+- [ADR-0016](0016-dependabot-review-skill.md) — the `/dependabot-review` skill
+  and the major-bumps-are-not-suppressed decision this ADR keeps intact.
+- `.claude/rules/pr-workflow.md` — operational rule updated alongside this ADR.
+- `.claude/rules/branch-strategy.md` — Dependabot branch exception, updated to
+  reference this ADR.
+- **Watch signal**: if an unattended patch/minor merge ever lands a regression,
+  revisit conditions 2–3 (tighten to patch-only, or add a soak window).

--- a/docs/adr/0024-scheduled-dependabot-merge.md
+++ b/docs/adr/0024-scheduled-dependabot-merge.md
@@ -1,4 +1,4 @@
-# 0024. Scheduled unattended Dependabot merge for patch/minor bumps
+# 0024. Scheduled unattended Dependabot review-and-merge
 
 - **Status**: Accepted
 - **Date**: 2026-05-25
@@ -13,103 +13,117 @@ per-session and explicit."
 
 [ADR-0016](0016-dependabot-review-skill.md) builds on that: it deletes the
 old CI auto-approval bot, un-suppresses major bumps so every update opens a
-PR, and introduces the `/dependabot-review` skill. Its condition-1 mapping is
-explicit — "the maintainer's invocation of `/dependabot-review` IS the
-per-session grant." The whole model assumes a human is present at merge time,
-invoking the skill by hand.
+PR, and introduces the `/dependabot-review` skill. The skill audits each open
+Dependabot PR (CHANGELOG / release notes, advisory database, diff sanity),
+**applies any required code-side adaptation as commits on the Dependabot
+branch**, and squash-merges the ones it can clear — for every bump type,
+patch through major. Its condition-1 mapping is explicit: "the maintainer's
+invocation of `/dependabot-review` IS the per-session grant." The whole model
+assumes a human is present at merge time, invoking the skill by hand.
 
 That assumption is the bottleneck this ADR addresses. Dependabot opens a steady
-stream of patch and minor bumps (one PR per dependency per update type, weekly).
-For that risk class the audit signal is fully mechanisable:
+stream of bumps (one PR per dependency per update type, weekly). The skill's
+audit is the substantive work: it reads the release notes, checks advisories,
+inspects the diff, and — for a bump that needs source changes to compile or
+keep behaviour — writes those changes and lets the full check matrix validate
+them. The human's `/dependabot-review` keystroke adds no signal beyond
+launching that audit; it is pure latency.
 
-- the diff is confined to `Cargo.toml` / `Cargo.lock` (cargo) or a single
-  workflow `uses:` line (github-actions);
-- advisory exposure is checkable against the GitHub Advisory Database;
-- behavioural deltas are readable from the dependency's release notes;
-- and branch protection already runs the full matrix on every PR.
-
-Requiring a human to invoke a skill by hand for each of these — when nothing in
-the audit needs human judgement on a clean patch/minor result — is pure
-latency. Major bumps are different: ADR-0016 deliberately surfaced them as PRs
-precisely because their behavioural changes (e.g. `actions/checkout@v4 → @v5`
-changing default `fetch-depth`) can pass a green test suite while still
-altering behaviour, so a human reading the release notes remains the right
-gate for majors.
+Majors are not a special case here. ADR-0016 surfaced them as PRs precisely so
+the skill's release-note reading + code-side adaptation could handle them
+rather than having Dependabot silently suppress them. The release-note reading
+that ADR-0016 wanted for majors is performed *by the audit*, attended or not —
+it is not something the human keystroke contributes.
 
 ## Decision
 
-A **scheduled, maintainer-operated automation** MAY squash-merge a Dependabot
-PR without a per-session human invocation when **all** of the following hold:
+A **scheduled, maintainer-operated automation** MAY run the
+`/dependabot-review`-equivalent flow — audit, apply required code-side
+adaptation, and squash-merge — **without a per-session human invocation**, for
+Dependabot PRs of any bump type (patch, minor, or major), when **all** of the
+following hold for a given PR:
 
 1. **Author is `dependabot[bot]`.** No other author qualifies for unattended
    merge under this ADR.
-2. **The bump is patch or minor**, not major. Major-version bumps are always
-   commented and left for a human merge (preserving ADR-0016's intent).
-3. **The automated audit returns a clean (`SAFE`) verdict** — diff sanity
-   (only the manifest/lockfile or a single `uses:` line), no GitHub Advisory
-   Database hit against the new version, and release notes between the old and
-   new version showing no breaking or undocumented behavioural change.
-4. **Full check rollup is green** — every check, required AND non-required, in
-   `pass` or `skipping` (ADR-0013 condition 2, unchanged).
-5. **The merge is a direct squash** (`gh pr merge <N> --squash`; ADR-0013
+2. **The audit clears the PR** with a `SAFE` verdict (no change needed) or a
+   `FIXED` verdict (the automation applied the required code-side adaptation as
+   commits on the Dependabot branch, and that adaptation is what makes the PR
+   correct). The audit covers diff sanity, GitHub Advisory Database exposure,
+   and release notes across every version between old and new.
+3. **Full check rollup is green** on the final commit — every check, required
+   AND non-required, in `pass` or `skipping` (ADR-0013 condition 2, unchanged).
+   For a `FIXED` PR this is the rollup *after* the adaptation commits.
+4. **The merge is a direct squash** (`gh pr merge <N> --squash`; ADR-0013
    condition 4, unchanged).
-6. **The audit posts its verdict as a PR comment before merging**, so the
-   rationale is on the record. A PR that does not clear the audit
-   (`BLOCKED` / `NEEDS_REVIEW`) is commented and left open for a human; it is
-   never merged unattended.
+5. **The audit posts its verdict as a PR comment before merging**, so the
+   rationale is on the record. A PR the audit cannot clear (`BLOCKED` /
+   `NEEDS_REVIEW` — e.g. an advisory hit, an unexpected diff, or a behavioural
+   change the automation cannot safely adapt to) is commented and left open for
+   a human; it is never merged unattended.
 
-For this narrow class, the scheduled automation's configured run **is** the
+For Dependabot PRs, the scheduled automation's configured run **is** the
 maintainer's standing authorization — it replaces ADR-0013 clause 1's
 per-session human invocation. ADR-0013 clause 1 continues to govern every
 **non-Dependabot** bot-initiated merge unchanged: those still require explicit,
-current-session permission. This ADR does not widen bot-merge authority beyond
-Dependabot patch/minor bumps.
+current-session permission. This ADR widens bot-merge authority only to
+unattended operation on Dependabot PRs; the gate that decides *which* PRs merge
+is the audit verdict + full rollup, exactly as in the attended skill.
 
 ADR-0013 condition 3 (auto-review converged on HEAD) is satisfied as in
-ADR-0016: the automation's own audit on the PR's latest commit is the converged
+ADR-0016: the automation's own audit on the PR's final commit is the converged
 review.
 
 ## Rationale
 
 The per-session-permission rule in ADR-0013 exists to stop an AI assistant from
-merging on stale or assumed authority. The risk it guards against is a merge
-decision made without a human having recently decided to allow it. This ADR
-does not erode that guard for the general case — it carves out one narrow,
-low-risk, fully-auditable class and replaces "a human invoked the skill this
-session" with "the maintainer deliberately configured a recurring job to merge
-exactly this class, under a gate that is at least as strict as the manual one."
+merging on stale or assumed authority — a merge decision made without a human
+having recently decided to allow it. This ADR does not erode that guard for the
+general case; it records the maintainer's deliberate, standing decision that a
+recurring job may run the *same* audit-and-merge the attended skill already
+runs, under the *same* gate.
+
+The gate that decides what merges is unchanged from the attended skill: a
+`SAFE`/`FIXED` audit verdict plus a green full rollup. The semver level of the
+bump is not part of that gate, because it never was in the attended skill — the
+skill handles majors by reading their release notes and adapting the code, and
+the full check matrix validates the result. Carving majors out of the
+unattended path would not match the attended behaviour the maintainer is
+choosing to schedule; it would just reintroduce a human keystroke that adds no
+signal the audit does not already produce.
 
 The structural protection that actually keeps red checks off `main` —
 ADR-0013 condition 2, full-rollup-green — is retained verbatim. The advisory
-check, diff-sanity check, and verdict comment trail are all retained. The only
-thing removed is the human keystroke at merge time, for the class where that
-keystroke was rubber-stamping a mechanisable verdict.
-
-Excluding majors keeps the one case where human judgement still pays for itself
-(release-note reading for behavioural deltas) on the human path.
+check, diff-sanity check, release-note reading, and verdict-comment trail are
+all retained. The only thing removed is the human keystroke at launch time.
 
 ## Consequences
 
 **Positive**
 
-- Routine patch/minor bumps merge without waiting for a hand-driven session.
-- The upgrade backlog stays small; security patches delivered as patch/minor
-  bumps land promptly.
-- Every unattended merge leaves a verdict comment, so the audit trail is
-  richer than a silent native auto-merge would be.
+- Dependabot bumps the audit can clear merge without waiting for a hand-driven
+  session, including majors that need a code-side adaptation.
+- The upgrade backlog stays small; security patches land promptly regardless of
+  whether they ship as a patch or a major.
+- Every unattended merge leaves a verdict comment, so the audit trail is richer
+  than a silent native auto-merge would be.
 
 **Negative / risks**
 
-- A malicious or buggy patch/minor release that ships clean release notes, has
-  no advisory filed yet, and passes the full check matrix could merge
-  unattended. Mitigations: the diff-sanity gate rejects anything beyond the
-  manifest/lockfile or single `uses:` line; the advisory check re-runs each
-  scheduled pass (a later-filed advisory blocks a not-yet-merged PR); and the
-  verdict comment makes the decision auditable after the fact.
 - The audit verdict is only as good as the automation producing it. A wrong
-  `SAFE` on a patch/minor merges without a human. This is the residual risk the
-  maintainer accepts for this class; majors and any non-`SAFE` verdict remain
-  on the human path.
+  `SAFE`/`FIXED` merges without a human. This is the residual risk the
+  maintainer accepts in exchange for unattended operation. It is bounded by the
+  same controls as the attended skill: a malicious or buggy release that ships
+  clean release notes and no filed advisory and passes the full matrix is the
+  worst case, and the diff-sanity gate (only manifest/lockfile or a single
+  `uses:` line for the dependency itself), the per-run advisory re-check (a
+  later-filed advisory blocks a not-yet-merged PR), and the verdict comment are
+  the mitigations.
+- Majors that need code-side adaptation are the highest-judgement case. The
+  automation merges them only on a `FIXED` verdict validated by a green full
+  rollup; anything it is unsure about becomes `NEEDS_REVIEW` and waits for a
+  human. The residual risk is that the automation is over-confident on a major
+  adaptation; the full matrix is the backstop, and a regression that slips
+  through is the watch signal below.
 
 ## Alternatives considered
 
@@ -117,27 +131,26 @@ Excluding majors keeps the one case where human judgement still pays for itself
   scale to unattended operation, which is the entire point of this change. The
   manual path remains available and is unchanged.
 - **GitHub-native Dependabot auto-merge.** Rejected: it merges on check status
-  alone, with no changelog/advisory audit and no verdict trail. This ADR's gate
-  is strictly stronger.
-- **Unattended auto-merge for all bumps including majors.** Rejected: majors
-  carry the behavioural-change risk ADR-0016 deliberately routed through a
-  human, and a green test suite does not rule that risk out.
-- **Restrict to patch only.** Considered. Minor bumps under semver are additive
-  and, combined with the full-rollup-green + advisory + changelog gate, carry
-  acceptable risk; including them captures most of the backlog-reduction
-  benefit. The maintainer may tighten to patch-only later if minor bumps prove
-  troublesome — that would be a follow-up ADR.
+  alone, with no changelog/advisory audit, no code-side adaptation, and no
+  verdict trail. This ADR's gate is strictly stronger.
+- **Restrict the unattended path to patch/minor, keep majors human.** Rejected:
+  it does not match the attended skill (which handles majors), and the human
+  keystroke it would preserve for majors adds no signal beyond the audit's own
+  release-note reading. The real gate on a major is the same as on a patch — a
+  cleared audit plus a green full rollup — so a semver carve-out would be an
+  arbitrary restriction, not a safety control.
 
 ## References
 
 - [ADR-0013](0013-conditional-bot-driven-merge.md) — the four-clause
-  bot-merge gate this ADR adapts clause 1 of, for Dependabot patch/minor only.
+  bot-merge gate this ADR adapts clause 1 of, for Dependabot PRs.
 - [ADR-0015](0015-disable-github-merge-queue.md) — why condition 4 is a direct
   squash, not a merge-queue enqueue.
 - [ADR-0016](0016-dependabot-review-skill.md) — the `/dependabot-review` skill
-  and the major-bumps-are-not-suppressed decision this ADR keeps intact.
+  whose audit-and-merge behaviour (all bump types) this ADR runs unattended.
 - `.claude/rules/pr-workflow.md` — operational rule updated alongside this ADR.
 - `.claude/rules/branch-strategy.md` — Dependabot branch exception, updated to
   reference this ADR.
-- **Watch signal**: if an unattended patch/minor merge ever lands a regression,
-  revisit conditions 2–3 (tighten to patch-only, or add a soak window).
+- **Watch signal**: if an unattended merge ever lands a regression, revisit the
+  gate — e.g. require a human verdict for majors, or add a soak window before
+  the merge step.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,10 +90,10 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0010](0010-image-path-resolution-stays-strict.md) | Image path resolution stays strict (declines R6.100 `~` and folder-next-to-song) | Accepted (2026-04-28) |
 | [0011](0011-html-styles-stay-inline.md) | HTML styles stay inline-per-element (declines R6.100 `default/screen/print` + `html.style.embed`) | Accepted (2026-04-28) |
 | [0012](0012-macports-portfile-cargo-crates-tag-relative.md) | MacPorts Portfile cargo.crates is tag-relative, not HEAD-relative | Accepted (2026-04-29) |
-| [0013](0013-conditional-bot-driven-merge.md) | Bot-driven merge is allowed under explicit session permission | Accepted (2026-04-29; condition 4 updated by ADR-0015; clause 1 extended for Dependabot patch/minor by ADR-0024) |
+| [0013](0013-conditional-bot-driven-merge.md) | Bot-driven merge is allowed under explicit session permission | Accepted (2026-04-29; condition 4 updated by ADR-0015; clause 1 extended for unattended Dependabot merge by ADR-0024) |
 | [0014](0014-bravura-glyphs-as-svg-paths.md) | Bravura SMuFL glyphs ship as inline SVG paths, not as a bundled font | Accepted (2026-05-01) |
 | [0015](0015-disable-github-merge-queue.md) | Disable GitHub Merge Queue (supersedes ADR-0003) | Accepted (2026-05-03) |
-| [0016](0016-dependabot-review-skill.md) | Dependabot review moves from a CI bot to a session skill; major bumps are no longer suppressed | Accepted (2026-05-03; unattended patch/minor merge added by ADR-0024) |
+| [0016](0016-dependabot-review-skill.md) | Dependabot review moves from a CI bot to a session skill; major bumps are no longer suppressed | Accepted (2026-05-03; unattended scheduled run added by ADR-0024) |
 | [0017](0017-react-renders-from-ast.md) | React surface renders from AST; Rust HTML renderer demoted to static-output | Accepted (2026-05-10; consumer classification partially updated by ADR-0022) |
 | [0018](0018-phase-based-shell-orchestrated-workflows.md) | Phase-based shell-orchestrated workflows (declines cc-wf-studio / n8n / Agent SDK as substitutes) | Accepted (2026-05-16) |
 | [0019](0019-batch-mode-autopilot-issue.md) | Batch-mode autopilot-issue workflow (one PR aggregates multiple eligible issues per round) | Accepted (2026-05-17) |
@@ -101,4 +101,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0021](0021-docs-site-co-located-with-playground.md) | Docs site is co-located with the playground (option (a), not Docusaurus / VitePress / subdomain) | Accepted (2026-05-19) |
 | [0022](0022-react-as-canonical-preview-surface.md) | React as the canonical preview surface; `@chordsketch/ui-web` retired | Accepted (2026-05-20) |
 | [0023](0023-capo-transposes-displayed-chords.md) | `{capo}` directive transposes displayed chords | Accepted (2026-05-24) |
-| [0024](0024-scheduled-dependabot-merge.md) | Scheduled unattended Dependabot merge for patch/minor bumps (extends ADR-0013 clause 1) | Accepted (2026-05-25) |
+| [0024](0024-scheduled-dependabot-merge.md) | Scheduled unattended Dependabot review-and-merge, all bump types (extends ADR-0013 clause 1) | Accepted (2026-05-25) |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -101,4 +101,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0021](0021-docs-site-co-located-with-playground.md) | Docs site is co-located with the playground (option (a), not Docusaurus / VitePress / subdomain) | Accepted (2026-05-19) |
 | [0022](0022-react-as-canonical-preview-surface.md) | React as the canonical preview surface; `@chordsketch/ui-web` retired | Accepted (2026-05-20) |
 | [0023](0023-capo-transposes-displayed-chords.md) | `{capo}` directive transposes displayed chords | Accepted (2026-05-24) |
-| [0024](0024-scheduled-dependabot-merge.md) | Scheduled unattended Dependabot merge for patch/minor bumps (extends ADR-0013 clause 1) | Accepted (2026-05-26) |
+| [0024](0024-scheduled-dependabot-merge.md) | Scheduled unattended Dependabot merge for patch/minor bumps (extends ADR-0013 clause 1) | Accepted (2026-05-25) |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,10 +90,10 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0010](0010-image-path-resolution-stays-strict.md) | Image path resolution stays strict (declines R6.100 `~` and folder-next-to-song) | Accepted (2026-04-28) |
 | [0011](0011-html-styles-stay-inline.md) | HTML styles stay inline-per-element (declines R6.100 `default/screen/print` + `html.style.embed`) | Accepted (2026-04-28) |
 | [0012](0012-macports-portfile-cargo-crates-tag-relative.md) | MacPorts Portfile cargo.crates is tag-relative, not HEAD-relative | Accepted (2026-04-29) |
-| [0013](0013-conditional-bot-driven-merge.md) | Bot-driven merge is allowed under explicit session permission | Accepted (2026-04-29; condition 4 updated by ADR-0015) |
+| [0013](0013-conditional-bot-driven-merge.md) | Bot-driven merge is allowed under explicit session permission | Accepted (2026-04-29; condition 4 updated by ADR-0015; clause 1 extended for Dependabot patch/minor by ADR-0024) |
 | [0014](0014-bravura-glyphs-as-svg-paths.md) | Bravura SMuFL glyphs ship as inline SVG paths, not as a bundled font | Accepted (2026-05-01) |
 | [0015](0015-disable-github-merge-queue.md) | Disable GitHub Merge Queue (supersedes ADR-0003) | Accepted (2026-05-03) |
-| [0016](0016-dependabot-review-skill.md) | Dependabot review moves from a CI bot to a session skill; major bumps are no longer suppressed | Accepted (2026-05-03) |
+| [0016](0016-dependabot-review-skill.md) | Dependabot review moves from a CI bot to a session skill; major bumps are no longer suppressed | Accepted (2026-05-03; unattended patch/minor merge added by ADR-0024) |
 | [0017](0017-react-renders-from-ast.md) | React surface renders from AST; Rust HTML renderer demoted to static-output | Accepted (2026-05-10; consumer classification partially updated by ADR-0022) |
 | [0018](0018-phase-based-shell-orchestrated-workflows.md) | Phase-based shell-orchestrated workflows (declines cc-wf-studio / n8n / Agent SDK as substitutes) | Accepted (2026-05-16) |
 | [0019](0019-batch-mode-autopilot-issue.md) | Batch-mode autopilot-issue workflow (one PR aggregates multiple eligible issues per round) | Accepted (2026-05-17) |
@@ -101,3 +101,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0021](0021-docs-site-co-located-with-playground.md) | Docs site is co-located with the playground (option (a), not Docusaurus / VitePress / subdomain) | Accepted (2026-05-19) |
 | [0022](0022-react-as-canonical-preview-surface.md) | React as the canonical preview surface; `@chordsketch/ui-web` retired | Accepted (2026-05-20) |
 | [0023](0023-capo-transposes-displayed-chords.md) | `{capo}` directive transposes displayed chords | Accepted (2026-05-24) |
+| [0024](0024-scheduled-dependabot-merge.md) | Scheduled unattended Dependabot merge for patch/minor bumps (extends ADR-0013 clause 1) | Accepted (2026-05-26) |


### PR DESCRIPTION
## What

Add ADR-0024 and accompanying rule updates that let a scheduled,
maintainer-operated automation run the `/dependabot-review`-equivalent
flow — audit, apply required code-side adaptation, squash-merge —
**without a per-session human invocation**, for Dependabot PRs of **any
bump type (patch, minor, or major)**.

- `docs/adr/0024-scheduled-dependabot-merge.md` — new ADR extending
  ADR-0013 clause 1 for Dependabot PRs.
- `.claude/rules/pr-workflow.md` — new "Scheduled unattended Dependabot
  review-and-merge" subsection under the bot-merge gate.
- `.claude/rules/branch-strategy.md` — Dependabot exception references
  ADR-0024.
- `docs/adr/{0013,0016}.md` + `docs/adr/README.md` — cross-reference
  notes and index row.

## Why

ADR-0013 clause 1 requires explicit current-session human permission for
any bot-initiated merge, and ADR-0016 maps that to a human's
`/dependabot-review` invocation. A scheduled, unattended job has no human
present at merge time, so under the current text it cannot merge anything
— every Dependabot bump waits for a hand-driven invocation.

The skill's audit is the substantive work (release-note reading, advisory
check, diff sanity, and code-side adaptation where needed); the human
keystroke adds no signal beyond launching it. The merge gate is the audit
verdict (`SAFE`/`FIXED`) plus a green full check rollup — the semver level
is not a safety control, so majors are handled the same way the attended
skill already handles them rather than carved out. PRs the audit cannot
clear (`BLOCKED` / `NEEDS_REVIEW`) stay on the human path.

The structural protection that guards `main` (ADR-0013 condition 2,
full-rollup-green), the advisory and diff-sanity checks, and the
verdict-comment trail are all retained; only the human keystroke at launch
time is removed.

## Test results

Documentation-only change (one new ADR + cross-reference/rule/index
edits). No Rust, workflow, or build files touched, so `cargo
fmt/clippy/test` and the README/workflow smoke gates are not exercised by
this PR.

## Review summary

The unattended path deliberately mirrors the attended skill's gate
(`SAFE`/`FIXED` verdict + green full rollup) and applies only to
`dependabot[bot]` PRs; every non-Dependabot bot-initiated merge still
requires explicit per-session permission. The ADR's Alternatives section
records why a patch/minor-only carve-out was rejected.

Closes #2568
