### PR TITLE
Add a Stack layout primitive to the design system

### DIFF
--- a/design-system/DESIGN.md
+++ b/design-system/DESIGN.md
@@ -159,6 +159,48 @@ Token aliases in `tokens.css`:
   1080px (guides).
 - **Grid** — 12 columns, 24px gutter.
 
+### 4.1 Stack — the vertical-flow primitive
+
+Vertical spacing between stacked elements is owned by the
+**container**, never by the children. This is the one spacing model:
+it replaces per-child `margin-bottom` and the brittle margin-collapse
+that pattern leans on, and it removes the defensive `margin: 0`
+re-declarations that creep in when a child's own outer spacing is
+uncertain.
+
+`.stack` is a column flexbox whose `gap` is set by `--stack-gap`
+(default `--sp-4`); its direct children carry no outer block margin —
+the primitive zeroes `margin-block` on them, so it is correct with or
+without a global reset. Pick a rhythm with the numbered modifiers,
+which map 1:1 onto the space scale — one modifier per `--sp-*` step:
+
+| Class | `--stack-gap` |   | Class | `--stack-gap` |
+|---|---|---|---|---|
+| `.stack` | `--sp-4` (default) |   | `.stack-8`  | `--sp-8`  |
+| `.stack-1` | `--sp-1` |   | `.stack-10` | `--sp-10` |
+| `.stack-2` | `--sp-2` |   | `.stack-12` | `--sp-12` |
+| `.stack-3` | `--sp-3` |   | `.stack-16` | `--sp-16` |
+| `.stack-4` | `--sp-4` |   | `.stack-20` | `--sp-20` |
+| `.stack-5` | `--sp-5` |   | `.stack-24` | `--sp-24` |
+| `.stack-6` | `--sp-6` |   | `.stack-32` | `--sp-32` |
+
+```css
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap, var(--sp-4));
+}
+.stack > * { margin-block: 0; }
+.stack-1  { --stack-gap: var(--sp-1); }
+/* … one modifier per --sp-* step … */
+.stack-32 { --stack-gap: var(--sp-32); }
+```
+
+**Mixed rhythm = nested stacks.** Each stack level is internally
+uniform; vary the rhythm by nesting — e.g. a tight `.stack-2` heading
+group (title + lede) inside a looser `.stack-8` page. For a dynamic or
+off-scale gap, set `--stack-gap` directly instead of using a modifier.
+
 ---
 
 ## 5. Motion
@@ -288,6 +330,7 @@ layout in either place.
 | `ui_kits/web/editor.html` | Full-screen sample — ChordPro split editor (source + live preview) |
 | `ui_kits/web/editor-irealb.html` | Full-screen sample — iReal Pro bar-grid editor with metadata header and bar inspector |
 | `preview/index.html` | Component preview index |
+| `preview/layout-stack.html` | Stack — vertical-flow primitive (default gap, modifiers, nesting) |
 | `preview/components-buttons.html` | Buttons — variants, sizes, icon-only, disabled, loading |
 | `preview/components-forms.html` | Inputs, textarea, select, segmented, check, radio, switch |
 | `preview/components-cards.html` | Song / setlist / accent cards |
@@ -310,3 +353,8 @@ layout in either place.
   JetBrains Mono / Roboto / Source Serif 4 / Bravura Text. Source
   Serif 4 is restricted to chart-rendering surfaces (iReal Pro); UI
   text remains sans-serif and monospace.
+- **v1.1** — Added the `.stack` vertical-flow layout primitive (§4.1):
+  container-owned spacing via `--stack-gap`, numbered modifiers mapping
+  1:1 onto the `--sp-*` scale, nesting for mixed rhythm. Replaces
+  per-child `margin-bottom` / margin-collapse as the spacing model. No
+  new tokens.

--- a/design-system/DESIGN.md
+++ b/design-system/DESIGN.md
@@ -1,6 +1,6 @@
 # ChordSketch — Design System
 
-**Version 1.0** · English-primary UI · Light theme · Editorial / Professional
+**Version 1.1** · English-primary UI · Light theme · Editorial / Professional
 
 ChordSketch is a library of chord sheets with lyrics for **ChordPro** and
 **iReal Pro**. A tool for amateurs through professionals to search, edit,

--- a/design-system/preview/index.html
+++ b/design-system/preview/index.html
@@ -33,9 +33,10 @@ h1 { font-family: var(--font-display); font-weight: 900; font-size: var(--fs-60)
   <a href="../design-system.html" class="back">← Design System</a>
   <p class="eyebrow" style="margin-top: var(--sp-8);">ChordSketch · Components</p>
   <h1>Components.</h1>
-  <p class="deck">Single-component previews. Each page exercises the variants and states declared in <code style="font-family: var(--font-mono);">DESIGN.md §6</code>, against tokens from <code style="font-family: var(--font-mono);">tokens.css</code>.</p>
+  <p class="deck">Single-component and layout previews. Each page exercises the variants and states declared in <code style="font-family: var(--font-mono);">DESIGN.md §4 / §6</code>, against tokens from <code style="font-family: var(--font-mono);">tokens.css</code>.</p>
 
   <ol class="list">
+    <li><a href="layout-stack.html"><span class="name">Stack</span><span class="meta">§4.1 layout · gap-owned · 1:1 scale · nestable</span></a></li>
     <li><a href="components-buttons.html"><span class="name">Buttons</span><span class="meta">primary · secondary · ghost · danger</span></a></li>
     <li><a href="components-forms.html"><span class="name">Forms</span><span class="meta">input · select · textarea · segmented · check · radio · slider</span></a></li>
     <li><a href="components-cards.html"><span class="name">Cards</span><span class="meta">song · setlist · featured</span></a></li>

--- a/design-system/preview/layout-stack.html
+++ b/design-system/preview/layout-stack.html
@@ -96,7 +96,7 @@ a { color: inherit; }
     <p class="note">A tight <code>.stack-2</code> heading group (title + lede) inside a looser <code>.stack-8</code> page. Each level is internally uniform — no per-child margins anywhere.</p>
     <div class="stack stack-8">
       <div class="stack stack-2">
-        <h1 class="preview-h1" style="margin:0;">Page title</h1>
+        <p class="preview-h1" style="margin:0;">Page title</p>
         <p class="note" style="margin:0;">Lede sits --sp-2 under the title; the sections below sit --sp-8 apart.</p>
       </div>
       <div class="card">

--- a/design-system/preview/layout-stack.html
+++ b/design-system/preview/layout-stack.html
@@ -47,7 +47,6 @@ a { color: inherit; }
 .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-6); }
 .card h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-18); letter-spacing: -0.01em; }
 .card p { color: var(--text-secondary); font-size: var(--fs-14); }
-.card .eyebrow { margin: 0; }
 </style>
 </head>
 <body>
@@ -96,16 +95,16 @@ a { color: inherit; }
     <p class="note">A tight <code>.stack-2</code> heading group (title + lede) inside a looser <code>.stack-8</code> page. Each level is internally uniform — no per-child margins anywhere.</p>
     <div class="stack stack-8">
       <div class="stack stack-2">
-        <p class="preview-h1" style="margin:0;">Page title</p>
-        <p class="note" style="margin:0;">Lede sits --sp-2 under the title; the sections below sit --sp-8 apart.</p>
+        <p class="preview-h1">Page title</p>
+        <p class="note">Lede sits --sp-2 under the title; the sections below sit --sp-8 apart.</p>
       </div>
-      <div class="card">
+      <div class="card stack stack-2">
         <p class="eyebrow">Section</p>
-        <h3 style="margin:0;">First section</h3>
+        <h3>First section</h3>
       </div>
-      <div class="card">
+      <div class="card stack stack-2">
         <p class="eyebrow">Section</p>
-        <h3 style="margin:0;">Second section</h3>
+        <h3>Second section</h3>
       </div>
     </div>
   </section>

--- a/design-system/preview/layout-stack.html
+++ b/design-system/preview/layout-stack.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Stack — ChordSketch Layout</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+<link rel="stylesheet" href="../tokens.css">
+<style>
+* { box-sizing: border-box; } html, body { margin: 0; }
+body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875; color: var(--text-primary); background: var(--canvas); -webkit-font-smoothing: antialiased; }
+a { color: inherit; }
+.container { max-width: 960px; margin: 0 auto; padding: var(--sp-12) var(--sp-6); }
+.preview-back { font-family: var(--font-latin); font-size: var(--fs-12); font-weight: 600; letter-spacing: 0; color: var(--text-secondary); text-decoration: none; }
+.preview-back:hover { color: var(--text-primary); }
+.eyebrow { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-secondary); margin: var(--sp-8) 0 var(--sp-2); }
+.preview-h1 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-36); line-height: 1.111; letter-spacing: -0.02em; margin: 0 0 var(--sp-3); }
+.preview-deck { color: var(--text-secondary); margin: 0 0 var(--sp-12); max-width: 56ch; }
+.group { margin-bottom: var(--sp-12); }
+.group h2 { font-family: var(--font-latin); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0; color: var(--text-secondary); margin: 0 0 var(--sp-4); }
+.note { color: var(--text-secondary); font-size: var(--fs-14); margin: 0 0 var(--sp-4); max-width: 64ch; }
+.note code, code.inline { font-family: var(--font-mono); font-size: var(--fs-13); background: var(--ink-100); padding: 1px var(--sp-1); border-radius: var(--r-1); }
+
+/* ----- The primitive under preview (DESIGN.md §4.1) ----- */
+.stack { display: flex; flex-direction: column; gap: var(--stack-gap, var(--sp-4)); }
+.stack > * { margin-block: 0; }
+.stack-1  { --stack-gap: var(--sp-1); }
+.stack-2  { --stack-gap: var(--sp-2); }
+.stack-3  { --stack-gap: var(--sp-3); }
+.stack-4  { --stack-gap: var(--sp-4); }
+.stack-5  { --stack-gap: var(--sp-5); }
+.stack-6  { --stack-gap: var(--sp-6); }
+.stack-8  { --stack-gap: var(--sp-8); }
+.stack-10 { --stack-gap: var(--sp-10); }
+.stack-12 { --stack-gap: var(--sp-12); }
+.stack-16 { --stack-gap: var(--sp-16); }
+.stack-20 { --stack-gap: var(--sp-20); }
+.stack-24 { --stack-gap: var(--sp-24); }
+.stack-32 { --stack-gap: var(--sp-32); }
+
+/* ----- preview-only visual aids ----- */
+.demo-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-2); padding: var(--sp-3) var(--sp-4); font-family: var(--font-mono); font-size: var(--fs-13); color: var(--text-secondary); }
+.cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--sp-6); align-items: start; }
+.col-label { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-tertiary); margin: 0 0 var(--sp-2); }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: var(--sp-6); }
+.card h3 { font-family: var(--font-jp); font-weight: 700; font-size: var(--fs-18); letter-spacing: -0.01em; }
+.card p { color: var(--text-secondary); font-size: var(--fs-14); }
+.card .eyebrow { margin: 0; }
+</style>
+</head>
+<body>
+<main class="container">
+  <a href="index.html" class="preview-back">← Components</a>
+  <p class="eyebrow">Layout · §4.1</p>
+  <h1 class="preview-h1">Stack</h1>
+  <p class="preview-deck">The vertical-flow primitive. Spacing between stacked elements is owned by the container via <code class="inline">--stack-gap</code>, never by per-child <code class="inline">margin-bottom</code>. Numbered modifiers map 1:1 onto the <code class="inline">--sp-*</code> scale; mixed rhythm is expressed by nesting.</p>
+
+  <section class="group">
+    <h2>Default · <code>.stack</code> (gap = --sp-4)</h2>
+    <div class="stack">
+      <div class="demo-box">.stack child</div>
+      <div class="demo-box">.stack child</div>
+      <div class="demo-box">.stack child</div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Modifiers · one per scale step</h2>
+    <p class="note">Each modifier sets <code>--stack-gap</code> to the matching <code>--sp-*</code> token. Three steps shown side by side so the rhythm difference is visible.</p>
+    <div class="cols">
+      <div>
+        <p class="col-label">.stack-2 — --sp-2 (8px)</p>
+        <div class="stack stack-2">
+          <div class="demo-box">item</div><div class="demo-box">item</div><div class="demo-box">item</div>
+        </div>
+      </div>
+      <div>
+        <p class="col-label">.stack-6 — --sp-6 (24px)</p>
+        <div class="stack stack-6">
+          <div class="demo-box">item</div><div class="demo-box">item</div><div class="demo-box">item</div>
+        </div>
+      </div>
+      <div>
+        <p class="col-label">.stack-10 — --sp-10 (40px)</p>
+        <div class="stack stack-10">
+          <div class="demo-box">item</div><div class="demo-box">item</div><div class="demo-box">item</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Mixed rhythm · nested stacks</h2>
+    <p class="note">A tight <code>.stack-2</code> heading group (title + lede) inside a looser <code>.stack-8</code> page. Each level is internally uniform — no per-child margins anywhere.</p>
+    <div class="stack stack-8">
+      <div class="stack stack-2">
+        <h1 class="preview-h1" style="margin:0;">Page title</h1>
+        <p class="note" style="margin:0;">Lede sits --sp-2 under the title; the sections below sit --sp-8 apart.</p>
+      </div>
+      <div class="card">
+        <p class="eyebrow">Section</p>
+        <h3 style="margin:0;">First section</h3>
+      </div>
+      <div class="card">
+        <p class="eyebrow">Section</p>
+        <h3 style="margin:0;">Second section</h3>
+      </div>
+    </div>
+  </section>
+
+  <section class="group">
+    <h2>Children own no margin</h2>
+    <p class="note">A <code>.stack-4</code> wrapping native <code>&lt;h3&gt;</code> / <code>&lt;p&gt;</code> with no margin rules of their own. The primitive zeroes <code>margin-block</code> on direct children, so the only vertical spacing is the gap — correct with or without a global reset.</p>
+    <div class="stack stack-4 card">
+      <h3>Heading with default UA margin</h3>
+      <p>This paragraph and the heading above are spaced only by the stack gap (--sp-4); the user-agent margins on <code class="inline">h3</code> / <code class="inline">p</code> are neutralised by the primitive.</p>
+      <p>A second paragraph, evenly --sp-4 below.</p>
+    </div>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## What

Add a `.stack` vertical-flow layout primitive to the design system.

- `DESIGN.md` §4.1 — documents the rule, the class table (`.stack` plus `.stack-<n>`, one modifier per `--sp-*` step), and the canonical CSS.
- `design-system/preview/layout-stack.html` — preview page demonstrating the default gap, the modifiers side by side, nested mixed rhythm, and the "children carry no margin" contract. Linked from `preview/index.html`.
- `DESIGN.md` §9 (related files) and §10 (changelog, v1.1) updated.

`.stack` is a column flexbox whose `gap` is `--stack-gap` (default `--sp-4`); `.stack > *` get `margin-block: 0`, so the primitive is correct with or without a global reset. Numbered modifiers map 1:1 onto the spacing scale; mixed rhythm is composed by nesting. `--stack-gap` is the escape hatch for dynamic / off-scale gaps.

## Why

§4 (Space) defined the spacing scale but shipped no layout primitive, so consumers reinvented vertical rhythm — some with container `gap`, some with per-child `margin-bottom`. The `margin-bottom` model relies on margin-collapse (brittle: a sibling's own top margin silently changes the gap) and breeds defensive `margin: 0` re-declarations. One container-owned primitive removes that split. No new tokens.

## Test results

Static HTML/CSS (no build step). Rendered `preview/layout-stack.html` in headless Chromium and measured the computed gap between `.stack` children:

- `.stack` (default) → 16px (`--sp-4`)
- `.stack-2` → 8px, `.stack-6` → 24px, `.stack-10` → 40px (each matches its `--sp-*` step)
- direct `<h3>` / `<p>` children of a `.stack` report `margin-block: 0` — the user-agent margins are neutralised, so the only vertical spacing is the gap.

`preview/index.html` links the new page.

## Review summary

- No new dependency and no new token — every gap references the existing `--sp-*` scale.
- No Rust touched; `cargo fmt` / `clippy` / `test` are unaffected.
- New design-system class; existing surfaces (preview pages, UI kits) are unaffected until they opt in.

Closes #2597
