### PR TITLE
fix: render inline/hover chord diagrams without breaking layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the active orientation as a `data-orientation` attribute on its
   wrapper so consumers and tests can observe it without parsing the
   SVG. (#2572)
+- `{diagrams: inline}` and `{diagrams: hover}` chordsketch-only modes
+  render compact chord diagrams directly above each lyric line rather
+  than in the end-of-song diagram grid. `inline` replaces the chord
+  name with the compact diagram; `hover` keeps the chord name as text
+  and reveals the compact diagram on mouse hover or keyboard focus.
+  The compact layout uses a separate geometry (not a CSS `scale()`) to
+  keep the chord-name title and glyph text legible at smaller size.
+  (#2585)
+- Shared directive catalog (`directive_catalog.rs`) powers directive-name
+  and directive-value completion in the LSP / VS Code extension and the
+  web CodeMirror editor from a single source, replacing the previous
+  hand-maintained copies. The catalog is exposed via the wasm
+  `listDirectives()` and `directiveValueOptions()` exports so every
+  editing surface reads the same list. (#2585)
 
 ### Changed
 

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -3002,4 +3002,103 @@ mod tests {
         assert_eq!(resolve_orientation(Some("")), Orientation::Vertical);
         assert_eq!(try_parse_orientation_value(Some("")), None);
     }
+
+    // -----------------------------------------------------------------------
+    // DiagramsMode resolver edge cases (finding #5a)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_diagrams_mode_rejects_oversized_input() {
+        let big = "a".repeat(MAX_RESOLVER_INPUT_LEN + 1);
+        assert_eq!(try_parse_diagrams_mode(Some(&big)), None);
+        assert_eq!(resolve_diagrams_mode(Some(&big)), DiagramsMode::Section);
+    }
+
+    #[test]
+    fn resolve_diagrams_mode_empty_string_falls_back_to_section() {
+        assert_eq!(try_parse_diagrams_mode(Some("")), None);
+        assert_eq!(resolve_diagrams_mode(Some("")), DiagramsMode::Section);
+    }
+
+    // -----------------------------------------------------------------------
+    // Compact diagram class coverage in the CORE crate (finding #5b)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compact_vertical_guitar_carries_compact_class_not_horizontal() {
+        let data = DiagramData {
+            name: "Am".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![],
+        };
+        let svg = render_svg_with_options(&data, Orientation::Vertical, DiagramSize::Compact);
+        assert!(
+            svg.contains("chord-diagram-compact"),
+            "compact vertical guitar must carry chord-diagram-compact class; got: {svg}"
+        );
+        assert!(
+            !svg.contains("chord-diagram-horizontal"),
+            "compact vertical must not carry horizontal class; got: {svg}"
+        );
+    }
+
+    #[test]
+    fn compact_ukulele_carries_compact_class() {
+        let data = DiagramData {
+            name: "C".to_string(),
+            display_name: None,
+            strings: 4,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![0, 0, 0, 3],
+            fingers: vec![],
+        };
+        let svg = render_svg_with_options(&data, Orientation::Vertical, DiagramSize::Compact);
+        assert!(
+            svg.contains("chord-diagram-compact"),
+            "compact ukulele (4-string) must carry chord-diagram-compact class; got: {svg}"
+        );
+    }
+
+    #[test]
+    fn compact_keyboard_carries_compact_class() {
+        let v = KeyboardVoicing {
+            name: "C".to_string(),
+            display_name: None,
+            keys: vec![60, 64, 67],
+            root_key: 60,
+        };
+        let svg = render_keyboard_svg_with_size(&v, DiagramSize::Compact);
+        assert!(
+            svg.contains("keyboard-diagram-compact"),
+            "compact keyboard must carry keyboard-diagram-compact class; got: {svg}"
+        );
+    }
+
+    #[test]
+    fn render_svg_with_options_regular_vertical_byte_identical_to_with_orientation() {
+        // Back-compat pin: render_svg_with_options(data, Vertical, Regular)
+        // must be byte-identical to render_svg_with_orientation(data, Vertical).
+        let data = DiagramData {
+            name: "Am".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![],
+        };
+        let via_with_orientation = render_svg_with_orientation(&data, Orientation::Vertical);
+        let via_with_options =
+            render_svg_with_options(&data, Orientation::Vertical, DiagramSize::Regular);
+        assert_eq!(
+            via_with_orientation, via_with_options,
+            "render_svg_with_options(Vertical, Regular) must be byte-identical to \
+             render_svg_with_orientation(Vertical)"
+        );
+    }
 }

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -268,6 +268,30 @@ pub enum Orientation {
     Horizontal,
 }
 
+/// Physical size of a rendered chord diagram.
+///
+/// `Regular` is the original full-size diagram suited to the
+/// end-of-song diagram grid. `Compact` is a chordsketch extension
+/// laid out for sitting directly above a lyric line (the
+/// `{diagrams: inline}` / `{diagrams: hover}` modes): the grid
+/// geometry is shrunk substantially while the chord-name title and
+/// the finger / open / muted glyphs are kept near their legibility
+/// floor — a separate layout rather than a CSS `transform: scale()`,
+/// which would shrink the text into illegibility along with the
+/// geometry.
+///
+/// The enum is `#[non_exhaustive]` so a future intermediate size can
+/// be added without an API break, mirroring [`Orientation`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum DiagramSize {
+    /// Full-size diagram — the original layout. Default.
+    #[default]
+    Regular,
+    /// Compact layout for diagrams shown above a lyric line.
+    Compact,
+}
+
 // ---------------------------------------------------------------------------
 // SVG rendering constants
 // ---------------------------------------------------------------------------
@@ -303,6 +327,129 @@ const NUT_MARGIN_GLYPH_OFFSET: f32 = 10.0;
 /// both the vertical (along the x-axis) and horizontal (along the
 /// y-axis) renderers so the visual weight stays consistent.
 const OCTAVE_DOUBLE_DOT_OFFSET: f32 = 0.55;
+
+/// All size-dependent measurements for one fretted-diagram render pass.
+///
+/// The vertical and horizontal renderers read every geometry value and
+/// font size from this struct instead of the module-level constants
+/// directly, so the only difference between a [`DiagramSize::Regular`] and
+/// a [`DiagramSize::Compact`] render is which constructor
+/// ([`regular`](Self::regular) / [`compact`](Self::compact)) built the
+/// metrics. This keeps the two size variants from forking into duplicate
+/// renderer functions — a geometry fix lands once and applies to both
+/// sizes (cf. `.claude/rules/fix-propagation.md`).
+///
+/// `regular()` reproduces the historical hard-coded values verbatim; the
+/// `render_svg_default_byte_identical_across_chord_shapes` test pins that
+/// the regular output is byte-for-byte unchanged by this indirection.
+#[derive(Debug, Clone, Copy)]
+struct DiagramMetrics {
+    /// String-to-string spacing (SVG x-axis in vertical mode).
+    cell_w: f32,
+    /// Fret pitch (SVG y-axis in vertical mode).
+    cell_h: f32,
+    /// Space above the nut for the title + open/muted glyph row.
+    top_margin: f32,
+    /// Side gutter on each edge.
+    left_margin: f32,
+    /// Padding below the grid in the vertical layout.
+    bottom_pad_vertical: f32,
+    /// Padding below the grid in the horizontal layout.
+    bottom_pad_horizontal: f32,
+    /// Filled finger-position dot radius.
+    dot_radius: f32,
+    /// Open-string ring radius.
+    open_radius: f32,
+    /// Faint fretboard-inlay dot radius.
+    position_dot_radius: f32,
+    /// Distance from the nut at which open / muted glyphs sit.
+    nut_margin_glyph_offset: f32,
+    /// Chord-name title font size.
+    title_font: f32,
+    /// Baseline y of the chord-name title text.
+    title_baseline: f32,
+    /// Font size for the base-fret label and the muted-string `X` glyph.
+    label_font: f32,
+    /// Font size for finger numbers inside the dots.
+    finger_font: f32,
+    /// Baseline-centring offset added to a marker's centre y when drawing
+    /// text on/near it (the historical `+ 3.0`).
+    text_v_center: f32,
+    /// Nut line stroke width.
+    nut_stroke: f32,
+    /// String / fret line stroke width.
+    line_stroke: f32,
+    /// Extra CSS class appended to the root `<svg>` `class` attribute
+    /// (empty for regular, `" chord-diagram-compact"` for compact).
+    class_extra: &'static str,
+}
+
+impl DiagramMetrics {
+    /// Full-size metrics — byte-for-byte the historical layout.
+    const fn regular() -> Self {
+        Self {
+            cell_w: CELL_W,
+            cell_h: CELL_H,
+            top_margin: TOP_MARGIN,
+            left_margin: LEFT_MARGIN,
+            bottom_pad_vertical: 30.0,
+            bottom_pad_horizontal: 20.0,
+            dot_radius: DOT_RADIUS,
+            open_radius: OPEN_RADIUS,
+            position_dot_radius: POSITION_DOT_RADIUS,
+            nut_margin_glyph_offset: NUT_MARGIN_GLYPH_OFFSET,
+            title_font: 14.0,
+            title_baseline: 15.0,
+            label_font: 10.0,
+            finger_font: 8.0,
+            text_v_center: 3.0,
+            nut_stroke: 3.0,
+            line_stroke: 1.0,
+            class_extra: "",
+        }
+    }
+
+    /// Compact metrics for diagrams shown directly above a lyric line
+    /// (the `{diagrams: inline}` / `{diagrams: hover}` chordsketch modes).
+    ///
+    /// Grid geometry shrinks to roughly 0.55x of regular, but the glyph
+    /// fonts shrink only to ~0.8x and never below a legibility floor
+    /// (title 11, fingers 7). That divergence is the whole reason a
+    /// compact layout exists rather than a CSS `transform: scale()`,
+    /// which would shrink the text into illegibility along with the
+    /// geometry. `top_margin` is kept generous enough (22) that the
+    /// title and the open/muted glyph row do not collide.
+    const fn compact() -> Self {
+        Self {
+            cell_w: 9.0,
+            cell_h: 11.0,
+            top_margin: 22.0,
+            left_margin: 9.0,
+            bottom_pad_vertical: 10.0,
+            bottom_pad_horizontal: 8.0,
+            dot_radius: 3.2,
+            open_radius: 2.6,
+            position_dot_radius: 1.4,
+            nut_margin_glyph_offset: 5.0,
+            title_font: 11.0,
+            title_baseline: 9.0,
+            label_font: 8.0,
+            finger_font: 7.0,
+            text_v_center: 2.4,
+            nut_stroke: 2.0,
+            line_stroke: 0.75,
+            class_extra: " chord-diagram-compact",
+        }
+    }
+
+    /// Metrics for the requested [`DiagramSize`].
+    const fn for_size(size: DiagramSize) -> Self {
+        match size {
+            DiagramSize::Regular => Self::regular(),
+            DiagramSize::Compact => Self::compact(),
+        }
+    }
+}
 
 /// Fretboard position-marker frets for the given instrument
 /// (number of strings). Western guitar (6 strings) has inlays
@@ -356,6 +503,47 @@ pub fn render_svg(data: &DiagramData) -> String {
 /// ```
 #[must_use]
 pub fn render_svg_with_orientation(data: &DiagramData, orientation: Orientation) -> String {
+    render_svg_with_options(data, orientation, DiagramSize::Regular)
+}
+
+/// Render a chord diagram as an inline SVG string with explicit
+/// orientation and [size](DiagramSize).
+///
+/// [`render_svg`] and [`render_svg_with_orientation`] are thin wrappers
+/// that call this with [`DiagramSize::Regular`]; pass
+/// [`DiagramSize::Compact`] for the smaller above-a-lyric layout used by
+/// the `{diagrams: inline}` / `{diagrams: hover}` modes. The compact SVG
+/// carries an extra `chord-diagram-compact` class on its root element so
+/// consumers can target it from CSS.
+///
+/// Returns an empty string when `data.strings` or `data.frets_shown` is
+/// outside the valid range (same guard as the other entry points).
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_chordpro::chord_diagram::{
+///     DiagramData, DiagramSize, Orientation, render_svg_with_options,
+/// };
+///
+/// let data = DiagramData {
+///     name: "Am".to_string(),
+///     display_name: None,
+///     strings: 6,
+///     frets_shown: 5,
+///     base_fret: 1,
+///     frets: vec![-1, 0, 2, 2, 1, 0],
+///     fingers: vec![],
+/// };
+/// let svg = render_svg_with_options(&data, Orientation::Vertical, DiagramSize::Compact);
+/// assert!(svg.contains("chord-diagram-compact"));
+/// ```
+#[must_use]
+pub fn render_svg_with_options(
+    data: &DiagramData,
+    orientation: Orientation,
+    size: DiagramSize,
+) -> String {
     if data.strings < MIN_STRINGS
         || data.strings > MAX_STRINGS
         || data.frets_shown < MIN_FRETS_SHOWN
@@ -363,33 +551,59 @@ pub fn render_svg_with_orientation(data: &DiagramData, orientation: Orientation)
     {
         return String::new();
     }
+    let metrics = DiagramMetrics::for_size(size);
     // Exhaustive inside the defining crate — `#[non_exhaustive]` only forces
     // a wildcard on downstream consumers (see `render-pdf`). Adding a new
     // `Orientation` variant fails compilation here until a layout is added.
     match orientation {
-        Orientation::Vertical => render_svg_vertical_inner(data),
-        Orientation::Horizontal => render_svg_horizontal_inner(data),
+        Orientation::Vertical => render_svg_vertical_inner(data, &metrics),
+        Orientation::Horizontal => render_svg_horizontal_inner(data, &metrics),
     }
 }
 
-fn render_svg_vertical_inner(data: &DiagramData) -> String {
+fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
+    // Bind every metric to a local so the SVG format strings can
+    // inline-capture them by name (`{cell_w}` etc.). With
+    // `DiagramMetrics::regular()` these reproduce the historical literals
+    // exactly — guarded by `render_svg_default_byte_identical_across_chord_shapes`.
+    let DiagramMetrics {
+        cell_w,
+        cell_h,
+        top_margin,
+        left_margin,
+        bottom_pad_vertical,
+        dot_radius,
+        open_radius,
+        position_dot_radius,
+        nut_margin_glyph_offset,
+        title_font,
+        title_baseline,
+        label_font,
+        finger_font,
+        text_v_center,
+        nut_stroke,
+        line_stroke,
+        class_extra,
+        ..
+    } = *m;
+
     let num_strings = data.strings;
     let num_frets = data.frets_shown;
-    let grid_w = (num_strings - 1) as f32 * CELL_W;
-    let grid_h = num_frets as f32 * CELL_H;
-    let total_w = grid_w + LEFT_MARGIN * 2.0;
-    let total_h = grid_h + TOP_MARGIN + 30.0;
+    let grid_w = (num_strings - 1) as f32 * cell_w;
+    let grid_h = num_frets as f32 * cell_h;
+    let total_w = grid_w + left_margin * 2.0;
+    let total_h = grid_h + top_margin + bottom_pad_vertical;
 
     let mut svg = format!(
         "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{total_w}\" height=\"{total_h}\" \
-         viewBox=\"0 0 {total_w} {total_h}\" class=\"chord-diagram\">\n"
+         viewBox=\"0 0 {total_w} {total_h}\" class=\"chord-diagram{class_extra}\">\n"
     );
 
     // Chord name (uses display override if present)
-    let name_x = LEFT_MARGIN + grid_w / 2.0;
+    let name_x = left_margin + grid_w / 2.0;
     svg.push_str(&format!(
-        "<text x=\"{name_x}\" y=\"15\" text-anchor=\"middle\" \
-         font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\">{}</text>\n",
+        "<text x=\"{name_x}\" y=\"{title_baseline}\" text-anchor=\"middle\" \
+         font-family=\"sans-serif\" font-size=\"{title_font}\" font-weight=\"bold\">{}</text>\n",
         crate::escape::escape_xml(data.title())
     ));
 
@@ -398,19 +612,19 @@ fn render_svg_vertical_inner(data: &DiagramData) -> String {
     // suffix) — the position marker dots below already imply
     // "this is fret N on a real fretboard", so the bare integer
     // is enough.
-    let nut_y = TOP_MARGIN;
+    let nut_y = top_margin;
     if data.base_fret == 1 {
         svg.push_str(&format!(
-            "<line x1=\"{LEFT_MARGIN}\" y1=\"{nut_y}\" x2=\"{}\" y2=\"{nut_y}\" \
-             stroke=\"black\" stroke-width=\"3\"/>\n",
-            LEFT_MARGIN + grid_w
+            "<line x1=\"{left_margin}\" y1=\"{nut_y}\" x2=\"{}\" y2=\"{nut_y}\" \
+             stroke=\"black\" stroke-width=\"{nut_stroke}\"/>\n",
+            left_margin + grid_w
         ));
     } else {
         svg.push_str(&format!(
             "<text x=\"{}\" y=\"{}\" text-anchor=\"end\" \
-             font-family=\"sans-serif\" font-size=\"10\">{}</text>\n",
-            LEFT_MARGIN - 4.0,
-            nut_y + CELL_H / 2.0 + 3.0,
+             font-family=\"sans-serif\" font-size=\"{label_font}\">{}</text>\n",
+            left_margin - 4.0,
+            nut_y + cell_h / 2.0 + text_v_center,
             data.base_fret
         ));
     }
@@ -424,7 +638,7 @@ fn render_svg_vertical_inner(data: &DiagramData) -> String {
     // ukulele). The octave fret (12) gets a double dot on both
     // instruments to match real fretboard markers.
     let position_frets = position_marker_frets(num_strings);
-    let center_x = LEFT_MARGIN + grid_w / 2.0;
+    let center_x = left_margin + grid_w / 2.0;
     for &marker_fret in position_frets {
         // `marker_fret` is the absolute fret number on the real
         // fretboard. Convert to a row within the diagram by
@@ -440,41 +654,41 @@ fn render_svg_vertical_inner(data: &DiagramData) -> String {
         if row < 1 || row > num_frets as i32 {
             continue;
         }
-        let y = nut_y + (row as f32 - 0.5) * CELL_H;
+        let y = nut_y + (row as f32 - 0.5) * cell_h;
         if marker_fret == 12 {
             // Octave: double dot. Place on either side of the
             // diagram's horizontal centre.
             svg.push_str(&format!(
-                "<circle cx=\"{cx1}\" cy=\"{y}\" r=\"{POSITION_DOT_RADIUS}\" \
+                "<circle cx=\"{cx1}\" cy=\"{y}\" r=\"{position_dot_radius}\" \
                  fill=\"#D4D1D6\" class=\"position-marker\"/>\n\
-                 <circle cx=\"{cx2}\" cy=\"{y}\" r=\"{POSITION_DOT_RADIUS}\" \
+                 <circle cx=\"{cx2}\" cy=\"{y}\" r=\"{position_dot_radius}\" \
                  fill=\"#D4D1D6\" class=\"position-marker\"/>\n",
-                cx1 = center_x - CELL_W * OCTAVE_DOUBLE_DOT_OFFSET,
-                cx2 = center_x + CELL_W * OCTAVE_DOUBLE_DOT_OFFSET,
+                cx1 = center_x - cell_w * OCTAVE_DOUBLE_DOT_OFFSET,
+                cx2 = center_x + cell_w * OCTAVE_DOUBLE_DOT_OFFSET,
             ));
         } else {
             svg.push_str(&format!(
-                "<circle cx=\"{center_x}\" cy=\"{y}\" r=\"{POSITION_DOT_RADIUS}\" \
+                "<circle cx=\"{center_x}\" cy=\"{y}\" r=\"{position_dot_radius}\" \
                  fill=\"#D4D1D6\" class=\"position-marker\"/>\n"
             ));
         }
     }
 
     for i in 0..num_strings {
-        let x = LEFT_MARGIN + i as f32 * CELL_W;
+        let x = left_margin + i as f32 * cell_w;
         svg.push_str(&format!(
             "<line x1=\"{x}\" y1=\"{nut_y}\" x2=\"{x}\" y2=\"{}\" \
-             stroke=\"black\" stroke-width=\"1\"/>\n",
+             stroke=\"black\" stroke-width=\"{line_stroke}\"/>\n",
             nut_y + grid_h
         ));
     }
 
     for j in 0..=num_frets {
-        let y = nut_y + j as f32 * CELL_H;
+        let y = nut_y + j as f32 * cell_h;
         svg.push_str(&format!(
-            "<line x1=\"{LEFT_MARGIN}\" y1=\"{y}\" x2=\"{}\" y2=\"{y}\" \
-             stroke=\"black\" stroke-width=\"1\"/>\n",
-            LEFT_MARGIN + grid_w
+            "<line x1=\"{left_margin}\" y1=\"{y}\" x2=\"{}\" y2=\"{y}\" \
+             stroke=\"black\" stroke-width=\"{line_stroke}\"/>\n",
+            left_margin + grid_w
         ));
     }
 
@@ -483,35 +697,35 @@ fn render_svg_vertical_inner(data: &DiagramData) -> String {
         if i >= num_strings {
             break;
         }
-        let x = LEFT_MARGIN + i as f32 * CELL_W;
+        let x = left_margin + i as f32 * cell_w;
         if fret == -1 {
             // Muted (X)
-            let y = nut_y - NUT_MARGIN_GLYPH_OFFSET;
+            let y = nut_y - nut_margin_glyph_offset;
             svg.push_str(&format!(
                 "<text x=\"{x}\" y=\"{y}\" text-anchor=\"middle\" \
-                 font-family=\"sans-serif\" font-size=\"10\">X</text>\n"
+                 font-family=\"sans-serif\" font-size=\"{label_font}\">X</text>\n"
             ));
         } else if fret == 0 {
             // Open (O)
-            let y = nut_y - NUT_MARGIN_GLYPH_OFFSET;
+            let y = nut_y - nut_margin_glyph_offset;
             svg.push_str(&format!(
-                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{OPEN_RADIUS}\" \
-                 fill=\"none\" stroke=\"black\" stroke-width=\"1\"/>\n"
+                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{open_radius}\" \
+                 fill=\"none\" stroke=\"black\" stroke-width=\"{line_stroke}\"/>\n"
             ));
         } else {
             // Fretted dot
-            let y = nut_y + (fret as f32 - 0.5) * CELL_H;
+            let y = nut_y + (fret as f32 - 0.5) * cell_h;
             svg.push_str(&format!(
-                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{DOT_RADIUS}\" fill=\"black\"/>\n"
+                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{dot_radius}\" fill=\"black\"/>\n"
             ));
             // Finger number inside the dot (if available and non-zero)
             if let Some(&finger) = data.fingers.get(i) {
                 if finger > 0 {
                     svg.push_str(&format!(
                         "<text x=\"{x}\" y=\"{}\" text-anchor=\"middle\" \
-                         font-family=\"sans-serif\" font-size=\"8\" \
+                         font-family=\"sans-serif\" font-size=\"{finger_font}\" \
                          fill=\"white\">{finger}</text>\n",
-                        y + 3.0
+                        y + text_v_center
                     ));
                 }
             }
@@ -530,37 +744,61 @@ fn render_svg_vertical_inner(data: &DiagramData) -> String {
 /// The geometric layout mirrors the vertical renderer so behaviour stays in
 /// lockstep — anything that changes in one (open/muted placement, 12-fret
 /// double-dot, base-fret label, finger numbers) must change in the other.
-fn render_svg_horizontal_inner(data: &DiagramData) -> String {
+fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
+    // See `render_svg_vertical_inner` for why every metric is bound to a
+    // local. `regular()` reproduces the historical literals byte-for-byte.
+    let DiagramMetrics {
+        cell_w,
+        cell_h,
+        top_margin,
+        left_margin,
+        bottom_pad_horizontal,
+        dot_radius,
+        open_radius,
+        position_dot_radius,
+        nut_margin_glyph_offset,
+        title_font,
+        title_baseline,
+        label_font,
+        finger_font,
+        text_v_center,
+        nut_stroke,
+        line_stroke,
+        class_extra,
+        ..
+    } = *m;
+
     let num_strings = data.strings;
     let num_frets = data.frets_shown;
     // Semantic aliases — the horizontal layout's fret axis is the SVG
-    // x-axis, so use `CELL_H` (the vertical layout's fret pitch, the
+    // x-axis, so use `cell_h` (the vertical layout's fret pitch, the
     // larger of the two cell values) along that axis. Likewise the
-    // string axis is the SVG y-axis, so use `CELL_W` (the vertical
+    // string axis is the SVG y-axis, so use `cell_w` (the vertical
     // layout's string-to-string spacing, the smaller value). Using the
-    // same constants with swapped meanings preserves the
+    // same metrics with swapped meanings preserves the
     // wider-than-tall fretboard aspect ratio that the vertical
     // renderer already encodes — the diagram looks like a real
     // fretboard rotated 90°, not a vertical diagram with the labels
     // shuffled.
-    let fret_pitch = CELL_H;
-    let string_pitch = CELL_W;
+    let fret_pitch = cell_h;
+    let string_pitch = cell_w;
     let grid_w = num_frets as f32 * fret_pitch;
     let grid_h = (num_strings - 1) as f32 * string_pitch;
-    let total_w = grid_w + LEFT_MARGIN * 2.0;
-    let total_h = grid_h + TOP_MARGIN + 20.0;
+    let total_w = grid_w + left_margin * 2.0;
+    let total_h = grid_h + top_margin + bottom_pad_horizontal;
 
     let mut svg = format!(
         "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{total_w}\" height=\"{total_h}\" \
-         viewBox=\"0 0 {total_w} {total_h}\" class=\"chord-diagram chord-diagram-horizontal\">\n"
+         viewBox=\"0 0 {total_w} {total_h}\" \
+         class=\"chord-diagram chord-diagram-horizontal{class_extra}\">\n"
     );
 
     // Chord name (uses display override if present). Centred above the
     // fretboard so the visual weight matches the vertical layout's title.
-    let name_x = LEFT_MARGIN + grid_w / 2.0;
+    let name_x = left_margin + grid_w / 2.0;
     svg.push_str(&format!(
-        "<text x=\"{name_x}\" y=\"15\" text-anchor=\"middle\" \
-         font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\">{}</text>\n",
+        "<text x=\"{name_x}\" y=\"{title_baseline}\" text-anchor=\"middle\" \
+         font-family=\"sans-serif\" font-size=\"{title_font}\" font-weight=\"bold\">{}</text>\n",
         crate::escape::escape_xml(data.title())
     ));
 
@@ -569,19 +807,19 @@ fn render_svg_horizontal_inner(data: &DiagramData) -> String {
     // higher up the fretboard. The label sits above the first fret column
     // (the horizontal equivalent of the vertical layout's left-of-row label
     // position).
-    let nut_x = LEFT_MARGIN;
+    let nut_x = left_margin;
     if data.base_fret == 1 {
         svg.push_str(&format!(
-            "<line x1=\"{nut_x}\" y1=\"{TOP_MARGIN}\" x2=\"{nut_x}\" y2=\"{}\" \
-             stroke=\"black\" stroke-width=\"3\"/>\n",
-            TOP_MARGIN + grid_h
+            "<line x1=\"{nut_x}\" y1=\"{top_margin}\" x2=\"{nut_x}\" y2=\"{}\" \
+             stroke=\"black\" stroke-width=\"{nut_stroke}\"/>\n",
+            top_margin + grid_h
         ));
     } else {
         svg.push_str(&format!(
             "<text x=\"{}\" y=\"{}\" text-anchor=\"middle\" \
-             font-family=\"sans-serif\" font-size=\"10\">{}</text>\n",
+             font-family=\"sans-serif\" font-size=\"{label_font}\">{}</text>\n",
             nut_x + fret_pitch / 2.0,
-            TOP_MARGIN - 4.0,
+            top_margin - 4.0,
             data.base_fret
         ));
     }
@@ -590,9 +828,9 @@ fn render_svg_horizontal_inner(data: &DiagramData) -> String {
     // 12-fret marker becomes a double dot split along the **vertical**
     // axis at `cy ± string_pitch * OCTAVE_DOUBLE_DOT_OFFSET`, the geometric
     // mirror of the vertical layout's left/right split at
-    // `cx ± CELL_W * OCTAVE_DOUBLE_DOT_OFFSET` (in vertical mode CELL_W is the string pitch).
+    // `cx ± cell_w * OCTAVE_DOUBLE_DOT_OFFSET` (in vertical mode cell_w is the string pitch).
     let position_frets = position_marker_frets(num_strings);
-    let center_y = TOP_MARGIN + grid_h / 2.0;
+    let center_y = top_margin + grid_h / 2.0;
     for &marker_fret in position_frets {
         if (marker_fret as i32) < data.base_fret as i32 {
             continue;
@@ -604,16 +842,16 @@ fn render_svg_horizontal_inner(data: &DiagramData) -> String {
         let x = nut_x + (col as f32 - 0.5) * fret_pitch;
         if marker_fret == 12 {
             svg.push_str(&format!(
-                "<circle cx=\"{x}\" cy=\"{cy1}\" r=\"{POSITION_DOT_RADIUS}\" \
+                "<circle cx=\"{x}\" cy=\"{cy1}\" r=\"{position_dot_radius}\" \
                  fill=\"#D4D1D6\" class=\"position-marker\"/>\n\
-                 <circle cx=\"{x}\" cy=\"{cy2}\" r=\"{POSITION_DOT_RADIUS}\" \
+                 <circle cx=\"{x}\" cy=\"{cy2}\" r=\"{position_dot_radius}\" \
                  fill=\"#D4D1D6\" class=\"position-marker\"/>\n",
                 cy1 = center_y - string_pitch * OCTAVE_DOUBLE_DOT_OFFSET,
                 cy2 = center_y + string_pitch * OCTAVE_DOUBLE_DOT_OFFSET,
             ));
         } else {
             svg.push_str(&format!(
-                "<circle cx=\"{x}\" cy=\"{center_y}\" r=\"{POSITION_DOT_RADIUS}\" \
+                "<circle cx=\"{x}\" cy=\"{center_y}\" r=\"{position_dot_radius}\" \
                  fill=\"#D4D1D6\" class=\"position-marker\"/>\n"
             ));
         }
@@ -625,10 +863,10 @@ fn render_svg_horizontal_inner(data: &DiagramData) -> String {
     // 1 - i`, so the high-pitch string lands on the top row
     // (reader-view, ADR-0026).
     for i in 0..num_strings {
-        let y = TOP_MARGIN + i as f32 * string_pitch;
+        let y = top_margin + i as f32 * string_pitch;
         svg.push_str(&format!(
             "<line x1=\"{nut_x}\" y1=\"{y}\" x2=\"{}\" y2=\"{y}\" \
-             stroke=\"black\" stroke-width=\"1\"/>\n",
+             stroke=\"black\" stroke-width=\"{line_stroke}\"/>\n",
             nut_x + grid_w
         ));
     }
@@ -636,9 +874,9 @@ fn render_svg_horizontal_inner(data: &DiagramData) -> String {
     for j in 0..=num_frets {
         let x = nut_x + j as f32 * fret_pitch;
         svg.push_str(&format!(
-            "<line x1=\"{x}\" y1=\"{TOP_MARGIN}\" x2=\"{x}\" y2=\"{}\" \
-             stroke=\"black\" stroke-width=\"1\"/>\n",
-            TOP_MARGIN + grid_h
+            "<line x1=\"{x}\" y1=\"{top_margin}\" x2=\"{x}\" y2=\"{}\" \
+             stroke=\"black\" stroke-width=\"{line_stroke}\"/>\n",
+            top_margin + grid_h
         ));
     }
 
@@ -651,38 +889,38 @@ fn render_svg_horizontal_inner(data: &DiagramData) -> String {
             break;
         }
         let row = num_strings - 1 - i;
-        let y = TOP_MARGIN + row as f32 * string_pitch;
+        let y = top_margin + row as f32 * string_pitch;
         if fret == -1 {
             // Muted (X) — to the left of the nut, one per string row.
-            // `y + 3.0` is the same baseline-centring offset the vertical
-            // renderer uses for finger-number text.
-            let x = nut_x - NUT_MARGIN_GLYPH_OFFSET;
+            // `y + text_v_center` is the same baseline-centring offset the
+            // vertical renderer uses for finger-number text.
+            let x = nut_x - nut_margin_glyph_offset;
             svg.push_str(&format!(
                 "<text x=\"{x}\" y=\"{}\" text-anchor=\"middle\" \
-                 font-family=\"sans-serif\" font-size=\"10\">X</text>\n",
-                y + 3.0
+                 font-family=\"sans-serif\" font-size=\"{label_font}\">X</text>\n",
+                y + text_v_center
             ));
         } else if fret == 0 {
             // Open (O) — to the left of the nut, one per string row.
-            let x = nut_x - NUT_MARGIN_GLYPH_OFFSET;
+            let x = nut_x - nut_margin_glyph_offset;
             svg.push_str(&format!(
-                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{OPEN_RADIUS}\" \
-                 fill=\"none\" stroke=\"black\" stroke-width=\"1\"/>\n"
+                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{open_radius}\" \
+                 fill=\"none\" stroke=\"black\" stroke-width=\"{line_stroke}\"/>\n"
             ));
         } else {
             // Fretted dot — placed at the centre of its fret cell along the
             // string row.
             let x = nut_x + (fret as f32 - 0.5) * fret_pitch;
             svg.push_str(&format!(
-                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{DOT_RADIUS}\" fill=\"black\"/>\n"
+                "<circle cx=\"{x}\" cy=\"{y}\" r=\"{dot_radius}\" fill=\"black\"/>\n"
             ));
             if let Some(&finger) = data.fingers.get(i) {
                 if finger > 0 {
                     svg.push_str(&format!(
                         "<text x=\"{x}\" y=\"{}\" text-anchor=\"middle\" \
-                         font-family=\"sans-serif\" font-size=\"8\" \
+                         font-family=\"sans-serif\" font-size=\"{finger_font}\" \
                          fill=\"white\">{finger}</text>\n",
-                        y + 3.0
+                        y + text_v_center
                     ));
                 }
             }
@@ -837,6 +1075,108 @@ const BLACK_KEY_POSITIONS: [(u8, f32); 5] = [
     (10, 85.0), // A# (between A and B: 90 − 4.5 ≈ 85)
 ];
 
+/// White-key boundary multiples (in white-key widths) at which each black
+/// key is centred: C# at 1, D# at 2, F# at 4, G# at 5, A# at 6. Used to
+/// derive the compact black-key x-offsets from the compact white-key
+/// width — the regular [`BLACK_KEY_POSITIONS`] is kept as hand-rounded
+/// literals for byte-for-byte backward compatibility, so the two are NOT
+/// computed from a shared formula.
+const BLACK_KEY_BOUNDARY_MULTIPLES: [(u8, f32); 5] =
+    [(1, 1.0), (3, 2.0), (6, 4.0), (8, 5.0), (10, 6.0)];
+
+/// All size-dependent measurements for one keyboard-diagram render pass.
+///
+/// Like [`DiagramMetrics`] for fretted diagrams, this lets the keyboard
+/// renderer support [`DiagramSize::Compact`] without forking into a
+/// duplicate function. [`regular`](Self::regular) reproduces the
+/// historical literals (and reuses the existing position arrays) so the
+/// regular keyboard SVG is unchanged.
+#[derive(Debug, Clone)]
+struct KeyboardMetrics {
+    white_w: f32,
+    white_h: f32,
+    black_w: f32,
+    black_h: f32,
+    top_pad: f32,
+    side_pad: f32,
+    bottom_pad: f32,
+    title_font: f32,
+    title_baseline: f32,
+    white_positions: [(u8, f32); 7],
+    black_positions: [(u8, f32); 5],
+    class_extra: &'static str,
+}
+
+impl KeyboardMetrics {
+    /// Full-size keyboard metrics — the historical layout.
+    fn regular() -> Self {
+        Self {
+            white_w: KBD_WHITE_W,
+            white_h: KBD_WHITE_H,
+            black_w: KBD_BLACK_W,
+            black_h: KBD_BLACK_H,
+            top_pad: KBD_TOP_PAD,
+            side_pad: KBD_SIDE_PAD,
+            bottom_pad: 8.0,
+            title_font: 14.0,
+            title_baseline: 15.0,
+            white_positions: WHITE_KEY_POSITIONS,
+            black_positions: BLACK_KEY_POSITIONS,
+            class_extra: "",
+        }
+    }
+
+    /// Compact keyboard metrics for diagrams shown above a lyric line.
+    ///
+    /// Key geometry shrinks; the title font holds at 11 (the same
+    /// legibility floor the fretted compact layout uses). Black-key
+    /// offsets are recomputed from the compact white-key width via
+    /// [`BLACK_KEY_BOUNDARY_MULTIPLES`] — scaling the regular absolute
+    /// px offsets would misalign the black keys.
+    fn compact() -> Self {
+        let white_w = 9.0;
+        let black_w = 5.5;
+        let white_positions = [
+            (0u8, 0.0 * white_w),
+            (2, 1.0 * white_w),
+            (4, 2.0 * white_w),
+            (5, 3.0 * white_w),
+            (7, 4.0 * white_w),
+            (9, 5.0 * white_w),
+            (11, 6.0 * white_w),
+        ];
+        let mut black_positions = [(0u8, 0.0f32); 5];
+        let mut i = 0;
+        while i < BLACK_KEY_BOUNDARY_MULTIPLES.len() {
+            let (semitone, mult) = BLACK_KEY_BOUNDARY_MULTIPLES[i];
+            // Centre the black key on the white-key boundary.
+            black_positions[i] = (semitone, mult * white_w - black_w / 2.0);
+            i += 1;
+        }
+        Self {
+            white_w,
+            white_h: 34.0,
+            black_w,
+            black_h: 20.0,
+            top_pad: 18.0,
+            side_pad: 5.0,
+            bottom_pad: 6.0,
+            title_font: 11.0,
+            title_baseline: 9.0,
+            white_positions,
+            black_positions,
+            class_extra: " keyboard-diagram-compact",
+        }
+    }
+
+    fn for_size(size: DiagramSize) -> Self {
+        match size {
+            DiagramSize::Regular => Self::regular(),
+            DiagramSize::Compact => Self::compact(),
+        }
+    }
+}
+
 /// Normalise `keys` and `root_key` for display.
 ///
 /// When all keys are in 0–11 (pitch classes), shifts them to octave 4
@@ -896,9 +1236,42 @@ pub fn normalise_keyboard_keys(keys: &[u8], root_key: u8) -> (Vec<u8>, u8) {
 /// ```
 #[must_use]
 pub fn render_keyboard_svg(voicing: &KeyboardVoicing) -> String {
+    render_keyboard_svg_with_size(voicing, DiagramSize::Regular)
+}
+
+/// Render a keyboard chord diagram with an explicit [size](DiagramSize).
+///
+/// [`render_keyboard_svg`] is a thin wrapper that calls this with
+/// [`DiagramSize::Regular`]; pass [`DiagramSize::Compact`] for the smaller
+/// above-a-lyric layout used by the `{diagrams: inline}` / `{diagrams:
+/// hover}` modes. The compact SVG carries an extra
+/// `keyboard-diagram-compact` class on its root element.
+///
+/// Returns an empty string when `voicing.keys` is empty.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_chordpro::chord_diagram::{
+///     DiagramSize, KeyboardVoicing, render_keyboard_svg_with_size,
+/// };
+///
+/// let v = KeyboardVoicing {
+///     name: "Am".to_string(),
+///     display_name: None,
+///     keys: vec![69, 72, 76],
+///     root_key: 69,
+/// };
+/// let svg = render_keyboard_svg_with_size(&v, DiagramSize::Compact);
+/// assert!(svg.contains("keyboard-diagram-compact"));
+/// ```
+#[must_use]
+pub fn render_keyboard_svg_with_size(voicing: &KeyboardVoicing, size: DiagramSize) -> String {
     if voicing.keys.is_empty() {
         return String::new();
     }
+
+    let m = KeyboardMetrics::for_size(size);
 
     let (keys, root) = normalise_keyboard_keys(&voicing.keys, voicing.root_key);
 
@@ -912,28 +1285,38 @@ pub fn render_keyboard_svg(voicing: &KeyboardVoicing) -> String {
     let num_octaves = ((end_octave - start_octave) + 1).clamp(2, 3) as usize;
     let start_midi = (start_octave * 12) as u8;
 
-    let kbd_w = num_octaves as f32 * 7.0 * KBD_WHITE_W;
-    let total_w = kbd_w + KBD_SIDE_PAD * 2.0;
-    let total_h = KBD_TOP_PAD + KBD_WHITE_H + 8.0;
+    let octave_w = 7.0 * m.white_w;
+    let kbd_w = num_octaves as f32 * octave_w;
+    let total_w = kbd_w + m.side_pad * 2.0;
+    let total_h = m.top_pad + m.white_h + m.bottom_pad;
 
+    let class_extra = m.class_extra;
     let mut svg = format!(
         "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{total_w}\" height=\"{total_h}\" \
-         viewBox=\"0 0 {total_w} {total_h}\" class=\"keyboard-diagram\">\n"
+         viewBox=\"0 0 {total_w} {total_h}\" class=\"keyboard-diagram{class_extra}\">\n"
     );
 
     // Chord name label
     let name_x = total_w / 2.0;
+    let title_font = m.title_font;
+    let title_baseline = m.title_baseline;
     svg.push_str(&format!(
-        "<text x=\"{name_x}\" y=\"15\" text-anchor=\"middle\" \
-         font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\">{}</text>\n",
+        "<text x=\"{name_x}\" y=\"{title_baseline}\" text-anchor=\"middle\" \
+         font-family=\"sans-serif\" font-size=\"{title_font}\" font-weight=\"bold\">{}</text>\n",
         crate::escape::escape_xml(voicing.title())
     ));
+
+    let top_pad = m.top_pad;
+    let white_w = m.white_w;
+    let white_h = m.white_h;
+    let black_w = m.black_w;
+    let black_h = m.black_h;
 
     // --- Draw white keys first (black keys are drawn on top) ---
     for oct in 0..num_octaves {
         let oct_midi = start_midi.saturating_add((oct * 12) as u8);
-        let oct_x = KBD_SIDE_PAD + oct as f32 * 7.0 * KBD_WHITE_W;
-        for (semitone, x_off) in WHITE_KEY_POSITIONS {
+        let oct_x = m.side_pad + oct as f32 * octave_w;
+        for (semitone, x_off) in m.white_positions {
             let midi = oct_midi.saturating_add(semitone);
             let x = oct_x + x_off;
             let highlighted = keys.contains(&midi);
@@ -946,8 +1329,8 @@ pub fn render_keyboard_svg(voicing: &KeyboardVoicing) -> String {
                 "white"
             };
             svg.push_str(&format!(
-                "<rect x=\"{x}\" y=\"{KBD_TOP_PAD}\" width=\"{KBD_WHITE_W}\" \
-                 height=\"{KBD_WHITE_H}\" fill=\"{fill}\" stroke=\"black\" \
+                "<rect x=\"{x}\" y=\"{top_pad}\" width=\"{white_w}\" \
+                 height=\"{white_h}\" fill=\"{fill}\" stroke=\"black\" \
                  stroke-width=\"0.5\"/>\n"
             ));
         }
@@ -956,8 +1339,8 @@ pub fn render_keyboard_svg(voicing: &KeyboardVoicing) -> String {
     // --- Draw black keys on top ---
     for oct in 0..num_octaves {
         let oct_midi = start_midi.saturating_add((oct * 12) as u8);
-        let oct_x = KBD_SIDE_PAD + oct as f32 * 7.0 * KBD_WHITE_W;
-        for (semitone, x_off) in BLACK_KEY_POSITIONS {
+        let oct_x = m.side_pad + oct as f32 * octave_w;
+        for (semitone, x_off) in m.black_positions {
             let midi = oct_midi.saturating_add(semitone);
             let x = oct_x + x_off;
             let highlighted = keys.contains(&midi);
@@ -970,8 +1353,8 @@ pub fn render_keyboard_svg(voicing: &KeyboardVoicing) -> String {
                 "#222" // normal black key
             };
             svg.push_str(&format!(
-                "<rect x=\"{x}\" y=\"{KBD_TOP_PAD}\" width=\"{KBD_BLACK_W}\" \
-                 height=\"{KBD_BLACK_H}\" fill=\"{fill}\" stroke=\"black\" \
+                "<rect x=\"{x}\" y=\"{top_pad}\" width=\"{black_w}\" \
+                 height=\"{black_h}\" fill=\"{fill}\" stroke=\"black\" \
                  stroke-width=\"0.5\"/>\n"
             ));
         }
@@ -1097,6 +1480,121 @@ pub fn try_parse_orientation_value(value: Option<&str>) -> Option<OrientationKin
         "vertical" => Some(OrientationKind::Vertical),
         "horizontal" => Some(OrientationKind::Horizontal),
         _ => None,
+    }
+}
+
+/// How chord diagrams are surfaced for a song — a chordsketch extension to
+/// the `{diagrams}` directive.
+///
+/// `{diagrams: inline}` / `{diagrams: hover}` are NOT part of the ChordPro
+/// spec (which only defines on/off + instrument + position); they are a
+/// chordsketch-only facet that controls *where* diagrams appear relative
+/// to the chords above the lyrics, orthogonal to the instrument and
+/// position facets a value may also carry.
+///
+/// - [`Section`](Self::Section) (default) — the existing end-of-song
+///   diagram grid. Unchanged behaviour.
+/// - [`Inline`](Self::Inline) — each chord name above a lyric is replaced
+///   by its compact diagram (the diagram still shows the chord name).
+/// - [`Hover`](Self::Hover) — the chord name stays as text and the compact
+///   diagram is revealed on hover / keyboard focus.
+///
+/// `#[non_exhaustive]` so a future surfacing mode can be added without an
+/// API break, mirroring [`Orientation`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum DiagramsMode {
+    /// End-of-song diagram grid (the spec-standard placement). Default.
+    #[default]
+    Section,
+    /// Compact diagram replaces the chord name above each lyric.
+    Inline,
+    /// Compact diagram revealed on hover / focus over the chord name.
+    Hover,
+}
+
+/// Discriminant returned by [`try_parse_diagrams_mode`]. Mirrors the
+/// variants of [`DiagramsMode`] verbatim today.
+///
+/// Public so renderer call sites can distinguish "value was a recognised
+/// mode keyword" from "value was something else (instrument / position /
+/// typo)" — only the mode keywords (`inline` / `hover` / `section`) yield
+/// `Some`, so a `{diagrams: guitar}` line correctly returns `None` here
+/// and is handled by the instrument facet instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DiagramsModeKind {
+    /// Matches `DiagramsMode::Section`.
+    Section,
+    /// Matches `DiagramsMode::Inline`.
+    Inline,
+    /// Matches `DiagramsMode::Hover`.
+    Hover,
+}
+
+/// Strict parser for the chordsketch `{diagrams}` *mode* facet. Returns
+/// `None` for missing / empty / oversized input **and** for any value that
+/// is not one of the mode keywords (`section` / `inline` / `hover`) — so a
+/// `{diagrams: guitar}` (instrument) or `{diagrams: top}` (position) value
+/// returns `None` and is left for the instrument / position facets to
+/// interpret.
+///
+/// Bounds the `to_ascii_lowercase` allocation at [`MAX_RESOLVER_INPUT_LEN`]
+/// for the same reason [`try_parse_orientation_value`] does.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_chordpro::chord_diagram::{DiagramsModeKind, try_parse_diagrams_mode};
+///
+/// assert_eq!(try_parse_diagrams_mode(Some("inline")), Some(DiagramsModeKind::Inline));
+/// assert_eq!(try_parse_diagrams_mode(Some("HOVER")), Some(DiagramsModeKind::Hover));
+/// assert_eq!(try_parse_diagrams_mode(Some("section")), Some(DiagramsModeKind::Section));
+/// assert_eq!(try_parse_diagrams_mode(Some("guitar")), None);
+/// assert_eq!(try_parse_diagrams_mode(None), None);
+/// ```
+#[must_use]
+pub fn try_parse_diagrams_mode(value: Option<&str>) -> Option<DiagramsModeKind> {
+    let raw = value?.trim();
+    if raw.is_empty() || raw.len() > MAX_RESOLVER_INPUT_LEN {
+        return None;
+    }
+    match raw.to_ascii_lowercase().as_str() {
+        "section" => Some(DiagramsModeKind::Section),
+        "inline" => Some(DiagramsModeKind::Inline),
+        "hover" => Some(DiagramsModeKind::Hover),
+        _ => None,
+    }
+}
+
+/// Resolves the chordsketch `{diagrams}` mode facet, falling back to
+/// [`DiagramsMode::Section`] for missing / empty / unrecognised input.
+///
+/// Use [`try_parse_diagrams_mode`] when the caller needs to distinguish a
+/// recognised mode keyword from a non-mode value (instrument / position).
+///
+/// Shared by every renderer + binding so the mode parsing stays in one
+/// place — a future mode keyword lands here and propagates to every
+/// downstream surface automatically.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_chordpro::chord_diagram::{DiagramsMode, resolve_diagrams_mode};
+///
+/// assert_eq!(resolve_diagrams_mode(None), DiagramsMode::Section);
+/// assert_eq!(resolve_diagrams_mode(Some("inline")), DiagramsMode::Inline);
+/// assert_eq!(resolve_diagrams_mode(Some("hover")), DiagramsMode::Hover);
+/// assert_eq!(resolve_diagrams_mode(Some("guitar")), DiagramsMode::Section);
+/// ```
+#[must_use]
+pub fn resolve_diagrams_mode(value: Option<&str>) -> DiagramsMode {
+    match try_parse_diagrams_mode(value) {
+        Some(DiagramsModeKind::Inline) => DiagramsMode::Inline,
+        Some(DiagramsModeKind::Hover) => DiagramsMode::Hover,
+        // Section, and any unrecognised / oversized / missing input — fall
+        // back to the documented default.
+        _ => DiagramsMode::Section,
     }
 }
 

--- a/crates/chordpro/src/directive_catalog.rs
+++ b/crates/chordpro/src/directive_catalog.rs
@@ -661,7 +661,7 @@ mod tests {
     }
 
     #[test]
-    fn diagrams_enum_includes_inline_and_hover_extension_values() {
+    fn diagrams_enum_includes_section_inline_and_hover_values() {
         let values = directive_value_options("diagrams").expect("diagrams is an enum directive");
         for expected in [
             "on", "off", "guitar", "ukulele", "piano", "inline", "hover", "section",

--- a/crates/chordpro/src/directive_catalog.rs
+++ b/crates/chordpro/src/directive_catalog.rs
@@ -44,11 +44,13 @@ pub struct DirectiveInfo {
 ///
 /// `on` / `off` / `guitar` / `ukulele` / `piano` are the standard ChordPro
 /// values; `top` / `bottom` / `right` / `below` are the section-position
-/// keywords; `inline` / `hover` are the chordsketch surfacing-mode
-/// extension (ADR-0027). The parser also accepts the aliases `uke` /
-/// `keyboard` / `keys`, but completion offers the canonical forms only.
+/// keywords; `section` is the default end-of-song diagram grid mode;
+/// `inline` / `hover` are the chordsketch surfacing-mode extension
+/// (ADR-0027). The parser also accepts the aliases `uke` / `keyboard` /
+/// `keys`, but completion offers the canonical forms only.
 const DIAGRAMS_VALUES: &[&str] = &[
-    "on", "off", "guitar", "ukulele", "piano", "top", "bottom", "right", "below", "inline", "hover",
+    "on", "off", "guitar", "ukulele", "piano", "top", "bottom", "right", "below", "section",
+    "inline", "hover",
 ];
 
 /// Completable value set for the legacy `{pagetype: …}` directive.
@@ -661,11 +663,26 @@ mod tests {
     #[test]
     fn diagrams_enum_includes_inline_and_hover_extension_values() {
         let values = directive_value_options("diagrams").expect("diagrams is an enum directive");
-        for expected in ["on", "off", "guitar", "ukulele", "piano", "inline", "hover"] {
+        for expected in [
+            "on", "off", "guitar", "ukulele", "piano", "inline", "hover", "section",
+        ] {
             assert!(
                 values.contains(&expected),
                 "diagrams values missing {expected:?}"
             );
+        }
+    }
+
+    #[test]
+    fn every_enum_directive_has_at_least_one_value() {
+        for d in DIRECTIVES {
+            if let DirectiveValueKind::Enum(values) = d.value {
+                assert!(
+                    !values.is_empty(),
+                    "directive {:?} has Enum kind but empty values",
+                    d.name
+                );
+            }
         }
     }
 

--- a/crates/chordpro/src/directive_catalog.rs
+++ b/crates/chordpro/src/directive_catalog.rs
@@ -1,0 +1,692 @@
+//! Single source of truth for the ChordPro directive catalog.
+//!
+//! Every directive the parser recognises (see
+//! [`crate::ast::DirectiveKind::from_name`]) has one entry here, carrying
+//! its canonical name, short aliases, the shape of its value, and a
+//! one-line description. The catalog exists so editor tooling — the LSP
+//! completion provider (VS Code etc.) and, via the wasm bindings, the web
+//! CodeMirror editor and the playground "+ Directive" picker — all read
+//! ONE list instead of each maintaining its own drifting copy (see
+//! `.claude/rules/fix-propagation.md`, ADR-0028).
+//!
+//! The crate is zero-dependency, so the catalog is plain `&'static` data;
+//! serialization to JS happens at the wasm boundary, not here.
+//!
+//! A consistency test in this module asserts every catalog name + alias
+//! resolves through `DirectiveKind::from_name` to the same (non-`Unknown`)
+//! kind, so the catalog can never silently diverge from the parser.
+
+/// The value a directive accepts after its colon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectiveValueKind {
+    /// Value-less directive (e.g. `{new_page}`, `{soc}`).
+    None,
+    /// Free-form value with no fixed set (e.g. `{title: …}`, `{tempo: …}`).
+    FreeForm,
+    /// Value is one of a fixed set — completable (e.g. `{diagrams: …}`).
+    Enum(&'static [&'static str]),
+}
+
+/// One directive's catalog entry.
+#[derive(Debug, Clone, Copy)]
+pub struct DirectiveInfo {
+    /// Canonical directive name (what `from_name` canonicalises to).
+    pub name: &'static str,
+    /// Short / alternate spellings that resolve to the same directive.
+    pub aliases: &'static [&'static str],
+    /// What the directive accepts after the colon.
+    pub value: DirectiveValueKind,
+    /// One-line human description for completion documentation.
+    pub summary: &'static str,
+}
+
+/// Completable value set for `{diagrams: …}`.
+///
+/// `on` / `off` / `guitar` / `ukulele` / `piano` are the standard ChordPro
+/// values; `top` / `bottom` / `right` / `below` are the section-position
+/// keywords; `inline` / `hover` are the chordsketch surfacing-mode
+/// extension (ADR-0027). The parser also accepts the aliases `uke` /
+/// `keyboard` / `keys`, but completion offers the canonical forms only.
+const DIAGRAMS_VALUES: &[&str] = &[
+    "on", "off", "guitar", "ukulele", "piano", "top", "bottom", "right", "below", "inline", "hover",
+];
+
+/// Completable value set for the legacy `{pagetype: …}` directive.
+const PAGETYPE_VALUES: &[&str] = &["a4", "letter"];
+
+const NONE: DirectiveValueKind = DirectiveValueKind::None;
+const FREE: DirectiveValueKind = DirectiveValueKind::FreeForm;
+
+/// The directive catalog. One entry per directive recognised by
+/// [`crate::ast::DirectiveKind::from_name`]; the consistency test below
+/// enforces that correspondence in both directions.
+pub const DIRECTIVES: &[DirectiveInfo] = &[
+    // --- Metadata ---
+    DirectiveInfo {
+        name: "title",
+        aliases: &["t"],
+        value: FREE,
+        summary: "Song title",
+    },
+    DirectiveInfo {
+        name: "subtitle",
+        aliases: &["st"],
+        value: FREE,
+        summary: "Song subtitle",
+    },
+    DirectiveInfo {
+        name: "artist",
+        aliases: &[],
+        value: FREE,
+        summary: "Performing artist",
+    },
+    DirectiveInfo {
+        name: "composer",
+        aliases: &[],
+        value: FREE,
+        summary: "Composer",
+    },
+    DirectiveInfo {
+        name: "lyricist",
+        aliases: &[],
+        value: FREE,
+        summary: "Lyricist",
+    },
+    DirectiveInfo {
+        name: "album",
+        aliases: &[],
+        value: FREE,
+        summary: "Album",
+    },
+    DirectiveInfo {
+        name: "year",
+        aliases: &[],
+        value: FREE,
+        summary: "Year",
+    },
+    DirectiveInfo {
+        name: "key",
+        aliases: &[],
+        value: FREE,
+        summary: "Musical key",
+    },
+    DirectiveInfo {
+        name: "tempo",
+        aliases: &[],
+        value: FREE,
+        summary: "Tempo (BPM)",
+    },
+    DirectiveInfo {
+        name: "time",
+        aliases: &[],
+        value: FREE,
+        summary: "Time signature",
+    },
+    DirectiveInfo {
+        name: "capo",
+        aliases: &[],
+        value: FREE,
+        summary: "Capo fret position",
+    },
+    DirectiveInfo {
+        name: "sorttitle",
+        aliases: &[],
+        value: FREE,
+        summary: "Sort-order title",
+    },
+    DirectiveInfo {
+        name: "sortartist",
+        aliases: &[],
+        value: FREE,
+        summary: "Sort-order artist",
+    },
+    DirectiveInfo {
+        name: "arranger",
+        aliases: &[],
+        value: FREE,
+        summary: "Arranger",
+    },
+    DirectiveInfo {
+        name: "copyright",
+        aliases: &[],
+        value: FREE,
+        summary: "Copyright notice",
+    },
+    DirectiveInfo {
+        name: "duration",
+        aliases: &[],
+        value: FREE,
+        summary: "Song duration",
+    },
+    DirectiveInfo {
+        name: "tag",
+        aliases: &[],
+        value: FREE,
+        summary: "Categorisation tag",
+    },
+    // --- Transpose ---
+    DirectiveInfo {
+        name: "transpose",
+        aliases: &[],
+        value: FREE,
+        summary: "Transpose semitones",
+    },
+    // --- Song boundary ---
+    DirectiveInfo {
+        name: "new_song",
+        aliases: &["ns"],
+        value: NONE,
+        summary: "Start a new song",
+    },
+    // --- Comments ---
+    DirectiveInfo {
+        name: "comment",
+        aliases: &["c"],
+        value: FREE,
+        summary: "Comment line",
+    },
+    DirectiveInfo {
+        name: "comment_italic",
+        aliases: &["ci"],
+        value: FREE,
+        summary: "Italic comment",
+    },
+    DirectiveInfo {
+        name: "comment_box",
+        aliases: &["cb"],
+        value: FREE,
+        summary: "Boxed comment",
+    },
+    DirectiveInfo {
+        name: "highlight",
+        aliases: &[],
+        value: FREE,
+        summary: "Highlighted comment",
+    },
+    // --- Environments (sections) ---
+    DirectiveInfo {
+        name: "start_of_chorus",
+        aliases: &["soc"],
+        value: FREE,
+        summary: "Begin chorus (optional label)",
+    },
+    DirectiveInfo {
+        name: "end_of_chorus",
+        aliases: &["eoc"],
+        value: NONE,
+        summary: "End chorus",
+    },
+    DirectiveInfo {
+        name: "start_of_verse",
+        aliases: &["sov"],
+        value: FREE,
+        summary: "Begin verse (optional label)",
+    },
+    DirectiveInfo {
+        name: "end_of_verse",
+        aliases: &["eov"],
+        value: NONE,
+        summary: "End verse",
+    },
+    DirectiveInfo {
+        name: "start_of_bridge",
+        aliases: &["sob"],
+        value: FREE,
+        summary: "Begin bridge (optional label)",
+    },
+    DirectiveInfo {
+        name: "end_of_bridge",
+        aliases: &["eob"],
+        value: NONE,
+        summary: "End bridge",
+    },
+    DirectiveInfo {
+        name: "start_of_tab",
+        aliases: &["sot"],
+        value: FREE,
+        summary: "Begin tablature block",
+    },
+    DirectiveInfo {
+        name: "end_of_tab",
+        aliases: &["eot"],
+        value: NONE,
+        summary: "End tablature block",
+    },
+    DirectiveInfo {
+        name: "start_of_grid",
+        aliases: &["sog"],
+        value: FREE,
+        summary: "Begin chord grid",
+    },
+    DirectiveInfo {
+        name: "end_of_grid",
+        aliases: &["eog"],
+        value: NONE,
+        summary: "End chord grid",
+    },
+    // --- Delegate / verbatim environments ---
+    DirectiveInfo {
+        name: "start_of_abc",
+        aliases: &[],
+        value: NONE,
+        summary: "Begin ABC notation block",
+    },
+    DirectiveInfo {
+        name: "end_of_abc",
+        aliases: &[],
+        value: NONE,
+        summary: "End ABC notation block",
+    },
+    DirectiveInfo {
+        name: "start_of_ly",
+        aliases: &[],
+        value: NONE,
+        summary: "Begin Lilypond block",
+    },
+    DirectiveInfo {
+        name: "end_of_ly",
+        aliases: &[],
+        value: NONE,
+        summary: "End Lilypond block",
+    },
+    DirectiveInfo {
+        name: "start_of_svg",
+        aliases: &[],
+        value: NONE,
+        summary: "Begin SVG block",
+    },
+    DirectiveInfo {
+        name: "end_of_svg",
+        aliases: &[],
+        value: NONE,
+        summary: "End SVG block",
+    },
+    DirectiveInfo {
+        name: "start_of_textblock",
+        aliases: &[],
+        value: NONE,
+        summary: "Begin preformatted text block",
+    },
+    DirectiveInfo {
+        name: "end_of_textblock",
+        aliases: &[],
+        value: NONE,
+        summary: "End preformatted text block",
+    },
+    DirectiveInfo {
+        name: "start_of_musicxml",
+        aliases: &[],
+        value: NONE,
+        summary: "Begin MusicXML block",
+    },
+    DirectiveInfo {
+        name: "end_of_musicxml",
+        aliases: &[],
+        value: NONE,
+        summary: "End MusicXML block",
+    },
+    // --- Recall ---
+    DirectiveInfo {
+        name: "chorus",
+        aliases: &[],
+        value: FREE,
+        summary: "Recall the last chorus (optional label)",
+    },
+    // --- Page control ---
+    DirectiveInfo {
+        name: "new_page",
+        aliases: &["np"],
+        value: NONE,
+        summary: "Page break",
+    },
+    DirectiveInfo {
+        name: "new_physical_page",
+        aliases: &["npp"],
+        value: NONE,
+        summary: "Physical page break",
+    },
+    DirectiveInfo {
+        name: "column_break",
+        aliases: &["colb"],
+        value: NONE,
+        summary: "Column break",
+    },
+    DirectiveInfo {
+        name: "columns",
+        aliases: &["col"],
+        value: FREE,
+        summary: "Number of columns",
+    },
+    DirectiveInfo {
+        name: "pagetype",
+        aliases: &[],
+        value: DirectiveValueKind::Enum(PAGETYPE_VALUES),
+        summary: "Page size (legacy)",
+    },
+    // --- Font / size / colour ---
+    DirectiveInfo {
+        name: "textfont",
+        aliases: &["tf"],
+        value: FREE,
+        summary: "Lyrics font",
+    },
+    DirectiveInfo {
+        name: "textsize",
+        aliases: &["ts"],
+        value: FREE,
+        summary: "Lyrics size",
+    },
+    DirectiveInfo {
+        name: "textcolour",
+        aliases: &["tc"],
+        value: FREE,
+        summary: "Lyrics colour",
+    },
+    DirectiveInfo {
+        name: "chordfont",
+        aliases: &["cf"],
+        value: FREE,
+        summary: "Chord font",
+    },
+    DirectiveInfo {
+        name: "chordsize",
+        aliases: &["cs"],
+        value: FREE,
+        summary: "Chord size",
+    },
+    DirectiveInfo {
+        name: "chordcolour",
+        aliases: &["cc"],
+        value: FREE,
+        summary: "Chord colour",
+    },
+    DirectiveInfo {
+        name: "tabfont",
+        aliases: &[],
+        value: FREE,
+        summary: "Tablature font",
+    },
+    DirectiveInfo {
+        name: "tabsize",
+        aliases: &[],
+        value: FREE,
+        summary: "Tablature size",
+    },
+    DirectiveInfo {
+        name: "tabcolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Tablature colour",
+    },
+    DirectiveInfo {
+        name: "titlefont",
+        aliases: &[],
+        value: FREE,
+        summary: "Title font",
+    },
+    DirectiveInfo {
+        name: "titlesize",
+        aliases: &[],
+        value: FREE,
+        summary: "Title size",
+    },
+    DirectiveInfo {
+        name: "titlecolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Title colour",
+    },
+    DirectiveInfo {
+        name: "chorusfont",
+        aliases: &[],
+        value: FREE,
+        summary: "Chorus font",
+    },
+    DirectiveInfo {
+        name: "chorussize",
+        aliases: &[],
+        value: FREE,
+        summary: "Chorus size",
+    },
+    DirectiveInfo {
+        name: "choruscolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Chorus colour",
+    },
+    DirectiveInfo {
+        name: "footerfont",
+        aliases: &[],
+        value: FREE,
+        summary: "Footer font",
+    },
+    DirectiveInfo {
+        name: "footersize",
+        aliases: &[],
+        value: FREE,
+        summary: "Footer size",
+    },
+    DirectiveInfo {
+        name: "footercolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Footer colour",
+    },
+    DirectiveInfo {
+        name: "headerfont",
+        aliases: &[],
+        value: FREE,
+        summary: "Header font",
+    },
+    DirectiveInfo {
+        name: "headersize",
+        aliases: &[],
+        value: FREE,
+        summary: "Header size",
+    },
+    DirectiveInfo {
+        name: "headercolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Header colour",
+    },
+    DirectiveInfo {
+        name: "labelfont",
+        aliases: &[],
+        value: FREE,
+        summary: "Section-label font",
+    },
+    DirectiveInfo {
+        name: "labelsize",
+        aliases: &[],
+        value: FREE,
+        summary: "Section-label size",
+    },
+    DirectiveInfo {
+        name: "labelcolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Section-label colour",
+    },
+    DirectiveInfo {
+        name: "gridfont",
+        aliases: &[],
+        value: FREE,
+        summary: "Grid font",
+    },
+    DirectiveInfo {
+        name: "gridsize",
+        aliases: &[],
+        value: FREE,
+        summary: "Grid size",
+    },
+    DirectiveInfo {
+        name: "gridcolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Grid colour",
+    },
+    DirectiveInfo {
+        name: "tocfont",
+        aliases: &[],
+        value: FREE,
+        summary: "Table-of-contents font",
+    },
+    DirectiveInfo {
+        name: "tocsize",
+        aliases: &[],
+        value: FREE,
+        summary: "Table-of-contents size",
+    },
+    DirectiveInfo {
+        name: "toccolour",
+        aliases: &[],
+        value: FREE,
+        summary: "Table-of-contents colour",
+    },
+    // --- Chord definitions and diagrams ---
+    DirectiveInfo {
+        name: "define",
+        aliases: &[],
+        value: FREE,
+        summary: "Define a chord shape",
+    },
+    DirectiveInfo {
+        name: "chord",
+        aliases: &[],
+        value: FREE,
+        summary: "Reference a defined chord",
+    },
+    DirectiveInfo {
+        name: "diagrams",
+        aliases: &[],
+        value: DirectiveValueKind::Enum(DIAGRAMS_VALUES),
+        summary: "Chord-diagram visibility / instrument / position / mode",
+    },
+    DirectiveInfo {
+        name: "no_diagrams",
+        aliases: &["nodiagrams"],
+        value: NONE,
+        summary: "Suppress chord diagrams",
+    },
+    // --- Generic metadata + image ---
+    DirectiveInfo {
+        name: "meta",
+        aliases: &[],
+        value: FREE,
+        summary: "Generic metadata (key value)",
+    },
+    DirectiveInfo {
+        name: "image",
+        aliases: &[],
+        value: FREE,
+        summary: "Embed an image",
+    },
+];
+
+/// Returns the full directive catalog.
+#[must_use]
+pub fn directives() -> &'static [DirectiveInfo] {
+    DIRECTIVES
+}
+
+/// Looks up a directive entry by canonical name or alias (case-insensitive).
+#[must_use]
+pub fn lookup(name: &str) -> Option<&'static DirectiveInfo> {
+    let lower = name.trim().to_ascii_lowercase();
+    DIRECTIVES
+        .iter()
+        .find(|d| d.name == lower || d.aliases.contains(&lower.as_str()))
+}
+
+/// Returns the completable value set for a directive whose value is an
+/// [`DirectiveValueKind::Enum`], or `None` for free-form / value-less
+/// directives and unknown names. Alias-aware.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_chordpro::directive_catalog::directive_value_options;
+///
+/// assert!(directive_value_options("diagrams").unwrap().contains(&"inline"));
+/// assert_eq!(directive_value_options("title"), None);
+/// assert_eq!(directive_value_options("not-a-directive"), None);
+/// ```
+#[must_use]
+pub fn directive_value_options(name: &str) -> Option<&'static [&'static str]> {
+    match lookup(name)?.value {
+        DirectiveValueKind::Enum(values) => Some(values),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::DirectiveKind;
+
+    #[test]
+    fn every_catalog_name_and_alias_resolves_to_a_known_directive() {
+        // The catalog must never list a name the parser does not know:
+        // each canonical name and alias must resolve through `from_name`
+        // to a non-`Unknown` kind, and every alias must resolve to the
+        // same kind as its canonical name. This is the guard against the
+        // catalog drifting from `DirectiveKind::from_name`.
+        for d in DIRECTIVES {
+            let canonical_kind = DirectiveKind::from_name(d.name);
+            assert!(
+                !matches!(canonical_kind, DirectiveKind::Unknown(_)),
+                "catalog directive {:?} is not recognised by from_name",
+                d.name
+            );
+            for alias in d.aliases {
+                assert_eq!(
+                    DirectiveKind::from_name(alias),
+                    canonical_kind,
+                    "alias {alias:?} of {:?} resolves to a different kind",
+                    d.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn catalog_names_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for d in DIRECTIVES {
+            assert!(seen.insert(d.name), "duplicate catalog name {:?}", d.name);
+        }
+    }
+
+    #[test]
+    fn diagrams_enum_includes_inline_and_hover_extension_values() {
+        let values = directive_value_options("diagrams").expect("diagrams is an enum directive");
+        for expected in ["on", "off", "guitar", "ukulele", "piano", "inline", "hover"] {
+            assert!(
+                values.contains(&expected),
+                "diagrams values missing {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn free_form_and_value_less_directives_have_no_value_options() {
+        assert_eq!(directive_value_options("title"), None);
+        assert_eq!(directive_value_options("new_page"), None);
+    }
+
+    #[test]
+    fn lookup_is_alias_aware_and_case_insensitive() {
+        assert_eq!(lookup("SOC").map(|d| d.name), Some("start_of_chorus"));
+        assert_eq!(lookup("t").map(|d| d.name), Some("title"));
+        assert_eq!(lookup("Diagrams").map(|d| d.name), Some("diagrams"));
+        assert!(lookup("definitely-not-a-directive").is_none());
+    }
+
+    #[test]
+    fn pagetype_offers_its_enum_values() {
+        let values = directive_value_options("pagetype").expect("pagetype is an enum directive");
+        assert!(values.contains(&"a4"));
+        assert!(values.contains(&"letter"));
+    }
+}

--- a/crates/chordpro/src/lib.rs
+++ b/crates/chordpro/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ast;
 pub mod chord;
 pub mod chord_diagram;
 pub mod config;
+pub mod directive_catalog;
 pub mod escape;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod external_tool;

--- a/crates/chordpro/tests/golden_directives.rs
+++ b/crates/chordpro/tests/golden_directives.rs
@@ -609,7 +609,10 @@ fn diagrams_directive_value_extensions_golden_test() {
     for (input, expected_value) in cases {
         let song = parse(input).expect("parse failed");
         let Line::Directive(ref d) = song.lines[0] else {
-            panic!("expected a directive for {input:?}, got: {:?}", song.lines[0]);
+            panic!(
+                "expected a directive for {input:?}, got: {:?}",
+                song.lines[0]
+            );
         };
         assert_eq!(
             d.kind,

--- a/crates/chordpro/tests/golden_directives.rs
+++ b/crates/chordpro/tests/golden_directives.rs
@@ -592,3 +592,35 @@ fn page_control_directives_golden_test() {
         }
     }
 }
+
+#[test]
+fn diagrams_directive_value_extensions_golden_test() {
+    // chordsketch extension: `inline` / `hover` ride on the standard
+    // `{diagrams}` directive as plain values, so the parser classifies the
+    // line as `DirectiveKind::Diagrams` and preserves the value verbatim
+    // for the renderer's mode facet to interpret. No new directive kind or
+    // syntax is introduced — this golden pins that contract so a future
+    // parser change cannot silently drop or rewrite the value.
+    let cases = [
+        ("{diagrams: inline}", "inline"),
+        ("{diagrams: hover}", "hover"),
+        ("{diagrams: section}", "section"),
+    ];
+    for (input, expected_value) in cases {
+        let song = parse(input).expect("parse failed");
+        let Line::Directive(ref d) = song.lines[0] else {
+            panic!("expected a directive for {input:?}, got: {:?}", song.lines[0]);
+        };
+        assert_eq!(
+            d.kind,
+            DirectiveKind::Diagrams,
+            "{input:?} should classify as Diagrams"
+        );
+        assert_eq!(d.name, "diagrams");
+        assert_eq!(
+            d.value.as_deref(),
+            Some(expected_value),
+            "{input:?} should preserve its value verbatim"
+        );
+    }
+}

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -10,6 +10,7 @@
 //! Context detection works by scanning the line text up to the cursor column
 //! and finding the innermost open delimiter.
 
+use chordsketch_chordpro::directive_catalog::{self, DirectiveValueKind};
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, Documentation, MarkupContent, MarkupKind,
 };
@@ -28,6 +29,14 @@ pub enum CompletionContext {
     },
     /// After `{meta: `: complete known metadata keys.
     MetadataKey { prefix: String },
+    /// After `{<directive>: ` for a directive whose value is a fixed set
+    /// (e.g. `{diagrams: }`): complete that directive's allowed values.
+    DirectiveValue {
+        /// Canonical directive name (lowercased).
+        directive: String,
+        /// Value characters typed so far (lowercased prefix).
+        prefix: String,
+    },
     /// Inside `[...]`: complete chord names.
     ChordName { prefix: String },
     /// Not inside a recognized completion context.
@@ -113,7 +122,15 @@ pub fn detect_context(line: &str, col: usize) -> CompletionContext {
             if directive_name == "meta" {
                 return CompletionContext::MetadataKey { prefix };
             }
-            // Other directive values — no completion implemented yet.
+            // Directives whose value is a fixed set (e.g. `{diagrams: }`)
+            // complete their allowed values; free-form / value-less
+            // directives still offer nothing (ADR-0028).
+            if directive_catalog::directive_value_options(&directive_name).is_some() {
+                return CompletionContext::DirectiveValue {
+                    directive: directive_name,
+                    prefix,
+                };
+            }
             return CompletionContext::None;
         }
         // Before the colon: completing the directive name.
@@ -133,105 +150,6 @@ pub fn detect_context(line: &str, col: usize) -> CompletionContext {
 // ---------------------------------------------------------------------------
 // Static completion data
 // ---------------------------------------------------------------------------
-
-/// All canonical ChordPro directive names with optional alias info.
-///
-/// Each entry is `(canonical_name, alias_note)` where `alias_note` is
-/// `Some("alias: soc")` for directives that have short aliases.
-const DIRECTIVES: &[(&str, Option<&str>)] = &[
-    // Metadata
-    ("title", Some("alias: t")),
-    ("subtitle", Some("alias: st")),
-    ("artist", None),
-    ("composer", None),
-    ("lyricist", None),
-    ("album", None),
-    ("year", None),
-    ("key", None),
-    ("tempo", None),
-    ("time", None),
-    ("capo", None),
-    ("sorttitle", None),
-    ("sortartist", None),
-    ("arranger", None),
-    ("copyright", None),
-    ("duration", None),
-    ("tag", None),
-    // Transpose
-    ("transpose", None),
-    // Song boundary
-    ("new_song", Some("alias: ns")),
-    // Formatting / comment
-    ("comment", Some("alias: c")),
-    ("comment_italic", Some("alias: ci")),
-    ("comment_box", Some("alias: cb")),
-    // Environments
-    ("start_of_chorus", Some("alias: soc")),
-    ("end_of_chorus", Some("alias: eoc")),
-    ("start_of_verse", Some("alias: sov")),
-    ("end_of_verse", Some("alias: eov")),
-    ("start_of_bridge", Some("alias: sob")),
-    ("end_of_bridge", Some("alias: eob")),
-    ("start_of_tab", Some("alias: sot")),
-    ("end_of_tab", Some("alias: eot")),
-    ("start_of_grid", Some("alias: sog")),
-    ("end_of_grid", Some("alias: eog")),
-    ("start_of_abc", None),
-    ("end_of_abc", None),
-    ("start_of_ly", None),
-    ("end_of_ly", None),
-    ("start_of_svg", None),
-    ("end_of_svg", None),
-    ("start_of_textblock", None),
-    ("end_of_textblock", None),
-    // Recall
-    ("chorus", None),
-    // Page control
-    ("new_page", Some("alias: np")),
-    ("new_physical_page", Some("alias: npp")),
-    ("column_break", Some("alias: colb")),
-    ("columns", Some("alias: col")),
-    // Font/size/color (inline)
-    ("textfont", Some("alias: tf")),
-    ("textsize", Some("alias: ts")),
-    ("textcolour", Some("alias: tc")),
-    ("chordfont", Some("alias: cf")),
-    ("chordsize", Some("alias: cs")),
-    ("chordcolour", Some("alias: cc")),
-    ("tabfont", None),
-    ("tabsize", None),
-    ("tabcolour", None),
-    // Font/size/color (title-level)
-    ("titlefont", None),
-    ("titlesize", None),
-    ("titlecolour", None),
-    ("chorusfont", None),
-    ("chorussize", None),
-    ("choruscolour", None),
-    ("footerfont", None),
-    ("footersize", None),
-    ("footercolour", None),
-    ("headerfont", None),
-    ("headersize", None),
-    ("headercolour", None),
-    ("labelfont", None),
-    ("labelsize", None),
-    ("labelcolour", None),
-    ("gridfont", None),
-    ("gridsize", None),
-    ("gridcolour", None),
-    ("tocfont", None),
-    ("tocsize", None),
-    ("toccolour", None),
-    // Chord definitions
-    ("define", None),
-    ("chord", None),
-    ("diagrams", None),
-    // Generic metadata
-    ("meta", None),
-    // Image
-    ("image", None),
-];
 
 /// Common `{meta: KEY}` keys.
 const META_KEYS: &[&str] = &[
@@ -271,19 +189,50 @@ const SUFFIXES: &[&str] = &[
 // ---------------------------------------------------------------------------
 
 /// Returns directive name completion items matching `prefix`.
+///
+/// Sourced from the shared `chordsketch_chordpro::directive_catalog` so the
+/// LSP, the web editor, and the playground all offer the same directive set
+/// (ADR-0028) — no hand-maintained copy to drift.
 #[must_use]
 pub fn directive_items(prefix: &str) -> Vec<CompletionItem> {
-    DIRECTIVES
+    directive_catalog::directives()
         .iter()
-        .filter(|(name, _)| name.starts_with(prefix))
-        .map(|(name, alias)| {
-            let detail = alias.map(ToString::to_string);
+        .filter(|d| d.name.starts_with(prefix))
+        .map(|d| {
+            // Surface the first short alias (if any) in `detail`, matching
+            // the prior "alias: soc" hint shape.
+            let detail = d.aliases.first().map(|a| format!("alias: {a}"));
             CompletionItem {
-                label: name.to_string(),
+                label: d.name.to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
                 detail,
+                documentation: Some(Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::PlainText,
+                    value: d.summary.to_string(),
+                })),
                 ..Default::default()
             }
+        })
+        .collect()
+}
+
+/// Returns value completion items for an enum-valued directive (e.g.
+/// `{diagrams: }`), filtered by `prefix`. Empty for free-form / value-less
+/// directives and unknown names. Backed by the shared directive catalog
+/// (ADR-0028).
+#[must_use]
+pub fn directive_value_items(directive: &str, prefix: &str) -> Vec<CompletionItem> {
+    let Some(values) = directive_catalog::directive_value_options(directive) else {
+        return Vec::new();
+    };
+    let _ = DirectiveValueKind::None; // keep the import meaningful for readers
+    values
+        .iter()
+        .filter(|v| v.starts_with(prefix))
+        .map(|v| CompletionItem {
+            label: (*v).to_string(),
+            kind: Some(CompletionItemKind::VALUE),
+            ..Default::default()
         })
         .collect()
 }
@@ -556,8 +505,59 @@ mod tests {
 
     #[test]
     fn context_directive_value_non_meta_is_none() {
-        // Inside a directive value that is not `meta` — no completion.
+        // A FREE-FORM directive value (e.g. `{title: …}`) still offers no
+        // completion — only enum-valued directives do (ADR-0028).
         let ctx = detect_context("{title: My", 10);
         assert_eq!(ctx, CompletionContext::None);
+    }
+
+    #[test]
+    fn context_enum_directive_value_completes() {
+        // `{diagrams: }` is enum-valued, so the cursor after the colon is a
+        // DirectiveValue context carrying the directive name + typed prefix.
+        let ctx = detect_context("{diagrams: ", 11);
+        assert_eq!(
+            ctx,
+            CompletionContext::DirectiveValue {
+                directive: "diagrams".to_string(),
+                prefix: String::new(),
+            }
+        );
+        let ctx2 = detect_context("{diagrams: in", 13);
+        assert_eq!(
+            ctx2,
+            CompletionContext::DirectiveValue {
+                directive: "diagrams".to_string(),
+                prefix: "in".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn directive_value_items_offers_diagrams_values() {
+        let items = directive_value_items("diagrams", "");
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"inline"));
+        assert!(labels.contains(&"hover"));
+        assert!(labels.contains(&"off"));
+        // Prefix filtering narrows the set.
+        let inl = directive_value_items("diagrams", "in");
+        assert!(inl.iter().all(|i| i.label.starts_with("in")));
+        assert!(inl.iter().any(|i| i.label == "inline"));
+    }
+
+    #[test]
+    fn directive_value_items_empty_for_free_form() {
+        assert!(directive_value_items("title", "").is_empty());
+        assert!(directive_value_items("not-a-directive", "").is_empty());
+    }
+
+    #[test]
+    fn directive_items_still_includes_previously_missing_directives() {
+        // The catalog fixed the hand-list's gaps — these must now appear.
+        let labels: Vec<String> = directive_items("").into_iter().map(|i| i.label).collect();
+        for name in ["highlight", "no_diagrams", "pagetype", "start_of_musicxml"] {
+            assert!(labels.contains(&name.to_string()), "missing {name}");
+        }
     }
 }

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -1,16 +1,17 @@
 //! LSP completion support for ChordPro files.
 //!
 //! Completion items are built from static, compile-time data — no external
-//! files or network access. The three completion contexts are:
+//! files or network access. The four completion contexts are:
 //!
-//! - **Directive name**: inside `{...}` before or at the `:`
+//! - **Directive name**: inside `{...}` before the `:`
+//! - **Directive value**: after the `:` of an enum-valued directive (e.g. `{diagrams: }`)
 //! - **Chord name**: inside `[...]`
 //! - **Metadata key**: inside `{meta: ...}` after the space
 //!
 //! Context detection works by scanning the line text up to the cursor column
 //! and finding the innermost open delimiter.
 
-use chordsketch_chordpro::directive_catalog::{self, DirectiveValueKind};
+use chordsketch_chordpro::directive_catalog;
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, Documentation, MarkupContent, MarkupKind,
 };
@@ -225,7 +226,6 @@ pub fn directive_value_items(directive: &str, prefix: &str) -> Vec<CompletionIte
     let Some(values) = directive_catalog::directive_value_options(directive) else {
         return Vec::new();
     };
-    let _ = DirectiveValueKind::None; // keep the import meaningful for readers
     values
         .iter()
         .filter(|v| v.starts_with(prefix))

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -27,7 +27,8 @@ use tower_lsp::lsp_types::{
 use tower_lsp::{Client, LanguageServer};
 
 use crate::completion::{
-    CompletionContext, chord_items, detect_context, directive_items, meta_key_items,
+    CompletionContext, chord_items, detect_context, directive_items, directive_value_items,
+    meta_key_items,
 };
 use crate::convert::parse_error_to_diagnostic;
 use crate::encoding::{
@@ -232,6 +233,9 @@ impl LanguageServer for Backend {
         let items = match detect_context(&line_owned, col) {
             CompletionContext::DirectiveName { prefix } => directive_items(&prefix),
             CompletionContext::MetadataKey { prefix } => meta_key_items(&prefix),
+            CompletionContext::DirectiveValue { directive, prefix } => {
+                directive_value_items(&directive, &prefix)
+            }
             CompletionContext::ChordName { prefix } => chord_items(&prefix),
             CompletionContext::None => return Ok(None),
         };

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -39,9 +39,9 @@ use wasm_bindgen::prelude::*;
 use crate::{
     RenderOptions, chord_diagram_svg_inner, chord_diagram_svg_inner_with_options,
     chord_diagram_svg_inner_with_orientation, do_chord_typography, do_convert_chordpro_to_irealb,
-    do_convert_irealb_to_chordpro_text, do_parse_chordpro, do_parse_irealb, do_render_ireal_svg,
-    do_render_string, do_serialize_irealb, render_string_with_warnings_core, resolve_config_inner,
-    validate_inner,
+    do_convert_irealb_to_chordpro_text, do_directive_value_options, do_list_directives,
+    do_parse_chordpro, do_parse_irealb, do_render_ireal_svg, do_render_string, do_serialize_irealb,
+    render_string_with_warnings_core, resolve_config_inner, validate_inner,
 };
 
 // `do_render_bytes` / `render_bytes_with_warnings_core` /
@@ -766,7 +766,7 @@ pub fn chord_diagram_svg_with_defines_orientation(
 /// — the chordsketch extension surface used by the React JSX walker when a
 /// song carries `{diagrams: inline}` / `{diagrams: hover}`.
 ///
-/// Renders the smaller above-a-lyric layout ([`DiagramSize::Compact`]
+/// Renders the smaller above-a-lyric layout (`DiagramSize::Compact`
 /// in the core) while honouring the same `{define}` voicings and
 /// orientation knob as the regular export. The compact SVG carries an
 /// extra `chord-diagram-compact` (or `keyboard-diagram-compact`) class on
@@ -900,6 +900,77 @@ export function chordDiagramSvgWithDefinesOrientationCompact(
   defines: Array<[string, string]>,
   orientation?: ChordDiagramOrientation | null,
 ): string | null;
+"#;
+
+/// Return the ChordPro directive catalog as a JS array of `DirectiveInfo`
+/// objects (ADR-0028).
+///
+/// Each entry carries the directive's canonical `name`, its `aliases`, the
+/// `valueKind` (`"none"` / `"freeform"` / `"enum"`), the allowed `values`
+/// (non-empty only for `"enum"`), and a one-line `summary`. The web
+/// editor's completion source and the playground's directive picker both
+/// consume this so they offer the same directive set the LSP does, sourced
+/// from the single catalog in `chordsketch_chordpro::directive_catalog`.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string only if serialisation fails — a
+/// defensive path callers can treat as infallible in normal use.
+#[wasm_bindgen(js_name = listDirectives, skip_typescript)]
+pub fn list_directives() -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(&do_list_directives())
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Return the allowed value set for an enum-valued directive (alias-aware),
+/// or `null` for free-form / value-less directives and unknown names
+/// (ADR-0028).
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string only if serialisation fails.
+#[wasm_bindgen(js_name = directiveValueOptions, skip_typescript)]
+pub fn directive_value_options(name: &str) -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(&do_directive_value_options(name))
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const DIRECTIVE_CATALOG_TS: &'static str = r#"
+/**
+ * A single directive-catalog entry returned by {@link listDirectives}
+ * (ADR-0028). The web editor's completion source and the playground's
+ * directive picker drive their directive lists off this shared catalog so
+ * they offer the same set the LSP / VS Code completion does.
+ */
+export interface DirectiveInfo {
+  /** Canonical directive name (e.g. `"diagrams"`, `"title"`). */
+  name: string;
+  /** Recognised aliases for the directive (e.g. `["t"]` for `title`). */
+  aliases: string[];
+  /**
+   * Shape of the directive's value:
+   * - `"none"`     — value-less (`{new_song}`);
+   * - `"freeform"` — free text (`{title: ...}`);
+   * - `"enum"`     — a fixed set, surfaced in `values`.
+   */
+  valueKind: "none" | "freeform" | "enum";
+  /** Allowed values when `valueKind === "enum"`; empty otherwise. */
+  values: string[];
+  /** One-line human-readable summary of the directive. */
+  summary: string;
+}
+
+/**
+ * Return the ChordPro directive catalog as an array of {@link DirectiveInfo}.
+ */
+export function listDirectives(): DirectiveInfo[];
+
+/**
+ * Return the allowed value set for an enum-valued directive (alias-aware),
+ * or `null` for free-form / value-less directives and unknown names.
+ */
+export function directiveValueOptions(name: string): string[] | null;
 "#;
 
 /// Serializable shape returned by [`parse_chordpro_with_warnings`]

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -37,10 +37,11 @@ use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    RenderOptions, chord_diagram_svg_inner, chord_diagram_svg_inner_with_orientation,
-    do_chord_typography, do_convert_chordpro_to_irealb, do_convert_irealb_to_chordpro_text,
-    do_parse_chordpro, do_parse_irealb, do_render_ireal_svg, do_render_string, do_serialize_irealb,
-    render_string_with_warnings_core, resolve_config_inner, validate_inner,
+    RenderOptions, chord_diagram_svg_inner, chord_diagram_svg_inner_with_options,
+    chord_diagram_svg_inner_with_orientation, do_chord_typography, do_convert_chordpro_to_irealb,
+    do_convert_irealb_to_chordpro_text, do_parse_chordpro, do_parse_irealb, do_render_ireal_svg,
+    do_render_string, do_serialize_irealb, render_string_with_warnings_core, resolve_config_inner,
+    validate_inner,
 };
 
 // `do_render_bytes` / `render_bytes_with_warnings_core` /
@@ -761,6 +762,46 @@ pub fn chord_diagram_svg_with_defines_orientation(
     .map_err(|e| JsValue::from_str(&e))
 }
 
+/// Compact-size counterpart of [`chord_diagram_svg_with_defines_orientation`]
+/// — the chordsketch extension surface used by the React JSX walker when a
+/// song carries `{diagrams: inline}` / `{diagrams: hover}`.
+///
+/// Renders the smaller above-a-lyric layout ([`DiagramSize::Compact`]
+/// in the core) while honouring the same `{define}` voicings and
+/// orientation knob as the regular export. The compact SVG carries an
+/// extra `chord-diagram-compact` (or `keyboard-diagram-compact`) class on
+/// its root element.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string when:
+///   * `instrument` is not one of `"guitar"` / `"ukulele"` / `"piano"`
+///     (or their aliases).
+///   * `defines` is not a deserialisable `[[string, string], …]` array.
+#[must_use = "callers must handle the unknown-instrument error"]
+#[wasm_bindgen(js_name = chordDiagramSvgWithDefinesOrientationCompact, skip_typescript)]
+pub fn chord_diagram_svg_with_defines_orientation_compact(
+    chord: &str,
+    instrument: &str,
+    defines: JsValue,
+    orientation: Option<String>,
+) -> Result<Option<String>, JsValue> {
+    let defines_vec: Vec<(String, String)> = if defines.is_undefined() || defines.is_null() {
+        Vec::new()
+    } else {
+        serde_wasm_bindgen::from_value(defines)
+            .map_err(|e| JsValue::from_str(&format!("invalid defines argument: {e}")))?
+    };
+    chord_diagram_svg_inner_with_options(
+        chord,
+        instrument,
+        &defines_vec,
+        orientation.as_deref(),
+        true,
+    )
+    .map_err(|e| JsValue::from_str(&e))
+}
+
 /// Validate ChordPro input and return any parse errors as structured
 /// records.
 ///
@@ -836,6 +877,24 @@ export function chordDiagramSvgWithOrientation(
  * `{define}` voicings first. `defines` is an array of `[name, raw]` tuples.
  */
 export function chordDiagramSvgWithDefinesOrientation(
+  chord: string,
+  instrument: string,
+  defines: Array<[string, string]>,
+  orientation?: ChordDiagramOrientation | null,
+): string | null;
+
+/**
+ * Compact-size variant of {@link chordDiagramSvgWithDefinesOrientation} — a
+ * chordsketch extension for diagrams shown directly above a lyric line (the
+ * `{diagrams: inline}` / `{diagrams: hover}` modes). The geometry is smaller
+ * but the chord-name title and finger glyphs stay legible (not a CSS scale).
+ * The returned SVG carries an extra `chord-diagram-compact` (fretted) or
+ * `keyboard-diagram-compact` (piano) class on its root element.
+ *
+ * Returns `null` when the chord is not in the built-in voicing database.
+ * Throws on unknown instrument.
+ */
+export function chordDiagramSvgWithDefinesOrientationCompact(
   chord: string,
   instrument: string,
   defines: Array<[string, string]>,

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -310,6 +310,54 @@ pub(crate) struct ValidationErrorPayload {
     pub(crate) message: String,
 }
 
+/// Serializable directive-catalog entry exposed to JS via
+/// [`bindings::list_directives`]. Mirrors
+/// `chordsketch_chordpro::directive_catalog::DirectiveInfo`, flattened for
+/// the `serde_wasm_bindgen` boundary (the core crate stays serde-free).
+///
+/// `value_kind` is `"none"` / `"freeform"` / `"enum"`; `values` is the
+/// allowed set when `value_kind == "enum"`, empty otherwise.
+#[derive(Serialize)]
+pub(crate) struct DirectiveInfoPayload {
+    pub(crate) name: String,
+    pub(crate) aliases: Vec<String>,
+    pub(crate) value_kind: String,
+    pub(crate) values: Vec<String>,
+    pub(crate) summary: String,
+}
+
+/// Maps the core directive catalog into the serializable payload shape.
+/// Native helper shared by the wasm wrapper and unit tests.
+pub(crate) fn do_list_directives() -> Vec<DirectiveInfoPayload> {
+    use chordsketch_chordpro::directive_catalog::{self, DirectiveValueKind};
+    directive_catalog::directives()
+        .iter()
+        .map(|d| {
+            let (value_kind, values) = match d.value {
+                DirectiveValueKind::None => ("none", Vec::new()),
+                DirectiveValueKind::FreeForm => ("freeform", Vec::new()),
+                DirectiveValueKind::Enum(vs) => {
+                    ("enum", vs.iter().map(|v| (*v).to_string()).collect())
+                }
+            };
+            DirectiveInfoPayload {
+                name: d.name.to_string(),
+                aliases: d.aliases.iter().map(|a| (*a).to_string()).collect(),
+                value_kind: value_kind.to_string(),
+                values,
+                summary: d.summary.to_string(),
+            }
+        })
+        .collect()
+}
+
+/// Returns the allowed value set for an enum-valued directive (alias-aware),
+/// or `None` for free-form / value-less directives and unknown names.
+pub(crate) fn do_directive_value_options(name: &str) -> Option<Vec<String>> {
+    chordsketch_chordpro::directive_catalog::directive_value_options(name)
+        .map(|vs| vs.iter().map(|v| (*v).to_string()).collect())
+}
+
 /// Shared inner helper used by both the wasm-bindgen wrapper and native
 /// unit tests. Keeping this free of any wasm-bindgen imports means
 /// `cargo test -p chordsketch-wasm` runs without hitting the "cannot
@@ -1771,6 +1819,40 @@ mod tests {
             chord_diagram_svg_inner_with_options("XYZ-not-a-chord", "guitar", &[], None, true)
                 .unwrap();
         assert!(result.is_none());
+    }
+
+    // ---- directive catalog exports (ADR-0028) ----
+
+    #[test]
+    fn do_list_directives_covers_catalog_and_marks_enum_values() {
+        let list = do_list_directives();
+        assert!(
+            list.len() >= 70,
+            "expected the full catalog, got {}",
+            list.len()
+        );
+        let diagrams = list
+            .iter()
+            .find(|d| d.name == "diagrams")
+            .expect("diagrams entry present");
+        assert_eq!(diagrams.value_kind, "enum");
+        assert!(diagrams.values.iter().any(|v| v == "inline"));
+        assert!(diagrams.values.iter().any(|v| v == "hover"));
+        let title = list.iter().find(|d| d.name == "title").unwrap();
+        assert_eq!(title.value_kind, "freeform");
+        assert!(title.values.is_empty());
+    }
+
+    #[test]
+    fn do_directive_value_options_is_enum_only_and_alias_aware() {
+        assert!(
+            do_directive_value_options("diagrams")
+                .unwrap()
+                .contains(&"inline".to_string())
+        );
+        assert!(do_directive_value_options("soc").is_none()); // alias of start_of_chorus (free-form)
+        assert!(do_directive_value_options("title").is_none());
+        assert!(do_directive_value_options("not-a-directive").is_none());
     }
 }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -317,7 +317,12 @@ pub(crate) struct ValidationErrorPayload {
 ///
 /// `value_kind` is `"none"` / `"freeform"` / `"enum"`; `values` is the
 /// allowed set when `value_kind == "enum"`, empty otherwise.
+///
+/// Serialised camelCase (`valueKind`) to match the `DirectiveInfo`
+/// TypeScript shape declared in `bindings.rs` and consumed by the React
+/// completion source + playground picker.
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct DirectiveInfoPayload {
     pub(crate) name: String,
     pub(crate) aliases: Vec<String>,

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1828,6 +1828,28 @@ mod tests {
 
     // ---- directive catalog exports (ADR-0028) ----
 
+    // If this set changes, update the DirectiveInfo `valueKind` union in
+    // crates/wasm/src/bindings.rs (DIRECTIVE_CATALOG_TS) and
+    // packages/react/src/chordpro-completion.ts in lockstep.
+    #[test]
+    fn do_list_directives_value_kind_is_one_of_the_known_set() {
+        use std::collections::BTreeSet;
+        let kinds: BTreeSet<String> = do_list_directives()
+            .iter()
+            .map(|d| d.value_kind.clone())
+            .collect();
+        let expected: BTreeSet<String> = ["none", "freeform", "enum"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            kinds, expected,
+            "value_kind strings must be exactly {{\"none\", \"freeform\", \"enum\"}}; \
+             update the DirectiveInfo `valueKind` union in bindings.rs and \
+             chordpro-completion.ts if this set changes"
+        );
+    }
+
     #[test]
     fn do_list_directives_covers_catalog_and_marks_enum_values() {
         let list = do_list_directives();

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -225,12 +225,37 @@ pub(crate) fn chord_diagram_svg_inner_with_orientation(
     defines: &[(String, String)],
     orientation: Option<&str>,
 ) -> std::result::Result<Option<String>, String> {
+    chord_diagram_svg_inner_with_options(chord, instrument, defines, orientation, false)
+}
+
+/// Variant of [`chord_diagram_svg_inner_with_orientation`] that also takes
+/// the chordsketch compact-size flag.
+///
+/// `compact == true` selects [`DiagramSize::Compact`] — the smaller
+/// above-a-lyric layout used by the `{diagrams: inline}` / `{diagrams:
+/// hover}` modes — for both fretted and keyboard diagrams. `false`
+/// reproduces the regular-size output exactly. `compact` is a plain bool
+/// here (rather than the core `DiagramSize` enum) to keep this wire-shape
+/// layer dependency-light, matching the already-stringly `orientation`
+/// argument; it is mapped to `DiagramSize` immediately below.
+pub(crate) fn chord_diagram_svg_inner_with_options(
+    chord: &str,
+    instrument: &str,
+    defines: &[(String, String)],
+    orientation: Option<&str>,
+    compact: bool,
+) -> std::result::Result<Option<String>, String> {
     use chordsketch_chordpro::chord_diagram::{
-        render_keyboard_svg, render_svg_with_orientation, resolve_orientation,
+        DiagramSize, render_keyboard_svg_with_size, render_svg_with_options, resolve_orientation,
     };
     use chordsketch_chordpro::voicings::{lookup_diagram, lookup_keyboard_voicing};
 
     let resolved = resolve_orientation(orientation);
+    let size = if compact {
+        DiagramSize::Compact
+    } else {
+        DiagramSize::Regular
+    };
 
     match instrument.to_ascii_lowercase().as_str() {
         "piano" | "keyboard" | "keys" => {
@@ -252,7 +277,10 @@ pub(crate) fn chord_diagram_svg_inner_with_orientation(
             // Keyboard diagrams have no orientation knob — the
             // argument is accepted but ignored here.
             let _ = defines;
-            Ok(lookup_keyboard_voicing(chord, &[]).map(|v| render_keyboard_svg(&v)))
+            Ok(
+                lookup_keyboard_voicing(chord, &[])
+                    .map(|v| render_keyboard_svg_with_size(&v, size)),
+            )
         }
         "guitar" | "ukulele" | "uke" => {
             // `frets_shown = 5` matches the default ChordPro HTML
@@ -261,7 +289,7 @@ pub(crate) fn chord_diagram_svg_inner_with_orientation(
             // produced by `<ChordDiagram>` visually match the
             // sheet output from `<ChordSheet>` for the same chord.
             Ok(lookup_diagram(chord, defines, instrument, 5)
-                .map(|d| render_svg_with_orientation(&d, resolved)))
+                .map(|d| render_svg_with_options(&d, resolved, size)))
         }
         other => Err(format!(
             "unknown instrument {other:?}; expected one of \"guitar\", \"ukulele\", \"piano\""
@@ -1691,6 +1719,58 @@ mod tests {
                 .unwrap()
                 .unwrap();
         assert!(!oriented.contains("chord-diagram-horizontal"));
+    }
+
+    // -----------------------------------------------------------------------
+    // chord_diagram_svg_inner_with_options — the compact-size flag the
+    // chordsketch `{diagrams: inline}` / `{diagrams: hover}` modes use.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn chord_diagram_svg_inner_compact_marks_class() {
+        let svg = chord_diagram_svg_inner_with_options("Am", "guitar", &[], None, true)
+            .unwrap()
+            .expect("Am voicing should resolve for guitar");
+        assert!(svg.contains("chord-diagram-compact"));
+    }
+
+    #[test]
+    fn chord_diagram_svg_inner_compact_false_matches_orientation_path() {
+        // compact=false must reproduce the regular orientation-aware output
+        // exactly, so the new flag is additive for existing callers.
+        let regular = chord_diagram_svg_inner_with_orientation("Am", "guitar", &[], None)
+            .unwrap()
+            .unwrap();
+        let via_options = chord_diagram_svg_inner_with_options("Am", "guitar", &[], None, false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(regular, via_options);
+    }
+
+    #[test]
+    fn chord_diagram_svg_inner_compact_keyboard_marks_class() {
+        let svg = chord_diagram_svg_inner_with_options("C", "piano", &[], None, true)
+            .unwrap()
+            .expect("C voicing should resolve for piano");
+        assert!(svg.contains("keyboard-diagram-compact"));
+    }
+
+    #[test]
+    fn chord_diagram_svg_inner_compact_horizontal_marks_both_classes() {
+        let svg =
+            chord_diagram_svg_inner_with_options("Am", "guitar", &[], Some("horizontal"), true)
+                .unwrap()
+                .unwrap();
+        assert!(svg.contains("chord-diagram-horizontal"));
+        assert!(svg.contains("chord-diagram-compact"));
+    }
+
+    #[test]
+    fn chord_diagram_svg_inner_compact_unknown_chord_returns_none() {
+        let result =
+            chord_diagram_svg_inner_with_options("XYZ-not-a-chord", "guitar", &[], None, true)
+                .unwrap();
+        assert!(result.is_none());
     }
 }
 

--- a/docs/adr/0027-inline-hover-compact-chord-diagrams.md
+++ b/docs/adr/0027-inline-hover-compact-chord-diagrams.md
@@ -1,0 +1,133 @@
+# 0027. Inline / hover chord diagrams use a dedicated compact layout
+
+- **Status**: Accepted
+- **Date**: 2026-05-31
+
+## Context
+
+ChordSketch renders chord names above the lyrics (the `[C]word` inline-chord
+syntax) and, separately, an end-of-song grid of full-size chord diagrams that
+the `{diagrams}` directive turns on. Users reading a sheet to learn the shapes
+have to look away from the lyric line, down to the grid, and back.
+
+Two new ways to surface the diagrams next to the chords they belong to were
+requested:
+
+- each chord name above a lyric is **replaced** by its diagram; and
+- the chord name stays as text and the diagram appears on **hover / focus**.
+
+Both place a diagram where a single chord name used to sit. The existing
+diagram SVG is laid out for the end-of-song grid: at the ~120×160 px it
+renders, dropping one above every chord would blow up line height and crowd
+the page. Simply shrinking that SVG with a CSS `transform: scale()` is not
+acceptable either — scaling shrinks the chord-name title and the
+finger / open / muted glyphs together with the geometry, and below roughly
+0.7× the text stops being legible, which defeats the point (the diagram has to
+be readable at a glance, inline, mid-lyric).
+
+The standard ChordPro `{diagrams}` directive only defines visibility
+(`on` / `off`), an instrument (`guitar` / `ukulele` / `piano`), and a section
+position (`top` / `bottom` / …). There is no spec value for "show the diagrams
+inline with the chords." So surfacing this needs a chordsketch-only extension,
+and a way to render a physically smaller diagram that stays legible.
+
+## Decision
+
+1. Add two **chordsketch-only values** to the existing `{diagrams}` directive:
+   `inline` and `hover`. They are a new orthogonal *mode* facet of the
+   directive value, resolved at render time alongside the existing
+   visibility / instrument / position facets — last-wins per facet — so
+   `{diagrams: inline}` and `{diagrams: guitar}` each apply to their own
+   facet and compose. The default mode stays `section` (the end-of-song grid),
+   so existing songs render unchanged. `inline` / `hover` imply visible.
+
+2. Add a dedicated **compact diagram layout** (`DiagramSize::Compact`) to the
+   chord-diagram generator, rather than CSS-scaling the regular SVG. The
+   compact layout shrinks the grid *geometry* substantially (≈0.55×) while
+   holding the glyph fonts near a legibility floor (chord-name title ≥ 11 px,
+   finger numbers ≥ 7 px) and keeping stroke widths and dot radii
+   proportionally large. The chord-name title is always rendered, so even in
+   `inline` mode — where the diagram replaces the text name — the name is
+   never lost.
+
+Both the value space and the compact layout live in the foundation crate
+(`chordsketch-chordpro::chord_diagram`) and are exposed through the existing
+wasm chord-diagram surface, so every consumer reads one source of truth.
+
+## Rationale
+
+- **A value, not a new directive.** `inline` / `hover` ride on `{diagrams}` as
+  plain values, so no new `DirectiveKind`, no AST/JSON schema change, and no
+  new syntax — the parser already preserves the value and the renderers resolve
+  it. This mirrors how `guitar` / `top` are handled today and keeps the
+  round-trip and the directive catalog trivial.
+- **A separate layout, not a CSS scale.** The whole requirement is "smaller but
+  still legible." Only a re-laid-out variant can shrink geometry on a different
+  curve from text; a `transform: scale()` cannot. Authoring it in Rust (not in
+  a React/CSS layer) keeps it on the same generator every renderer uses, so the
+  compact diagram cannot drift from the regular one
+  (`.claude/rules/playground-is-a-sample.md`).
+- **A `DiagramSize` knob mirrors the `Orientation` precedent.** ADR-0026 added
+  orientation as a `#[non_exhaustive]` enum plus a `render_svg_with_*` entry
+  point and a string resolver shared across renderers and bindings. `DiagramSize`
+  follows the same shape (`render_svg_with_options`, `resolve_diagrams_mode`,
+  `try_parse_diagrams_mode`), so the two knobs compose (compact × horizontal)
+  and the codebase has one consistent pattern for diagram render options.
+- **Mode as an orthogonal facet** keeps the lenient, last-wins `{diagrams}`
+  parsing the renderers already implement: a non-mode value (instrument /
+  position) returns `None` from the mode resolver and is left to the other
+  facets, so adding the facet cannot regress existing `{diagrams}` lines.
+
+## Consequences
+
+- `inline` / `hover` are non-standard: a `.cho` file using them renders the grid
+  (the default mode) under any other ChordPro implementation, not inline. This
+  is the accepted cost of a useful extension; the file still parses and renders
+  everywhere because the value is just ignored as an unknown mode elsewhere.
+- The compact constants (cell sizes, font floors) are tuned by eye against the
+  inline rendering, not derived from a formula. They are pinned by unit tests
+  (compact carries its marker class, stays smaller than regular on both axes,
+  and keeps the 11 px / 7 px font floors) so a later tweak that scales the text
+  below the floor fails CI.
+- A new render option threads through the wasm chord-diagram surface. The napi /
+  ffi bindings expose the same chord-diagram functions and will gain the compact
+  variant as a fix-propagation follow-up (`.claude/rules/fix-propagation.md`
+  §Bindings); web (wasm) is the only surface that needs it now.
+- Per [ADR-0017](0017-react-renders-from-ast.md) /
+  `.claude/rules/renderer-parity.md`, the actual inline/hover *placement* is
+  being implemented on the React JSX walker first; the three Rust renderers
+  (text / HTML / PDF) are owed the same `resolve_diagrams_mode` +
+  compact-diagram handling as tracked follow-up (PDF/print has no hover, so
+  `hover` degrades to `inline` or `section` there — to be documented when those
+  renderers land it).
+
+## Alternatives considered
+
+- **CSS `transform: scale()` on the regular SVG.** Rejected: shrinks text into
+  illegibility along with the geometry, which is exactly the failure the user
+  called out. A separate layout is the only way to keep the title and glyphs
+  readable at inline size.
+- **A new directive (e.g. `{inline_diagrams}`).** Rejected: a new directive
+  needs a new `DirectiveKind`, AST/JSON serialisation, catalog entry, and parser
+  arm, for no gain over a value on the directive that already controls diagrams.
+- **A TypeScript/React-only compact renderer.** Rejected: a second diagram
+  implementation would drift from the Rust generator the other renderers use,
+  violating `playground-is-a-sample.md`; and it could never reach the Rust
+  renderers that owe parity.
+- **Encode the mode in the AST (a `DiagramsMode` field on the directive).**
+  Rejected: the value already lives on `Directive::value`; resolving the mode at
+  render time (like instrument / position / orientation) avoids an AST change and
+  keeps round-trip output byte-identical.
+
+## References
+
+- [ADR-0026](0026-horizontal-chord-diagram-default-string-order.md) — the
+  `Orientation` knob this mirrors
+- [ADR-0017](0017-react-renders-from-ast.md) — React JSX walker as a renderer
+  sister site
+- `.claude/rules/renderer-parity.md` — four-renderer parity obligation
+- `.claude/rules/playground-is-a-sample.md` — why the layout lives in the library
+- `.claude/rules/fix-propagation.md` — the binding sister-group follow-up
+- `crates/chordpro/src/chord_diagram.rs` — `DiagramSize`, `render_svg_with_options`,
+  `render_keyboard_svg_with_size`, `DiagramsMode`, `resolve_diagrams_mode`
+- `docs/adr/README.md` — ADR index

--- a/docs/adr/0028-shared-directive-catalog.md
+++ b/docs/adr/0028-shared-directive-catalog.md
@@ -1,0 +1,125 @@
+# 0028. Shared directive catalog as the single source of truth for completion
+
+- **Status**: Accepted
+- **Date**: 2026-05-31
+
+## Context
+
+ChordPro directive knowledge was duplicated across the codebase, with each
+copy free to drift from the parser that actually defines what a directive
+is (`chordsketch_chordpro::ast::DirectiveKind::from_name`):
+
+- The LSP completion provider (`crates/lsp/src/completion.rs`) carried a
+  hand-maintained `const DIRECTIVES` array. It had already drifted —
+  missing `highlight`, `no_diagrams`, `pagetype`, `start_of_musicxml` /
+  `end_of_musicxml`, and others the parser recognises — so VS Code (and
+  any LSP host) offered an incomplete directive list.
+- The playground's "+ Directive" picker (`packages/playground`) hard-coded
+  13 of the ~50 directives.
+- The web CodeMirror editor offered no directive completion at all.
+
+Two product requirements made this worse rather than just untidy:
+
+1. The "Add Directive" list must be complete and must not silently fall
+   behind the parser again.
+2. Directives whose value is a fixed set — `{diagrams: on|off|guitar|…}`,
+   now also `inline` / `hover` (ADR-0027) — should offer those values as
+   completions, in **both** the VS Code extension **and** the web editor.
+
+Adding value completion to three independently-maintained lists would have
+tripled the drift surface.
+
+## Decision
+
+Introduce one **directive catalog** in the zero-dependency foundation
+crate, `chordsketch_chordpro::directive_catalog`, listing every directive
+with its canonical name, aliases, value shape
+(`None` / `FreeForm` / `Enum(values)`), and a one-line summary. Every
+surface reads it:
+
+- The **LSP** (`crates/lsp`) sources `directive_items` from the catalog
+  (deleting its hand-maintained array) and gains a new
+  `CompletionContext::DirectiveValue` plus a `directive_value_items`
+  builder, so an enum-valued directive completes its values after the
+  colon. VS Code inherits this with no extension-side change — it already
+  delegates completion to the `chordsketch-lsp` server.
+- The **wasm** crate (`crates/wasm`) exports `listDirectives()` and
+  `directiveValueOptions(name)`, serialising the catalog at the wasm
+  boundary (the core crate stays serde-free). The web CodeMirror editor
+  and the playground picker consume these (wired in a follow-up change),
+  so they offer the same set as VS Code.
+
+A consistency test in `directive_catalog` asserts every catalog name and
+alias resolves through `DirectiveKind::from_name` to the same non-`Unknown`
+kind, so the catalog cannot silently diverge from the parser.
+
+## Rationale
+
+- **Right layer.** `chordsketch-chordpro` already owns `DirectiveKind`,
+  compiles to wasm (for the browser surfaces), and is linked by the LSP
+  (for VS Code). It is the only place a single list reaches every consumer.
+  Putting the catalog in the playground or the LSP would leave the others
+  out (`.claude/rules/playground-is-a-sample.md`,
+  `.claude/rules/fix-propagation.md`).
+- **Root-cause fix, not another copy.** The drift was caused by *having
+  multiple lists*. Syncing them by hand is the prohibited band-aid
+  (`.claude/rules/root-cause-fixes.md`); one catalog + a consistency test
+  removes the failure mode instead of papering over it.
+- **Zero-dependency core preserved.** The catalog is plain `&'static`
+  data; serialization to JS happens only in the wasm crate, which already
+  depends on `serde` / `serde-wasm-bindgen`. `code-style.md`'s
+  "`chordsketch-chordpro` has zero external dependencies" rule is intact.
+- **Catalog ↔ parser kept honest by test, not by refactor.** Deriving
+  `from_name` from the catalog was considered and rejected (below); a
+  bidirectional consistency test gives the same guarantee without
+  rewriting the parser's hot path.
+
+## Consequences
+
+- The LSP directive list is now complete and self-maintaining: adding a
+  directive to the parser without adding a catalog entry (or vice versa)
+  fails the consistency test.
+- VS Code gains directive-value completion for free (the test
+  `context_directive_value_non_meta_is_none` stays valid — free-form
+  values like `{title: …}` still offer nothing; only enum directives
+  complete).
+- The wasm bundle gains two small additive exports (`listDirectives`,
+  `directiveValueOptions`) in the lean `@chordsketch/wasm` build the web
+  surfaces load.
+- The catalog's `summary` strings are lightweight (one line each), not a
+  full help system; richer hover docs remain the LSP `hover.rs`
+  responsibility. Folding `hover.rs`'s separate `DIRECTIVE_DOCS` list into
+  the catalog is a natural follow-up (sister-site per
+  `fix-propagation.md`) but out of scope here; until then it is a third
+  list and a known debt, called out so it is not forgotten.
+- Per `fix-propagation.md` §Bindings, the catalog export is wasm-only by
+  design: ffi / napi host no completion consumer, so they intentionally do
+  not get `listDirectives` / `directiveValueOptions`.
+
+## Alternatives considered
+
+- **Keep three hand-maintained lists, sync manually.** Rejected: that *is*
+  the current bug. No automated guard; the next directive re-opens the gap.
+- **Derive `DirectiveKind::from_name` from the catalog.** Rejected: the
+  parser's `from_name` / `resolve_with_selector` carry dynamic arms
+  (`StartOfSection` / `Meta` / `Image` / `ConfigOverride` / `Unknown`), the
+  last-hyphen selector split, and case/multibyte edge cases. Rewriting that
+  as a table-driven lookup is a large blast radius for a completion
+  feature; a consistency test achieves the same drift-prevention safely.
+- **Export the catalog only from the LSP, share it with the web editor via
+  the language server in the browser.** Rejected: the web playground runs
+  no language server; only the wasm path reaches the browser.
+
+## References
+
+- [ADR-0027](0027-inline-hover-compact-chord-diagrams.md) — adds the
+  `inline` / `hover` values the catalog's `diagrams` enum surfaces.
+- [ADR-0017](0017-react-renders-from-ast.md) — the AST/JSON boundary the
+  wasm exports cross.
+- `.claude/rules/fix-propagation.md`, `.claude/rules/root-cause-fixes.md`,
+  `.claude/rules/playground-is-a-sample.md`, `.claude/rules/code-style.md`.
+- `crates/chordpro/src/directive_catalog.rs` — the catalog + consistency test.
+- `crates/lsp/src/completion.rs`, `crates/lsp/src/server.rs` — LSP consumer
+  + directive-value completion.
+- `crates/wasm/src/lib.rs`, `crates/wasm/src/bindings.rs` — `listDirectives`
+  / `directiveValueOptions` exports.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -104,3 +104,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0024](0024-scheduled-dependabot-merge.md) | Scheduled unattended Dependabot review-and-merge, all bump types (extends ADR-0013 clause 1) | Accepted (2026-05-25) |
 | [0025](0025-build-time-syntax-highlighting-shiki.md) | Build-time syntax highlighting for the docs site uses Shiki (preserves ADR-0021 zero-JS posture; reuses in-repo ChordPro TextMate grammar) | Accepted (2026-05-28) |
 | [0026](0026-horizontal-chord-diagram-default-string-order.md) | Horizontal chord diagrams render reader-view only (high pitch on top, matches tablature stave order); player-view is not supported | Accepted (2026-05-30) |
+| [0027](0027-inline-hover-compact-chord-diagrams.md) | Inline / hover chord diagrams use a dedicated compact layout (chordsketch `{diagrams: inline}` / `{diagrams: hover}` extension; not a CSS scale) | Accepted (2026-05-31) |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -105,3 +105,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0025](0025-build-time-syntax-highlighting-shiki.md) | Build-time syntax highlighting for the docs site uses Shiki (preserves ADR-0021 zero-JS posture; reuses in-repo ChordPro TextMate grammar) | Accepted (2026-05-28) |
 | [0026](0026-horizontal-chord-diagram-default-string-order.md) | Horizontal chord diagrams render reader-view only (high pitch on top, matches tablature stave order); player-view is not supported | Accepted (2026-05-30) |
 | [0027](0027-inline-hover-compact-chord-diagrams.md) | Inline / hover chord diagrams use a dedicated compact layout (chordsketch `{diagrams: inline}` / `{diagrams: hover}` extension; not a CSS scale) | Accepted (2026-05-31) |
+| [0028](0028-shared-directive-catalog.md) | Shared directive catalog in `chordsketch-chordpro` is the single source of truth for directive-name + value completion across LSP / web / playground | Accepted (2026-05-31) |

--- a/packages/playground/src/chordpro/main.tsx
+++ b/packages/playground/src/chordpro/main.tsx
@@ -550,6 +550,26 @@ function PlaygroundApp(): JSX.Element {
 
   const editorRef = useRef<ChordSourceAreaHandle | null>(null);
 
+  // Directive picker options, sourced from the shared @chordsketch/wasm
+  // catalog (ADR-0028) so the list stays complete and never drifts from
+  // what the parser, editor completion, and LSP recognise.
+  const [directiveCatalog, setDirectiveCatalog] = useState<
+    DirectiveCatalogEntry[]
+  >([]);
+  useEffect(() => {
+    let cancelled = false;
+    loadChordproCatalog()
+      .then((catalog) => {
+        if (!cancelled) setDirectiveCatalog(catalog.listDirectives());
+      })
+      .catch(() => {
+        // wasm unavailable: leave the picker with only its placeholder.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   useEffect(() => {
     if (version !== null) return;
     void wasmReady.then(() => {

--- a/packages/playground/src/chordpro/main.tsx
+++ b/packages/playground/src/chordpro/main.tsx
@@ -24,6 +24,8 @@ import {
   setCapoInSource,
   type ChordRepositionEvent,
   type ChordSourceAreaHandle,
+  loadChordproCatalog,
+  type DirectiveCatalogEntry,
 } from '@chordsketch/react';
 import '@chordsketch/react/styles.css';
 
@@ -736,19 +738,18 @@ function PlaygroundApp(): JSX.Element {
                   <option value="" disabled>
                     + Directive
                   </option>
-                  <option value="{title: }">title</option>
-                  <option value="{subtitle: }">subtitle</option>
-                  <option value="{artist: }">artist</option>
-                  <option value="{composer: }">composer</option>
-                  <option value="{key: }">key</option>
-                  <option value="{tempo: }">tempo</option>
-                  <option value="{time: }">time</option>
-                  <option value="{capo: }">capo</option>
-                  <option value="{comment: }">comment</option>
-                  <option value="{comment_italic: }">comment_italic</option>
-                  <option value="{comment_box: }">comment_box</option>
-                  <option value="{define: }">define</option>
-                  <option value="{image: }">image</option>
+                  {directiveCatalog.map((directive) => (
+                    <option
+                      key={directive.name}
+                      value={
+                        directive.valueKind === 'none'
+                          ? `{${directive.name}}`
+                          : `{${directive.name}: }`
+                      }
+                    >
+                      {directive.name}
+                    </option>
+                  ))}
                 </select>
                 <select
                   className="chordsketch-app__select insert-picker"

--- a/packages/playground/tests-e2e/diagrams-inline-hover.spec.ts
+++ b/packages/playground/tests-e2e/diagrams-inline-hover.spec.ts
@@ -1,0 +1,128 @@
+import { type Page, expect, test } from '@playwright/test';
+
+// Inline / hover compact chord diagrams (ADR-0027). The placement is a
+// React-JSX-walker feature (`@chordsketch/react`), and its three known
+// regressions are all CSS-layout effects that jsdom unit tests cannot
+// observe:
+//
+//   1. `{diagrams: inline}` — a chord-LESS lyric segment must sit on the
+//      same baseline as a chord-bearing segment's lyric. A missing
+//      `align-items: flex-end` lets the chord-less lyric float up level
+//      with the tall diagram instead of the lyric row.
+//   2. `{key}` / `{tempo}` `.meta-inline` chips must stay small inline
+//      chips. A stray `song--diagrams-bottom` wrapper (the position
+//      modifier defaults to `bottom`) flips `.song` to a flex column and
+//      stretches every body child — including the chips — to full width.
+//   3. `{diagrams: hover}` — the popover diagram floats free of the line
+//      so it must render at the full-size geometry (ADR-0027: "the hover
+//      popover floats free, so it uses the full-size diagram"). A compact
+//      SVG, or the absolutely-positioned popover collapsing to the
+//      trigger's ~10px inline width, makes the diagram unreadable (~0px).
+//
+// Per `.claude/rules/playground-smoke.md` these are exactly the "in-process
+// suites are blind to the integration" cases that require a real-browser
+// smoke: each assertion below measures the rendered geometry that the unit
+// tests cannot, and would fail on a silent CSS regression while the DOM
+// node still exists.
+
+async function setSource(page: Page, text: string) {
+  // The CodeMirror editor renders a contenteditable. Wait for it to be
+  // visible AND focusable before typing: clicking the DOM node before
+  // CodeMirror has claimed keyboard events would send `ControlOrMeta+a`
+  // into the void, so the type would APPEND to the sample instead of
+  // replacing it — and the test would then measure the wrong source.
+  const editor = page.locator('.cm-content');
+  await editor.waitFor({ state: 'visible' });
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.type(text);
+}
+
+test.describe('inline / hover compact chord diagrams (ADR-0027)', () => {
+  test('{diagrams: inline}: chord-less lyric shares the lyric baseline and meta chips stay inline', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.goto('chordpro/', { waitUntil: 'networkidle' });
+    await setSource(
+      page,
+      ['{key: G}', '{tempo: 120}', '{diagrams: inline}', 'Hello [C]world'].join('\n'),
+    );
+
+    // The inline diagram cell must mount (the feature actually engaged,
+    // not a silent degrade to plain chord names).
+    const inlineCell = page.locator('.chord-block-inline-diagram svg').first();
+    await expect(inlineCell).toBeVisible();
+
+    // Bug 1 — baseline alignment. The chord-less block ("Hello ") and the
+    // chord-bearing block ("world") lyrics must share a bottom edge. The
+    // 2px tolerance absorbs sub-pixel rounding only; the regression
+    // (missing `align-items: flex-end`) floats the chord-less lyric to
+    // the top of the tall diagram row, measured at ~71px spread.
+    const lyricBottoms = await page
+      .locator('.line--inline-diagrams .chord-block .lyrics')
+      .evaluateAll((els) => els.map((el) => Math.round(el.getBoundingClientRect().bottom)));
+    expect(lyricBottoms.length).toBeGreaterThanOrEqual(2);
+    const spread = Math.max(...lyricBottoms) - Math.min(...lyricBottoms);
+    expect(spread).toBeLessThanOrEqual(2);
+
+    // Bug 2 — the {key}/{tempo} chips must stay narrow inline chips, NOT
+    // stretch to the content width. Measure each chip against its
+    // container; a flex-column `.song` stretch makes a chip ~= container
+    // width. A real chip is well under half the content width.
+    const contentWidth = await page
+      .locator('.chordsketch-sheet__content')
+      .evaluate((el) => el.getBoundingClientRect().width);
+    const chipWidths = await page
+      .locator('.meta-inline')
+      .evaluateAll((els) => els.map((el) => Math.round(el.getBoundingClientRect().width)));
+    expect(chipWidths.length).toBeGreaterThanOrEqual(2);
+    for (const w of chipWidths) {
+      expect(w).toBeLessThan(contentWidth * 0.5);
+    }
+
+    expect(errors).toEqual([]);
+  });
+
+  test('{diagrams: hover}: the popover renders a full-size, readable diagram', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.goto('chordpro/', { waitUntil: 'networkidle' });
+    // Push the chord line down so the `bottom: 100%` popover has room to
+    // render above it inside the preview viewport.
+    await setSource(
+      page,
+      ['{diagrams: hover}', '', '', '', '', '', 'line one', 'line two', '[C]Hello [G]world'].join(
+        '\n',
+      ),
+    );
+
+    // Hover mode keeps the chord NAME as a focusable trigger; the inline
+    // diagram cell must NOT be used here.
+    const trigger = page.locator('.chord-has-diagram').first();
+    await expect(trigger).toBeVisible();
+    expect(await page.locator('.chord-block-inline-diagram').count()).toBe(0);
+
+    // Reveal the popover (CSS :hover) and measure the inner SVG. Bug 3:
+    // the SVG must render at its intrinsic full size, not collapse to the
+    // trigger's inline width. The full-size guitar diagram is 120×160;
+    // the >80 / >100 floors are deliberately generous so the test tracks
+    // "readable" rather than an exact pixel count — yet they still catch
+    // the regression, which collapsed the SVG to ~0.17px.
+    await trigger.hover();
+    const popoverSvg = page.locator('.chord-diagram-popover svg').first();
+    await expect(popoverSvg).toBeVisible();
+    const box = await popoverSvg.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThan(80);
+    expect(box!.height).toBeGreaterThan(100);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/playground/tests-e2e/directive-catalog.spec.ts
+++ b/packages/playground/tests-e2e/directive-catalog.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+const PLAYGROUND_PATH = './chordpro/';
+
+// The "Insert directive" picker is driven by the shared @chordsketch/wasm
+// directive catalog (ADR-0028) rather than a hard-coded list. This smoke
+// proves the integration end to end in the deployed bundle: the wasm
+// `listDirectives` export loads, the playground consumes it, and the
+// resulting option list is complete — none of which the in-process unit
+// suites observe, since they stub the wasm boundary (see
+// .claude/rules/playground-smoke.md).
+test.describe('playground directive picker', () => {
+  test('populates the directive picker from the shared wasm catalog', async ({
+    page,
+  }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.goto(PLAYGROUND_PATH);
+
+    const picker = page.getByRole('combobox', {
+      name: 'Insert ChordPro directive',
+    });
+    await expect(picker).toBeVisible();
+
+    // Directives the old hard-coded list omitted are now present. `pagetype`
+    // and `diagrams` were both absent before the catalog wiring, so their
+    // presence is a regression guard against the picker silently falling
+    // back to a stale subset.
+    await expect(picker.locator('option', { hasText: /^pagetype$/ })).toHaveCount(
+      1,
+    );
+    await expect(picker.locator('option', { hasText: /^diagrams$/ })).toHaveCount(
+      1,
+    );
+
+    // The enum-valued `diagrams` directive inserts a colon-ready stub so the
+    // editor's value completion can follow; a value-less directive would not
+    // carry the trailing `: `.
+    await expect(
+      picker.locator('option[value="{diagrams: }"]'),
+    ).toHaveCount(1);
+
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "@chordsketch/wasm": "^0.5.0",
+    "@codemirror/autocomplete": "^6.18.0",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/language": "^6.12.3",
     "@codemirror/search": "^6.7.0",

--- a/packages/react/src/chord-diagram.tsx
+++ b/packages/react/src/chord-diagram.tsx
@@ -32,6 +32,17 @@ export interface ChordDiagramProps extends Omit<HTMLAttributes<HTMLDivElement>, 
    */
   orientation?: ChordDiagramOrientation;
   /**
+   * Render the compact above-a-lyric layout (a chordsketch extension
+   * used by the `{diagrams: inline}` / `{diagrams: hover}` modes).
+   * Defaults to `false` (the full-size diagram). The compact SVG keeps
+   * the chord-name title and finger glyphs legible while shrinking the
+   * grid geometry, and carries a `chord-diagram-compact` /
+   * `keyboard-diagram-compact` class on its root for CSS targeting.
+   * Falls back to the regular size on `@chordsketch/wasm` bundles that
+   * predate the compact export.
+   */
+  compact?: boolean;
+  /**
    * Optional node shown while the WASM module loads. Defaults to
    * a minimal `role="status"` placeholder.
    */
@@ -109,6 +120,7 @@ export function ChordDiagram({
   instrument = 'guitar',
   defines,
   orientation,
+  compact,
   loadingFallback,
   notFoundFallback = defaultNotFoundFallback,
   errorFallback = defaultErrorFallback,
@@ -122,9 +134,12 @@ export function ChordDiagram({
     wasmLoader,
     defines,
     orientation,
+    compact,
   );
 
-  const wrapperClass = ['chordsketch-diagram', className].filter(Boolean).join(' ');
+  const wrapperClass = ['chordsketch-diagram', compact && 'chordsketch-diagram--compact', className]
+    .filter(Boolean)
+    .join(' ');
   // Surface the active orientation as a DOM attribute so consumers
   // and tests can observe it without parsing the SVG. Omitted (not
   // emitted as `data-orientation=""`) when the prop is unset so the

--- a/packages/react/src/chord-source-area.tsx
+++ b/packages/react/src/chord-source-area.tsx
@@ -1,6 +1,7 @@
 import type { HTMLAttributes } from 'react';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
+import { autocompletion, completionKeymap } from '@codemirror/autocomplete';
 import {
   defaultKeymap,
   history,
@@ -24,6 +25,7 @@ import {
   placeholder as placeholderExtension,
 } from '@codemirror/view';
 
+import { chordProCompletionSource } from './chordpro-completion';
 import { chordProLanguage, chordProTagTable } from './chordpro-language';
 
 /** Imperative handle exposed via `ref` from {@link ChordSourceArea}. */
@@ -386,7 +388,12 @@ export const ChordSourceArea = forwardRef<ChordSourceAreaHandle, ChordSourceArea
         chordProLanguage,
         syntaxHighlighting(designSystemHighlight),
         designSystemTheme,
+        // ChordPro directive + directive-value completion, sourced from the
+        // shared `@chordsketch/wasm` catalog so the web editor offers the
+        // same set as the LSP / VS Code (ADR-0028).
+        autocompletion({ override: [chordProCompletionSource()] }),
         keymap.of([
+          ...completionKeymap,
           ...defaultKeymap,
           ...historyKeymap,
           ...searchKeymap,

--- a/packages/react/src/chordpro-completion.ts
+++ b/packages/react/src/chordpro-completion.ts
@@ -65,15 +65,21 @@ export const loadChordproCatalog: ChordproCatalogLoader = async () => {
   };
 };
 
-/** Characters that may appear in a directive name (matches the parser). */
+/**
+ * Conservative superset of the characters seen in catalog directive names;
+ * used as `validFor` so CodeMirror keeps the popup open as the user types.
+ * Not a formal parser char-class.
+ */
 const DIRECTIVE_NAME_RE = /^[A-Za-z0-9_+.-]*$/;
 /** Characters that may appear in a completable directive value token. */
 const DIRECTIVE_VALUE_RE = /^[A-Za-z0-9_-]*$/;
 
 /**
  * Resolved completion context from the text before the caret on one line.
- * `from` is the 0-based offset (within `textBefore`) where the replaceable
- * token starts. `null` means "no ChordPro completion here".
+ * `from` is a 0-based offset from the start of the containing line
+ * (`line.text`); the CompletionSource adds `line.from` to get the
+ * document-absolute offset CodeMirror needs. `null` means "no ChordPro
+ * completion here".
  */
 export type ChordproCompletionContext =
   | { kind: 'directive'; prefix: string; from: number }

--- a/packages/react/src/chordpro-completion.ts
+++ b/packages/react/src/chordpro-completion.ts
@@ -1,0 +1,172 @@
+import type { CompletionContext, CompletionResult, CompletionSource } from '@codemirror/autocomplete';
+
+/**
+ * CodeMirror 6 autocomplete for ChordPro directives and their values,
+ * backed by the shared `@chordsketch/wasm` directive catalog (ADR-0028).
+ *
+ * The catalog is the SAME source the LSP completion reads, so the web
+ * editor offers exactly the directive set + enum values that VS Code does
+ * — no second hand-maintained list to drift.
+ *
+ * Two contexts are completed:
+ * - inside `{…}` before the colon → directive names;
+ * - after the colon of an enum-valued directive (e.g. `{diagrams: }`) →
+ *   that directive's allowed values.
+ *
+ * Free-form directive values (`{title: …}`) and chord brackets (`[…]`)
+ * are intentionally not completed here.
+ */
+
+/** One directive-catalog entry as returned by `@chordsketch/wasm`'s `listDirectives()`. */
+export interface DirectiveCatalogEntry {
+  name: string;
+  aliases: string[];
+  valueKind: 'none' | 'freeform' | 'enum';
+  values: string[];
+  summary: string;
+}
+
+/**
+ * Narrow structural view of the catalog functions this module needs.
+ * Kept structural (not a dependency on the wasm module's generated types)
+ * so the default loader can cast the dynamic import and tests can inject a
+ * plain stub — mirroring `useChordDiagram`'s `DiagramRenderer` approach.
+ */
+export interface ChordproCatalog {
+  listDirectives(): DirectiveCatalogEntry[];
+  directiveValueOptions(name: string): string[] | null | undefined;
+}
+
+/** Async catalog provider. Production uses the default lazy wasm loader. */
+export type ChordproCatalogLoader = () => Promise<ChordproCatalog>;
+
+interface WasmCatalogModule {
+  default: () => Promise<unknown>;
+  listDirectives: () => DirectiveCatalogEntry[];
+  directiveValueOptions: (name: string) => string[] | null | undefined;
+}
+
+/**
+ * Lazily load the directive catalog from `@chordsketch/wasm` (ADR-0028).
+ *
+ * This is the default backing for {@link chordProCompletionSource}, and is
+ * exported so other consumers — the playground's "Insert directive" picker,
+ * for instance — drive their directive list from the same single source the
+ * editor completion and the LSP use, rather than a hand-maintained copy.
+ */
+export const loadChordproCatalog: ChordproCatalogLoader = async () => {
+  const mod = (await import('@chordsketch/wasm')) as unknown as WasmCatalogModule;
+  // Both wasm-pack outputs expose a `default` init; the nodejs build's is a
+  // no-op, the web build's loads the `.wasm`. Mirrors `useChordDiagram`.
+  await mod.default();
+  return {
+    listDirectives: () => mod.listDirectives(),
+    directiveValueOptions: (name: string) => mod.directiveValueOptions(name),
+  };
+};
+
+/** Characters that may appear in a directive name (matches the parser). */
+const DIRECTIVE_NAME_RE = /^[A-Za-z0-9_+.-]*$/;
+/** Characters that may appear in a completable directive value token. */
+const DIRECTIVE_VALUE_RE = /^[A-Za-z0-9_-]*$/;
+
+/**
+ * Resolved completion context from the text before the caret on one line.
+ * `from` is the 0-based offset (within `textBefore`) where the replaceable
+ * token starts. `null` means "no ChordPro completion here".
+ */
+export type ChordproCompletionContext =
+  | { kind: 'directive'; prefix: string; from: number }
+  | { kind: 'value'; directive: string; prefix: string; from: number }
+  | null;
+
+/**
+ * Detect the completion context from the line text up to the caret.
+ *
+ * Mirrors the LSP's `detect_context` brace logic: the innermost unclosed
+ * `{` decides whether we are completing a directive name (before the colon)
+ * or a directive value (after it). Exported for unit testing.
+ */
+export function detectChordproCompletion(textBefore: string): ChordproCompletionContext {
+  const lastOpen = textBefore.lastIndexOf('{');
+  if (lastOpen === -1) return null;
+  const afterOpen = textBefore.slice(lastOpen + 1);
+  // A `}` between the `{` and the caret means the directive already closed.
+  if (afterOpen.includes('}')) return null;
+
+  const colon = afterOpen.indexOf(':');
+  if (colon === -1) {
+    // Directive name: prefix is the text after `{` with any leading space
+    // skipped. Bail if it contains a character a directive name cannot.
+    const trimmedStart = afterOpen.length - afterOpen.trimStart().length;
+    const prefix = afterOpen.slice(trimmedStart);
+    if (!DIRECTIVE_NAME_RE.test(prefix)) return null;
+    return { kind: 'directive', prefix: prefix.toLowerCase(), from: lastOpen + 1 + trimmedStart };
+  }
+
+  // Directive value: directive name is before the colon; the value token is
+  // after it with leading spaces skipped.
+  const directive = afterOpen.slice(0, colon).trim().toLowerCase();
+  if (!directive) return null;
+  const rawValue = afterOpen.slice(colon + 1);
+  const valueStart = rawValue.length - rawValue.trimStart().length;
+  const prefix = rawValue.slice(valueStart);
+  // Only single-token enum values are completed; a space means free text.
+  if (!DIRECTIVE_VALUE_RE.test(prefix)) return null;
+  return {
+    kind: 'value',
+    directive,
+    prefix: prefix.toLowerCase(),
+    from: lastOpen + 1 + colon + 1 + valueStart,
+  };
+}
+
+/**
+ * Build the CodeMirror {@link CompletionSource}. Production callers use the
+ * default loader (lazy `@chordsketch/wasm`); tests inject a stub catalog.
+ *
+ * The catalog is fetched once and cached on the returned source.
+ */
+export function chordProCompletionSource(
+  loader: ChordproCatalogLoader = loadChordproCatalog,
+): CompletionSource {
+  let cache: ChordproCatalog | null = null;
+  return async (context: CompletionContext): Promise<CompletionResult | null> => {
+    const line = context.state.doc.lineAt(context.pos);
+    const textBefore = line.text.slice(0, context.pos - line.from);
+    const detected = detectChordproCompletion(textBefore);
+    if (!detected) return null;
+
+    if (cache === null) {
+      try {
+        cache = await loader();
+      } catch {
+        // wasm unavailable (e.g. SSR / load failure): no completion rather
+        // than throwing into the editor.
+        return null;
+      }
+    }
+
+    if (detected.kind === 'directive') {
+      const options = cache.listDirectives().map((d) => ({
+        label: d.name,
+        type: 'keyword',
+        detail: d.aliases[0] ? `alias: ${d.aliases[0]}` : undefined,
+        info: d.summary,
+      }));
+      return {
+        from: line.from + detected.from,
+        options,
+        validFor: DIRECTIVE_NAME_RE,
+      };
+    }
+
+    const values = cache.directiveValueOptions(detected.directive);
+    if (!values || values.length === 0) return null;
+    return {
+      from: line.from + detected.from,
+      options: values.map((v) => ({ label: v, type: 'value' })),
+      validFor: DIRECTIVE_VALUE_RE,
+    };
+  };
+}

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -24,7 +24,7 @@
 // `DANGEROUS_URI_SCHEMES` here in the same PR per
 // `.claude/rules/sanitizer-security.md` §"Security Asymmetry".
 
-import { Fragment, cloneElement, isValidElement, useMemo, useState } from 'react';
+import { Fragment, cloneElement, isValidElement, useId, useMemo, useState } from 'react';
 import type { CSSProperties, DragEvent as ReactDragEvent, JSX, ReactNode } from 'react';
 
 import { ChordDiagram } from './chord-diagram';
@@ -1647,16 +1647,21 @@ function ChordCell(props: {
     </>
   );
 
+  // Stable ID required for the aria-describedby / id pairing below.
+  const tooltipId = useId();
+
   if (mode === 'hover') {
     return (
       <span
         className="chord chord-has-diagram"
         style={chordStyle ?? undefined}
         tabIndex={0}
+        aria-describedby={tooltipId}
         {...(dragProps ?? {})}
       >
         {nameNode}
         <ChordDiagram
+          id={tooltipId}
           chord={chordName}
           instrument={instrument}
           orientation={orientation}

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1560,6 +1560,9 @@ function renderLyricsLine(
     sourceLine: number;
     onChordReposition: (event: ChordRepositionEvent) => void;
   } | null = null,
+  /** Inline / hover diagram config (ADR-0027); `null` keeps the
+   * plain chord-name rendering. */
+  diagrams: LyricsDiagramConfig | null = null,
 ): JSX.Element {
   return (
     <LyricsLine
@@ -1570,6 +1573,7 @@ function renderLyricsLine(
       caret={caret}
       reposition={reposition}
       className="line"
+      diagrams={diagrams}
     />
   );
 }
@@ -1590,6 +1594,104 @@ interface LyricsLineProps {
   /** 1-indexed source line decoration applied to the root `.line`
    * div by `pushElement` for the editor↔preview caret-sync wire. */
   'data-source-line'?: number;
+  /** Inline / hover diagram config (ADR-0027). `null` / `'section'`
+   * keeps the plain chord-name rendering. */
+  diagrams?: LyricsDiagramConfig | null;
+}
+
+/**
+ * Inline / hover diagram config threaded to {@link LyricsLine} so the
+ * chord-block renderer can show compact diagrams above the lyrics
+ * (ADR-0027). Resolved once on the walk context and passed per line.
+ */
+interface LyricsDiagramConfig {
+  mode: DiagramsMode;
+  instrument: ChordDiagramInstrument;
+  orientation: ChordDiagramOrientation | undefined;
+  defines: ReadonlyArray<readonly [string, string]> | undefined;
+}
+
+/**
+ * Renders the chord cell above a lyric segment when diagrams are shown
+ * inline / hover (ADR-0027). A component (not a bare JSX fragment) so the
+ * `useChordDiagram` hook inside `<ChordDiagram>` runs per chord — the
+ * walker cannot call hooks inside its segment `.map`.
+ *
+ * - `inline`: the compact diagram replaces the chord name. The
+ *   not-found / loading / error fallbacks are the chord-name node, so an
+ *   unknown chord (or a not-yet-loaded diagram) still shows its name —
+ *   the name is never lost.
+ * - `hover`: the chord name stays visible and the compact diagram is a
+ *   popover revealed on hover / keyboard focus (the reveal is CSS in
+ *   `styles.css`, keyed on `:hover` / `:focus` / `:focus-within`).
+ */
+function ChordCell(props: {
+  mode: 'inline' | 'hover';
+  chord: ChordproChord;
+  marker: ReactNode;
+  chordStyle: CSSProperties | null;
+  dragProps: Record<string, unknown> | undefined;
+  instrument: ChordDiagramInstrument;
+  orientation: ChordDiagramOrientation | undefined;
+  defines: ReadonlyArray<readonly [string, string]> | undefined;
+}): JSX.Element {
+  const { mode, chord, marker, chordStyle, dragProps, instrument, orientation, defines } =
+    props;
+  // The wasm voicing lookup keys on the plain chord name (same source
+  // the end-of-song grid uses), NOT the unicode-accidental display form.
+  const chordName = chord.display ?? chord.name;
+  const nameNode = (
+    <>
+      {marker}
+      {renderChord(chord)}
+    </>
+  );
+
+  if (mode === 'hover') {
+    return (
+      <span
+        className="chord chord-has-diagram"
+        style={chordStyle ?? undefined}
+        tabIndex={0}
+        {...(dragProps ?? {})}
+      >
+        {nameNode}
+        <ChordDiagram
+          chord={chordName}
+          instrument={instrument}
+          orientation={orientation}
+          defines={defines}
+          compact
+          className="chord-diagram-popover"
+          role="tooltip"
+          notFoundFallback={null}
+          loadingFallback={null}
+          errorFallback={null}
+        />
+      </span>
+    );
+  }
+
+  // inline: the compact diagram stands in for the chord name.
+  return (
+    <span
+      className="chord chord-block-inline-diagram"
+      style={chordStyle ?? undefined}
+      {...(dragProps ?? {})}
+    >
+      <ChordDiagram
+        chord={chordName}
+        instrument={instrument}
+        orientation={orientation}
+        defines={defines}
+        compact
+        className="chord-block-diagram"
+        notFoundFallback={nameNode}
+        loadingFallback={nameNode}
+        errorFallback={() => nameNode}
+      />
+    </span>
+  );
 }
 
 interface DropTarget {
@@ -1626,6 +1728,7 @@ function LyricsLine({
   reposition,
   className,
   'data-source-line': dataSourceLine,
+  diagrams,
 }: LyricsLineProps): JSX.Element {
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
   // Pre-walk segments to record per-chord source columns and
@@ -1785,14 +1888,31 @@ function LyricsLine({
         return (
           <span key={i} className="chord-block">
             {segment.chord ? (
-              <span
-                className="chord"
-                style={chordStyle ?? undefined}
-                {...(chordDragProps ?? {})}
-              >
-                {chordMarker}
-                {renderChord(segment.chord)}
-              </span>
+              diagrams &&
+              (diagrams.mode === 'inline' || diagrams.mode === 'hover') ? (
+                // chordsketch inline / hover diagram above the lyric
+                // (ADR-0027). `<ChordCell>` is a component so its
+                // `useChordDiagram` hook can run per chord.
+                <ChordCell
+                  mode={diagrams.mode}
+                  chord={segment.chord}
+                  marker={chordMarker}
+                  chordStyle={chordStyle}
+                  dragProps={chordDragProps ?? undefined}
+                  instrument={diagrams.instrument}
+                  orientation={diagrams.orientation}
+                  defines={diagrams.defines}
+                />
+              ) : (
+                <span
+                  className="chord"
+                  style={chordStyle ?? undefined}
+                  {...(chordDragProps ?? {})}
+                >
+                  {chordMarker}
+                  {renderChord(segment.chord)}
+                </span>
+              )
             ) : lineHasChords ? (
               <span
                 className="chord"
@@ -2485,10 +2605,22 @@ export type DiagramsPosition = 'bottom' | 'top' | 'right' | 'below';
  * until reset", and a single section is emitted at song end with
  * the last value that won).
  */
+/**
+ * How chord diagrams are surfaced — a chordsketch extension to the
+ * `{diagrams}` directive (ADR-0027). Mirrors the Rust `DiagramsMode`.
+ * `'section'` (default) is the end-of-song grid; `'inline'` replaces
+ * each chord name above a lyric with its compact diagram; `'hover'`
+ * keeps the name and reveals the compact diagram on hover / focus.
+ */
+type DiagramsMode = 'section' | 'inline' | 'hover';
+
 interface DiagramsState {
   visible: boolean;
   position: DiagramsPosition;
   instrument?: ChordDiagramInstrument;
+  /** Surfacing mode (ADR-0027), orthogonal to instrument / position
+   * so `{diagrams: inline}` and `{diagrams: guitar}` compose. */
+  mode: DiagramsMode;
 }
 
 // Collect unique chord names used in lyrics, plus any chord
@@ -2740,6 +2872,10 @@ const DIAGRAMS_POSITIONS = new Set<DiagramsPosition>([
   'right',
   'below',
 ]);
+// Mode keywords recognised on a `{diagrams: …}` value (chordsketch
+// extension, ADR-0027). Kept separate from instrument / position so a
+// value matches exactly one facet; `section` restores the default grid.
+const DIAGRAMS_MODES = new Set<DiagramsMode>(['section', 'inline', 'hover']);
 
 // Translate AST-stored instrument shorthand to the canonical
 // `ChordDiagramInstrument` value. Mirrors the equivalent map in
@@ -2778,7 +2914,11 @@ function diagramsValueAsInstrument(
 // followed by `{diagrams: piano}` keeps both — position `top`,
 // instrument `piano`).
 function resolveDiagramsState(song: ChordproSong): DiagramsState {
-  const state: DiagramsState = { visible: true, position: 'bottom' };
+  const state: DiagramsState = {
+    visible: true,
+    position: 'bottom',
+    mode: 'section',
+  };
   for (const line of song.lines) {
     if (line.kind !== 'directive') continue;
     const kind = line.value.kind;
@@ -2804,6 +2944,13 @@ function resolveDiagramsState(song: ChordproSong): DiagramsState {
     state.visible = true;
     if (DIAGRAMS_POSITIONS.has(value as DiagramsPosition)) {
       state.position = value as DiagramsPosition;
+      continue;
+    }
+    if (DIAGRAMS_MODES.has(value as DiagramsMode)) {
+      // chordsketch extension (ADR-0027): `inline` / `hover` choose how
+      // diagrams are surfaced (`section` restores the default grid).
+      // Orthogonal to instrument / position, so it sets only `mode`.
+      state.mode = value as DiagramsMode;
       continue;
     }
     const instr = diagramsValueAsInstrument(value);
@@ -3339,6 +3486,27 @@ interface WalkContext {
    * `.lyrics` becomes a drop target.
    */
   onChordReposition?: (event: ChordRepositionEvent) => void;
+  /**
+   * Diagram state (visibility / mode / instrument / position) resolved
+   * once over the whole song. The per-line chord-block renderer reads
+   * this to decide inline / hover rendering above the lyrics (ADR-0027),
+   * and the end-of-song grid reuses it. `null` when `chordDiagrams` is
+   * not enabled.
+   */
+  diagramsState?: DiagramsState | null;
+  /**
+   * Per-`{define}` chord voicings collected once so inline / hover
+   * diagrams honour user-defined shapes (mirrors the end-of-song grid).
+   */
+  diagramDefines?: ReadonlyArray<readonly [string, string]>;
+  /**
+   * Consumer-supplied default instrument / orientation for diagrams,
+   * copied from `options.chordDiagrams` so the per-line chord-block
+   * renderer (which only has `ctx`, not `options`) can fall back to
+   * them for inline / hover diagrams (ADR-0027).
+   */
+  chordDiagramsInstrument?: ChordDiagramInstrument;
+  chordDiagramsOrientation?: ChordDiagramOrientation;
 }
 
 /**
@@ -3914,6 +4082,17 @@ function renderLine(ctx: WalkContext, line: ChordproLine, key: number): void {
           lyricsOverride,
           placement,
           repositionCtx,
+          ctx.diagramsState && ctx.diagramsState.visible
+            ? {
+                mode: ctx.diagramsState.mode,
+                instrument:
+                  ctx.diagramsState.instrument ??
+                  ctx.chordDiagramsInstrument ??
+                  'guitar',
+                orientation: ctx.chordDiagramsOrientation,
+                defines: ctx.diagramDefines,
+              }
+            : null,
         ),
         sourceLine,
         null,
@@ -3988,6 +4167,10 @@ export function renderChordproAst(
         : null,
     transposedKeyDirectives: options.transposedKeyDirectives ?? {},
     onChordReposition: options.onChordReposition,
+    diagramsState: options.chordDiagrams ? resolveDiagramsState(song) : null,
+    diagramDefines: options.chordDiagrams ? collectDefines(song) : undefined,
+    chordDiagramsInstrument: options.chordDiagrams?.instrument,
+    chordDiagramsOrientation: options.chordDiagrams?.orientation,
   };
   // Emit header first so metadata lands above the body even when
   // the source has metadata directives interleaved with lines.
@@ -4044,7 +4227,10 @@ export function renderChordproAst(
   // `resolveDiagramsState` walks the lines once; capture it here so
   // the song-class modifier below shares the same state object
   // without re-walking.
-  const diagramsState = options.chordDiagrams ? resolveDiagramsState(song) : null;
+  // Reuse the state already resolved onto `ctx` before the body walk so
+  // the per-line chord-block renderer (inline / hover) and this
+  // end-of-song grid share one state object.
+  const diagramsState = ctx.diagramsState ?? null;
   // `right` requires a different DOM shape (two-column flex with
   // the body wrapped in a single flow container) so the diagram
   // column sits beside the body without forcing the body's line
@@ -4052,7 +4238,15 @@ export function renderChordproAst(
   // here so the rendering branch downstream can wrap the body.
   let rightSection: ReactNode = null;
   let bottomSection: ReactNode = null;
-  if (diagramsState?.visible && options.chordDiagrams) {
+  // The end-of-song grid is the `section` mode (default). In the
+  // `inline` / `hover` chordsketch modes (ADR-0027) the diagrams are
+  // shown above the lyrics by the chord-block renderer instead, so the
+  // grid is suppressed here.
+  if (
+    diagramsState?.visible &&
+    diagramsState.mode === 'section' &&
+    options.chordDiagrams
+  ) {
     const chordDiagramsOpts = options.chordDiagrams;
     const names = collectChordNames(song);
     if (names.length > 0) {

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1621,9 +1621,13 @@ interface LyricsDiagramConfig {
  *   not-found / loading / error fallbacks are the chord-name node, so an
  *   unknown chord (or a not-yet-loaded diagram) still shows its name —
  *   the name is never lost.
- * - `hover`: the chord name stays visible and the compact diagram is a
+ * - `hover`: the chord name stays visible and the full-size diagram is a
  *   popover revealed on hover / keyboard focus (the reveal is CSS in
- *   `styles.css`, keyed on `:hover` / `:focus` / `:focus-within`).
+ *   `styles.css`, keyed on `:hover` / `:focus` / `:focus-within`). The
+ *   popover floats free of the line, so it is NOT compact — a compact
+ *   SVG there renders too small to read. Only `inline` mode keeps
+ *   `compact`, because there the diagram sits in the chord slot above
+ *   the lyric where vertical space is tight.
  */
 function ChordCell(props: {
   mode: 'inline' | 'hover';
@@ -1668,7 +1672,6 @@ function ChordCell(props: {
           instrument={instrument}
           orientation={orientation}
           defines={defines}
-          compact
           className="chord-diagram-popover"
           role="tooltip"
           notFoundFallback={null}
@@ -1848,9 +1851,24 @@ function LyricsLine({
   // `.lyrics` sub-element below.
   const lineMarker =
     caret && caret.row === 'line' ? renderMarker(caret.lineRatio) : null;
+  // Layout contract for inline diagrams (ADR-0027): the chord-block
+  // flex items must bottom-align so every `.lyrics` row sits on the
+  // same baseline regardless of the (tall) compact diagram stacked
+  // above the chord-bearing blocks. Without this, a chord-less block
+  // — which has only a `.lyrics` row and no diagram above it — keeps
+  // the line's default top alignment and its lyric floats up level
+  // with the diagrams instead of the lyric row. The `align-items:
+  // flex-end` is applied via the `.line--inline-diagrams` CSS rule,
+  // gated to `inline` mode so regular and hover layouts (whose chord
+  // row is only ~1em tall) are unaffected. Appended to the base
+  // className the component already builds so the `line line--active`
+  // / `data-source-line` decoration `pushElement` clones in survives.
+  const baseClassName = className ?? 'line';
+  const rootClassName =
+    diagrams?.mode === 'inline' ? `${baseClassName} line--inline-diagrams` : baseClassName;
   return (
     <div
-      className={className ?? 'line'}
+      className={rootClassName}
       data-source-line={dataSourceLine}
       onDragOver={handleLineDragOver}
       onDragLeave={handleLineDragLeave}
@@ -4336,9 +4354,24 @@ export function renderChordproAst(
   // body wrapped in `.song__body` (see below); the other
   // modifiers (`top` / `bottom` / `below`) only need the section
   // to carry `data-position` and the wrapper class.
-  const songClass = diagramsState?.visible
-    ? `song song--diagrams-${diagramsState.position}`
-    : 'song';
+  //
+  // The modifier is meaningful ONLY when the end-of-song diagram grid
+  // is actually emitted — i.e. `section` mode (the grid is gated on
+  // `mode === 'section'` above). Every `song--diagrams-*` rule in the
+  // stylesheet exists to position that grid section (`-bottom` pins it
+  // with `margin-top: auto` under a column-flex parent; `-right` lays
+  // it out as a sticky two-column flex). In `inline` / `hover` mode
+  // there is no grid and no wrapper sibling, so applying the modifier
+  // would flip `.song` to `display: flex; flex-direction: column` with
+  // a single child group — turning every body element (lines, sections,
+  // and the top-level `{key}` / `{tempo}` `.meta-inline` chips) into an
+  // independent flex-column item that stacks vertically / stretches to
+  // full width. `position` defaults to `bottom`, so without this gate
+  // an inline/hover song silently picks up `song--diagrams-bottom`.
+  const songClass =
+    diagramsState?.visible && diagramsState.mode === 'section'
+      ? `song song--diagrams-${diagramsState.position}`
+      : 'song';
 
   if (rightSection !== null) {
     // Right-column layout. `.song__body` is a single flex item

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1637,8 +1637,10 @@ function ChordCell(props: {
 }): JSX.Element {
   const { mode, chord, marker, chordStyle, dragProps, instrument, orientation, defines } =
     props;
-  // The wasm voicing lookup keys on the plain chord name (same source
-  // the end-of-song grid uses), NOT the unicode-accidental display form.
+  // The wasm voicing lookup keys on the {define} display override when
+  // present, falling back to the raw chord name — the same expression
+  // collectChordNames uses for the end-of-song grid. The
+  // unicodeAccidentals() / renderChord formatting is NOT applied here.
   const chordName = chord.display ?? chord.name;
   const nameNode = (
     <>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -87,6 +87,21 @@ export {
   type ChordSourceAreaProps,
 } from './chord-source-area';
 export { chordProLanguage, chordProTagTable } from './chordpro-language';
+
+// ChordPro directive + directive-value completion (ADR-0028). The
+// `<ChordSourceArea>` wires `chordProCompletionSource` into CodeMirror
+// automatically; `loadChordproCatalog` is exposed so other consumers
+// (e.g. an "Insert directive" picker) can drive their directive list from
+// the same shared `@chordsketch/wasm` catalog the editor + LSP use.
+export {
+  chordProCompletionSource,
+  loadChordproCatalog,
+  detectChordproCompletion,
+  type ChordproCatalog,
+  type ChordproCatalogLoader,
+  type ChordproCompletionContext,
+  type DirectiveCatalogEntry,
+} from './chordpro-completion';
 export { SplitLayout, type SplitLayoutProps } from './split-layout';
 export {
   RendererPreview,

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1533,6 +1533,49 @@
    The wrapper class `song--diagrams-<position>` on `.song` is the
    modifier the consumer's CSS can hook into for layout shifts
    that need to reach the wrapper itself (notably `right`). */
+/* ---- Inline / hover chord diagrams (ADR-0027) ----
+   `{diagrams: inline}` replaces each chord name above a lyric with its
+   compact diagram; `{diagrams: hover}` keeps the name and reveals the
+   compact diagram on hover / keyboard focus. */
+
+/* Inline: the compact diagram sits in the chord slot above the lyric.
+   The SVG carries its own width / height, so let it block-flow. */
+.chordsketch-sheet__content .chord-block-inline-diagram {
+  line-height: 1;
+}
+.chordsketch-sheet__content .chord-block-inline-diagram .chordsketch-diagram,
+.chordsketch-sheet__content .chord-block-inline-diagram .chord-diagram {
+  display: block;
+}
+
+/* Hover: the chord name stays as the trigger; the diagram is a popover.
+   `.chord-has-diagram` is the focusable chord span (tabIndex=0). */
+.chordsketch-sheet__content .chord-has-diagram {
+  cursor: help;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+}
+.chordsketch-sheet__content .chord-diagram-popover {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  z-index: 20;
+  display: none;
+  margin-bottom: 4px;
+  padding: 4px;
+  background: var(--cs-surface, #ffffff);
+  border: 1px solid var(--cs-border, #d4d1d6);
+  border-radius: var(--cs-r-2, 4px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+/* Reveal on mouse hover AND keyboard focus (`:focus` on the span itself
+   and `:focus-within` for focus moving into the popover). */
+.chordsketch-sheet__content .chord-has-diagram:hover .chord-diagram-popover,
+.chordsketch-sheet__content .chord-has-diagram:focus .chord-diagram-popover,
+.chordsketch-sheet__content .chord-has-diagram:focus-within .chord-diagram-popover {
+  display: block;
+}
+
 .chordsketch-sheet__content .chord-diagrams {
   margin-top: 1.5rem;
 }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1302,6 +1302,19 @@
   flex-wrap: wrap;
   margin: 0.1em 0;
 }
+/* Inline diagrams (ADR-0027): bottom-align the chord-blocks within a
+   line so every `.lyrics` row lines up on the same baseline no matter
+   how tall the compact diagram stacked above a chord-bearing block
+   is. A chord-less block has only a `.lyrics` row; with the default
+   (effectively top) cross-axis alignment its lyric floats up level
+   with the diagrams instead of the lyric baseline row. Scoped to
+   `inline` mode only (the walker adds `line--inline-diagrams` when
+   `diagrams.mode === 'inline'`) so regular chord-name and hover
+   layouts — whose chord row is only ~1em tall — keep their existing
+   layout and snapshots. */
+.chordsketch-sheet__content .line--inline-diagrams {
+  align-items: flex-end;
+}
 .chordsketch-sheet__content .chord-block {
   display: inline-flex;
   flex-direction: column;
@@ -1561,12 +1574,34 @@
   left: 0;
   z-index: 20;
   display: none;
+  /* Shrink-wrap the diagram instead of inheriting the trigger's
+     inline width. The trigger (`.chord-has-diagram`) is only as wide
+     as the chord name (~10px), and `position: absolute` makes this
+     popover's containing block that same narrow span. Without an
+     explicit width the inner `<svg>` collapses to the 10px line box —
+     the diagram renders at ~0px. `width: max-content` lets the
+     popover size to the SVG's own intrinsic `width`/`height`
+     attributes (120×160 for the full-size diagram). */
+  width: max-content;
   margin-bottom: 4px;
   padding: 4px;
   background: var(--cs-surface, #ffffff);
   border: 1px solid var(--cs-border, #d4d1d6);
   border-radius: var(--cs-r-2, 4px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+/* The popover's inner SVG keeps its intrinsic px size (the Rust
+   renderer emits `width`/`height` attributes). The shared
+   `.chordsketch-diagram svg` rule below caps every diagram svg at
+   `max-width: 100%`; inside this absolutely-positioned popover that
+   `100%` resolves against the ~10px trigger box and crushes the
+   diagram to ~0px. Lift the cap here (and pin `width: auto` so the svg
+   uses its emitted attribute width) so the popover always paints the
+   full-size 120×160 diagram. `display: block` / `height: auto` are
+   already supplied by `.chordsketch-diagram svg`. */
+.chordsketch-sheet__content .chord-diagram-popover svg {
+  max-width: none;
+  width: auto;
 }
 /* Reveal on mouse hover AND keyboard focus (`:focus` on the span itself
    and `:focus-within` for focus moving into the popover). */

--- a/packages/react/src/use-chord-diagram.ts
+++ b/packages/react/src/use-chord-diagram.ts
@@ -51,6 +51,21 @@ interface DiagramRenderer {
     defines: Array<[string, string]>,
     orientation: ChordDiagramOrientation | null | undefined,
   ) => string | null | undefined;
+  /**
+   * Compact-size variant honouring the chordsketch `{diagrams: inline}`
+   * / `{diagrams: hover}` modes. Same arguments as
+   * `chordDiagramSvgWithDefinesOrientation` but returns the smaller
+   * above-a-lyric layout (geometry shrunk, glyphs kept legible — see
+   * the Rust `DiagramSize::Compact`). Absent on `@chordsketch/wasm`
+   * bundles predating the compact export, so callers must
+   * feature-detect and fall back to the regular export.
+   */
+  chordDiagramSvgWithDefinesOrientationCompact?: (
+    chord: string,
+    instrument: string,
+    defines: Array<[string, string]>,
+    orientation: ChordDiagramOrientation | null | undefined,
+  ) => string | null | undefined;
 }
 
 /** Diagram orientation accepted by {@link useChordDiagram}. */
@@ -158,6 +173,7 @@ export function useChordDiagram(
   loader: ChordDiagramWasmLoader = defaultLoader,
   defines?: ReadonlyArray<readonly [string, string]>,
   orientation?: ChordDiagramOrientation,
+  compact?: boolean,
 ): ChordDiagramResult {
   const [svg, setSvg] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -201,17 +217,44 @@ export function useChordDiagram(
         // `<ChordDiagram>` instances logs the message exactly once
         // across the whole page rather than once per instance.
         const definesArray = defines ? defines.map(([n, r]) => [n, r] as [string, string]) : [];
+        // Clear oversized orientation strings before crossing the
+        // wasm ABI — see `MAX_ORIENTATION_INPUT_LEN`. A hostile
+        // direct caller that bypasses the TS `ChordDiagramOrientation`
+        // constraint with `as` cannot force the wasm side into an
+        // allocation it would otherwise reject.
+        const safeOrientation =
+          typeof orientation === 'string' && orientation.length > MAX_ORIENTATION_INPUT_LEN
+            ? null
+            : (orientation ?? null);
         let result: string | null | undefined;
-        if (renderer.chordDiagramSvgWithDefinesOrientation) {
-          // Clear oversized orientation strings before crossing the
-          // wasm ABI — see `MAX_ORIENTATION_INPUT_LEN`. A hostile
-          // direct caller that bypasses the TS `ChordDiagramOrientation`
-          // constraint with `as` cannot force the wasm side into an
-          // allocation it would otherwise reject.
-          const safeOrientation =
-            typeof orientation === 'string' && orientation.length > MAX_ORIENTATION_INPUT_LEN
-              ? null
-              : (orientation ?? null);
+        if (compact && renderer.chordDiagramSvgWithDefinesOrientationCompact) {
+          // Compact above-a-lyric layout (`{diagrams: inline}` /
+          // `{diagrams: hover}`). Only reachable when the loaded bundle
+          // exposes the compact export.
+          result = renderer.chordDiagramSvgWithDefinesOrientationCompact(
+            chord,
+            instrument,
+            definesArray,
+            safeOrientation,
+          );
+        } else if (renderer.chordDiagramSvgWithDefinesOrientation) {
+          // `compact` requested but the loaded bundle predates the
+          // compact export: degrade to the regular-size diagram rather
+          // than throwing, and warn once so the staleness is auditable
+          // (same latch policy as the orientation fallback below).
+          if (compact) {
+            const staleCompactKey = 'compact-export-missing';
+            if (!staleBundleWarnings.has(staleCompactKey)) {
+              staleBundleWarnings.add(staleCompactKey);
+              // eslint-disable-next-line no-console
+              console.warn(
+                '[@chordsketch/react] useChordDiagram: the loaded @chordsketch/wasm bundle ' +
+                  'does not expose chordDiagramSvgWithDefinesOrientationCompact; rendering the ' +
+                  'regular (full-size) diagram. Update @chordsketch/wasm to honour the ' +
+                  'compact prop.',
+              );
+            }
+          }
           result = renderer.chordDiagramSvgWithDefinesOrientation(
             chord,
             instrument,
@@ -265,7 +308,7 @@ export function useChordDiagram(
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chord, instrument, definesKey, orientation]);
+  }, [chord, instrument, definesKey, orientation, compact]);
 
   return { svg, loading, error };
 }

--- a/packages/react/tests/chord-diagram-compact.test.tsx
+++ b/packages/react/tests/chord-diagram-compact.test.tsx
@@ -1,0 +1,121 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ChordDiagram } from '../src/chord-diagram';
+import { __resetStaleBundleWarnings } from '../src/use-chord-diagram';
+
+/**
+ * `<ChordDiagram compact>` plumbing: a stub WASM loader records which
+ * export the hook reached for, so we can assert the compact-size path and
+ * its graceful degradation without a real WASM build. Mirrors the
+ * `chord-diagram-defines` test's approach.
+ */
+type DiagramCall = {
+  fn: 'compact' | 'orientation' | 'defines' | 'plain';
+  chord: string;
+  orientation: string | null | undefined;
+};
+
+/** Loader that exposes the compact export (current @chordsketch/wasm). */
+function compactCapableLoader(record: (c: DiagramCall) => void) {
+  return async () => ({
+    default: async () => undefined,
+    chord_diagram_svg: (chord: string) => {
+      record({ fn: 'plain', chord, orientation: undefined });
+      return '<svg data-stub="plain"></svg>';
+    },
+    chordDiagramSvgWithDefinesOrientation: (
+      chord: string,
+      _instrument: string,
+      _defines: Array<[string, string]>,
+      orientation: string | null | undefined,
+    ) => {
+      record({ fn: 'orientation', chord, orientation });
+      return '<svg data-stub="orientation"></svg>';
+    },
+    chordDiagramSvgWithDefinesOrientationCompact: (
+      chord: string,
+      _instrument: string,
+      _defines: Array<[string, string]>,
+      orientation: string | null | undefined,
+    ) => {
+      record({ fn: 'compact', chord, orientation });
+      return '<svg class="chord-diagram-compact" data-stub="compact"></svg>';
+    },
+  });
+}
+
+/** Older loader WITHOUT the compact export (pre-compact bundle). */
+function legacyLoader(record: (c: DiagramCall) => void) {
+  return async () => ({
+    default: async () => undefined,
+    chord_diagram_svg: (chord: string) => {
+      record({ fn: 'plain', chord, orientation: undefined });
+      return '<svg data-stub="plain"></svg>';
+    },
+    chordDiagramSvgWithDefinesOrientation: (
+      chord: string,
+      _instrument: string,
+      _defines: Array<[string, string]>,
+      orientation: string | null | undefined,
+    ) => {
+      record({ fn: 'orientation', chord, orientation });
+      return '<svg data-stub="orientation"></svg>';
+    },
+  });
+}
+
+describe('<ChordDiagram compact>', () => {
+  it('reaches the compact export when the bundle exposes it', async () => {
+    __resetStaleBundleWarnings();
+    const calls: DiagramCall[] = [];
+    render(
+      <ChordDiagram
+        chord="Am"
+        instrument="guitar"
+        compact
+        orientation="vertical"
+        wasmLoader={compactCapableLoader((c) => calls.push(c))}
+      />,
+    );
+    await waitFor(() => expect(calls.length).toBeGreaterThan(0));
+    expect(calls[0]?.fn).toBe('compact');
+    expect(calls[0]?.orientation).toBe('vertical');
+  });
+
+  it('marks the wrapper with the compact modifier class', async () => {
+    __resetStaleBundleWarnings();
+    const { container } = render(
+      <ChordDiagram chord="Am" instrument="guitar" compact wasmLoader={compactCapableLoader(() => {})} />,
+    );
+    await waitFor(() =>
+      expect(container.querySelector('.chordsketch-diagram--compact')).not.toBeNull(),
+    );
+  });
+
+  it('gracefully degrades to the regular diagram on a pre-compact bundle', async () => {
+    __resetStaleBundleWarnings();
+    const calls: DiagramCall[] = [];
+    render(
+      <ChordDiagram
+        chord="Am"
+        instrument="guitar"
+        compact
+        wasmLoader={legacyLoader((c) => calls.push(c))}
+      />,
+    );
+    // Falls through to the orientation export rather than throwing.
+    await waitFor(() => expect(calls.length).toBeGreaterThan(0));
+    expect(calls[0]?.fn).toBe('orientation');
+  });
+
+  it('does not reach the compact export when compact is not requested', async () => {
+    __resetStaleBundleWarnings();
+    const calls: DiagramCall[] = [];
+    render(
+      <ChordDiagram chord="Am" instrument="guitar" wasmLoader={compactCapableLoader((c) => calls.push(c))} />,
+    );
+    await waitFor(() => expect(calls.length).toBeGreaterThan(0));
+    expect(calls[0]?.fn).toBe('orientation');
+  });
+});

--- a/packages/react/tests/chordpro-completion.test.ts
+++ b/packages/react/tests/chordpro-completion.test.ts
@@ -94,6 +94,66 @@ describe('detectChordproCompletion', () => {
   it('returns null when the value already contains a space (free text)', () => {
     expect(detectChordproCompletion('{title: My Song')).toBeNull();
   });
+
+  it('two leading spaces after colon: from accounts for both spaces', () => {
+    // '{diagrams:  inl' — two spaces between the colon and 'inl'.
+    // The single-space case is '{diagrams: inl' → from=11 (tested above).
+    // With two spaces: afterOpen = 'diagrams:  inl', colon=8,
+    // rawValue = '  inl', valueStart=2, so from = lastOpen+1 + colon+1 + valueStart
+    //   = 0+1 + 8+1 + 2 = 12.
+    const result = detectChordproCompletion('{diagrams:  inl');
+    expect(result).toEqual({
+      kind: 'value',
+      directive: 'diagrams',
+      prefix: 'inl',
+      from: 12,
+    });
+  });
+
+  it('value-less directive alias returns null after its colon', async () => {
+    // 'new_song' has valueKind='none'; its alias 'ns' also has no enum values.
+    // After '{ns: ', chordProCompletionSource must return null because
+    // directiveValueOptions('ns') returns null for non-enum directives.
+    const result = await complete('{ns: ');
+    expect(result).toBeNull();
+  });
+});
+
+// If the Rust-side known set changes, update the union in
+// crates/wasm/src/bindings.rs (DIRECTIVE_CATALOG_TS) and in
+// DirectiveCatalogEntry['valueKind'] above, in lockstep.
+// Mirrors: crates/wasm/src/lib.rs::do_list_directives_value_kind_is_one_of_the_known_set
+describe('valueKind union stays in lockstep with the wasm catalog (none/freeform/enum)', () => {
+  it('the three known literal strings are the complete set', () => {
+    // This array is the canonical enumeration. Adding a 4th kind here
+    // requires updating the DirectiveCatalogEntry valueKind union above AND
+    // the Rust test in crates/wasm/src/lib.rs.
+    const KNOWN: ReadonlyArray<DirectiveCatalogEntry['valueKind']> = [
+      'none',
+      'freeform',
+      'enum',
+    ];
+    expect(KNOWN).toEqual(['none', 'freeform', 'enum']);
+  });
+
+  it('a none-valued directive entry round-trips through the completion source', () => {
+    const entry = CATALOG.find((d) => d.valueKind === 'none');
+    expect(entry).toBeDefined();
+    // value-less directives must have an empty values array
+    expect(entry?.values).toHaveLength(0);
+  });
+
+  it('a freeform-valued directive entry round-trips through the completion source', () => {
+    const entry = CATALOG.find((d) => d.valueKind === 'freeform');
+    expect(entry).toBeDefined();
+    expect(entry?.values).toHaveLength(0);
+  });
+
+  it('an enum-valued directive entry round-trips through the completion source', () => {
+    const entry = CATALOG.find((d) => d.valueKind === 'enum');
+    expect(entry).toBeDefined();
+    expect((entry?.values.length ?? 0)).toBeGreaterThan(0);
+  });
 });
 
 describe('chordProCompletionSource', () => {

--- a/packages/react/tests/chordpro-completion.test.ts
+++ b/packages/react/tests/chordpro-completion.test.ts
@@ -124,16 +124,20 @@ describe('detectChordproCompletion', () => {
 // DirectiveCatalogEntry['valueKind'] above, in lockstep.
 // Mirrors: crates/wasm/src/lib.rs::do_list_directives_value_kind_is_one_of_the_known_set
 describe('valueKind union stays in lockstep with the wasm catalog (none/freeform/enum)', () => {
-  it('the three known literal strings are the complete set', () => {
-    // This array is the canonical enumeration. Adding a 4th kind here
-    // requires updating the DirectiveCatalogEntry valueKind union above AND
-    // the Rust test in crates/wasm/src/lib.rs.
+  it('every stub catalog entry has a valueKind in the known set', () => {
+    // The TypeScript type annotation ReadonlyArray<DirectiveCatalogEntry['valueKind']>
+    // is the compile-time guard (tsc --noEmit rejects any value outside the union).
+    // The runtime guard for the *real* catalog is the Rust test
+    // `do_list_directives_value_kind_is_one_of_the_known_set` in
+    // crates/wasm/src/lib.rs. This test verifies the mock fixture is consistent.
     const KNOWN: ReadonlyArray<DirectiveCatalogEntry['valueKind']> = [
       'none',
       'freeform',
       'enum',
     ];
-    expect(KNOWN).toEqual(['none', 'freeform', 'enum']);
+    for (const entry of CATALOG) {
+      expect(KNOWN).toContain(entry.valueKind);
+    }
   });
 
   it('a none-valued directive entry round-trips through the completion source', () => {

--- a/packages/react/tests/chordpro-completion.test.ts
+++ b/packages/react/tests/chordpro-completion.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { CompletionContext } from '@codemirror/autocomplete';
+import {
+  detectChordproCompletion,
+  chordProCompletionSource,
+  type ChordproCatalog,
+  type DirectiveCatalogEntry,
+} from '../src/chordpro-completion';
+
+const CATALOG: DirectiveCatalogEntry[] = [
+  {
+    name: 'title',
+    aliases: ['t'],
+    valueKind: 'freeform',
+    values: [],
+    summary: 'Song title',
+  },
+  {
+    name: 'diagrams',
+    aliases: [],
+    valueKind: 'enum',
+    values: ['on', 'off', 'guitar', 'ukulele', 'piano', 'inline', 'hover'],
+    summary: 'Chord diagram display',
+  },
+  {
+    name: 'new_song',
+    aliases: ['ns'],
+    valueKind: 'none',
+    values: [],
+    summary: 'Start a new song',
+  },
+];
+
+const stubCatalog: ChordproCatalog = {
+  listDirectives: () => CATALOG,
+  directiveValueOptions: (name) => {
+    const directive = CATALOG.find((d) => d.name === name);
+    return directive && directive.valueKind === 'enum' ? directive.values : null;
+  },
+};
+
+const stubLoader = () => Promise.resolve(stubCatalog);
+
+function complete(doc: string, pos: number = doc.length) {
+  const state = EditorState.create({ doc });
+  const context = new CompletionContext(state, pos, true);
+  return chordProCompletionSource(stubLoader)(context);
+}
+
+describe('detectChordproCompletion', () => {
+  it('detects a directive-name context inside an unclosed brace', () => {
+    expect(detectChordproCompletion('{di')).toEqual({
+      kind: 'directive',
+      prefix: 'di',
+      from: 1,
+    });
+  });
+
+  it('skips leading whitespace after the opening brace', () => {
+    expect(detectChordproCompletion('{ di')).toEqual({
+      kind: 'directive',
+      prefix: 'di',
+      from: 2,
+    });
+  });
+
+  it('detects a directive-value context after the colon', () => {
+    expect(detectChordproCompletion('{diagrams: ')).toEqual({
+      kind: 'value',
+      directive: 'diagrams',
+      prefix: '',
+      from: 11,
+    });
+  });
+
+  it('carries the typed value prefix in a value context', () => {
+    expect(detectChordproCompletion('{diagrams: inl')).toEqual({
+      kind: 'value',
+      directive: 'diagrams',
+      prefix: 'inl',
+      from: 11,
+    });
+  });
+
+  it('returns null when there is no opening brace', () => {
+    expect(detectChordproCompletion('just lyrics')).toBeNull();
+  });
+
+  it('returns null once the directive brace is closed', () => {
+    expect(detectChordproCompletion('{diagrams}')).toBeNull();
+  });
+
+  it('returns null when the value already contains a space (free text)', () => {
+    expect(detectChordproCompletion('{title: My Song')).toBeNull();
+  });
+});
+
+describe('chordProCompletionSource', () => {
+  it('offers every catalog directive inside an unclosed brace', async () => {
+    const result = await complete('{');
+    expect(result).not.toBeNull();
+    expect(result?.from).toBe(1);
+    expect(result?.options.map((o) => o.label)).toEqual([
+      'title',
+      'diagrams',
+      'new_song',
+    ]);
+  });
+
+  it('anchors the replacement after the brace when a prefix is typed', async () => {
+    const result = await complete('{dia');
+    expect(result?.from).toBe(1);
+    // The source returns the full set; CodeMirror filters by `validFor`.
+    expect(result?.options.some((o) => o.label === 'diagrams')).toBe(true);
+  });
+
+  it('offers the enum values of an enum-valued directive after the colon', async () => {
+    const result = await complete('{diagrams: ');
+    expect(result?.from).toBe(11);
+    expect(result?.options.map((o) => o.label)).toContain('inline');
+    expect(result?.options.map((o) => o.label)).toContain('hover');
+  });
+
+  it('offers no value completion for a free-form directive', async () => {
+    expect(await complete('{title: ')).toBeNull();
+  });
+
+  it('offers nothing outside a directive brace', async () => {
+    expect(await complete('plain lyric line')).toBeNull();
+  });
+});

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3818,7 +3818,12 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     // Keyboard-reachable trigger (the popover reveal is CSS :focus).
     expect(trigger?.getAttribute('tabindex')).toBe('0');
     expect(trigger?.textContent).toContain('C');
-    expect(container.querySelector('.chord-diagram-popover')).not.toBeNull();
+    const popover = container.querySelector('.chord-diagram-popover');
+    expect(popover).not.toBeNull();
+    // aria-describedby / id linkage for assistive technology (useId).
+    const tooltipId = trigger?.getAttribute('aria-describedby');
+    expect(tooltipId).toBeTruthy();
+    expect(popover?.getAttribute('id')).toBe(tooltipId);
     expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
     expect(container.querySelector('.chord-diagrams')).toBeNull();
   });

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3903,4 +3903,162 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
     expect(container.querySelector('.chord-diagrams')).toBeNull();
   });
-});
+
+  // A song with a chord-bearing segment followed by a chord-LESS
+  // segment on the same line, plus `{key}` / `{tempo}` directives and
+  // a `{diagrams: …}` mode. Exercises the inline-diagram baseline-
+  // alignment hook, the meta-inline chip-className invariant, and the
+  // `song--diagrams-*` wrapper gate.
+  function mixedSegmentSong(diagramsValue: string): ChordproSong {
+    return {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'key', value: 'G', kind: { tag: 'key' }, selector: null },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'tempo', value: '120', kind: { tag: 'tempo' }, selector: null },
+        },
+        {
+          kind: 'directive',
+          value: {
+            name: 'diagrams',
+            value: diagramsValue,
+            kind: { tag: 'diagrams' },
+            selector: null,
+          },
+        },
+        {
+          kind: 'lyrics',
+          value: {
+            segments: [
+              { chord: { name: 'C', detail: null, display: null }, text: 'Hello ', spans: [] },
+              { chord: null, text: 'world', spans: [] },
+            ],
+          },
+        },
+      ],
+    };
+  }
+
+  test('when diagrams mode is inline, then the lyrics line carries the line--inline-diagrams baseline hook (only in inline)', () => {
+    // In inline mode the compact diagram makes the chord row ~40px
+    // tall, so a chord-LESS block's lyric floats up to the top of the
+    // row instead of sitting on the lyric baseline next to the
+    // chord-bearing block's lyric. The fix bottom-aligns the line's
+    // flex items via `.line--inline-diagrams`.
+    //
+    // jsdom has no layout engine, so this only proves the structural
+    // hook (the CSS selector) is emitted in inline mode and withheld
+    // elsewhere. The ACTUAL baseline alignment is verified in a real
+    // browser by `tests-e2e/diagrams-inline-hover.spec.ts`.
+    const inline = render(
+      renderChordproAst(mixedSegmentSong('inline'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const inlineLine = inline.container.querySelector('div.line');
+    expect(inlineLine).not.toBeNull();
+    expect(inlineLine?.classList.contains('line--inline-diagrams')).toBe(true);
+    // The line still carries the compact diagram cell (chord-bearing
+    // block) AND the chord-less block whose lyric must align.
+    expect(inlineLine?.querySelector('.chord-block-inline-diagram')).not.toBeNull();
+    expect(inline.container.textContent).toContain('world');
+
+    // Regular (section) mode must NOT get the modifier — gating the
+    // bottom-alignment to inline keeps regular/hover layout (and their
+    // snapshots) unchanged.
+    const section = render(
+      renderChordproAst(mixedSegmentSong('section'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    expect(
+      section.container.querySelector('div.line')?.classList.contains('line--inline-diagrams'),
+    ).toBe(false);
+
+    // Hover mode keeps the chord NAME as the trigger (same ~1em height
+    // as regular), so it does NOT need — and must not get — the hook.
+    const hover = render(
+      renderChordproAst(mixedSegmentSong('hover'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    expect(
+      hover.container.querySelector('div.line')?.classList.contains('line--inline-diagrams'),
+    ).toBe(false);
+  });
+
+  test('when the diagram mode changes, then the {key} / {tempo} meta-inline chip classNames stay mode-independent', () => {
+    // The reported regression was that `{diagrams: inline}` restyled the
+    // top-level `{key}` / `{tempo}` chips (stacked / full-width). The
+    // ROOT CAUSE — a stray `song--diagrams-bottom` wrapper flipping the
+    // article to a flex column — is pinned by the next test, and the
+    // VISUAL effect (chip width) is verified in a real browser by
+    // `tests-e2e/diagrams-inline-hover.spec.ts`.
+    //
+    // This test guards a narrower, walker-level invariant that neither
+    // of those covers: the chips themselves must be emitted with the
+    // same className regardless of diagram mode — a future walker branch
+    // that added a mode-dependent class directly to a chip would slip
+    // past the wrapper-class test. It deliberately does NOT claim to
+    // prove the chips "render identically" (jsdom can't measure layout).
+    const inline = render(
+      renderChordproAst(mixedSegmentSong('inline'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const section = render(
+      renderChordproAst(mixedSegmentSong('section'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const chipClasses = (root: HTMLElement): string[] =>
+      Array.from(root.querySelectorAll('.meta-inline')).map((el) => (el as HTMLElement).className);
+    const sectionChips = chipClasses(section.container);
+    // Both modes surface the {key} and {tempo} markers.
+    expect(sectionChips.length).toBe(2);
+    expect(chipClasses(inline.container)).toEqual(sectionChips);
+    // Each chip's className is byte-identical across modes.
+    const keyChip = (root: HTMLElement): string =>
+      (root.querySelector('.meta-inline--key') as HTMLElement).className;
+    expect(keyChip(inline.container)).toBe(keyChip(section.container));
+    const tempoChip = (root: HTMLElement): string =>
+      (root.querySelector('.meta-inline--tempo') as HTMLElement).className;
+    expect(tempoChip(inline.container)).toBe(tempoChip(section.container));
+  });
+
+  test('when diagrams mode is inline or hover, then the song--diagrams-* wrapper modifier is withheld (it fires only when the end-of-song grid is emitted)', () => {
+    // Bug 1 root cause: the wrapper class carried
+    // `song--diagrams-${position}` whenever diagrams were *visible*,
+    // and `position` defaults to `bottom`. So `{diagrams: inline}` and
+    // `{diagrams: hover}` — which suppress the end-of-song grid and
+    // emit NO wrapper sibling — still flipped the article to
+    // `.song--diagrams-bottom` (display:flex / column). With no grid
+    // sibling and no `.song__body` wrapper, every body child (lines,
+    // sections, and the top-level `{key}` / `{tempo}` `.meta-inline`
+    // chips) became an independent flex-column item and stacked /
+    // stretched to full width. jsdom has no layout engine so it can't
+    // measure the stacking, but the WRONG WRAPPER CLASS that causes it
+    // is structurally observable — this test pins the invariant
+    // "position modifier ⇔ grid present" that the className alone never
+    // expressed.
+    //
+    // Inline mode: no grid, so the wrapper must be plain `.song`
+    // (block flow). NOT `song--diagrams-bottom`.
+    const inline = render(
+      renderChordproAst(mixedSegmentSong('inline'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const inlineSong = inline.container.querySelector('.song');
+    expect(inlineSong).not.toBeNull();
+    expect(inlineSong?.className).toBe('song');
+    // Defensive: no `song--diagrams-*` modifier of any position leaks
+    // into inline mode (guards a future `position` directive in an
+    // inline song from re-introducing the bug under a different
+    // suffix).
+    expect(inlineSong?.className).not.toMatch(/\bsong--diagrams-/);
+    // The inline body has no end-of-song grid and no `.song__body`
+    // wrapper — both are section-mode-only.
+    expect(inline.container.querySelector('.chord-diagrams')).toBeNull();
+    expect(inline.container.querySelector('.song__body')).toBeNull();
+
+    // Hover mode: same as inline — grid suppressed, plain `.song`.
+    const hover = render(
+      renderChordproAst(mixedSegmentSong('hover'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    expect(hover.container.querySelector('.song')?.className).toBe('song');
+    expect(hover.container.querySelector('.chord-diagrams')).toBeNull();
+    expect(hover.container.querySelector('.song__body')).toBeNull();
+

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3756,3 +3756,104 @@ describe('renderChordproAst', () => {
     }
   });
 });
+describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
+  // A song with N `{diagrams: …}` directive lines + one chord-bearing
+  // lyric line. The `<ChordDiagram>` mounted by inline / hover lazily
+  // loads wasm asynchronously; like the existing grid tests we assert
+  // only the SYNCHRONOUS wrapper structure (classes / fallbacks), never
+  // the resolved SVG.
+  function songWithDiagramsValues(
+    ...values: Array<string | null>
+  ): ChordproSong {
+    return {
+      metadata: EMPTY_META,
+      lines: [
+        ...values.map((value) => ({
+          kind: 'directive' as const,
+          value: {
+            name: 'diagrams',
+            value,
+            kind: { tag: 'diagrams' as const },
+            selector: null,
+          },
+        })),
+        {
+          kind: 'lyrics' as const,
+          value: {
+            segments: [
+              {
+                chord: { name: 'C', detail: null, display: null },
+                text: 'Do',
+                spans: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+  }
+
+  test('{diagrams: inline} replaces the chord name with a compact diagram cell above the lyric', () => {
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('inline'), {
+        chordDiagrams: { instrument: 'guitar' },
+      }),
+    );
+    expect(container.querySelector('.chord-block-inline-diagram')).not.toBeNull();
+    expect(container.querySelector('.lyrics')?.textContent).toContain('Do');
+    // The chord name survives (loading / not-found fallback).
+    expect(container.querySelector('.chord-block')?.textContent).toContain('C');
+    // The end-of-song grid is suppressed in inline mode.
+    expect(container.querySelector('.chord-diagrams')).toBeNull();
+  });
+
+  test('{diagrams: hover} keeps the chord name and adds a focusable popover trigger', () => {
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('hover'), {
+        chordDiagrams: { instrument: 'guitar' },
+      }),
+    );
+    const trigger = container.querySelector('.chord-has-diagram');
+    expect(trigger).not.toBeNull();
+    // Keyboard-reachable trigger (the popover reveal is CSS :focus).
+    expect(trigger?.getAttribute('tabindex')).toBe('0');
+    expect(trigger?.textContent).toContain('C');
+    expect(container.querySelector('.chord-diagram-popover')).not.toBeNull();
+    expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
+    expect(container.querySelector('.chord-diagrams')).toBeNull();
+  });
+
+  test('default (section) mode renders the end-of-song grid, not inline cells', () => {
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues(null), {
+        chordDiagrams: { instrument: 'guitar' },
+      }),
+    );
+    expect(container.querySelector('.chord-diagrams')).not.toBeNull();
+    expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
+    expect(container.querySelector('.chord-has-diagram')).toBeNull();
+  });
+
+  test('{diagrams: off} after {diagrams: inline} suppresses inline diagrams (last-wins visibility)', () => {
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('inline', 'off'), {
+        chordDiagrams: { instrument: 'guitar' },
+      }),
+    );
+    expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
+    expect(container.querySelector('.chord-diagrams')).toBeNull();
+    expect(container.querySelector('.chord')?.textContent).toContain('C');
+  });
+
+  test('{diagrams: inline} and {diagrams: guitar} compose (mode + instrument are independent facets)', () => {
+    const { container } = render(
+      // No instrument option — {diagrams: guitar} supplies it and
+      // {diagrams: inline} supplies the mode.
+      renderChordproAst(songWithDiagramsValues('inline', 'guitar'), {
+        chordDiagrams: {},
+      }),
+    );
+    expect(container.querySelector('.chord-block-inline-diagram')).not.toBeNull();
+    expect(container.querySelector('.chord-diagrams')).toBeNull();
+  });
+});

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3861,4 +3861,46 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     expect(container.querySelector('.chord-block-inline-diagram')).not.toBeNull();
     expect(container.querySelector('.chord-diagrams')).toBeNull();
   });
+
+  test('{diagrams: section} after {diagrams: inline} restores the end-of-song grid', () => {
+    // `section` is the default mode; writing it explicitly after `inline`
+    // must revert to the end-of-song diagram grid (last-wins), so a user
+    // who set `{diagrams: inline}` can switch back without removing the
+    // first directive.
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('inline', 'section'), {
+        chordDiagrams: { instrument: 'guitar' },
+      }),
+    );
+    // End-of-song grid is restored.
+    expect(container.querySelector('.chord-diagrams')).not.toBeNull();
+    // Inline diagram cells are absent — section mode suppresses them.
+    expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
+  });
+
+  test('{diagrams: hover} with instrument: piano renders the hover popover', () => {
+    // Mirrors the existing guitar hover test; exercises the piano branch
+    // of the instrument-selection path so diagrams mode + non-guitar
+    // instrument compose correctly.
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('hover'), {
+        chordDiagrams: { instrument: 'piano' },
+      }),
+    );
+    const trigger = container.querySelector('.chord-has-diagram');
+    expect(trigger).not.toBeNull();
+    // Keyboard-reachable trigger (the popover reveal is CSS :focus).
+    expect(trigger?.getAttribute('tabindex')).toBe('0');
+    expect(trigger?.textContent).toContain('C');
+    // Popover container must be present.
+    const popover = container.querySelector('.chord-diagram-popover');
+    expect(popover).not.toBeNull();
+    // aria-describedby / id linkage for assistive technology.
+    const tooltipId = trigger?.getAttribute('aria-describedby');
+    expect(tooltipId).toBeTruthy();
+    expect(popover?.getAttribute('id')).toBe(tooltipId);
+    // Inline diagram cells and end-of-song grid are absent in hover mode.
+    expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
+    expect(container.querySelector('.chord-diagrams')).toBeNull();
+  });
 });


### PR DESCRIPTION
## What

Fixes three rendering bugs in the `{diagrams: inline}` / `{diagrams: hover}`
modes of the React JSX walker (`@chordsketch/react`), introduced with the
inline/hover feature in #2584:

1. **inline baseline** — a chord-less lyric segment floated up to the top of
   the tall compact-diagram row instead of resting on the lyric baseline next
   to chord-bearing segments.
2. **inline/hover meta chips** — the `{key}` / `{tempo}` `.meta-inline` chips
   were restyled (stacked, stretched to full width) whenever inline/hover was
   active.
3. **hover popover** — the popover diagram rendered at ~0px (unreadable).

## Why / root cause

- **(1)** `.line` is `display: flex` with default cross-axis alignment, so the
  chord-less block (no diagram above it) top-aligned against the tall diagram.
  Fixed by `align-items: flex-end` on a new `.line--inline-diagrams` class,
  added by the walker only in inline mode so regular/hover layouts are
  untouched.
- **(2)** The `song--diagrams-${position}` wrapper modifier was applied
  whenever diagrams were *visible*, but `position` defaults to `bottom`.
  Inline/hover emit no end-of-song grid and no `.song__body` wrapper sibling,
  so the stray `song--diagrams-bottom` flipped `.song` to `display: flex;
  flex-direction: column` and stretched every body child — including the meta
  chips. Fixed by gating the modifier to `section` mode, matching the
  grid-emission condition.
- **(3)** The hover popover floats free of the line, so the compact
  (above-a-lyric) size is wrong there — dropped the `compact` prop. The
  absolutely-positioned popover also inherited
  `.chordsketch-diagram svg { max-width: 100% }`, which resolved against the
  ~10px trigger box and crushed the svg. Added `width: max-content` on the
  popover and `max-width: none; width: auto` on its svg so it paints the
  full-size 120×160 diagram.

All three are React-JSX-surface CSS/layout concerns; per ADR-0027 the
inline/hover placement is implemented on the React walker first, so there is
no Rust renderer sister-site to update.

## Test results

- `@chordsketch/react` vitest: 120 passed; `tsc --noEmit`: clean.
- playground `tsc --noEmit`: clean; playground Playwright e2e: 65 passed.
- New Playwright smoke `tests-e2e/diagrams-inline-hover.spec.ts` measures the
  rendered geometry in a real browser (jsdom can't observe these CSS-layout
  effects): lyric baselines align (spread ≤ 2px), chips stay narrow
  (< 50% of content width), and the hover popover svg renders full size
  (> 80×100px). Each assertion was confirmed to fail when its fix is reverted
  (baseline spread → 71px; popover → 0.17px).

## Review summary

Reviewed for correctness, security, renderer-parity / fix-propagation, and
test coverage. The key finding — the original unit tests asserted only DOM
structure for CSS-layout bugs (no regression protection) — is resolved by the
new browser-measured smoke. Sister-site audit confirmed no Rust renderer
implements inline/hover yet (ADR-0027 §Consequences), so no parity work is
owed.
