### PR TITLE
Unify select styling and make Transpose/Capo native selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,28 +53,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{capo}` directive before rendering, or pass `cli_transpose +
   capo` explicitly, to recover the pre-change output. (#2560)
 - `@chordsketch/react`: `<Capo>` and `<Transpose>` switch from
-  `− / + / Reset` buttons to a native `<input type="range">`
-  slider with a current-value readout. Keyboard support now comes
-  from the native range input (arrow keys, Home / End, PageUp /
-  PageDown); the legacy `+ / = / − / _ / 0` wrapper-level
-  shortcuts are removed. `<Capo>` accepts a new `bestPositions`
-  prop that paints ★ markers at the "easiest capo position" tied
-  set — pair with the new `computeBestCapoPositions` helper.
-  `<Transpose>`'s default UI range narrows to `±6` (down from
+  `− / + / Reset` buttons to a native `<select>` dropdown, styled
+  to match the rest of the design-system selects (white surface,
+  `--border-strong` hairline, inline chevrons-up-down caret).
+  Keyboard and screen-reader support come from the native select;
+  the legacy `+ / = / − / _ / 0` wrapper-level shortcuts are
+  removed. Options are listed highest-first (`<Transpose>`
+  `+6 … -6`, `<Capo>` `12 … 0`). `<Capo>` accepts a new
+  `bestPositions` prop that flags ★ on the "easiest capo position"
+  options — pair with the new `computeBestCapoPositions` helper.
+  `<Transpose>`'s default option range narrows to `±6` (down from
   `±11`); the feature ceiling `TRANSPOSE_MIN` / `TRANSPOSE_MAX`
   remains `±11` and hosts can pass explicit `min` / `max` to
-  widen the slider. **Breaking**: the `resetValue` prop is
-  removed from both `<Capo>` and `<Transpose>` — there is no
-  longer a Reset button, and the native slider's Home key (or a
-  controlled `onChange(0)` from the host) covers the same
-  ergonomics. (#2560)
-- `@chordsketch/react`: the `<Capo>` slider's host-supplied
-  `value` (controlled mode) and the source-derived `{capo: N}`
-  (source-pair mode) are now clamped into `[min, max]` at render
-  time as well as at change time, so a host that passes
-  `value=10` with default `max=12` sees the slider thumb and the
-  `<output>` readout agree on the displayed value. Same change
-  applied to `<Transpose>`. (#2560)
+  widen it. **Breaking**: the `resetValue` prop is removed from
+  both `<Capo>` and `<Transpose>` — there is no longer a Reset
+  button; a controlled `onChange(0)` from the host covers the
+  same ergonomics. (#2560)
+- `@chordsketch/react`: the `<Capo>` host-supplied `value`
+  (controlled mode) and the source-derived `{capo: N}`
+  (source-pair mode) are resolved to the nearest rendered
+  `<option>` at render time, so an out-of-range or off-grid value
+  (e.g. `value=10` with default `max=12`, or an off-step value)
+  selects a real option instead of leaving the control showing
+  the wrong fret. Same change applied to `<Transpose>`. (#2560)
 - `@chordsketch/react`: `<Capo>`'s `aria-describedby` id is now
   generated via React 18's `useId()` instead of `Math.random()`,
   so server-rendered hosts (Next.js, Remix) no longer hit
@@ -96,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (and the matching `BEST_CAPO_MAX` constant /
   `BestCapoResult` type) — computes the capo positions tied for
   the lowest accidental-glyph count from a parsed song, driving
-  `<Capo>`'s ★ slider markers. Mirrors the canonical-spelling
+  `<Capo>`'s ★ option flags. Mirrors the canonical-spelling
   pipeline from `chordsketch_chordpro::transpose::canonical_key_spelling`
   on the React side so no extra wasm function is needed. (#2560)
 - `chordsketch_chordpro::transpose::effective_transpose(file, cli,

--- a/design-system/preview/components-forms.html
+++ b/design-system/preview/components-forms.html
@@ -27,18 +27,40 @@ a { color: inherit; }
 .field .help { font-size: var(--fs-13); color: var(--text-secondary); }
 .field .err { font-size: var(--fs-13); color: var(--danger-fg); }
 
-.input, .textarea, .select {
+.input, .textarea {
   width: 100%; padding: 0 var(--sp-3); height: 36px;
   border: 1px solid var(--border-strong); border-radius: var(--r-2);
   background: var(--surface); font: 400 var(--fs-14)/1 var(--font-jp); color: var(--text-primary);
   transition: border-color var(--dur-1) var(--ease-out), box-shadow var(--dur-1) var(--ease-out);
 }
 .textarea { height: auto; padding: var(--sp-3); line-height: 1.6; resize: vertical; min-height: 96px; font-family: var(--font-jp); }
-.input:hover, .textarea:hover, .select:hover { border-color: var(--text-secondary); }
-.input:focus, .textarea:focus, .select:focus { outline: none; border-color: var(--crimson-500); box-shadow: var(--focus-ring); }
+.input:hover, .textarea:hover { border-color: var(--text-secondary); }
+.input:focus, .textarea:focus { outline: none; border-color: var(--crimson-500); box-shadow: var(--focus-ring); }
 .input.error { border-color: var(--danger-fg); }
-.input:disabled, .textarea:disabled, .select:disabled { background: var(--ink-50); color: var(--text-tertiary); cursor: not-allowed; }
+.input:disabled, .textarea:disabled { background: var(--ink-50); color: var(--text-tertiary); cursor: not-allowed; }
 .input::placeholder { color: var(--text-tertiary); }
+
+/* Select — white surface with a `--border-strong` hairline,
+   `--r-2` corners, and an inline chevrons-up-down caret (lucide)
+   replacing the platform-native arrow. Matches the playground's
+   `.chordsketch-app__select`: hover darkens the border only;
+   focus uses the canonical crimson `--focus-ring`. */
+.select {
+  width: 100%; height: 36px;
+  padding: 0 var(--sp-8) 0 var(--sp-3);
+  border: 1px solid var(--border-strong); border-radius: var(--r-2);
+  background-color: var(--surface);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right var(--sp-3) center;
+  font: 400 var(--fs-14)/1 var(--font-jp); color: var(--text-primary);
+  appearance: none; -webkit-appearance: none; -moz-appearance: none;
+  cursor: pointer;
+  transition: background-color var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out), box-shadow var(--dur-1) var(--ease-out);
+}
+.select:hover { border-color: var(--text-secondary); }
+.select:focus { outline: none; border-color: var(--crimson-500); box-shadow: var(--focus-ring); }
+.select:disabled { background-color: var(--ink-50); color: var(--text-tertiary); cursor: not-allowed; }
 
 /* Segmented */
 .segmented { display: inline-flex; border: 1px solid var(--border-strong); border-radius: var(--r-2); overflow: hidden; }

--- a/design-system/ui_kits/web/editor-irealb.html
+++ b/design-system/ui_kits/web/editor-irealb.html
@@ -90,8 +90,14 @@ a { color: inherit; text-decoration: none; }
    apart when the design token set evolves. */
 .meta-field label,
 .width-mode-row > .width-mode-card > .caption { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-tertiary); }
-.meta-field input, .meta-field select { height: 32px; padding: 0 var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2); background: var(--ink-50); font: 500 var(--fs-14)/1 var(--font-mono); color: var(--text-primary); transition: border-color var(--dur-1) var(--ease-out), background var(--dur-1) var(--ease-out); font-variant-numeric: tabular-nums; }
-.meta-field input:focus, .meta-field select:focus { outline: none; border-color: var(--crimson-500); background: var(--surface); box-shadow: var(--focus-ring); }
+.meta-field input { height: 32px; padding: 0 var(--sp-3); border: 1px solid var(--border); border-radius: var(--r-2); background: var(--ink-50); font: 500 var(--fs-14)/1 var(--font-mono); color: var(--text-primary); transition: border-color var(--dur-1) var(--ease-out), background var(--dur-1) var(--ease-out); font-variant-numeric: tabular-nums; }
+.meta-field input:focus { outline: none; border-color: var(--crimson-500); background: var(--surface); box-shadow: var(--focus-ring); }
+/* Select — white surface matching the canonical `.select` and the
+   playground's `.chordsketch-app__select`: `--border-strong`
+   hairline, `--r-2` corners, inline chevrons-up-down caret. */
+.meta-field select { height: 32px; padding: 0 var(--sp-8) 0 var(--sp-3); border: 1px solid var(--border-strong); border-radius: var(--r-2); background-color: var(--surface); background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>"); background-repeat: no-repeat; background-position: right var(--sp-3) center; font: 500 var(--fs-14)/1 var(--font-mono); color: var(--text-primary); appearance: none; -webkit-appearance: none; -moz-appearance: none; cursor: pointer; transition: background-color var(--dur-1) var(--ease-out), border-color var(--dur-1) var(--ease-out), box-shadow var(--dur-1) var(--ease-out); font-variant-numeric: tabular-nums; }
+.meta-field select:hover { border-color: var(--text-secondary); }
+.meta-field select:focus { outline: none; border-color: var(--crimson-500); box-shadow: var(--focus-ring); }
 /* Key field: root <select> and Major/Minor segmented control share
    one horizontal row so the field's vertical height matches every
    other .meta-field (label + 32px control). Without this wrapper

--- a/packages/playground/src/chordpro/main.tsx
+++ b/packages/playground/src/chordpro/main.tsx
@@ -794,7 +794,7 @@ function PlaygroundApp(): JSX.Element {
               <p className="eyebrow">Preview · HTML</p>
               <span className="meta">{previewMeta}</span>
               {/* Export PDF lives in the pane header (right-aligned
-                  via `.pane-head__export`) so the slider toolbar
+                  via `.pane-head__export`) so the performance toolbar
                   underneath only carries the two transposition
                   controls. */}
               <PdfExport
@@ -835,7 +835,7 @@ function PlaygroundApp(): JSX.Element {
               chordDiagramsOrientation={diagramsOrientation}
               onChordDiagramsOrientationChange={setDiagramsOrientation}
               /* `transposeMin/Max` left at the PreviewToolbar default
-                 (±6) so the slider rail stays readable on narrow
+                 (±6) so the option list stays compact on narrow
                  preview panes. The feature ceiling of ±11 is still
                  reachable by hosts that pass an explicit override. */
             />

--- a/packages/playground/src/playground.css
+++ b/packages/playground/src/playground.css
@@ -308,9 +308,9 @@ a {
   gap: 0.25rem;
   padding: 0 0.75rem;
   border-right: 1px solid var(--cs-border, #E8E6EA);
-  /* `min-height` instead of `height` — slider tool-groups
-   * (Transpose / Capo) need to grow taller than a row of buttons
-   * to accommodate their tick labels (#2560). */
+  /* `min-height` rather than `height` so a tool-group row flexes to
+   * its tallest control (button or select) without a hard cap that
+   * would clip a taller future control. */
   min-height: 28px;
 }
 
@@ -325,16 +325,6 @@ a {
   letter-spacing: 0;
   color: var(--cs-text-tertiary, #8A8790);
   margin-right: 0.5rem;
-}
-
-.tool-group .transpose-value {
-  font-family: var(--cs-font-mono, "JetBrains Mono", ui-monospace, monospace);
-  font-size: 0.8125rem;
-  padding: 0 0.5rem;
-  min-width: 28px;
-  text-align: center;
-  color: var(--cs-text-primary, #0A0A0B);
-  font-feature-settings: "tnum" 1;
 }
 
 .segmented {
@@ -1254,7 +1244,7 @@ a {
   height: 28px;
   padding: 0 28px 0 0.75rem;
   background: var(--cs-surface, #FFFFFF)
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%2367646D' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>")
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>")
     no-repeat right 8px center;
   color: var(--cs-text-primary, #0A0A0B);
   border: 1px solid var(--cs-border-strong, #D4D1D6);

--- a/packages/playground/tests-e2e/diagrams-orientation-toggle.spec.ts
+++ b/packages/playground/tests-e2e/diagrams-orientation-toggle.spec.ts
@@ -54,9 +54,10 @@ test('diagrams orientation toggle flips the rendered SVG class end-to-end', asyn
   // 4px radius matches the editor select. A raw browser default
   // would be 0 (Chromium native select renders square corners).
   expect(tokenSnapshot.borderRadius).toBe('4px');
-  // 32px height matches the editor select. Native select height is
-  // user-agent dependent and would not be 32px.
-  expect(tokenSnapshot.height).toBe('32px');
+  // 28px height matches the unified toolbar selects (and the
+  // playground's `.chordsketch-app__select`). Native select height is
+  // user-agent dependent and would not be 28px.
+  expect(tokenSnapshot.height).toBe('28px');
 
   await orientSelect.selectOption('horizontal');
 

--- a/packages/playground/tests-e2e/performance-toolbar.spec.ts
+++ b/packages/playground/tests-e2e/performance-toolbar.spec.ts
@@ -1,6 +1,6 @@
 // Smoke verification that the playground's preview pane mounts the
-// performance toolbar (#2545, #2560) — Transpose / Capo sliders
-// plus a pane-head Export PDF button — and that the slider
+// performance toolbar (#2545, #2560) — Transpose / Capo selects
+// plus a pane-head Export PDF button — and that the select
 // controls drive the underlying state correctly.
 //
 // Structural assertions only: this verifies the controls exist
@@ -27,55 +27,52 @@ test.describe('performance toolbar', () => {
     await expect(toolbar.getByRole('group', { name: 'Export' })).toHaveCount(0);
   });
 
-  test('Transpose slider drives the readout value', async ({ page }) => {
+  test('Transpose select drives the selected value', async ({ page }) => {
     await page.goto('./chordpro/');
     const transposeGroup = page.getByRole('group', { name: 'Transpose' });
-    const slider = transposeGroup.getByRole('slider', { name: 'Transpose' });
-    await slider.fill('1');
-    // The Transpose `<output>` uses aria-live but stays in the DOM as
-    // the inner text of `.chordsketch-transpose__value` — assert on
-    // the visible text rather than coupling to an internal attribute.
-    // The tick rail also renders `+1` as a label, so target the
-    // readout element directly.
-    await expect(
-      transposeGroup.locator('.chordsketch-transpose__value'),
-    ).toHaveText('+1');
+    const select = transposeGroup.getByRole('combobox', { name: 'Transpose' });
+    await select.selectOption('1');
+    await expect(select).toHaveValue('1');
   });
 
-  test('Capo slider rewrites the {capo: N} directive in the editor source', async ({
+  test('Capo select rewrites the {capo: N} directive in the editor source', async ({
     page,
   }) => {
     await page.goto('./chordpro/');
     const editor = page.locator('.cm-editor .cm-content');
     await expect(editor).toBeVisible();
-    // The bundled sample has no {capo} directive; setting the slider
+    // The bundled sample has no {capo} directive; setting the select
     // to 1 inserts `{capo: 1}` after the metadata anchor. We don't
     // pin the exact position — just assert the directive shows up.
     const capoGroup = page.getByRole('group', { name: 'Capo' });
-    await capoGroup.getByRole('slider', { name: 'Capo' }).fill('1');
+    await capoGroup.getByRole('combobox', { name: 'Capo' }).selectOption('1');
     await expect(editor).toContainText('{capo: 1}');
   });
 
-  test('Transpose slider exposes the toolbar default ±6 range', async ({ page }) => {
+  test('Transpose select exposes the toolbar default ±6 range, highest-first', async ({
+    page,
+  }) => {
     await page.goto('./chordpro/');
     const transposeGroup = page.getByRole('group', { name: 'Transpose' });
-    const slider = transposeGroup.getByRole('slider', { name: 'Transpose' });
-    // PreviewToolbar defaults `transposeMin/Max` to ±6 so the
-    // tick rail's 13 labels stay readable on narrow preview panes.
-    // Hosts that want the feature ceiling (±11) pass it explicitly.
-    await expect(slider).toHaveAttribute('min', '-6');
-    await expect(slider).toHaveAttribute('max', '6');
-    await slider.fill('-6');
-    await expect(
-      transposeGroup.locator('.chordsketch-transpose__value'),
-    ).toHaveText('-6');
+    const select = transposeGroup.getByRole('combobox', { name: 'Transpose' });
+    // PreviewToolbar defaults `transposeMin/Max` to ±6. Options are
+    // rendered highest-first (`+6 … -6`); hosts that want the
+    // feature ceiling (±11) pass it explicitly.
+    const options = select.locator('option');
+    await expect(options).toHaveCount(13);
+    await expect(options.first()).toHaveAttribute('value', '6');
+    await expect(options.last()).toHaveAttribute('value', '-6');
+    await select.selectOption('-6');
+    await expect(select).toHaveValue('-6');
   });
 
-  test('Capo slider exposes the 0..=12 range', async ({ page }) => {
+  test('Capo select exposes the 0..=12 range, highest-first', async ({ page }) => {
     await page.goto('./chordpro/');
     const capoGroup = page.getByRole('group', { name: 'Capo' });
-    const slider = capoGroup.getByRole('slider', { name: 'Capo' });
-    await expect(slider).toHaveAttribute('min', '0');
-    await expect(slider).toHaveAttribute('max', '12');
+    const select = capoGroup.getByRole('combobox', { name: 'Capo' });
+    const options = select.locator('option');
+    await expect(options).toHaveCount(13);
+    await expect(options.first()).toHaveAttribute('value', '12');
+    await expect(options.last()).toHaveAttribute('value', '0');
   });
 });

--- a/packages/playground/tests-e2e/render-format-toggle.spec.ts
+++ b/packages/playground/tests-e2e/render-format-toggle.spec.ts
@@ -15,9 +15,9 @@
 //
 // Selectors target the React playground (#2454 / #2475):
 // `.chordsketch-preview .song` is the AST → JSX root, and chord
-// labels live inside `.chord-block .chord` spans. As of #2560 the
-// transpose control is a native `<input type="range">` slider with
-// the accessible name "Transpose".
+// labels live inside `.chord-block .chord` spans. The transpose
+// control is a native `<select>` with the accessible name
+// "Transpose" (combobox role), its options listed highest-first.
 
 import { expect, test } from '@playwright/test';
 
@@ -51,7 +51,7 @@ test.describe('playground render inline path', () => {
     const initial = await chordTexts(page);
     expect(initial.length).toBeGreaterThan(0);
 
-    await page.getByRole('slider', { name: 'Transpose' }).fill('1');
+    await page.getByRole('combobox', { name: 'Transpose' }).selectOption('1');
     await expect
       .poll(async () => (await chordTexts(page)).join('|'))
       .not.toBe(initial.join('|'));
@@ -65,13 +65,13 @@ test.describe('playground render inline path', () => {
   }) => {
     await page.goto('./chordpro/');
     await expect(page.locator('.chordsketch-preview .song')).toBeVisible();
-    const transposeSlider = page.getByRole('slider', { name: 'Transpose' });
+    const transposeSelect = page.getByRole('combobox', { name: 'Transpose' });
 
     const seen = new Set<string>();
     seen.add((await chordTexts(page)).join('|'));
     let last = (await chordTexts(page)).join('|');
     for (let i = 1; i <= 4; i++) {
-      await transposeSlider.fill(String(i));
+      await transposeSelect.selectOption(String(i));
       await expect.poll(async () => (await chordTexts(page)).join('|')).not.toBe(last);
       last = (await chordTexts(page)).join('|');
       seen.add(last);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -415,17 +415,16 @@ export function Controls() {
 }
 ```
 
-The component renders a native `<input type="range">` slider and a
-signed current-value readout. The readout is an `<output>` with
-`aria-live="polite"` so screen readers announce changes; keyboard
-users get the native range input's built-in semantics (arrow keys,
-Home / End, PageUp / PageDown). The slider's default UI range is
-`±6` semitones — narrower than the feature ceiling
+The component renders a native `<select>` whose options list every
+semitone offset, highest-first (`+6 … 0 … -6`); keyboard and
+screen-reader support come from the native select. The default
+option range is `±6` semitones — narrower than the feature ceiling
 `TRANSPOSE_MIN` / `TRANSPOSE_MAX` (`±11`) — so hosts that want a
 wider range pass explicit `min` / `max` props (down to `-11` /
-up to `+11`). Values are clamped into `[min, max]` in both the
-controlled mode's `value` prop (display-side clamp) and via the
-hook's own `setValue`.
+up to `+11`). The controlled `value` is resolved to the nearest
+rendered option at render time (so an out-of-range or off-step
+value still selects a real option), and the hook's own `setValue`
+clamps into `[min, max]`.
 
 ### `useTranspose` — state helper for custom UIs
 

--- a/packages/react/src/best-capo.ts
+++ b/packages/react/src/best-capo.ts
@@ -5,9 +5,9 @@
 // `-c` semitones. The "best capo" picker enumerates `c ∈ [0..=12]`,
 // counts how many accidental glyphs would appear in the chord-root
 // labels at each `c`, and returns the set of positions tied for the
-// minimum. The slider in `<Capo>` paints a ★ marker at each tied
-// position so the user can see at a glance which capo fret produces
-// the simplest spelling.
+// minimum. The `<Capo>` select flags a ★ on each tied option so
+// the user can see at a glance which capo fret produces the
+// simplest spelling.
 //
 // Mirrors `canonical_key_spelling` in
 // `crates/chordpro/src/transpose.rs`: black keys spell as flats
@@ -29,7 +29,7 @@ import type {
  * Inclusive upper bound for the candidate capo positions
  * `computeBestCapoPositions` enumerates. Re-exports `CAPO_MAX` from
  * `chord-source-edit.ts` so the search range stays in lockstep with
- * the slider's physical range — if `CAPO_MAX` widens to support a
+ * the `<Capo>` select's option range — if `CAPO_MAX` widens to support a
  * longer guitar neck, the best-capo picker enumerates the new
  * positions automatically.
  */

--- a/packages/react/src/capo.tsx
+++ b/packages/react/src/capo.tsx
@@ -23,7 +23,7 @@ type CapoModeProps =
   | {
       /** Current capo position (controlled mode). */
       value: number;
-      /** Fired when the slider's input value changes. */
+      /** Fired when the select value changes. */
       onChange: (next: number) => void;
       source?: undefined;
       onSourceChange?: undefined;
@@ -32,7 +32,7 @@ type CapoModeProps =
       /** Full ChordPro source — the `{capo: N}` directive is read out. */
       source: string;
       /**
-       * Fired when the slider's input value changes.
+       * Fired when the select value changes.
        * Receives the updated source with the `{capo: N}` directive
        * inserted / updated / removed via {@link setCapoInSource}.
        *
@@ -52,12 +52,18 @@ export type CapoProps = CapoModeProps &
     min?: number;
     /** Maximum capo position. Defaults to {@link CAPO_MAX} (`12`). */
     max?: number;
-    /** Step size for the slider. Defaults to `1`. */
+    /**
+     * Step between adjacent options. Defaults to `1`. A `value` /
+     * `{capo:N}` that does not land on the option grid snaps to the
+     * nearest rendered option, so a non-dividing `step` never leaves
+     * the select showing an unselectable value. A non-positive `step`
+     * (or `max < min`) produces an empty, inert select.
+     */
     step?: number;
     /**
-     * Optional label shown inline with the slider. Defaults to
-     * `"Capo"`. Pass `null` to omit the visible label; the
-     * component still exposes `aria-label` on the wrapper.
+     * Optional label shown inline before the select. Defaults to
+     * `"Capo"`. Pass `null` to omit the visible label; the select
+     * still carries an `aria-label`.
      */
     label?: React.ReactNode;
     /**
@@ -66,32 +72,38 @@ export type CapoProps = CapoModeProps &
      * source was rewritten with.
      */
     onCapoChange?: (next: number) => void;
-    /** Format the capo indicator. Defaults to a bare integer. */
-    formatValue?: (value: number) => React.ReactNode;
     /**
-     * Capo positions to surface as ★ markers on the slider — pass
-     * `BestCapoResult.positions` from {@link computeBestCapoPositions}
-     * (in `best-capo.ts`). Entries outside `[min, max]` are
-     * silently ignored. Pass an empty array (or omit) to suppress
-     * the markers. The ★ marker has no behavioural effect; it is
-     * purely a visual hint. Declared as `ReadonlyArray<number>`
-     * so the caller cannot mutate it in place after handing it to
-     * the component.
+     * Format an option's capo value. Defaults to a bare integer.
+     * The result is rendered as the `<option>`'s text content (a
+     * ` ★` suffix is appended for best-capo positions), so the
+     * return type is `string | number` — elements do not render
+     * inside `<option>`.
+     */
+    formatValue?: (value: number) => string | number;
+    /**
+     * Capo positions to surface with a ★ marker on the matching
+     * option — pass `BestCapoResult.positions` from
+     * {@link computeBestCapoPositions} (in `best-capo.ts`). Entries
+     * outside `[min, max]` are silently ignored. Pass an empty
+     * array (or omit) to suppress the markers. The ★ marker has no
+     * behavioural effect; it is purely a visual hint. Declared as
+     * `ReadonlyArray<number>` so the caller cannot mutate it in
+     * place after handing it to the component.
      */
     bestPositions?: ReadonlyArray<number>;
     /**
      * Active transpose offset, in source-pair mode. When the host
-     * also drives a `<Transpose>` slider, pass the same value here
+     * also drives a `<Transpose>` select, pass the same value here
      * so the ★ best-capo recommendations reflect the
-     * *transposed* chord roots — moving the transpose slider
+     * *transposed* chord roots — changing the transpose value
      * shifts which capo positions zero out the accidentals.
      * Defaults to `0` (no transpose). Ignored in controlled mode
      * (the host supplies `bestPositions` directly).
      *
      * Values must fit in an `i8` (`-128..=127`); the wasm parser
      * rejects anything wider at deserialisation time. Hosts that
-     * wire this prop to a `<Transpose>` slider's value never need
-     * to worry — the slider clamps to its `min` / `max` (`±6` by
+     * wire this prop to a `<Transpose>` select's value never need
+     * to worry — the select clamps to its `min` / `max` (`±6` by
      * default).
      */
     transpose?: number;
@@ -108,16 +120,17 @@ function isSourceMode(
 }
 
 /**
- * Accessible capo control: a native `<input type="range">` slider
- * with a current-value readout and optional ★ markers at the
- * "easiest capo position" tied set. Keyboard support comes from
- * the native range input (Arrow keys, Home / End, PageUp /
- * PageDown).
+ * Accessible capo control: a native `<select>` listing every fret
+ * position between `min` and `max`, styled as the design-system
+ * select (white surface, hairline border, inline chevrons-up-down
+ * caret) to match the playground's `.chordsketch-app__select`.
+ * Best-capo positions are flagged with a ★ on the matching option.
+ * Keyboard and screen-reader support come from the native select.
  *
  * Two API shapes are supported and mutually exclusive:
  *
  * 1. **Controlled** — `value` + `onChange`. Acts as a pure
- *    slider, identical in shape to `<Transpose>`.
+ *    select, identical in shape to `<Transpose>`.
  *
  *    ```tsx
  *    const [capo, setCapo] = useState(0);
@@ -125,7 +138,7 @@ function isSourceMode(
  *    ```
  *
  * 2. **Source-pair** — `source` + `onSourceChange`. The capo
- *    value is derived from `source` via {@link readCapo}; slider
+ *    value is derived from `source` via {@link readCapo}; select
  *    changes write the new source through {@link setCapoInSource}
  *    and emit the result via `onSourceChange`. Use this shape
  *    when the host already owns the ChordPro string — there is no
@@ -135,7 +148,7 @@ function isSourceMode(
  *    <Capo source={source} onSourceChange={setSource} />
  *    ```
  *
- * Per ADR-0023, the slider's value drives a render-time `-capo`
+ * Per ADR-0023, the selected value drives a render-time `-capo`
  * semitone shift applied by the renderer pipeline; this component
  * itself does not transpose chord lines.
  */
@@ -168,7 +181,7 @@ export function Capo(props: CapoProps): JSX.Element {
   // with chord roots already shifted by `transpose - capo` — pair
   // that with `parseSongCapo`'s capo-undo in `computeBestCapoPositions`
   // and the best-capo enumeration runs against the *transposed*
-  // chord roots, so moving the `<Transpose>` slider shifts the
+  // chord roots, so changing the `<Transpose>` value shifts the
   // ★ recommendations alongside the song.
   //
   // Controlled mode passes `skip: true` so the wasm module is
@@ -193,13 +206,31 @@ export function Capo(props: CapoProps): JSX.Element {
     (next: number): number => clampValue(next, min, max),
     [min, max],
   );
-  // The host may pass a `value` outside `[min, max]` (controlled
-  // mode) or the source may carry a `{capo: N}` outside the
-  // slider's range. Native `<input type="range">` will visually
-  // clamp the thumb to the bound but the `<output>` readout would
-  // surface the raw value, producing a "thumb at +6 / readout +10"
-  // disagreement. Clamp at render time so both surfaces agree.
-  const displayValue = clamp(rawValue);
+  // Highest fret first so the dropdown reads top-down as
+  // `12 … 0` (capo position increases toward the top, matching
+  // the ↕ caret and the `<Transpose>` ordering).
+  const options = useMemo(() => {
+    if (step <= 0 || max < min) return [] as number[];
+    const out: number[] = [];
+    for (let p = max; p >= min; p -= step) out.push(p);
+    return out;
+  }, [min, max, step]);
+
+  // Resolve the host value (controlled `value`, or `{capo: N}` from
+  // the source) to the nearest rendered option. A native <select>
+  // cannot display a value with no matching <option>, so an
+  // out-of-range value (clamped here) or an off-grid value (when
+  // `step` does not divide the range) would otherwise leave the
+  // control showing the wrong fret. Snapping keeps it in sync.
+  const displayValue = useMemo(() => {
+    const bounded = clamp(rawValue);
+    if (options.length === 0) return bounded;
+    return options.reduce(
+      (best, opt) =>
+        Math.abs(opt - bounded) < Math.abs(best - bounded) ? opt : best,
+      options[0],
+    );
+  }, [rawValue, options, clamp]);
 
   const emit = useCallback(
     (next: number): void => {
@@ -215,12 +246,8 @@ export function Capo(props: CapoProps): JSX.Element {
     [clamp, sourceMode, source, onSourceChange, onCapoChange, onChange],
   );
 
-  const handleSliderChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>): void => {
-      // The native range input clamps on its own, but parse +
-      // re-clamp anyway so a programmatic `event.target.value`
-      // outside `min..=max` (e.g. driven by automation in tests)
-      // still lands inside the contract.
+  const handleSelectChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>): void => {
       const parsed = Number.parseInt(event.target.value, 10);
       if (Number.isNaN(parsed)) return;
       emit(parsed);
@@ -228,10 +255,9 @@ export function Capo(props: CapoProps): JSX.Element {
     [emit],
   );
 
-  // Build the ★ marker positions. We keep only entries that fall
-  // inside `min..=max` so a host that narrowed the range does not
-  // see stranded markers outside the slider track. Empty list →
-  // no markers rendered.
+  // Build the ★ marker set. We keep only entries that fall inside
+  // `min..=max` so a host that narrowed the range does not flag
+  // options it cannot reach. Empty list → no markers.
   const markers = useMemo(() => {
     if (!effectiveBestPositions || effectiveBestPositions.length === 0) return [] as number[];
     const seen = new Set<number>();
@@ -239,11 +265,9 @@ export function Capo(props: CapoProps): JSX.Element {
     for (const pos of effectiveBestPositions) {
       // Reject non-finite or non-integer entries before the range
       // check: NaN slips past `pos < min || pos > max` (every NaN
-      // comparison evaluates to false in JS) and would otherwise
-      // produce a `left: NaN%` CSS rule and a `data-best-capo="NaN"`
-      // attribute on the marker span. Infinity is rejected for the
-      // same reason. Integer-only matches the contract of capo
-      // positions (`computeBestCapoPositions` always emits integers).
+      // comparison evaluates to false in JS). Integer-only matches
+      // the contract of capo positions (`computeBestCapoPositions`
+      // always emits integers).
       if (!Number.isInteger(pos)) continue;
       if (pos < min || pos > max) continue;
       if (seen.has(pos)) continue;
@@ -252,6 +276,7 @@ export function Capo(props: CapoProps): JSX.Element {
     }
     return result.sort((a, b) => a - b);
   }, [effectiveBestPositions, min, max]);
+  const markerSet = useMemo(() => new Set(markers), [markers]);
 
   // Use React 18's `useId` so the generated id is stable across
   // server-render and client-hydration. The previous `Math.random()`
@@ -260,29 +285,12 @@ export function Capo(props: CapoProps): JSX.Element {
   const baseId = useId();
   const markerDescriptionId = markers.length > 0 ? `${baseId}-capo-best` : undefined;
 
-  const range = max - min;
   const ariaLabel =
     typeof divProps['aria-label'] === 'string'
       ? divProps['aria-label']
       : typeof label === 'string'
         ? label
         : 'Capo';
-
-  // Tick marks AND numeric labels at every step — every grid
-  // line is annotated so the user does not have to interpolate.
-  const ticks = useMemo(() => {
-    if (range <= 0 || step <= 0) return [] as Array<{ pos: number; major: boolean }>;
-    const out: Array<{ pos: number; major: boolean }> = [];
-    for (let p = min; p <= max; p += step) {
-      out.push({ pos: p, major: true });
-    }
-    return out;
-  }, [min, max, step, range]);
-
-  const handleDecrement = useCallback(() => emit(displayValue - step), [emit, displayValue, step]);
-  const handleIncrement = useCallback(() => emit(displayValue + step), [emit, displayValue, step]);
-  const decrementDisabled = displayValue <= min;
-  const incrementDisabled = displayValue >= max;
 
   return (
     <div
@@ -291,99 +299,25 @@ export function Capo(props: CapoProps): JSX.Element {
       aria-label={ariaLabel}
       className={['chordsketch-capo', className].filter(Boolean).join(' ')}
     >
-      <div className="chordsketch-capo__header">
-        {label !== null ? (
-          <span className="chordsketch-capo__label" aria-hidden="true">
-            {label}
-          </span>
-        ) : (
-          <span />
-        )}
-        <output
-          className="chordsketch-capo__value"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {formatValue(displayValue)}
-        </output>
-      </div>
-      <div className="chordsketch-capo__controls">
-        <button
-          type="button"
-          className="chordsketch-capo__btn chordsketch-capo__btn--decrement"
-          onClick={handleDecrement}
-          disabled={decrementDisabled}
-          aria-label={step === 1 ? 'Capo down one fret' : `Capo down ${step} frets`}
-        >
-          −
-        </button>
-        <div className="chordsketch-capo__slider-wrap">
-          <input
-            type="range"
-            className="chordsketch-capo__slider"
-            min={min}
-            max={max}
-            step={step}
-            value={displayValue}
-            onChange={handleSliderChange}
-            aria-label={ariaLabel}
-            aria-describedby={markerDescriptionId}
-          />
-          {range > 0 ? (
-            <>
-              <div className="chordsketch-capo__ticks" aria-hidden="true">
-                {ticks.map(({ pos, major }) => (
-                  <span
-                    key={pos}
-                    className={
-                      major
-                        ? 'chordsketch-capo__tick chordsketch-capo__tick--major'
-                        : 'chordsketch-capo__tick'
-                    }
-                    style={{ left: `${((pos - min) / range) * 100}%` }}
-                  />
-                ))}
-              </div>
-              <div className="chordsketch-capo__tick-labels" aria-hidden="true">
-                {ticks
-                  .filter(({ major }) => major)
-                  .map(({ pos }) => (
-                    <span
-                      key={pos}
-                      className="chordsketch-capo__tick-label"
-                      style={{ left: `${((pos - min) / range) * 100}%` }}
-                    >
-                      {pos}
-                    </span>
-                  ))}
-              </div>
-              {markers.length > 0 ? (
-                <div className="chordsketch-capo__markers" aria-hidden="true">
-                  {markers.map((pos) => (
-                    <span
-                      key={pos}
-                      className="chordsketch-capo__marker"
-                      style={{ left: `${((pos - min) / range) * 100}%` }}
-                      data-best-capo={pos}
-                    >
-                      ★
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-            </>
-          ) : null}
-        </div>
-        <button
-          type="button"
-          className="chordsketch-capo__btn chordsketch-capo__btn--increment"
-          onClick={handleIncrement}
-          disabled={incrementDisabled}
-          aria-label={step === 1 ? 'Capo up one fret' : `Capo up ${step} frets`}
-        >
-          +
-        </button>
-      </div>
+      {label !== null ? (
+        <span className="chordsketch-capo__label" aria-hidden="true">
+          {label}
+        </span>
+      ) : null}
+      <select
+        className="chordsketch-capo__select"
+        value={displayValue}
+        onChange={handleSelectChange}
+        aria-label={ariaLabel}
+        aria-describedby={markerDescriptionId}
+      >
+        {options.map((pos) => (
+          <option key={pos} value={pos} data-best-capo={markerSet.has(pos) ? pos : undefined}>
+            {formatValue(pos)}
+            {markerSet.has(pos) ? ' ★' : ''}
+          </option>
+        ))}
+      </select>
       {markerDescriptionId ? (
         <span id={markerDescriptionId} className="chordsketch-capo__sr-only">
           ★ marks the easiest capo position{markers.length === 1 ? '' : 's'} —
@@ -394,12 +328,10 @@ export function Capo(props: CapoProps): JSX.Element {
           failure so the user sees that the ★ markers are
           unavailable instead of a silent absence. `role="status"`
           + `aria-live="polite"` so screen readers announce it
-          without interrupting the user. Visually rendered as
-          subtle text alongside the slider. The error is not
-          rendered in controlled mode (the host owns AST parsing
-          and supplies `bestPositions` directly), nor while the
-          parse is in flight (loading spinners belong to the host).
-       */}
+          without interrupting the user. The error is not rendered
+          in controlled mode (the host owns AST parsing and supplies
+          `bestPositions` directly), nor while the parse is in
+          flight (loading spinners belong to the host). */}
       {sourceMode && sourceAstError && !sourceAstLoading ? (
         <span
           className="chordsketch-capo__hint chordsketch-capo__hint--error"

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -32,7 +32,7 @@ export interface PreviewToolbarProps
   /**
    * Minimum transpose offset. Defaults to
    * {@link TRANSPOSE_DEFAULT_MIN} (`-6`) — the same default the
-   * standalone `<Transpose>` slider uses. Hosts that need the
+   * standalone `<Transpose>` select uses. Hosts that need the
    * wider feature range (`±11`) pass it explicitly.
    */
   transposeMin?: number;
@@ -195,7 +195,7 @@ export function PreviewToolbar({
           label="Capo"
           /* Thread the active transpose offset through so the
              ★ best-capo markers shift with the host's
-             `<Transpose>` slider — best-capo recommendations
+             `<Transpose>` select — best-capo recommendations
              are computed against the *transposed* chord roots. */
           transpose={transpose}
         />

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -149,366 +149,80 @@
 }
 
 /* ------------------------------------------------------------------
- * Slider (Transpose / Capo).
+ * Transpose / Capo select.
  *
- * The visual contract is the design-system Slider component (see
- * `design-system/preview/components-forms.html`): a 4px ink-200
- * track with crimson thumb, `−` / `+` step buttons on either
- * side, tick marks at every step position, numeric labels under
- * the major ticks, and a monospace value readout on the right.
- * Both Capo and Transpose share the same vertical layout so they
- * sit on the same horizontal baseline in the toolbar.
+ * The visual contract is the design-system select (see
+ * `design-system/preview/components-forms.html`) and the
+ * playground's `.chordsketch-app__select` header select: a white
+ * surface with a `--cs-border-strong` hairline, `--cs-r-2` corners,
+ * and an inline chevrons-up-down caret. Each control renders a
+ * label followed by a native `<select>` on one row so Transpose
+ * and Capo sit on the same baseline in the toolbar.
  *
  * Class names stay component-scoped (`chordsketch-*`) so a host
- * that already uses `<input type="range">` elsewhere is not
- * affected. Hosts shipping `design-system/tokens.css` pick up
- * the same paint via the `--cs-*` aliases above.
+ * that already uses a `<select>` elsewhere is not affected. Hosts
+ * shipping `design-system/tokens.css` pick up the same paint via
+ * the `--cs-*` aliases above.
  * ------------------------------------------------------------------ */
 
-/* Outer wrapper (group). Two-row layout: the top row carries the
- * label and the live value readout, the bottom row carries the
- * `−` / slider / `+` controls plus tick labels. The two-row shape
- * gives the slider track full horizontal width without crowding
- * the label or the readout. Both Capo and Transpose use the same
- * structure so they sit on identical baselines in the toolbar. */
 .chordsketch-transpose,
 .chordsketch-capo {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: var(--cs-sp-1, 0.25rem);
-  /* Stretch to fill the parent's column. The slider's tick rail
-   * has a sensible minimum (`.__slider-wrap` carries its own
-   * min-width) so the host can park the control in tight
-   * spaces without exploding the label row. */
-  flex: 1 1 auto;
-  width: 100%;
-  /* Tick labels live inside `__slider-wrap`'s own
-   * `padding-bottom`, so the outer wrapper does not need to
-   * reserve additional space. (The earlier 18px allocation
-   * here double-padded the box and stretched the toolbar
-   * vertically.) */
-  font-family: var(--cs-font-jp, inherit);
-  color: var(--cs-text-primary, inherit);
-  line-height: 1;
-}
-
-/* Top row: label on the left, readout on the right. Width is set
- * to 100% so the `justify-content: space-between` actually has
- * room to push the readout to the right edge of the slider's
- * available column. */
-.chordsketch-transpose__header,
-.chordsketch-capo__header {
-  display: flex;
-  width: 100%;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--cs-sp-3, 0.75rem);
-}
-
-/* Bottom row: `−` button, slider track wrap, `+` button. Width
- * pinned to the parent column so the wrap inside can flex to
- * fill the available horizontal space (otherwise the controls
- * row settles on the wrap's own min-width). */
-.chordsketch-transpose__controls,
-.chordsketch-capo__controls {
-  display: flex;
-  width: 100%;
+  display: inline-flex;
   align-items: center;
   gap: var(--cs-sp-2, 0.5rem);
+  font-family: var(--cs-font-latin, inherit);
+  font-weight: 600;
+  font-size: var(--cs-fs-12, 0.75rem);
+  letter-spacing: 0;
+  color: var(--cs-text-secondary, currentColor);
+  line-height: 1;
 }
 
 .chordsketch-transpose__label,
 .chordsketch-capo__label {
+  flex-shrink: 0;
+}
+
+.chordsketch-transpose__select,
+.chordsketch-capo__select {
+  height: 28px;
+  padding: 0 1.75rem 0 0.75rem;
+  background-color: var(--cs-surface, #FFFFFF);
+  background-image: url(
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>"
+  );
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  color: var(--cs-text-primary, inherit);
+  border: 1px solid var(--cs-border-strong, #D4D1D6);
+  border-radius: 4px;
   font-family: var(--cs-font-jp, inherit);
   font-weight: 500;
   font-size: var(--cs-fs-13, 0.8125rem);
-  color: var(--cs-text-secondary, currentColor);
-}
-
-/* `−` / `+` step buttons. */
-.chordsketch-transpose__btn,
-.chordsketch-capo__btn {
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  background: var(--cs-surface, #FFFFFF);
-  border: 1px solid var(--cs-border-strong, #D4D1D6);
-  border-radius: var(--cs-r-2, 4px);
-  color: var(--cs-text-primary, inherit);
-  font-family: var(--cs-font-latin, inherit);
-  font-weight: 600;
-  font-size: var(--cs-fs-14, 0.875rem);
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    background var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out),
-    border-color var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out);
-}
-.chordsketch-transpose__btn:hover:not(:disabled),
-.chordsketch-capo__btn:hover:not(:disabled) {
-  background: var(--cs-surface-hover, #F6F4F7);
-  border-color: var(--cs-text-secondary, #67646D);
-}
-.chordsketch-transpose__btn:focus-visible,
-.chordsketch-capo__btn:focus-visible {
-  outline: none;
-  box-shadow: var(--cs-focus-ring, 0 0 0 2px #FFFFFF, 0 0 0 4px #BD1642);
-}
-.chordsketch-transpose__btn:disabled,
-.chordsketch-capo__btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.4;
-}
-
-.chordsketch-transpose__value,
-.chordsketch-capo__value {
-  min-width: 3ch;
-  text-align: right;
-  font-family: var(--cs-font-mono, ui-monospace, monospace);
-  font-size: var(--cs-fs-13, 0.8125rem);
-  font-weight: 600;
-  color: var(--cs-text-primary, inherit);
   font-variant-numeric: tabular-nums;
-}
-
-/* Slider-track wrapper. Holds the input + ticks + labels (+ ★ on
- * Capo). Position context for every absolute child. Inside the
- * `__controls` row the wrap takes the remaining horizontal space
- * between the two step buttons. */
-.chordsketch-transpose__slider-wrap,
-.chordsketch-capo__slider-wrap {
-  position: relative;
-  flex: 1 1 auto;
-  /* The labelled tick rail has 13 numerals across the track
-   * (Transpose ±6 → −6..+6; Capo → 0..12). Each two-digit label
-   * needs ~16px to avoid colliding with its neighbours, so the
-   * slider wrap needs to stretch to at least 12rem (~192px). */
-  min-width: 12rem;
-  /* The wrap holds three layers stacked over a 24px slider track:
-   *   - tick lines (small): rendered on the track itself
-   *   - ★ best-capo markers: sit ~10px above the track
-   *   - numeric tick labels: sit ~14px below the track
-   * Reserve space for all three so the wrap's bounding box
-   * matches what the user actually sees. Without this padding,
-   * `overflow: hidden` from a host would visibly clip the
-   * labels and ★ above/below the track. */
-  padding-top: 14px;
-  padding-bottom: 16px;
-}
-.chordsketch-transpose__slider-wrap > .chordsketch-transpose__slider,
-.chordsketch-capo__slider-wrap > .chordsketch-capo__slider {
-  display: block;
-}
-
-.chordsketch-transpose__slider,
-.chordsketch-capo__slider {
+  letter-spacing: 0;
+  appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  appearance: none;
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  height: 24px;
-  background: transparent;
-  margin: 0;
   cursor: pointer;
+  transition: background-color var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out),
+    border-color var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out),
+    box-shadow var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out);
 }
-.chordsketch-transpose__slider:focus,
-.chordsketch-capo__slider:focus {
+.chordsketch-transpose__select:hover:not(:disabled),
+.chordsketch-capo__select:hover:not(:disabled) {
+  border-color: var(--cs-text-secondary, #67646D);
+}
+.chordsketch-transpose__select:focus-visible,
+.chordsketch-capo__select:focus-visible {
   outline: none;
+  border-color: var(--cs-crimson-500, #BD1642);
+  box-shadow: var(--cs-focus-ring, 0 0 0 2px #FFFFFF, 0 0 0 4px #BD1642);
 }
-
-/* Track — vendor pseudos must be in separate selectors. */
-.chordsketch-transpose__slider::-webkit-slider-runnable-track,
-.chordsketch-capo__slider::-webkit-slider-runnable-track {
-  height: 4px;
-  background: var(--cs-ink-200, #E8E6EA);
-  border-radius: var(--cs-r-full, 9999px);
-}
-.chordsketch-transpose__slider::-moz-range-track,
-.chordsketch-capo__slider::-moz-range-track {
-  height: 4px;
-  background: var(--cs-ink-200, #E8E6EA);
-  border-radius: var(--cs-r-full, 9999px);
-}
-
-/* Thumb. The thumb's outer box is exactly 16×16px so the
- * `inset: 0 8px` on the tick rail (= thumb half-width) keeps
- * ticks, labels, and ★ markers perfectly aligned with the
- * thumb at every value. The white inner ring is painted with
- * `box-shadow: inset` instead of a CSS `border` (which would
- * grow the outer box to 20×20 under the default content-box
- * sizing and break the alignment).
- *
- * Margin-top centres the 16px thumb on the 4px track:
- * (4 − 16) / 2 = −6px. */
-.chordsketch-transpose__slider::-webkit-slider-thumb,
-.chordsketch-capo__slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  box-sizing: border-box;
-  width: 16px;
-  height: 16px;
-  border: 0;
-  border-radius: var(--cs-r-full, 9999px);
-  background: var(--cs-crimson-500, #BD1642);
-  box-shadow:
-    inset 0 0 0 2px var(--cs-ink-0, #FFFFFF),
-    var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
-  margin-top: -6px;
-  transition:
-    background var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out),
-    transform var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out);
-}
-.chordsketch-transpose__slider::-moz-range-thumb,
-.chordsketch-capo__slider::-moz-range-thumb {
-  box-sizing: border-box;
-  width: 16px;
-  height: 16px;
-  border: 0;
-  border-radius: var(--cs-r-full, 9999px);
-  background: var(--cs-crimson-500, #BD1642);
-  box-shadow:
-    inset 0 0 0 2px var(--cs-ink-0, #FFFFFF),
-    var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
-  transition:
-    background var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out),
-    transform var(--cs-dur-1, 120ms) var(--cs-ease-out, ease-out);
-}
-.chordsketch-transpose__slider:hover::-webkit-slider-thumb,
-.chordsketch-capo__slider:hover::-webkit-slider-thumb {
-  background: var(--cs-crimson-600, #A30F37);
-}
-.chordsketch-transpose__slider:hover::-moz-range-thumb,
-.chordsketch-capo__slider:hover::-moz-range-thumb {
-  background: var(--cs-crimson-600, #A30F37);
-}
-.chordsketch-transpose__slider:active::-webkit-slider-thumb,
-.chordsketch-capo__slider:active::-webkit-slider-thumb {
-  transform: scale(1.08);
-}
-.chordsketch-transpose__slider:active::-moz-range-thumb,
-.chordsketch-capo__slider:active::-moz-range-thumb {
-  transform: scale(1.08);
-}
-.chordsketch-transpose__slider:focus-visible::-webkit-slider-thumb,
-.chordsketch-capo__slider:focus-visible::-webkit-slider-thumb {
-  box-shadow:
-    inset 0 0 0 2px var(--cs-ink-0, #FFFFFF),
-    var(--cs-focus-ring, 0 0 0 2px #FFFFFF, 0 0 0 4px #BD1642);
-}
-.chordsketch-transpose__slider:focus-visible::-moz-range-thumb,
-.chordsketch-capo__slider:focus-visible::-moz-range-thumb {
-  box-shadow:
-    inset 0 0 0 2px var(--cs-ink-0, #FFFFFF),
-    var(--cs-focus-ring, 0 0 0 2px #FFFFFF, 0 0 0 4px #BD1642);
-}
-.chordsketch-transpose__slider:disabled,
-.chordsketch-capo__slider:disabled {
+.chordsketch-transpose__select:disabled,
+.chordsketch-capo__select:disabled {
   cursor: not-allowed;
   opacity: 0.5;
-}
-
-/* Tick rail — short vertical bars centered on the 4px track at
- * every step position. The wrap is 24px so the rail sits at
- * 50% (= the track centre line). Z-index 0 so the thumb (z-index
- * 1) sits above.
- *
- * `inset: 0 8px`: the native range-input thumb is 16px wide so
- * its centre travels between `min + 8px` (left bound) and
- * `max − 8px` (right bound) inside the track. Inset the tick
- * rail by the thumb half-width so `left: 0%` lines up with the
- * thumb at `min` and `left: 100%` lines up with the thumb at
- * `max`. Without this every tick is offset 8px outward from the
- * matching thumb position. */
-.chordsketch-transpose__ticks,
-.chordsketch-capo__ticks {
-  position: absolute;
-  inset: 0 8px;
-  pointer-events: none;
-  z-index: 0;
-}
-.chordsketch-transpose__tick,
-.chordsketch-capo__tick {
-  position: absolute;
-  /* `top: 14px + 12px = 26px`: 14px padding-top + 12px (= slider
-   * vertical centre, half of the 24px hit area). Anchor in pixels
-   * rather than `50%` because the wrap's padding-box is now
-   * asymmetric (14px top, 16px bottom) and `50%` would land below
-   * the slider's centre line. */
-  top: 26px;
-  width: 1px;
-  height: 6px;
-  transform: translate(-50%, -50%);
-  background: var(--cs-ink-300, #D4D1D6);
-  border-radius: var(--cs-r-full, 9999px);
-}
-.chordsketch-transpose__tick--major,
-.chordsketch-capo__tick--major {
-  height: 10px;
-  background: var(--cs-ink-500, #8A8790);
-}
-
-/* Numeric tick labels — small monospace numerals positioned just
- * under the slider track. Same `left/right: 8px` inset as the
- * tick rail so labels align with their tick marks (and the thumb
- * at the matching value).
- *
- * `top`: place the labels just below the slider track's bottom
- * edge so they fit inside the wrap's 14+24+16 = 54px box without
- * clipping. 14px padding-top + 24px slider + 2px gap = 40px. */
-.chordsketch-transpose__tick-labels,
-.chordsketch-capo__tick-labels {
-  position: absolute;
-  top: 40px;
-  left: 8px;
-  right: 8px;
-  height: 14px;
-  pointer-events: none;
-  font-family: var(--cs-font-mono, ui-monospace, monospace);
-  /* 9px — every step carries a label (Transpose 13, Capo 13);
-   * pair the tight scale with the 12rem-min slider track so the
-   * 2-character (`-6` / `12`) endpoints clear their neighbours. */
-  font-size: 0.5625rem;
-  line-height: 1;
-  letter-spacing: -0.02em;
-  color: var(--cs-text-tertiary, #8A8790);
-  font-variant-numeric: tabular-nums;
-}
-.chordsketch-transpose__tick-label,
-.chordsketch-capo__tick-label {
-  position: absolute;
-  transform: translateX(-50%);
-}
-
-/* Capo-only: ★ best-position markers, above the track. Same
- * thumb half-width inset as the tick rail so each ★ sits
- * directly over the slider's thumb when the value matches. */
-.chordsketch-capo__markers {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 8px;
-  right: 8px;
-  pointer-events: none;
-  z-index: 2;
-}
-.chordsketch-capo__marker {
-  position: absolute;
-  /* Sit ★ just above the slider track. 14px padding-top
-   * accommodates the marker's ~12px glyph plus 2px breathing
-   * room. */
-  top: 0;
-  transform: translateX(-50%);
-  font-size: var(--cs-fs-12, 0.75rem);
-  line-height: 1;
-  color: var(--cs-crimson-500, #BD1642);
-  opacity: 0.95;
 }
 
 .chordsketch-capo__sr-only {
@@ -548,8 +262,9 @@
  */
 .chordsketch-preview-toolbar {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--cs-sp-3, 0.75rem);
   padding: var(--cs-sp-3, 0.75rem) var(--cs-sp-4, 1rem);
 }
@@ -560,16 +275,6 @@
   gap: var(--cs-sp-2, 0.5rem);
 }
 
-/* The Transpose and Capo groups stack vertically inside the
- * toolbar so each slider can spread to the full toolbar width
- * and give its 13 tick labels the maximum horizontal room.
- * The Export group (when present) stays shrink-to-fit on the
- * right via its own toolbar layout. */
-.chordsketch-preview-toolbar__group--transpose,
-.chordsketch-preview-toolbar__group--capo {
-  width: 100%;
-}
-
 .chordsketch-preview-toolbar__label {
   font-size: 0.85em;
   opacity: 0.7;
@@ -578,8 +283,9 @@
 /* Diagrams group label matches the ChordPro editor's control-label
  * pattern (#2572) so the toolbar's font weight + colour stay on the
  * same axis as the design-system form controls — the `__label`
- * default above only covers the legacy slider groups (Transpose /
- * Capo), which paint their own group typography. */
+ * default above only covers the Transpose / Capo select groups,
+ * which paint their own label typography via the
+ * `.chordsketch-transpose` / `.chordsketch-capo` wrapper rule. */
 .chordsketch-preview-toolbar__group--diagrams
   .chordsketch-preview-toolbar__label {
   font-family: var(--cs-font-latin);
@@ -600,15 +306,15 @@
  * `.select` rule) or the existing `<ChordProEditor>` /
  * `<IrealBarGrid>` selects. */
 .chordsketch-preview-toolbar__diagrams-orientation {
-  height: 32px;
+  height: 28px;
   padding: 0 1.75rem 0 0.75rem;
   background-color: var(--cs-surface);
-  /* Single-source inline caret so the select doesn't fall back to
-   * the platform-native arrow that would not honour the design
-   * tokens. The 24×24 viewBox + currentColor stroke matches the
-   * `<PdfExport>` icon weight visually. */
+  /* Single-source inline chevrons-up-down caret so the select doesn't
+   * fall back to the platform-native arrow that would not honour the
+   * design tokens. Mirrors the editor / preview selects and the
+   * playground's `.chordsketch-app__select`. */
   background-image: url(
-    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238A8790' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>"
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>"
   );
   background-repeat: no-repeat;
   background-position: right 0.5rem center;
@@ -623,12 +329,13 @@
   -webkit-appearance: none;
   -moz-appearance: none;
   cursor: pointer;
-  transition: border-color var(--cs-dur-1) var(--cs-ease-out),
+  transition: background-color var(--cs-dur-1) var(--cs-ease-out),
+    border-color var(--cs-dur-1) var(--cs-ease-out),
     box-shadow var(--cs-dur-1) var(--cs-ease-out);
 }
 
 .chordsketch-preview-toolbar__diagrams-orientation:hover {
-  border-color: var(--cs-ink-500);
+  border-color: var(--cs-text-secondary);
 }
 
 .chordsketch-preview-toolbar__diagrams-orientation:focus-visible {
@@ -2231,9 +1938,17 @@
 }
 
 .chordsketch-chord-pro-editor__select {
-  height: 32px;
-  padding: 0 0.75rem;
-  background: var(--cs-surface);
+  height: 28px;
+  padding: 0 1.75rem 0 0.75rem;
+  background-color: var(--cs-surface);
+  /* Inline chevrons-up-down caret (lucide), stroke `--cs-text-secondary`,
+   * matching the playground's `.chordsketch-app__select` header select.
+   * Same inline-SVG technique as the diagrams-orientation select. */
+  background-image: url(
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>"
+  );
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
   color: var(--cs-text-primary);
   border: 1px solid var(--cs-border-strong);
   border-radius: 4px;
@@ -2242,12 +1957,17 @@
   font-size: 0.8125rem;
   letter-spacing: 0;
   text-transform: none;
-  transition: border-color var(--cs-dur-1) var(--cs-ease-out),
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  cursor: pointer;
+  transition: background-color var(--cs-dur-1) var(--cs-ease-out),
+    border-color var(--cs-dur-1) var(--cs-ease-out),
     box-shadow var(--cs-dur-1) var(--cs-ease-out);
 }
 
 .chordsketch-chord-pro-editor__select:hover {
-  border-color: var(--cs-ink-500);
+  border-color: var(--cs-text-secondary);
 }
 
 .chordsketch-chord-pro-editor__select:focus-visible {
@@ -2265,43 +1985,6 @@
   font-size: 0.75rem;
   letter-spacing: 0;
   color: var(--cs-text-secondary);
-}
-
-.chordsketch-chord-pro-editor__transpose .chordsketch-transpose__button {
-  height: 32px;
-  min-width: 32px;
-  padding: 0 0.75rem;
-  background: var(--cs-surface);
-  color: var(--cs-text-primary);
-  border: 1px solid var(--cs-border-strong);
-  border-radius: 4px;
-  font-family: var(--cs-font-jp);
-  font-weight: 500;
-  font-size: 0.875rem;
-  letter-spacing: 0;
-  text-transform: none;
-  line-height: 1;
-  transition: background var(--cs-dur-1) var(--cs-ease-out),
-    border-color var(--cs-dur-1) var(--cs-ease-out);
-}
-
-.chordsketch-chord-pro-editor__transpose .chordsketch-transpose__button:hover {
-  background: var(--cs-surface-hover);
-  border-color: var(--cs-ink-500);
-}
-
-.chordsketch-chord-pro-editor__transpose .chordsketch-transpose__button:focus-visible {
-  outline: none;
-  border-color: var(--cs-crimson-500);
-  box-shadow: var(--cs-focus-ring);
-}
-
-.chordsketch-chord-pro-editor__transpose .chordsketch-transpose__value {
-  font-family: var(--cs-font-mono);
-  font-feature-settings: "tnum" 1;
-  letter-spacing: 0;
-  text-transform: none;
-  color: var(--cs-text-primary);
 }
 
 .chordsketch-chord-pro-editor__split {
@@ -2370,9 +2053,15 @@
 }
 
 .chordsketch-chord-pro-preview__select {
-  height: 32px;
-  padding: 0 0.75rem;
-  background: var(--cs-surface);
+  height: 28px;
+  padding: 0 1.75rem 0 0.75rem;
+  background-color: var(--cs-surface);
+  /* Inline chevrons-up-down caret — see the editor select above. */
+  background-image: url(
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>"
+  );
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
   color: var(--cs-text-primary);
   border: 1px solid var(--cs-border-strong);
   border-radius: 4px;
@@ -2381,12 +2070,17 @@
   font-size: 0.8125rem;
   letter-spacing: 0;
   text-transform: none;
-  transition: border-color var(--cs-dur-1) var(--cs-ease-out),
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  cursor: pointer;
+  transition: background-color var(--cs-dur-1) var(--cs-ease-out),
+    border-color var(--cs-dur-1) var(--cs-ease-out),
     box-shadow var(--cs-dur-1) var(--cs-ease-out);
 }
 
 .chordsketch-chord-pro-preview__select:hover {
-  border-color: var(--cs-ink-500);
+  border-color: var(--cs-text-secondary);
 }
 
 .chordsketch-chord-pro-preview__select:focus-visible {
@@ -2404,43 +2098,6 @@
   font-size: 0.75rem;
   letter-spacing: 0;
   color: var(--cs-text-secondary);
-}
-
-.chordsketch-chord-pro-preview__transpose .chordsketch-transpose__button {
-  height: 32px;
-  min-width: 32px;
-  padding: 0 0.75rem;
-  background: var(--cs-surface);
-  color: var(--cs-text-primary);
-  border: 1px solid var(--cs-border-strong);
-  border-radius: 4px;
-  font-family: var(--cs-font-jp);
-  font-weight: 500;
-  font-size: 0.875rem;
-  letter-spacing: 0;
-  text-transform: none;
-  line-height: 1;
-  transition: background var(--cs-dur-1) var(--cs-ease-out),
-    border-color var(--cs-dur-1) var(--cs-ease-out);
-}
-
-.chordsketch-chord-pro-preview__transpose .chordsketch-transpose__button:hover {
-  background: var(--cs-surface-hover);
-  border-color: var(--cs-ink-500);
-}
-
-.chordsketch-chord-pro-preview__transpose .chordsketch-transpose__button:focus-visible {
-  outline: none;
-  border-color: var(--cs-crimson-500);
-  box-shadow: var(--cs-focus-ring);
-}
-
-.chordsketch-chord-pro-preview__transpose .chordsketch-transpose__value {
-  font-family: var(--cs-font-mono);
-  font-feature-settings: "tnum" 1;
-  letter-spacing: 0;
-  text-transform: none;
-  color: var(--cs-text-primary);
 }
 
 .chordsketch-chord-pro-preview__body {
@@ -2543,11 +2200,37 @@
 .chordsketch-ireal-bar-grid__field select {
   height: 32px;
   padding: 0 0.5rem;
-  background: var(--cs-surface, #ffffff);
+  background-color: var(--cs-surface, #ffffff);
   border: 1px solid var(--cs-border-strong, #d4d1d6);
   border-radius: 4px;
   color: inherit;
   font: inherit;
+  transition: background-color var(--cs-dur-1) var(--cs-ease-out),
+    border-color var(--cs-dur-1) var(--cs-ease-out),
+    box-shadow var(--cs-dur-1) var(--cs-ease-out);
+}
+
+/* Select-only chrome: the chevrons-up-down caret + `appearance` reset
+ * + right padding belong on the `<select>` alone — the text / number
+ * inputs that share the base rule above must keep their native
+ * affordances (no dropdown arrow, no reset of the number spinners). */
+.chordsketch-ireal-bar-grid__field select {
+  padding: 0 1.75rem 0 0.5rem;
+  /* Inline chevrons-up-down caret — mirrors the ChordPro selects and
+   * the playground's `.chordsketch-app__select`. */
+  background-image: url(
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>"
+  );
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  cursor: pointer;
+}
+
+.chordsketch-ireal-bar-grid__field select:hover:not(:disabled) {
+  border-color: var(--cs-text-secondary, #67646d);
 }
 
 .chordsketch-ireal-bar-grid__field input:focus-visible,
@@ -2559,7 +2242,7 @@
 
 .chordsketch-ireal-bar-grid__field input:disabled,
 .chordsketch-ireal-bar-grid__field select:disabled {
-  background: var(--cs-canvas, #fafaf7);
+  background-color: var(--cs-canvas, #fafaf7);
   color: var(--cs-text-secondary, #67646d);
   cursor: not-allowed;
 }

--- a/packages/react/src/transpose.tsx
+++ b/packages/react/src/transpose.tsx
@@ -4,48 +4,58 @@ import { useCallback, useMemo } from 'react';
 import { clamp as clampValue } from './clamp';
 
 /**
- * Default minimum the `<Transpose>` slider exposes when the host
+ * Default minimum the `<Transpose>` select exposes when the host
  * does not pass `min` explicitly. The `TRANSPOSE_MIN` /
  * `TRANSPOSE_MAX` constants in `chord-source-edit.ts` are the
- * absolute feature limits (`±11`); the slider's default render
+ * absolute feature limits (`±11`); the select's default option
  * range is the narrower `±6` per #2560, since wider transposition
- * is rarely useful in practice and the narrower scale is easier
- * to read on a slider.
+ * is rarely useful in practice.
  */
 export const TRANSPOSE_DEFAULT_MIN = -6;
-/** Default maximum the `<Transpose>` slider exposes. See {@link TRANSPOSE_DEFAULT_MIN}. */
+/** Default maximum the `<Transpose>` select exposes. See {@link TRANSPOSE_DEFAULT_MIN}. */
 export const TRANSPOSE_DEFAULT_MAX = 6;
 
 /** Props accepted by {@link Transpose}. */
 export interface TransposeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /** Current semitone offset (controlled mode). */
   value: number;
-  /** Fired when the slider's input value changes. */
+  /** Fired when the select value changes. */
   onChange: (next: number) => void;
   /**
-   * Minimum offset the slider will emit. Defaults to
+   * Minimum offset the select will emit. Defaults to
    * {@link TRANSPOSE_DEFAULT_MIN} (`-6`). Pass an explicit value
    * (down to the `TRANSPOSE_MIN` floor of `-11`) to widen the
    * range.
    */
   min?: number;
   /**
-   * Maximum offset the slider will emit. Defaults to
+   * Maximum offset the select will emit. Defaults to
    * {@link TRANSPOSE_DEFAULT_MAX} (`+6`). Pass an explicit value
    * (up to the `TRANSPOSE_MAX` ceiling of `+11`) to widen the
    * range.
    */
   max?: number;
-  /** Step size for the slider. Defaults to `1`. */
+  /**
+   * Step between adjacent options. Defaults to `1`. A controlled
+   * `value` that does not land on the option grid snaps to the
+   * nearest rendered option, so a non-dividing `step` never leaves
+   * the select showing an unselectable value. A non-positive `step`
+   * (or `max < min`) produces an empty, inert select.
+   */
   step?: number;
   /**
-   * Optional label shown inline with the slider. Defaults to
+   * Optional label shown inline before the select. Defaults to
    * `"Transpose"`. Pass `null` to omit the visible label; the
-   * component still exposes `aria-label` on the wrapper.
+   * select still carries an `aria-label`.
    */
   label?: React.ReactNode;
-  /** Format the semitone indicator. Defaults to signed integer. */
-  formatValue?: (value: number) => React.ReactNode;
+  /**
+   * Format an option's semitone value. Defaults to signed integer.
+   * The result is rendered as the `<option>`'s text content, so the
+   * return type is `string | number` — elements do not render
+   * inside `<option>`.
+   */
+  formatValue?: (value: number) => string | number;
 }
 
 function defaultFormat(value: number): string {
@@ -54,12 +64,12 @@ function defaultFormat(value: number): string {
 }
 
 /**
- * Accessible transposition control: a native `<input type="range">`
- * slider flanked by `−` / `+` step buttons, tick marks at every
- * step position, numeric labels under the major ticks, and a
- * signed current-value readout. Keyboard support comes from the
- * native range input (Arrow keys, Home / End, PageUp / PageDown)
- * plus the `−` / `+` buttons.
+ * Accessible transposition control: a native `<select>` listing
+ * every semitone offset between `min` and `max`, styled as the
+ * design-system select (white surface, hairline border, inline
+ * chevrons-up-down caret) to match the playground's
+ * `.chordsketch-app__select`. Keyboard and screen-reader support
+ * come from the native select.
  *
  * The component is **controlled** — pass `value` and `onChange`.
  * Wire up `useTranspose()` next to it if you want the internal
@@ -86,41 +96,39 @@ export function Transpose({
     [min, max],
   );
 
-  // Clamp the host-supplied `value` for display purposes. The native
-  // range input visually pins the thumb to the bound when `value`
-  // is out of range, but the `<output>` readout would otherwise
-  // surface the raw (unclamped) prop and disagree with the thumb.
-  const displayValue = clamp(value);
+  // Highest offset first so the dropdown reads top-down as
+  // `+6 … 0 … -6` (pitch up at the top, matching the ↕ caret).
+  const options = useMemo(() => {
+    if (step <= 0 || max < min) return [] as number[];
+    const out: number[] = [];
+    for (let p = max; p >= min; p -= step) out.push(p);
+    return out;
+  }, [min, max, step]);
 
-  const handleSliderChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>): void => {
+  // Resolve the host `value` to the nearest rendered option. A
+  // native <select> cannot display a value that has no matching
+  // <option>, so an out-of-range value (clamped here) or an
+  // off-grid value (when `step` does not divide the range) would
+  // otherwise leave the control showing the wrong offset. Snapping
+  // to the nearest option keeps the selection in sync with state.
+  const displayValue = useMemo(() => {
+    const bounded = clamp(value);
+    if (options.length === 0) return bounded;
+    return options.reduce(
+      (best, opt) =>
+        Math.abs(opt - bounded) < Math.abs(best - bounded) ? opt : best,
+      options[0],
+    );
+  }, [value, options, clamp]);
+
+  const handleSelectChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>): void => {
       const parsed = Number.parseInt(event.target.value, 10);
       if (Number.isNaN(parsed)) return;
       onChange(clamp(parsed));
     },
     [onChange, clamp],
   );
-
-  const handleDecrement = useCallback(() => {
-    onChange(clamp(displayValue - step));
-  }, [onChange, clamp, displayValue, step]);
-  const handleIncrement = useCallback(() => {
-    onChange(clamp(displayValue + step));
-  }, [onChange, clamp, displayValue, step]);
-
-  // Tick marks AND numeric labels at every `step` between `min`
-  // and `max` — every grid line is annotated so the user does
-  // not have to interpolate. Marked `major` for the existing
-  // tick-styling pipeline.
-  const range = max - min;
-  const ticks = useMemo(() => {
-    if (range <= 0 || step <= 0) return [] as Array<{ pos: number; major: boolean }>;
-    const out: Array<{ pos: number; major: boolean }> = [];
-    for (let p = min; p <= max; p += step) {
-      out.push({ pos: p, major: true });
-    }
-    return out;
-  }, [min, max, step, range]);
 
   const ariaLabel =
     typeof divProps['aria-label'] === 'string'
@@ -129,9 +137,6 @@ export function Transpose({
         ? label
         : 'Transpose';
 
-  const decrementDisabled = displayValue <= min;
-  const incrementDisabled = displayValue >= max;
-
   return (
     <div
       {...divProps}
@@ -139,84 +144,23 @@ export function Transpose({
       aria-label={ariaLabel}
       className={['chordsketch-transpose', className].filter(Boolean).join(' ')}
     >
-      <div className="chordsketch-transpose__header">
-        {label !== null ? (
-          <span className="chordsketch-transpose__label" aria-hidden="true">
-            {label}
-          </span>
-        ) : (
-          <span />
-        )}
-        <output
-          className="chordsketch-transpose__value"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {formatValue(displayValue)}
-        </output>
-      </div>
-      <div className="chordsketch-transpose__controls">
-        <button
-          type="button"
-          className="chordsketch-transpose__btn chordsketch-transpose__btn--decrement"
-          onClick={handleDecrement}
-          disabled={decrementDisabled}
-          aria-label={step === 1 ? 'Transpose down one semitone' : `Transpose down ${step} semitones`}
-        >
-          −
-        </button>
-        <div className="chordsketch-transpose__slider-wrap">
-          <input
-            type="range"
-            className="chordsketch-transpose__slider"
-            min={min}
-            max={max}
-            step={step}
-            value={displayValue}
-            onChange={handleSliderChange}
-            aria-label={ariaLabel}
-          />
-          {range > 0 ? (
-            <>
-              <div className="chordsketch-transpose__ticks" aria-hidden="true">
-                {ticks.map(({ pos, major }) => (
-                  <span
-                    key={pos}
-                    className={
-                      major
-                        ? 'chordsketch-transpose__tick chordsketch-transpose__tick--major'
-                        : 'chordsketch-transpose__tick'
-                    }
-                    style={{ left: `${((pos - min) / range) * 100}%` }}
-                  />
-                ))}
-              </div>
-              <div className="chordsketch-transpose__tick-labels" aria-hidden="true">
-                {ticks
-                  .filter(({ major }) => major)
-                  .map(({ pos }) => (
-                    <span
-                      key={pos}
-                      className="chordsketch-transpose__tick-label"
-                      style={{ left: `${((pos - min) / range) * 100}%` }}
-                    >
-                      {defaultFormat(pos)}
-                    </span>
-                  ))}
-              </div>
-            </>
-          ) : null}
-        </div>
-        <button
-          type="button"
-          className="chordsketch-transpose__btn chordsketch-transpose__btn--increment"
-          onClick={handleIncrement}
-          disabled={incrementDisabled}
-          aria-label={step === 1 ? 'Transpose up one semitone' : `Transpose up ${step} semitones`}
-        >
-          +
-        </button>
-      </div>
+      {label !== null ? (
+        <span className="chordsketch-transpose__label" aria-hidden="true">
+          {label}
+        </span>
+      ) : null}
+      <select
+        className="chordsketch-transpose__select"
+        value={displayValue}
+        onChange={handleSelectChange}
+        aria-label={ariaLabel}
+      >
+        {options.map((pos) => (
+          <option key={pos} value={pos}>
+            {formatValue(pos)}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }

--- a/packages/react/src/use-chordpro-ast.ts
+++ b/packages/react/src/use-chordpro-ast.ts
@@ -34,8 +34,8 @@ export interface ChordproParseOptions {
    * (`-128..=127`); values outside that range are rejected at
    * deserialisation time and surface as a parse error on the
    * hook's `error` state. Callers driving the value through the
-   * `<Transpose>` slider stay well inside the range because the
-   * slider clamps via its `min` / `max` props.
+   * `<Transpose>` select stay well inside the range because the
+   * select only offers options bounded by its `min` / `max` props.
    */
   transpose?: number;
   /**

--- a/packages/react/tests/capo.test.tsx
+++ b/packages/react/tests/capo.test.tsx
@@ -212,14 +212,16 @@ describe('<Capo>', () => {
     expect(opt5?.textContent).toBe('Fret 5 ★');
   });
 
-  test('changing the select to a programmatic out-of-range value clamps the emitted value', () => {
-    // A test driver (or unusual browser automation) may fire a change
-    // event with a value outside [min, max]. `emit` still applies
-    // `clamp` before forwarding, so `onChange` always receives a
-    // value within bounds.
+  test('a programmatic out-of-range select change is coerced away and does not emit', () => {
+    // A native <select> can only hold one of its rendered option
+    // values. Firing a change with a value outside [min, max] (a test
+    // driver / unusual automation) makes the browser — and jsdom —
+    // reset the value to '' (selectedIndex -1), which the change
+    // handler parses as NaN and ignores. The option set is the
+    // boundary, so onChange never receives an out-of-range value.
     const onChange = vi.fn();
     render(<Capo value={0} onChange={onChange} min={0} max={5} />);
     fireEvent.change(getSelect(), { target: { value: '9' } });
-    expect(onChange).toHaveBeenLastCalledWith(5);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/tests/capo.test.tsx
+++ b/packages/react/tests/capo.test.tsx
@@ -4,33 +4,33 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { Capo } from '../src/index';
 
-function getSlider(): HTMLInputElement {
-  return screen.getByRole('slider', { name: 'Capo' }) as HTMLInputElement;
+function getSelect(): HTMLSelectElement {
+  return screen.getByRole('combobox', { name: 'Capo' }) as HTMLSelectElement;
+}
+
+function bestCapoOptionValues(): string[] {
+  return Array.from(document.querySelectorAll('option[data-best-capo]')).map((o) =>
+    o.getAttribute('data-best-capo') ?? '',
+  );
 }
 
 describe('<Capo>', () => {
-  test('renders the controlled value as a range slider', () => {
+  test('renders the controlled value as a select with 0..12 options', () => {
     render(<Capo value={3} onChange={vi.fn()} />);
-    expect(screen.getByRole('group', { name: 'Capo' })).toBeTruthy();
-    const slider = getSlider();
-    expect(slider.type).toBe('range');
-    expect(slider.min).toBe('0');
-    expect(slider.max).toBe('12');
-    expect(slider.value).toBe('3');
+    const select = getSelect();
+    expect(select.value).toBe('3');
+    const options = Array.from(select.options);
+    expect(options).toHaveLength(13); // 12..0 inclusive
+    // Highest fret first: 12 at the top, 0 at the bottom.
+    expect(options[0].value).toBe('12');
+    expect(options[options.length - 1].value).toBe('0');
   });
 
-  test('changing the slider emits the parsed value in controlled mode', () => {
+  test('changing the select emits the parsed value in controlled mode', () => {
     const onChange = vi.fn();
     render(<Capo value={0} onChange={onChange} />);
-    fireEvent.change(getSlider(), { target: { value: '7' } });
+    fireEvent.change(getSelect(), { target: { value: '7' } });
     expect(onChange).toHaveBeenLastCalledWith(7);
-  });
-
-  test('clamps a programmatic value outside min/max to the bound', () => {
-    const onChange = vi.fn();
-    render(<Capo value={0} onChange={onChange} min={0} max={5} />);
-    fireEvent.change(getSlider(), { target: { value: '9' } });
-    expect(onChange).toHaveBeenLastCalledWith(5);
   });
 
   test('source-pair mode reads {capo} from the source string', () => {
@@ -41,10 +41,10 @@ describe('<Capo>', () => {
         onSourceChange={onSourceChange}
       />,
     );
-    expect(getSlider().value).toBe('5');
+    expect(getSelect().value).toBe('5');
   });
 
-  test('source-pair mode rewrites the directive on slider change', () => {
+  test('source-pair mode rewrites the directive on select change', () => {
     function Host(): JSX.Element {
       const [source, setSource] = useState('{title: Demo}\n[C]Hello');
       return (
@@ -56,12 +56,12 @@ describe('<Capo>', () => {
     }
 
     render(<Host />);
-    expect(getSlider().value).toBe('0');
-    fireEvent.change(getSlider(), { target: { value: '1' } });
+    expect(getSelect().value).toBe('0');
+    fireEvent.change(getSelect(), { target: { value: '1' } });
     expect(screen.getByTestId('src').textContent).toBe(
       '{title: Demo}\n{capo: 1}\n[C]Hello',
     );
-    expect(getSlider().value).toBe('1');
+    expect(getSelect().value).toBe('1');
   });
 
   test('source-pair mode fires onCapoChange alongside onSourceChange', () => {
@@ -74,42 +74,44 @@ describe('<Capo>', () => {
         onCapoChange={onCapoChange}
       />,
     );
-    fireEvent.change(getSlider(), { target: { value: '3' } });
+    fireEvent.change(getSelect(), { target: { value: '3' } });
     expect(onSourceChange).toHaveBeenCalledWith(
       '{title: Demo}\n{capo: 3}\n[C]Hello',
     );
     expect(onCapoChange).toHaveBeenLastCalledWith(3);
   });
 
-  test('honours custom min/max bounds', () => {
+  test('honours custom min/max bounds in the option range', () => {
     render(<Capo value={3} onChange={vi.fn()} min={0} max={3} />);
-    const slider = getSlider();
-    expect(slider.min).toBe('0');
-    expect(slider.max).toBe('3');
+    const options = Array.from(getSelect().options);
+    expect(options).toHaveLength(4); // 3..0 inclusive
+    expect(options[0].value).toBe('3');
+    expect(options[options.length - 1].value).toBe('0');
   });
 
-  test('renders ★ markers for each bestPositions entry inside the range', () => {
+  test('flags ★ on each bestPositions option inside the range', () => {
     render(
       <Capo value={0} onChange={vi.fn()} bestPositions={[0, 5, 7, 99]} />,
     );
-    const markers = document.querySelectorAll('.chordsketch-capo__marker');
-    expect(markers.length).toBe(3);
-    const positions = Array.from(markers).map((m) =>
-      m.getAttribute('data-best-capo'),
-    );
-    expect(positions).toEqual(['0', '5', '7']);
+    // Options render highest-first, so the flagged ones appear in
+    // descending DOM order.
+    expect(bestCapoOptionValues()).toEqual(['7', '5', '0']);
+    // The ★ glyph is appended to the flagged option's visible text.
+    const opt5 = Array.from(getSelect().options).find((o) => o.value === '5');
+    expect(opt5?.textContent).toContain('★');
   });
 
-  test('omits the ★ marker block when bestPositions is empty', () => {
+  test('flags no option when bestPositions is empty', () => {
     render(<Capo value={0} onChange={vi.fn()} bestPositions={[]} />);
-    expect(document.querySelector('.chordsketch-capo__markers')).toBeNull();
+    expect(bestCapoOptionValues()).toEqual([]);
+    expect(document.querySelector('.chordsketch-capo__sr-only')).toBeNull();
   });
 
   test('rejects NaN, Infinity, and non-integer entries from bestPositions', () => {
     // NaN slips through `pos < min || pos > max` because every NaN
     // comparison evaluates to false. Without the `Number.isInteger`
-    // guard the marker span would render with `left: NaN%`. Test
-    // the full set of pathological inputs in one shot.
+    // guard a `data-best-capo="NaN"` option would render. Test the
+    // full set of pathological inputs in one shot.
     render(
       <Capo
         value={0}
@@ -117,27 +119,96 @@ describe('<Capo>', () => {
         bestPositions={[Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 3.5, 4]}
       />,
     );
-    const markers = document.querySelectorAll('.chordsketch-capo__marker');
-    expect(markers.length).toBe(1);
-    expect(markers[0]?.getAttribute('data-best-capo')).toBe('4');
+    expect(bestCapoOptionValues()).toEqual(['4']);
   });
 
-  test('exposes the slider value via the visible readout', () => {
-    // The tick rail now labels every step, so a plain `getByText('4')`
-    // would match the tick label as well as the `<output>` readout.
-    // Target the `<output>` element directly.
+  test('reflects the controlled value as the select value', () => {
     render(<Capo value={4} onChange={vi.fn()} />);
-    const out = document.querySelector('.chordsketch-capo__value');
-    expect(out?.textContent).toBe('4');
+    expect(getSelect().value).toBe('4');
   });
 
-  test('clamps an out-of-range value prop in the readout (display path)', () => {
-    // Host passing `value=15` with `max=12`: the native range
-    // input clamps the thumb visually, but the `<output>` would
-    // otherwise display the raw 15 and disagree with the thumb.
-    // Pin the render-time clamp.
+  test('clamps an out-of-range value prop so the selection stays in range', () => {
+    // Host passing `value=15` with `max=12`: the render-time clamp
+    // pins the selection to `12` (no `15` option exists to land on).
     render(<Capo value={15} onChange={vi.fn()} min={0} max={12} />);
-    const out = document.querySelector('.chordsketch-capo__value');
-    expect(out?.textContent).toBe('12');
+    expect(getSelect().value).toBe('12');
+  });
+
+  test('step=2 generates every-other-fret options in descending order', () => {
+    render(<Capo value={0} onChange={vi.fn()} min={0} max={12} step={2} />);
+    const values = Array.from(getSelect().options).map((o) => o.value);
+    expect(values).toEqual(['12', '10', '8', '6', '4', '2', '0']);
+  });
+
+  test('an off-grid value snaps to the nearest rendered option (step=2)', () => {
+    // `value=3` is in range but off the every-2 grid; snap to 2 or 4
+    // rather than silently showing the first option.
+    render(<Capo value={3} onChange={vi.fn()} min={0} max={12} step={2} />);
+    const selected = Number.parseInt(getSelect().value, 10);
+    expect([2, 4]).toContain(selected);
+    const values = Array.from(getSelect().options).map((o) => o.value);
+    expect(values).toContain(getSelect().value);
+  });
+
+  test('an unambiguously-nearest option is selected when value is off-grid (step=3)', () => {
+    // options are 12,9,6,3,0; value=5 is distance 1 from 6 and 2 from
+    // 3 — must snap to 6, not the first option.
+    render(<Capo value={5} onChange={vi.fn()} min={0} max={12} step={3} />);
+    expect(getSelect().value).toBe('6');
+  });
+
+  test('source-pair mode snaps an off-grid {capo} directive to the nearest option', () => {
+    render(
+      <Capo
+        source={'{title: Demo}\n{capo: 3}\n[C]Hello'}
+        onSourceChange={vi.fn()}
+        step={2}
+      />,
+    );
+    const selected = Number.parseInt(getSelect().value, 10);
+    expect([2, 4]).toContain(selected);
+    const values = Array.from(getSelect().options).map((o) => o.value);
+    expect(values).toContain(getSelect().value);
+  });
+
+  test('each flagged option carries data-best-capo equal to its own value', () => {
+    render(<Capo value={0} onChange={vi.fn()} bestPositions={[5, 7]} />);
+    const flagged = Array.from(document.querySelectorAll('option[data-best-capo]'));
+    expect(flagged.length).toBe(2);
+    for (const opt of flagged) {
+      expect(opt.getAttribute('data-best-capo')).toBe(opt.getAttribute('value'));
+    }
+  });
+
+  test('renders no options when max < min', () => {
+    render(<Capo value={0} onChange={vi.fn()} min={12} max={0} />);
+    expect(Array.from(getSelect().options)).toHaveLength(0);
+  });
+
+  test('sr-only description is plural when multiple best positions are flagged', () => {
+    render(<Capo value={0} onChange={vi.fn()} bestPositions={[3, 5]} />);
+    expect(
+      document.querySelector('.chordsketch-capo__sr-only')?.textContent,
+    ).toContain('positions');
+  });
+
+  test('sr-only description is singular when exactly one best position is flagged', () => {
+    render(<Capo value={0} onChange={vi.fn()} bestPositions={[5]} />);
+    const text = document.querySelector('.chordsketch-capo__sr-only')?.textContent ?? '';
+    expect(text).toContain('position');
+    expect(text).not.toContain('positions');
+  });
+
+  test('custom formatValue combines with the ★ suffix on a flagged option', () => {
+    render(
+      <Capo
+        value={0}
+        onChange={vi.fn()}
+        bestPositions={[5]}
+        formatValue={(v) => `Fret ${v}`}
+      />,
+    );
+    const opt5 = Array.from(getSelect().options).find((o) => o.value === '5');
+    expect(opt5?.textContent).toBe('Fret 5 ★');
   });
 });

--- a/packages/react/tests/capo.test.tsx
+++ b/packages/react/tests/capo.test.tsx
@@ -211,4 +211,15 @@ describe('<Capo>', () => {
     const opt5 = Array.from(getSelect().options).find((o) => o.value === '5');
     expect(opt5?.textContent).toBe('Fret 5 ★');
   });
+
+  test('changing the select to a programmatic out-of-range value clamps the emitted value', () => {
+    // A test driver (or unusual browser automation) may fire a change
+    // event with a value outside [min, max]. `emit` still applies
+    // `clamp` before forwarding, so `onChange` always receives a
+    // value within bounds.
+    const onChange = vi.fn();
+    render(<Capo value={0} onChange={onChange} min={0} max={5} />);
+    fireEvent.change(getSelect(), { target: { value: '9' } });
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
 });

--- a/packages/react/tests/chord-pro-preview.test.tsx
+++ b/packages/react/tests/chord-pro-preview.test.tsx
@@ -122,7 +122,7 @@ describe('<ChordProPreview>', () => {
     expect(select.value).toBe('pdf');
   });
 
-  test('uncontrolled transpose: slider changes fire internal updates', () => {
+  test('uncontrolled transpose: select changes fire internal updates', () => {
     render(
       <ChordProPreview
         source="src"
@@ -130,12 +130,12 @@ describe('<ChordProPreview>', () => {
         wasmLoader={makeLoader(makeStub())}
       />,
     );
-    const slider = screen.getByRole('slider', { name: 'Transpose' });
-    fireEvent.change(slider, { target: { value: '1' } });
-    // The Transpose readout displays the current value; the
-    // component should now show +1.
-    const output = screen.getByRole('status');
-    expect(output.textContent).toContain('+1');
+    const select = screen.getByRole('combobox', { name: 'Transpose' }) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '1' } });
+    // The Transpose select reflects the current value; the
+    // component should now show +1 on the selected option.
+    expect(select.value).toBe('1');
+    expect(select.selectedOptions[0]?.textContent).toContain('+1');
   });
 
   test('controlled transpose: host owns state via onTransposeChange', () => {
@@ -155,8 +155,8 @@ describe('<ChordProPreview>', () => {
       );
     }
     render(<Controlled />);
-    const slider = screen.getByRole('slider', { name: 'Transpose' });
-    fireEvent.change(slider, { target: { value: '1' } });
+    const select = screen.getByRole('combobox', { name: 'Transpose' });
+    fireEvent.change(select, { target: { value: '1' } });
     expect(onTransposeChange).toHaveBeenCalledWith(1);
   });
 
@@ -173,7 +173,7 @@ describe('<ChordProPreview>', () => {
     ).toBeTruthy();
   });
 
-  test('transposeMin / transposeMax bound the transpose slider', () => {
+  test('transposeMin / transposeMax bound the transpose select option range', () => {
     function Controlled() {
       const [t, setT] = useState(0);
       return (
@@ -188,14 +188,14 @@ describe('<ChordProPreview>', () => {
       );
     }
     render(<Controlled />);
-    const slider = screen.getByRole('slider', { name: 'Transpose' }) as HTMLInputElement;
-    expect(slider.min).toBe('-3');
-    expect(slider.max).toBe('3');
-    // A programmatic value beyond max clamps to max.
-    fireEvent.change(slider, { target: { value: '9' } });
-    const output = screen.getByRole('status');
-    expect(output.textContent).toContain('+3');
-    expect(slider.value).toBe('3');
+    const select = screen.getByRole('combobox', { name: 'Transpose' }) as HTMLSelectElement;
+    const options = Array.from(select.options);
+    expect(options[0].value).toBe('3');
+    expect(options[options.length - 1].value).toBe('-3');
+    // Selecting the max bound updates the value and the displayed option text.
+    fireEvent.change(select, { target: { value: '3' } });
+    expect(select.value).toBe('3');
+    expect(select.selectedOptions[0]?.textContent).toContain('+3');
   });
 
   test('format outside `formats` falls back to the first allowed format and warns in dev', () => {
@@ -231,8 +231,8 @@ describe('<ChordProPreview>', () => {
 
   test('incoming controlled transpose is clamped against [transposeMin, transposeMax]', () => {
     // Caller passes `transpose=15` but `transposeMax=5` — the
-    // displayed readout and forwarded value must clamp to 5, not
-    // render the out-of-range value.
+    // selected option must clamp to 5, not render the out-of-range
+    // value.
     render(
       <ChordProPreview
         source="src"
@@ -242,8 +242,9 @@ describe('<ChordProPreview>', () => {
         wasmLoader={makeLoader(makeStub())}
       />,
     );
-    const output = screen.getByRole('status');
-    expect(output.textContent).toContain('+5');
+    const select = screen.getByRole('combobox', { name: 'Transpose' }) as HTMLSelectElement;
+    expect(select.value).toBe('5');
+    expect(select.selectedOptions[0]?.textContent).toContain('+5');
   });
 
   test('transposeMin > transposeMax: dev warning fires and bounds are swapped', () => {
@@ -271,13 +272,12 @@ describe('<ChordProPreview>', () => {
       // would render the button disabled at 0 (since 0 >= 5 would
       // be true under the un-swapped check? actually 0 < 5 means it
       // would stay enabled — pivot to the down direction).
-      // Assert the slider is actionable: dragging the slider
-      // down should drop the readout to -1, confirming the
-      // swapped bounds did not pin the value at 0.
-      const slider = screen.getByRole('slider', { name: 'Transpose' });
-      fireEvent.change(slider, { target: { value: '-1' } });
-      const output = screen.getByRole('status');
-      expect(output.textContent).toContain('-1');
+      // Assert the select is actionable: picking -1 should drop the
+      // value to -1, confirming the swapped bounds did not pin it at
+      // 0 (an un-swapped `[5, -5]` range would have no -1 option).
+      const select = screen.getByRole('combobox', { name: 'Transpose' }) as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: '-1' } });
+      expect(select.value).toBe('-1');
     } finally {
       err.mockRestore();
     }
@@ -427,7 +427,7 @@ describe('<ChordProPreview>', () => {
     expect(screen.getByRole('group', { name: 'Transpose' })).toBeTruthy();
   });
 
-  test('performance toolbar transpose slider routes through onTransposeChange', () => {
+  test('performance toolbar transpose select routes through onTransposeChange', () => {
     const onTransposeChange = vi.fn();
     render(
       <ChordProPreview
@@ -441,7 +441,7 @@ describe('<ChordProPreview>', () => {
       />,
     );
     fireEvent.change(
-      screen.getByRole('slider', { name: 'Transpose' }),
+      screen.getByRole('combobox', { name: 'Transpose' }),
       { target: { value: '1' } },
     );
     expect(onTransposeChange).toHaveBeenCalledWith(1);

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -159,7 +159,7 @@ describe('<PreviewToolbar>', () => {
     expect(screen.getByRole('group', { name: 'Capo' })).toBeTruthy();
   });
 
-  test('Transpose slider reflects the host value and uses the ±6 default range', () => {
+  test('Transpose select reflects the host value and uses the ±6 default range', () => {
     render(
       <PreviewToolbar
         source={SAMPLE}
@@ -168,13 +168,15 @@ describe('<PreviewToolbar>', () => {
         onTransposeChange={vi.fn()}
       />,
     );
-    const slider = screen.getByRole('slider', { name: 'Transpose' }) as HTMLInputElement;
-    expect(slider.value).toBe('-6');
+    const select = screen.getByRole('combobox', { name: 'Transpose' }) as HTMLSelectElement;
+    expect(select.value).toBe('-6');
     // PreviewToolbar passes TRANSPOSE_DEFAULT_MIN/MAX (±6) so the
-    // slider stays readable on narrow preview panes. Hosts widening
-    // to the feature ceiling (±11) pass transposeMin/Max explicitly.
-    expect(slider.min).toBe('-6');
-    expect(slider.max).toBe('6');
+    // option list stays compact on narrow preview panes. Hosts
+    // widening to the feature ceiling (±11) pass transposeMin/Max
+    // explicitly.
+    const options = Array.from(select.options);
+    expect(options[0].value).toBe('6');
+    expect(options[options.length - 1].value).toBe('-6');
   });
 
   test('Capo group writes {capo} into source via onSourceChange', () => {
@@ -187,8 +189,8 @@ describe('<PreviewToolbar>', () => {
         onTransposeChange={vi.fn()}
       />,
     );
-    const capoSlider = screen.getByRole('slider', { name: 'Capo' }) as HTMLInputElement;
-    fireEvent.change(capoSlider, { target: { value: '1' } });
+    const capoSelect = screen.getByRole('combobox', { name: 'Capo' }) as HTMLSelectElement;
+    fireEvent.change(capoSelect, { target: { value: '1' } });
     expect(onSourceChange).toHaveBeenCalledWith(
       '{title: Demo}\n{key: G}\n{capo: 1}\n[C]Hello',
     );

--- a/packages/react/tests/transpose.test.tsx
+++ b/packages/react/tests/transpose.test.tsx
@@ -162,4 +162,17 @@ describe('<Transpose>', () => {
     render(<Transpose value={0} onChange={vi.fn()} min={6} max={-6} />);
     expect(Array.from(getSelect().options)).toHaveLength(0);
   });
+
+  test('changing the select to a programmatic out-of-range value clamps the emitted value', () => {
+    // A test driver (or unusual browser automation) may fire a change
+    // event with a value that is not among the rendered options.
+    // `handleSelectChange` still applies `clamp` before forwarding to
+    // `onChange`, so the emitted value always stays within [min, max].
+    const onChange = vi.fn();
+    render(<Transpose value={0} onChange={onChange} />);
+    fireEvent.change(getSelect(), { target: { value: '99' } });
+    expect(onChange).toHaveBeenLastCalledWith(6);
+    fireEvent.change(getSelect(), { target: { value: '-99' } });
+    expect(onChange).toHaveBeenLastCalledWith(-6);
+  });
 });

--- a/packages/react/tests/transpose.test.tsx
+++ b/packages/react/tests/transpose.test.tsx
@@ -163,16 +163,16 @@ describe('<Transpose>', () => {
     expect(Array.from(getSelect().options)).toHaveLength(0);
   });
 
-  test('changing the select to a programmatic out-of-range value clamps the emitted value', () => {
-    // A test driver (or unusual browser automation) may fire a change
-    // event with a value that is not among the rendered options.
-    // `handleSelectChange` still applies `clamp` before forwarding to
-    // `onChange`, so the emitted value always stays within [min, max].
+  test('a programmatic out-of-range select change is coerced away and does not emit', () => {
+    // A native <select> can only hold one of its rendered option
+    // values. Firing a change with a value that is not an option (a
+    // test driver / unusual automation) makes the browser — and
+    // jsdom — reset the value to '' (selectedIndex -1), which the
+    // change handler parses as NaN and ignores. The option set is the
+    // boundary, so onChange never receives an out-of-range value.
     const onChange = vi.fn();
     render(<Transpose value={0} onChange={onChange} />);
     fireEvent.change(getSelect(), { target: { value: '99' } });
-    expect(onChange).toHaveBeenLastCalledWith(6);
-    fireEvent.change(getSelect(), { target: { value: '-99' } });
-    expect(onChange).toHaveBeenLastCalledWith(-6);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/tests/transpose.test.tsx
+++ b/packages/react/tests/transpose.test.tsx
@@ -3,16 +3,13 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { Transpose, useTranspose } from '../src/index';
 
-function getSlider(): HTMLInputElement {
-  return screen.getByRole('slider', { name: 'Transpose' }) as HTMLInputElement;
+function getSelect(): HTMLSelectElement {
+  return screen.getByRole('combobox', { name: 'Transpose' }) as HTMLSelectElement;
 }
 
-// The tick rail renders the same numerals (e.g. `0`, `+3`) as the
-// readout, so plain text queries match more than once. Target the
-// `<output>` element directly when asserting on the displayed value.
-function getReadoutText(): string {
-  const out = document.querySelector('.chordsketch-transpose__value');
-  return out?.textContent ?? '';
+// Text shown on the currently-selected option.
+function getSelectedText(): string {
+  return getSelect().selectedOptions[0]?.textContent ?? '';
 }
 
 describe('useTranspose', () => {
@@ -76,61 +73,54 @@ describe('useTranspose', () => {
 });
 
 describe('<Transpose>', () => {
-  test('renders the controlled value as a range slider with default ±6 bounds', () => {
+  test('renders the controlled value as a select with default ±6 options', () => {
     render(<Transpose value={3} onChange={vi.fn()} />);
-    expect(screen.getByRole('group', { name: 'Transpose' })).toBeTruthy();
-    const slider = getSlider();
-    expect(slider.type).toBe('range');
-    expect(slider.min).toBe('-6');
-    expect(slider.max).toBe('6');
-    expect(slider.value).toBe('3');
+    const select = getSelect();
+    expect(select.value).toBe('3');
+    const options = Array.from(select.options);
+    expect(options).toHaveLength(13); // +6..-6 inclusive
+    // Highest offset first: + at the top, − at the bottom.
+    expect(options[0].value).toBe('6');
+    expect(options[options.length - 1].value).toBe('-6');
   });
 
-  test('renders the readout with a + sign for positive values', () => {
+  test('selected option shows a + sign for positive values', () => {
     render(<Transpose value={3} onChange={vi.fn()} />);
-    expect(getReadoutText()).toBe('+3');
+    expect(getSelectedText()).toBe('+3');
   });
 
-  test('renders without a + for zero and a − for negatives', () => {
+  test('selected option drops the + for zero and shows − for negatives', () => {
     const { rerender } = render(<Transpose value={0} onChange={vi.fn()} />);
-    expect(getReadoutText()).toBe('0');
+    expect(getSelectedText()).toBe('0');
     rerender(<Transpose value={-2} onChange={vi.fn()} />);
-    expect(getReadoutText()).toBe('-2');
+    expect(getSelectedText()).toBe('-2');
   });
 
-  test('changing the slider emits the parsed value', () => {
+  test('changing the select emits the parsed value', () => {
     const onChange = vi.fn();
     render(<Transpose value={0} onChange={onChange} />);
-    fireEvent.change(getSlider(), { target: { value: '4' } });
+    fireEvent.change(getSelect(), { target: { value: '4' } });
     expect(onChange).toHaveBeenLastCalledWith(4);
-    fireEvent.change(getSlider(), { target: { value: '-3' } });
+    fireEvent.change(getSelect(), { target: { value: '-3' } });
     expect(onChange).toHaveBeenLastCalledWith(-3);
   });
 
-  test('clamps programmatic values outside min/max to the bound', () => {
-    const onChange = vi.fn();
-    render(<Transpose value={0} onChange={onChange} />);
-    fireEvent.change(getSlider(), { target: { value: '99' } });
-    expect(onChange).toHaveBeenLastCalledWith(6);
-    fireEvent.change(getSlider(), { target: { value: '-99' } });
-    expect(onChange).toHaveBeenLastCalledWith(-6);
-  });
-
-  test('explicit min/max props widen past the default ±6 cap', () => {
+  test('explicit min/max props widen the option range past the default ±6 cap', () => {
     render(<Transpose value={0} onChange={vi.fn()} min={-11} max={11} />);
-    const slider = getSlider();
-    expect(slider.min).toBe('-11');
-    expect(slider.max).toBe('11');
+    const options = Array.from(getSelect().options);
+    expect(options).toHaveLength(23); // +11..-11 inclusive
+    expect(options[0].value).toBe('11');
+    expect(options[options.length - 1].value).toBe('-11');
   });
 
   test('forwards unknown props to the wrapper div', () => {
     render(<Transpose value={0} onChange={vi.fn()} data-testid="t" className="custom" />);
-    const group = screen.getByTestId('t');
-    expect(group.className).toContain('chordsketch-transpose');
-    expect(group.className).toContain('custom');
+    const wrapper = screen.getByTestId('t');
+    expect(wrapper.className).toContain('chordsketch-transpose');
+    expect(wrapper.className).toContain('custom');
   });
 
-  test('custom formatValue controls the indicator text', () => {
+  test('custom formatValue controls the option text', () => {
     render(
       <Transpose
         value={2}
@@ -138,15 +128,38 @@ describe('<Transpose>', () => {
         formatValue={(v) => `${v} st`}
       />,
     );
-    expect(getReadoutText()).toBe('2 st');
+    expect(getSelectedText()).toBe('2 st');
   });
 
-  test('clamps an out-of-range value prop in the readout (display path)', () => {
-    // Host passes `value=15` with default `max=6`: the native
-    // range input clamps the thumb to `+6` visually, but the
-    // `<output>` would otherwise show `+15` and disagree with
-    // the thumb. Pin the render-time clamp.
+  test('clamps an out-of-range value prop so the selection stays in range', () => {
+    // Host passes `value=15` with default `max=6`: the render-time
+    // clamp pins the selected option to `+6` (the select has no
+    // `15` option to land on).
     render(<Transpose value={15} onChange={vi.fn()} />);
-    expect(getReadoutText()).toBe('+6');
+    expect(getSelect().value).toBe('6');
+    expect(getSelectedText()).toBe('+6');
+  });
+
+  test('step=2 generates every-other-semitone options in descending order', () => {
+    render(<Transpose value={0} onChange={vi.fn()} min={-6} max={6} step={2} />);
+    const values = Array.from(getSelect().options).map((o) => o.value);
+    expect(values).toEqual(['6', '4', '2', '0', '-2', '-4', '-6']);
+  });
+
+  test('an off-grid value snaps to the nearest rendered option (step=2)', () => {
+    // `value=3` is in range but not on the every-2 grid. The select
+    // has no `3` option, so the control must snap to the nearest one
+    // (`2` or `4`) rather than silently showing `+6` (selectedIndex 0).
+    render(<Transpose value={3} onChange={vi.fn()} min={-6} max={6} step={2} />);
+    const selected = Number.parseInt(getSelect().value, 10);
+    expect([2, 4]).toContain(selected);
+    // Whatever it snaps to must be an option that actually exists.
+    const values = Array.from(getSelect().options).map((o) => o.value);
+    expect(values).toContain(getSelect().value);
+  });
+
+  test('renders no options when max < min', () => {
+    render(<Transpose value={0} onChange={vi.fn()} min={6} max={-6} />);
+    expect(Array.from(getSelect().options)).toHaveLength(0);
   });
 });

--- a/packages/ui-irealb-editor/src/style.css
+++ b/packages/ui-irealb-editor/src/style.css
@@ -201,13 +201,30 @@
   font: 500 0.8125rem/1.4 var(--font-jp);
   height: 32px;
   padding: 0 0.625rem;
-  border: 1px solid var(--ink-300);
+  border: 1px solid var(--border-strong);
   border-radius: 4px;
-  background: var(--ink-0);
+  background-color: var(--ink-0);
   color: var(--ink-1000);
   min-width: 0;
   transition: border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
     box-shadow 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* Select-only chrome: the chevrons-up-down caret + `appearance` reset
+ * + right padding belong on the `<select>` alone — the text / number
+ * inputs that share the base rule above keep their native affordances
+ * (no dropdown arrow, no reset of the number spinners). */
+.irealb-editor__select {
+  padding: 0 1.75rem 0 0.625rem;
+  /* Inline chevrons-up-down caret — unifies with the design-system
+   * selects / `@chordsketch/react`'s `.chordsketch-*__select`. */
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2367646D' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m7 15 5 5 5-5'/><path d='m7 9 5-5 5 5'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  cursor: pointer;
 }
 
 .irealb-editor__input:hover,


### PR DESCRIPTION
## What
- Unify every styled `<select>` to one chrome — white surface, `--border-strong` hairline, 4px radius, an inline chevrons-up-down caret, border-only hover, crimson focus — matching the playground's `.chordsketch-app__select`. Covers the ChordPro editor/preview Format select, the diagrams-orientation select, the iReal bar grid, `@chordsketch/ui-irealb-editor`, and the design-system reference (`components-forms.html`, `editor-irealb.html`).
- Convert `<Transpose>` and `<Capo>` from a slider + −/+ buttons to a native `<select>`. Options are listed highest-first (Transpose `+6 … −6`, Capo `12 … 0`); `<Capo>` flags best-capo positions with a ★ on the matching option (`data-best-capo` + a ` ★` suffix).
- Remove the old slider CSS (thumb/track/ticks/markers) and the now-dead `.tool-group .transpose-value` rule.

## Why
The toolbar/header selects and the Transpose/Capo controls each had their own look, diverging from the playground's sample-song select. One select style makes the UI consistent, and the dropdown is simpler to operate than the slider.

## Notes
- The caret + `appearance: none` live on a `select`-only rule so the text/number inputs that share a base rule (iReal bar grid, iReal editor) keep their native arrows and number spinners.
- Controlled and source-pair contracts and the `min`/`max`/`step`/`formatValue` props are preserved. An out-of-range or off-grid `value`/`{capo:N}` resolves to the nearest rendered option, so the selection never disagrees with the control's state (the guarantee the slider's step-snapping used to provide).
- `formatValue` is narrowed to `string | number` since it renders as `<option>` text.
- Radius is a literal `4px` (not `var(--cs-r-2)`) so it stays 4px under the playground's `--cs-r-2: 6px` override, matching `.chordsketch-app__select`.
- **Breaking** (unreleased `@chordsketch/react`): the slider-era keyboard shortcuts and the already-removed `resetValue` prop are gone; the control is now a `<select>`.

## Test results
- `@chordsketch/react`: `tsc --noEmit` clean; `vitest` 628 passing (added coverage for descending order, off-grid snap, step>1, max<min, ★ flagging, sr-only plural/singular, `formatValue`+★).
- playground: `tsc --noEmit` clean; Playwright smoke green for all non-docs specs (incl. the updated `performance-toolbar`, `render-format-toggle`, and `diagrams-orientation-toggle` token snapshot now asserting 28px/4px).
- No Rust surface touched; renderer parity not affected.

## Review summary
Reviewed for correctness, silent failures, type design, comment accuracy, test coverage, security, and the repo's own rules (fix-propagation across every select site, sister-site parity of the snap fix in both components, no dead CSS, English-only). Key fixes folded in: the select caret was split off shared `input, select` rules so inputs are untouched; the radius was pinned to literal 4px to survive the playground token override.

Closes #2574