### PR TITLE
Hide caret overlay in playground preview-only view

### DIFF
--- a/packages/playground/src/chordpro/main.tsx
+++ b/packages/playground/src/chordpro/main.tsx
@@ -846,9 +846,15 @@ function PlaygroundApp(): JSX.Element {
                 format="html"
                 chordDiagramsInstrument="guitar"
                 chordDiagramsOrientation={diagramsOrientation}
-                activeSourceLine={caret?.line}
-                caretColumn={caret?.column}
-                caretLineLength={caret?.lineLength}
+                /* The active-line highlight and caret marker only make
+                   sense in split view, where the editor sits beside the
+                   preview. In preview-only view the editor is unmounted,
+                   so the overlay would point at a caret the user cannot
+                   see — withhold the caret props so the rendered sheet
+                   stays clean. */
+                activeSourceLine={view === 'split' ? caret?.line : undefined}
+                caretColumn={view === 'split' ? caret?.column : undefined}
+                caretLineLength={view === 'split' ? caret?.lineLength : undefined}
                 onChordReposition={handleChordReposition}
               />
             </div>

--- a/packages/playground/tests-e2e/preview-mode-caret.spec.ts
+++ b/packages/playground/tests-e2e/preview-mode-caret.spec.ts
@@ -1,0 +1,113 @@
+// Regression coverage for the pane-visibility modes of the ChordPro
+// playground.
+//
+// The playground relays the editor caret into `<RendererPreview>` so
+// the split view can highlight the line being edited (`line--active`)
+// and draw a caret marker (`.caret-marker`). The overlay only makes
+// sense in split view, where the editor sits beside the preview. In
+// preview-only view the editor is unmounted, so the overlay would
+// point at a caret the user can no longer see — it must not render.
+// The caret state survives the view switch (it is only reset on editor
+// focus), so without an explicit guard the stale highlight leaks into
+// the clean rendered sheet.
+//
+// Assertions are structural (presence / absence of the overlay
+// classes), matching the rest of the e2e smoke suite. Each test
+// registers a `pageerror` listener so a JS exception thrown during a
+// view switch fails the test even when the DOM still renders, per
+// `.claude/rules/playground-smoke.md`.
+
+import { expect, test, type Page } from '@playwright/test';
+
+// Place the caret on a lyric line so the preview has a body element
+// mapped to that source line to highlight, and a lyric caret position
+// for the marker. Clicking inside `.cm-content` drives CodeMirror's
+// selection, which fires the playground's `onCaretChange` relay.
+async function focusLyricCaret(page: Page): Promise<void> {
+  const lyric = page
+    .locator('.cm-editor .cm-content')
+    .getByText('sweet', { exact: false });
+  // The default sample has exactly one "sweet"; assert it so the helper
+  // fails loudly rather than silently clicking the wrong line should the
+  // sample ever gain a second occurrence.
+  await expect(lyric).toHaveCount(1);
+  await lyric.click();
+}
+
+function trackPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('pageerror', (err) => errors.push(String(err)));
+  return errors;
+}
+
+test.describe('playground pane visibility', () => {
+  test('split view highlights the caret line once the editor is focused', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    const preview = page.locator('.pane.preview');
+    // Caret is null until the editor is focused, so a fresh load shows
+    // no overlay. Asserting the baseline makes the "appears on focus"
+    // assertion below meaningful.
+    await expect(preview.locator('.line--active')).toHaveCount(0);
+    await expect(preview.locator('.caret-marker')).toHaveCount(0);
+
+    await focusLyricCaret(page);
+    await expect(preview.locator('.line--active')).toBeVisible();
+    await expect(preview.locator('.caret-marker')).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('preview-only view suppresses the active-line highlight and caret marker', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    const editor = page.locator('.cm-editor');
+    await expect(editor).toBeVisible();
+
+    // Establish a caret in split view first and confirm the overlay is
+    // actually present, so the absence asserted after the switch is a
+    // real regression signal rather than a vacuous pass.
+    await focusLyricCaret(page);
+    const preview = page.locator('.pane.preview');
+    await expect(preview.locator('.line--active')).toBeVisible();
+    await expect(preview.locator('.caret-marker')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Preview' }).click();
+
+    // Editor is gone; the rendered sheet is still there...
+    await expect(editor).toHaveCount(0);
+    await expect(preview).toContainText('sweet');
+    // ...but the caret-driven overlay must not be.
+    await expect(preview.locator('.line--active')).toHaveCount(0);
+    await expect(preview.locator('.caret-marker')).toHaveCount(0);
+
+    // Returning to split restores the overlay — the suppression is
+    // scoped to the view, not a permanent teardown of the caret state.
+    await page.getByRole('button', { name: 'Split' }).click();
+    await expect(preview.locator('.line--active')).toBeVisible();
+    await expect(preview.locator('.caret-marker')).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('source-only view unmounts the preview pane entirely', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Source' }).click();
+    // The preview pane is gated out of the DOM in source-only view, so
+    // there is no surface for a stale overlay to render on.
+    await expect(page.locator('.pane.preview')).toHaveCount(0);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/playground/tests-e2e/preview-mode-caret.spec.ts
+++ b/packages/playground/tests-e2e/preview-mode-caret.spec.ts
@@ -21,12 +21,12 @@ import { expect, test, type Page } from '@playwright/test';
 
 // Place the caret on a lyric line so the preview has a body element
 // mapped to that source line to highlight, and a lyric caret position
-// for the marker. Clicking inside `.cm-content` drives CodeMirror's
+// for the marker. Clicking a `.cm-line` element drives CodeMirror's
 // selection, which fires the playground's `onCaretChange` relay.
 async function focusLyricCaret(page: Page): Promise<void> {
   const lyric = page
-    .locator('.cm-editor .cm-content')
-    .getByText('sweet', { exact: false });
+    .locator('.cm-editor .cm-line')
+    .filter({ hasText: 'sweet' });
   // The default sample has exactly one "sweet"; assert it so the helper
   // fails loudly rather than silently clicking the wrong line should the
   // sample ever gain a second occurrence.


### PR DESCRIPTION
## What

Gate the three caret props passed to `<RendererPreview>` in the ChordPro playground on split view: `view === 'split' ? caret?.<x> : undefined` for `activeSourceLine` / `caretColumn` / `caretLineLength`. Adds `packages/playground/tests-e2e/preview-mode-caret.spec.ts`.

## Why

The playground relays the editor caret into the preview so split view can highlight the edited line (`line--active`) and draw a caret marker (`.caret-marker`). The caret state survives a pane-visibility switch — it is only reset on editor focus — so in preview-only view, where the editor is unmounted, the stale overlay leaked into the otherwise-clean rendered sheet, pointing at a caret the user can no longer see. The overlay only makes sense in split view, where the editor is visible beside the preview.

The library already exposes the suppression mechanism (`undefined` caret props ⇒ no overlay); the fix is the playground passing `undefined` when its own editor pane is not mounted. Whether the editor is mounted is playground view state, so the gate belongs in the host, not the library.

Chord drag-reposition (`onChordReposition`) is intentionally left active in preview-only view: it is a valid source edit, and the `editorRef.current?.setCaret` call is a null-safe no-op when the editor is unmounted.

## Test results

- `npm run typecheck`: clean.
- `npm run build` (vite): the `chordpro` bundle builds clean.
- New Playwright spec: 3 tests pass — split view shows the overlay after focusing a lyric caret (with a null-caret baseline), preview-only view suppresses both overlay classes and restores them on return to split, and source-only view unmounts the preview pane entirely. Reverting the production gate makes the suppression test fail on the stale overlay persisting, confirming it catches the regression.

## Review summary

Playground host-wiring change only; no renderer or binding surface is touched, so renderer-parity and sanitizer-parity invariants are unaffected. The caret props are editor-internal cursor integers with no connection to user-supplied source, so there is no sanitization/injection impact.

## Sister-site audit

Checked every preview surface for the same "editor hidden but overlay shown" pattern:
- iRealPro playground (`packages/playground/src/irealpro/main.tsx`): no caret state, no caret props — not applicable.
- `<ChordProEditor>` (`packages/react/src/chord-pro-editor.tsx`): does not wire `onCaretChange` into its preview, so it never shows a caret overlay.
- `<ChordProPreview>` (`packages/react/src/chord-pro-preview.tsx`): does not expose `activeSourceLine` / `caretColumn` / `caretLineLength`.

The bug is unique to the ChordPro playground entry; no sibling fix is required.

## Deferred

None.

Closes #2576