### PR TITLE
Disable chord drag-and-drop repositioning in playground preview-only view

### DIFF
--- a/packages/playground/src/chordpro/main.tsx
+++ b/packages/playground/src/chordpro/main.tsx
@@ -881,7 +881,17 @@ function PlaygroundApp(): JSX.Element {
                 activeSourceLine={view === 'split' ? caret?.line : undefined}
                 caretColumn={view === 'split' ? caret?.column : undefined}
                 caretLineLength={view === 'split' ? caret?.lineLength : undefined}
-                onChordReposition={handleChordReposition}
+                /* Chord drag-and-drop repositioning is an editing
+                   gesture: a drop mutates the ChordPro source the
+                   editor displays. Preview-only view is a read-only
+                   display mode with the editor unmounted, so a drop
+                   there would silently rewrite source the user cannot
+                   see. Gate the callback on split view (matching the
+                   caret props above) so omitting it leaves every
+                   `.chord` span non-draggable in preview-only mode. */
+                onChordReposition={
+                  view === 'split' ? handleChordReposition : undefined
+                }
               />
             </div>
           </section>

--- a/packages/playground/tests-e2e/preview-mode-caret.spec.ts
+++ b/packages/playground/tests-e2e/preview-mode-caret.spec.ts
@@ -96,6 +96,40 @@ test.describe('playground pane visibility', () => {
     expect(errors).toEqual([]);
   });
 
+  test('preview-only view disables chord drag-and-drop repositioning', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    // Drag-and-drop chord repositioning is an editing gesture: a drop
+    // rewrites the ChordPro source the editor shows. In split view the
+    // editor is mounted, so the preview's `.chord` spans are drag
+    // sources (`draggable="true"`). Assert the affordance is present
+    // first so the absence asserted after the switch is a real
+    // regression signal, not a vacuous pass.
+    const preview = page.locator('.pane.preview');
+    await expect(preview.locator('.chord[draggable="true"]').first()).toBeVisible();
+
+    await page.getByRole('button', { name: 'Preview' }).click();
+
+    // Editor is gone; the rendered sheet is still there as a read-only
+    // display surface...
+    await expect(page.locator('.cm-editor')).toHaveCount(0);
+    await expect(preview).toContainText('sweet');
+    // ...but no chord may be draggable — preview-only is display-only,
+    // so a drop cannot silently rewrite source the user cannot see.
+    await expect(preview.locator('[draggable="true"]')).toHaveCount(0);
+
+    // Returning to split restores the drag affordance — the suppression
+    // is scoped to the view, not a permanent teardown.
+    await page.getByRole('button', { name: 'Split' }).click();
+    await expect(preview.locator('.chord[draggable="true"]').first()).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
   test('source-only view unmounts the preview pane entirely', async ({
     page,
   }) => {


### PR DESCRIPTION
## What

Make the ChordPro playground's **Preview** pane a true read-only display
surface. Gate the `onChordReposition` drag-and-drop callback on split view so
chords are no longer drag-editable in preview-only mode.

```tsx
onChordReposition={view === 'split' ? handleChordReposition : undefined}
```

## Why

The pane-visibility toggle has a `Preview` mode that unmounts the editor and
shows only the rendered sheet. `<RendererPreview>` was wired with
`onChordReposition` in every view, so chord drag-and-drop repositioning stayed
active even in preview-only mode — where a drop silently rewrote the ChordPro
source the user could no longer see (the editor is unmounted). Preview-only is
a display-only mode and must not accept edits.

Omitting the callback leaves every `.chord` span non-draggable and attaches no
drop handlers, per the React JSX walker's documented default
(`packages/react/src/chordpro-jsx.tsx` `onChordReposition` doc + unit test
`chordpro-jsx.test.tsx` "chord drag/drop affordances are off by default"). The
gate mirrors the adjacent caret-overlay props, which are already suppressed in
preview-only view. Split view (editor beside preview) keeps the editing gesture
because the source mutation is visible there.

This is host presentation policy, not library logic — the read-only capability
already exists in the library (the callback is optional), so the playground
merely opts out, per `.claude/rules/playground-is-a-sample.md`.

## Test results

- Added a Playwright smoke spec (`preview-mode-caret.spec.ts`) asserting the
  drag affordance is present in split view, absent in preview-only view, and
  restored on return to split — with a `pageerror` listener asserted empty, per
  `.claude/rules/playground-smoke.md`.
- The full e2e suite runs in CI's `playground-smoke` job (the production
  `vite preview` build requires the wasm toolchain + browser downloads not
  available in the authoring environment).

## Review summary

- code-review (high effort), security-review, and standard review: no findings.
- Sister-site audit (`.claude/rules/fix-propagation.md`): the playground is the
  only surface that wires `onChordReposition`. The VS Code preview, desktop app,
  and `<ChordProEditor>` all render through `<ChordProPreview>`, which never
  accepts the callback; the iReal Pro playground is a non-editable chart. No
  equivalent defect elsewhere.

## Sister-site audit

Checked every `onChordReposition` consumer and every preview surface — no other
surface offers chord drag in a read-only context. No renderer-parity or doc
(`CLAUDE.md`) triggers: no new directive, AST node, JSON field, validation, or
public API.

Closes #2603

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3SCpHq24BDzAkWdZ6iTut)_