### PR TITLE
fix: render inline/hover chord diagrams without breaking layout

### DIFF
--- a/packages/playground/tests-e2e/diagrams-inline-hover.spec.ts
+++ b/packages/playground/tests-e2e/diagrams-inline-hover.spec.ts
@@ -1,0 +1,128 @@
+import { type Page, expect, test } from '@playwright/test';
+
+// Inline / hover compact chord diagrams (ADR-0027). The placement is a
+// React-JSX-walker feature (`@chordsketch/react`), and its three known
+// regressions are all CSS-layout effects that jsdom unit tests cannot
+// observe:
+//
+//   1. `{diagrams: inline}` — a chord-LESS lyric segment must sit on the
+//      same baseline as a chord-bearing segment's lyric. A missing
+//      `align-items: flex-end` lets the chord-less lyric float up level
+//      with the tall diagram instead of the lyric row.
+//   2. `{key}` / `{tempo}` `.meta-inline` chips must stay small inline
+//      chips. A stray `song--diagrams-bottom` wrapper (the position
+//      modifier defaults to `bottom`) flips `.song` to a flex column and
+//      stretches every body child — including the chips — to full width.
+//   3. `{diagrams: hover}` — the popover diagram floats free of the line
+//      so it must render at the full-size geometry (ADR-0027: "the hover
+//      popover floats free, so it uses the full-size diagram"). A compact
+//      SVG, or the absolutely-positioned popover collapsing to the
+//      trigger's ~10px inline width, makes the diagram unreadable (~0px).
+//
+// Per `.claude/rules/playground-smoke.md` these are exactly the "in-process
+// suites are blind to the integration" cases that require a real-browser
+// smoke: each assertion below measures the rendered geometry that the unit
+// tests cannot, and would fail on a silent CSS regression while the DOM
+// node still exists.
+
+async function setSource(page: Page, text: string) {
+  // The CodeMirror editor renders a contenteditable. Wait for it to be
+  // visible AND focusable before typing: clicking the DOM node before
+  // CodeMirror has claimed keyboard events would send `ControlOrMeta+a`
+  // into the void, so the type would APPEND to the sample instead of
+  // replacing it — and the test would then measure the wrong source.
+  const editor = page.locator('.cm-content');
+  await editor.waitFor({ state: 'visible' });
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.type(text);
+}
+
+test.describe('inline / hover compact chord diagrams (ADR-0027)', () => {
+  test('{diagrams: inline}: chord-less lyric shares the lyric baseline and meta chips stay inline', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.goto('chordpro/', { waitUntil: 'networkidle' });
+    await setSource(
+      page,
+      ['{key: G}', '{tempo: 120}', '{diagrams: inline}', 'Hello [C]world'].join('\n'),
+    );
+
+    // The inline diagram cell must mount (the feature actually engaged,
+    // not a silent degrade to plain chord names).
+    const inlineCell = page.locator('.chord-block-inline-diagram svg').first();
+    await expect(inlineCell).toBeVisible();
+
+    // Bug 1 — baseline alignment. The chord-less block ("Hello ") and the
+    // chord-bearing block ("world") lyrics must share a bottom edge. The
+    // 2px tolerance absorbs sub-pixel rounding only; the regression
+    // (missing `align-items: flex-end`) floats the chord-less lyric to
+    // the top of the tall diagram row, measured at ~71px spread.
+    const lyricBottoms = await page
+      .locator('.line--inline-diagrams .chord-block .lyrics')
+      .evaluateAll((els) => els.map((el) => Math.round(el.getBoundingClientRect().bottom)));
+    expect(lyricBottoms.length).toBeGreaterThanOrEqual(2);
+    const spread = Math.max(...lyricBottoms) - Math.min(...lyricBottoms);
+    expect(spread).toBeLessThanOrEqual(2);
+
+    // Bug 2 — the {key}/{tempo} chips must stay narrow inline chips, NOT
+    // stretch to the content width. Measure each chip against its
+    // container; a flex-column `.song` stretch makes a chip ~= container
+    // width. A real chip is well under half the content width.
+    const contentWidth = await page
+      .locator('.chordsketch-sheet__content')
+      .evaluate((el) => el.getBoundingClientRect().width);
+    const chipWidths = await page
+      .locator('.meta-inline')
+      .evaluateAll((els) => els.map((el) => Math.round(el.getBoundingClientRect().width)));
+    expect(chipWidths.length).toBeGreaterThanOrEqual(2);
+    for (const w of chipWidths) {
+      expect(w).toBeLessThan(contentWidth * 0.5);
+    }
+
+    expect(errors).toEqual([]);
+  });
+
+  test('{diagrams: hover}: the popover renders a full-size, readable diagram', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.goto('chordpro/', { waitUntil: 'networkidle' });
+    // Push the chord line down so the `bottom: 100%` popover has room to
+    // render above it inside the preview viewport.
+    await setSource(
+      page,
+      ['{diagrams: hover}', '', '', '', '', '', 'line one', 'line two', '[C]Hello [G]world'].join(
+        '\n',
+      ),
+    );
+
+    // Hover mode keeps the chord NAME as a focusable trigger; the inline
+    // diagram cell must NOT be used here.
+    const trigger = page.locator('.chord-has-diagram').first();
+    await expect(trigger).toBeVisible();
+    expect(await page.locator('.chord-block-inline-diagram').count()).toBe(0);
+
+    // Reveal the popover (CSS :hover) and measure the inner SVG. Bug 3:
+    // the SVG must render at its intrinsic full size, not collapse to the
+    // trigger's inline width. The full-size guitar diagram is 120×160;
+    // the >80 / >100 floors are deliberately generous so the test tracks
+    // "readable" rather than an exact pixel count — yet they still catch
+    // the regression, which collapsed the SVG to ~0.17px.
+    await trigger.hover();
+    const popoverSvg = page.locator('.chord-diagram-popover svg').first();
+    await expect(popoverSvg).toBeVisible();
+    const box = await popoverSvg.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThan(80);
+    expect(box!.height).toBeGreaterThan(100);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1621,9 +1621,13 @@ interface LyricsDiagramConfig {
  *   not-found / loading / error fallbacks are the chord-name node, so an
  *   unknown chord (or a not-yet-loaded diagram) still shows its name —
  *   the name is never lost.
- * - `hover`: the chord name stays visible and the compact diagram is a
+ * - `hover`: the chord name stays visible and the full-size diagram is a
  *   popover revealed on hover / keyboard focus (the reveal is CSS in
- *   `styles.css`, keyed on `:hover` / `:focus` / `:focus-within`).
+ *   `styles.css`, keyed on `:hover` / `:focus` / `:focus-within`). The
+ *   popover floats free of the line, so it is NOT compact — a compact
+ *   SVG there renders too small to read. Only `inline` mode keeps
+ *   `compact`, because there the diagram sits in the chord slot above
+ *   the lyric where vertical space is tight.
  */
 function ChordCell(props: {
   mode: 'inline' | 'hover';
@@ -1668,7 +1672,6 @@ function ChordCell(props: {
           instrument={instrument}
           orientation={orientation}
           defines={defines}
-          compact
           className="chord-diagram-popover"
           role="tooltip"
           notFoundFallback={null}
@@ -1848,9 +1851,24 @@ function LyricsLine({
   // `.lyrics` sub-element below.
   const lineMarker =
     caret && caret.row === 'line' ? renderMarker(caret.lineRatio) : null;
+  // Layout contract for inline diagrams (ADR-0027): the chord-block
+  // flex items must bottom-align so every `.lyrics` row sits on the
+  // same baseline regardless of the (tall) compact diagram stacked
+  // above the chord-bearing blocks. Without this, a chord-less block
+  // — which has only a `.lyrics` row and no diagram above it — keeps
+  // the line's default top alignment and its lyric floats up level
+  // with the diagrams instead of the lyric row. The `align-items:
+  // flex-end` is applied via the `.line--inline-diagrams` CSS rule,
+  // gated to `inline` mode so regular and hover layouts (whose chord
+  // row is only ~1em tall) are unaffected. Appended to the base
+  // className the component already builds so the `line line--active`
+  // / `data-source-line` decoration `pushElement` clones in survives.
+  const baseClassName = className ?? 'line';
+  const rootClassName =
+    diagrams?.mode === 'inline' ? `${baseClassName} line--inline-diagrams` : baseClassName;
   return (
     <div
-      className={className ?? 'line'}
+      className={rootClassName}
       data-source-line={dataSourceLine}
       onDragOver={handleLineDragOver}
       onDragLeave={handleLineDragLeave}
@@ -4336,9 +4354,24 @@ export function renderChordproAst(
   // body wrapped in `.song__body` (see below); the other
   // modifiers (`top` / `bottom` / `below`) only need the section
   // to carry `data-position` and the wrapper class.
-  const songClass = diagramsState?.visible
-    ? `song song--diagrams-${diagramsState.position}`
-    : 'song';
+  //
+  // The modifier is meaningful ONLY when the end-of-song diagram grid
+  // is actually emitted — i.e. `section` mode (the grid is gated on
+  // `mode === 'section'` above). Every `song--diagrams-*` rule in the
+  // stylesheet exists to position that grid section (`-bottom` pins it
+  // with `margin-top: auto` under a column-flex parent; `-right` lays
+  // it out as a sticky two-column flex). In `inline` / `hover` mode
+  // there is no grid and no wrapper sibling, so applying the modifier
+  // would flip `.song` to `display: flex; flex-direction: column` with
+  // a single child group — turning every body element (lines, sections,
+  // and the top-level `{key}` / `{tempo}` `.meta-inline` chips) into an
+  // independent flex-column item that stacks vertically / stretches to
+  // full width. `position` defaults to `bottom`, so without this gate
+  // an inline/hover song silently picks up `song--diagrams-bottom`.
+  const songClass =
+    diagramsState?.visible && diagramsState.mode === 'section'
+      ? `song song--diagrams-${diagramsState.position}`
+      : 'song';
 
   if (rightSection !== null) {
     // Right-column layout. `.song__body` is a single flex item

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1302,6 +1302,19 @@
   flex-wrap: wrap;
   margin: 0.1em 0;
 }
+/* Inline diagrams (ADR-0027): bottom-align the chord-blocks within a
+   line so every `.lyrics` row lines up on the same baseline no matter
+   how tall the compact diagram stacked above a chord-bearing block
+   is. A chord-less block has only a `.lyrics` row; with the default
+   (effectively top) cross-axis alignment its lyric floats up level
+   with the diagrams instead of the lyric baseline row. Scoped to
+   `inline` mode only (the walker adds `line--inline-diagrams` when
+   `diagrams.mode === 'inline'`) so regular chord-name and hover
+   layouts — whose chord row is only ~1em tall — keep their existing
+   layout and snapshots. */
+.chordsketch-sheet__content .line--inline-diagrams {
+  align-items: flex-end;
+}
 .chordsketch-sheet__content .chord-block {
   display: inline-flex;
   flex-direction: column;
@@ -1561,12 +1574,34 @@
   left: 0;
   z-index: 20;
   display: none;
+  /* Shrink-wrap the diagram instead of inheriting the trigger's
+     inline width. The trigger (`.chord-has-diagram`) is only as wide
+     as the chord name (~10px), and `position: absolute` makes this
+     popover's containing block that same narrow span. Without an
+     explicit width the inner `<svg>` collapses to the 10px line box —
+     the diagram renders at ~0px. `width: max-content` lets the
+     popover size to the SVG's own intrinsic `width`/`height`
+     attributes (120×160 for the full-size diagram). */
+  width: max-content;
   margin-bottom: 4px;
   padding: 4px;
   background: var(--cs-surface, #ffffff);
   border: 1px solid var(--cs-border, #d4d1d6);
   border-radius: var(--cs-r-2, 4px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+/* The popover's inner SVG keeps its intrinsic px size (the Rust
+   renderer emits `width`/`height` attributes). The shared
+   `.chordsketch-diagram svg` rule below caps every diagram svg at
+   `max-width: 100%`; inside this absolutely-positioned popover that
+   `100%` resolves against the ~10px trigger box and crushes the
+   diagram to ~0px. Lift the cap here (and pin `width: auto` so the svg
+   uses its emitted attribute width) so the popover always paints the
+   full-size 120×160 diagram. `display: block` / `height: auto` are
+   already supplied by `.chordsketch-diagram svg`. */
+.chordsketch-sheet__content .chord-diagram-popover svg {
+  max-width: none;
+  width: auto;
 }
 /* Reveal on mouse hover AND keyboard focus (`:focus` on the span itself
    and `:focus-within` for focus moving into the popover). */

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -4062,3 +4062,19 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     expect(hover.container.querySelector('.chord-diagrams')).toBeNull();
     expect(hover.container.querySelector('.song__body')).toBeNull();
 
+    // Section mode: a chord IS present, so the end-of-song grid emits
+    // (position defaults to `bottom`). The wrapper MUST carry the
+    // `song song--diagrams-bottom` modifier AND wrap the body in a
+    // single `.song__body` flex child so only the body wrapper + the
+    // grid section feel the column-flex (chips inside flow inline).
+    const section = render(
+      renderChordproAst(mixedSegmentSong('section'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const sectionSong = section.container.querySelector('.song');
+    expect(sectionSong?.className).toBe('song song--diagrams-bottom');
+    expect(section.container.querySelector('.song__body')).not.toBeNull();
+    // Sanity: the grid that justifies the modifier really is present.
+    expect(section.container.querySelector('.chord-diagrams')).not.toBeNull();
+  });
+});
+

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3903,4 +3903,162 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     expect(container.querySelector('.chord-block-inline-diagram')).toBeNull();
     expect(container.querySelector('.chord-diagrams')).toBeNull();
   });
-});
+
+  // A song with a chord-bearing segment followed by a chord-LESS
+  // segment on the same line, plus `{key}` / `{tempo}` directives and
+  // a `{diagrams: …}` mode. Exercises the inline-diagram baseline-
+  // alignment hook, the meta-inline chip-className invariant, and the
+  // `song--diagrams-*` wrapper gate.
+  function mixedSegmentSong(diagramsValue: string): ChordproSong {
+    return {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'directive',
+          value: { name: 'key', value: 'G', kind: { tag: 'key' }, selector: null },
+        },
+        {
+          kind: 'directive',
+          value: { name: 'tempo', value: '120', kind: { tag: 'tempo' }, selector: null },
+        },
+        {
+          kind: 'directive',
+          value: {
+            name: 'diagrams',
+            value: diagramsValue,
+            kind: { tag: 'diagrams' },
+            selector: null,
+          },
+        },
+        {
+          kind: 'lyrics',
+          value: {
+            segments: [
+              { chord: { name: 'C', detail: null, display: null }, text: 'Hello ', spans: [] },
+              { chord: null, text: 'world', spans: [] },
+            ],
+          },
+        },
+      ],
+    };
+  }
+
+  test('when diagrams mode is inline, then the lyrics line carries the line--inline-diagrams baseline hook (only in inline)', () => {
+    // In inline mode the compact diagram makes the chord row ~40px
+    // tall, so a chord-LESS block's lyric floats up to the top of the
+    // row instead of sitting on the lyric baseline next to the
+    // chord-bearing block's lyric. The fix bottom-aligns the line's
+    // flex items via `.line--inline-diagrams`.
+    //
+    // jsdom has no layout engine, so this only proves the structural
+    // hook (the CSS selector) is emitted in inline mode and withheld
+    // elsewhere. The ACTUAL baseline alignment is verified in a real
+    // browser by `tests-e2e/diagrams-inline-hover.spec.ts`.
+    const inline = render(
+      renderChordproAst(mixedSegmentSong('inline'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const inlineLine = inline.container.querySelector('div.line');
+    expect(inlineLine).not.toBeNull();
+    expect(inlineLine?.classList.contains('line--inline-diagrams')).toBe(true);
+    // The line still carries the compact diagram cell (chord-bearing
+    // block) AND the chord-less block whose lyric must align.
+    expect(inlineLine?.querySelector('.chord-block-inline-diagram')).not.toBeNull();
+    expect(inline.container.textContent).toContain('world');
+
+    // Regular (section) mode must NOT get the modifier — gating the
+    // bottom-alignment to inline keeps regular/hover layout (and their
+    // snapshots) unchanged.
+    const section = render(
+      renderChordproAst(mixedSegmentSong('section'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    expect(
+      section.container.querySelector('div.line')?.classList.contains('line--inline-diagrams'),
+    ).toBe(false);
+
+    // Hover mode keeps the chord NAME as the trigger (same ~1em height
+    // as regular), so it does NOT need — and must not get — the hook.
+    const hover = render(
+      renderChordproAst(mixedSegmentSong('hover'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    expect(
+      hover.container.querySelector('div.line')?.classList.contains('line--inline-diagrams'),
+    ).toBe(false);
+  });
+
+  test('when the diagram mode changes, then the {key} / {tempo} meta-inline chip classNames stay mode-independent', () => {
+    // The reported regression was that `{diagrams: inline}` restyled the
+    // top-level `{key}` / `{tempo}` chips (stacked / full-width). The
+    // ROOT CAUSE — a stray `song--diagrams-bottom` wrapper flipping the
+    // article to a flex column — is pinned by the next test, and the
+    // VISUAL effect (chip width) is verified in a real browser by
+    // `tests-e2e/diagrams-inline-hover.spec.ts`.
+    //
+    // This test guards a narrower, walker-level invariant that neither
+    // of those covers: the chips themselves must be emitted with the
+    // same className regardless of diagram mode — a future walker branch
+    // that added a mode-dependent class directly to a chip would slip
+    // past the wrapper-class test. It deliberately does NOT claim to
+    // prove the chips "render identically" (jsdom can't measure layout).
+    const inline = render(
+      renderChordproAst(mixedSegmentSong('inline'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const section = render(
+      renderChordproAst(mixedSegmentSong('section'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const chipClasses = (root: HTMLElement): string[] =>
+      Array.from(root.querySelectorAll('.meta-inline')).map((el) => (el as HTMLElement).className);
+    const sectionChips = chipClasses(section.container);
+    // Both modes surface the {key} and {tempo} markers.
+    expect(sectionChips.length).toBe(2);
+    expect(chipClasses(inline.container)).toEqual(sectionChips);
+    // Each chip's className is byte-identical across modes.
+    const keyChip = (root: HTMLElement): string =>
+      (root.querySelector('.meta-inline--key') as HTMLElement).className;
+    expect(keyChip(inline.container)).toBe(keyChip(section.container));
+    const tempoChip = (root: HTMLElement): string =>
+      (root.querySelector('.meta-inline--tempo') as HTMLElement).className;
+    expect(tempoChip(inline.container)).toBe(tempoChip(section.container));
+  });
+
+  test('when diagrams mode is inline or hover, then the song--diagrams-* wrapper modifier is withheld (it fires only when the end-of-song grid is emitted)', () => {
+    // Bug 1 root cause: the wrapper class carried
+    // `song--diagrams-${position}` whenever diagrams were *visible*,
+    // and `position` defaults to `bottom`. So `{diagrams: inline}` and
+    // `{diagrams: hover}` — which suppress the end-of-song grid and
+    // emit NO wrapper sibling — still flipped the article to
+    // `.song--diagrams-bottom` (display:flex / column). With no grid
+    // sibling and no `.song__body` wrapper, every body child (lines,
+    // sections, and the top-level `{key}` / `{tempo}` `.meta-inline`
+    // chips) became an independent flex-column item and stacked /
+    // stretched to full width. jsdom has no layout engine so it can't
+    // measure the stacking, but the WRONG WRAPPER CLASS that causes it
+    // is structurally observable — this test pins the invariant
+    // "position modifier ⇔ grid present" that the className alone never
+    // expressed.
+    //
+    // Inline mode: no grid, so the wrapper must be plain `.song`
+    // (block flow). NOT `song--diagrams-bottom`.
+    const inline = render(
+      renderChordproAst(mixedSegmentSong('inline'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    const inlineSong = inline.container.querySelector('.song');
+    expect(inlineSong).not.toBeNull();
+    expect(inlineSong?.className).toBe('song');
+    // Defensive: no `song--diagrams-*` modifier of any position leaks
+    // into inline mode (guards a future `position` directive in an
+    // inline song from re-introducing the bug under a different
+    // suffix).
+    expect(inlineSong?.className).not.toMatch(/\bsong--diagrams-/);
+    // The inline body has no end-of-song grid and no `.song__body`
+    // wrapper — both are section-mode-only.
+    expect(inline.container.querySelector('.chord-diagrams')).toBeNull();
+    expect(inline.container.querySelector('.song__body')).toBeNull();
+
+    // Hover mode: same as inline — grid suppressed, plain `.song`.
+    const hover = render(
+      renderChordproAst(mixedSegmentSong('hover'), { chordDiagrams: { instrument: 'guitar' } }),
+    );
+    expect(hover.container.querySelector('.song')?.className).toBe('song');
+    expect(hover.container.querySelector('.chord-diagrams')).toBeNull();
+    expect(hover.container.querySelector('.song__body')).toBeNull();
+


### PR DESCRIPTION
## What

Fixes three rendering bugs in the `{diagrams: inline}` / `{diagrams: hover}`
modes of the React JSX walker (`@chordsketch/react`), introduced with the
inline/hover feature in #2584:

1. **inline baseline** — a chord-less lyric segment floated up to the top of
   the tall compact-diagram row instead of resting on the lyric baseline next
   to chord-bearing segments.
2. **inline/hover meta chips** — the `{key}` / `{tempo}` `.meta-inline` chips
   were restyled (stacked, stretched to full width) whenever inline/hover was
   active.
3. **hover popover** — the popover diagram rendered at ~0px (unreadable).

## Why / root cause

- **(1)** `.line` is `display: flex` with default cross-axis alignment, so the
  chord-less block (no diagram above it) top-aligned against the tall diagram.
  Fixed by `align-items: flex-end` on a new `.line--inline-diagrams` class,
  added by the walker only in inline mode so regular/hover layouts are
  untouched.
- **(2)** The `song--diagrams-${position}` wrapper modifier was applied
  whenever diagrams were *visible*, but `position` defaults to `bottom`.
  Inline/hover emit no end-of-song grid and no `.song__body` wrapper sibling,
  so the stray `song--diagrams-bottom` flipped `.song` to `display: flex;
  flex-direction: column` and stretched every body child — including the meta
  chips. Fixed by gating the modifier to `section` mode, matching the
  grid-emission condition.
- **(3)** The hover popover floats free of the line, so the compact
  (above-a-lyric) size is wrong there — dropped the `compact` prop. The
  absolutely-positioned popover also inherited
  `.chordsketch-diagram svg { max-width: 100% }`, which resolved against the
  ~10px trigger box and crushed the svg. Added `width: max-content` on the
  popover and `max-width: none; width: auto` on its svg so it paints the
  full-size 120×160 diagram.

All three are React-JSX-surface CSS/layout concerns; per ADR-0027 the
inline/hover placement is implemented on the React walker first, so there is
no Rust renderer sister-site to update.

## Test results

- `@chordsketch/react` vitest: 120 passed; `tsc --noEmit`: clean.
- playground `tsc --noEmit`: clean; playground Playwright e2e: 65 passed.
- New Playwright smoke `tests-e2e/diagrams-inline-hover.spec.ts` measures the
  rendered geometry in a real browser (jsdom can't observe these CSS-layout
  effects): lyric baselines align (spread ≤ 2px), chips stay narrow
  (< 50% of content width), and the hover popover svg renders full size
  (> 80×100px). Each assertion was confirmed to fail when its fix is reverted
  (baseline spread → 71px; popover → 0.17px).

## Review summary

Reviewed for correctness, security, renderer-parity / fix-propagation, and
test coverage. The key finding — the original unit tests asserted only DOM
structure for CSS-layout bugs (no regression protection) — is resolved by the
new browser-measured smoke. Sister-site audit confirmed no Rust renderer
implements inline/hover yet (ADR-0027 §Consequences), so no parity work is
owed.
