### PR TITLE
Show fret-number axis across the full visible range in chord diagrams

### DIFF
--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -561,6 +561,13 @@ pub fn render_svg_with_options(
         || data.strings > MAX_STRINGS
         || data.frets_shown < MIN_FRETS_SHOWN
         || data.frets_shown > MAX_FRETS_SHOWN
+        // `base_fret` is a public field, so a directly-constructed
+        // `DiagramData` can carry an out-of-range value the parser would
+        // have clamped. Reject it here the same way `strings` / `frets_shown`
+        // are rejected, so the fret-number axis cannot emit a negative label
+        // (`base_fret - 1` for `base_fret == 0`) or an absurd one.
+        || data.base_fret < 1
+        || data.base_fret > MAX_BASE_FRET
     {
         return String::new();
     }
@@ -621,11 +628,11 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
         crate::escape::escape_xml(data.title())
     ));
 
-    // Nut or base-fret indicator. When the diagram starts above
-    // fret 1 we label it with just the fret number (no "fr"
-    // suffix) — the position marker dots below already imply
-    // "this is fret N on a real fretboard", so the bare integer
-    // is enough.
+    // Nut (open position) or, for the compact size only, a single bare
+    // base-fret label (no "fr" suffix). The regular size labels the base
+    // fret as part of the full fret-number axis drawn below, so it needs no
+    // standalone label here; the position-marker dots already imply "this is
+    // fret N on a real fretboard".
     let nut_y = top_margin;
     if data.base_fret == 1 {
         svg.push_str(&format!(
@@ -649,9 +656,13 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
     // Fret-number axis: label every fret line in the visible window with its
     // absolute fret number (`base_fret - 1 + j`), so fret line 0 is the
     // nut/open position (labelled 0 when the diagram starts at the nut). The
-    // labels sit left of the grid, right-anchored inside the existing left
-    // margin, so the diagram's bounding box is unchanged. A `fret-number`
-    // class is emitted so consumers can restyle or hide the axis via CSS.
+    // labels sit left of the grid; `text-anchor="end"` fixes their right edge
+    // at `left_margin - 4`, so 1- and 2-digit numbers align without any
+    // width math (unlike the PDF renderer, whose left-anchored text engine
+    // has to subtract an estimated glyph width). They stay inside the
+    // existing left margin, so the diagram's bounding box is unchanged. A
+    // `fret-number` class is emitted so consumers can restyle or hide the
+    // axis via CSS.
     if show_fret_numbers {
         for j in 0..=num_frets {
             let fret_number = data.base_fret as i32 - 1 + j as i32;
@@ -839,11 +850,11 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
         crate::escape::escape_xml(data.title())
     ));
 
-    // Nut (vertical line on the left when at the open position) or the
-    // base-fret label above the leftmost fret cell when the diagram starts
-    // higher up the fretboard. The label sits above the first fret column
-    // (the horizontal equivalent of the vertical layout's left-of-row label
-    // position).
+    // Nut (vertical line on the left at the open position) or, for the
+    // compact size only, a single base-fret label above the leftmost fret
+    // cell. The regular size labels the base fret as part of the full
+    // fret-number axis drawn below the grid, so it needs no standalone label
+    // here.
     let nut_x = left_margin;
     if data.base_fret == 1 {
         svg.push_str(&format!(
@@ -3279,12 +3290,64 @@ mod tests {
             let j = svg[i..].find('"').unwrap();
             svg[i..i + j].parse().unwrap()
         };
+        // Every fret-number label's baseline y must fall inside the declared
+        // height, so a future margin/font tweak that pushes a label past the
+        // frame fails here rather than only being caught by eye.
+        let label_ys = |svg: &str| -> Vec<f32> {
+            svg.lines()
+                .filter(|l| l.contains("class=\"fret-number\""))
+                .map(|l| {
+                    let needle = "y=\"";
+                    let i = l.find(needle).unwrap() + needle.len();
+                    let j = l[i..].find('"').unwrap();
+                    l[i..i + j].parse().unwrap()
+                })
+                .collect()
+        };
         let data = open_c();
         let v = render_svg_with_orientation(&data, Orientation::Vertical);
         assert_eq!(extract(&v, "width"), 120.0);
         assert_eq!(extract(&v, "height"), 160.0);
+        assert!(
+            label_ys(&v).iter().all(|&y| y <= 160.0),
+            "vertical fret-number labels overflow the frame: {:?}",
+            label_ys(&v)
+        );
         let h = render_svg_with_orientation(&data, Orientation::Horizontal);
         assert_eq!(extract(&h, "width"), 140.0);
         assert_eq!(extract(&h, "height"), 130.0);
+        assert!(
+            label_ys(&h).iter().all(|&y| y <= 130.0),
+            "horizontal fret-number labels overflow the frame: {:?}",
+            label_ys(&h)
+        );
+    }
+
+    #[test]
+    fn render_rejects_out_of_range_base_fret() {
+        // `base_fret` is a public field, so a direct caller can supply a
+        // value the parser would have clamped. `base_fret == 0` would make
+        // the axis emit a `-1` label; an over-MAX value an absurd one. Both
+        // must be rejected (empty string) like out-of-range strings /
+        // frets_shown, in both orientations and both sizes.
+        for bad in [0, MAX_BASE_FRET + 1] {
+            let data = DiagramData {
+                name: "X".to_string(),
+                display_name: None,
+                strings: 6,
+                frets_shown: 5,
+                base_fret: bad,
+                frets: vec![-1, 0, 2, 2, 1, 0],
+                fingers: vec![],
+            };
+            for orientation in [Orientation::Vertical, Orientation::Horizontal] {
+                for size in [DiagramSize::Regular, DiagramSize::Compact] {
+                    assert!(
+                        render_svg_with_options(&data, orientation, size).is_empty(),
+                        "base_fret={bad} must render empty for {orientation:?}/{size:?}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -382,6 +382,14 @@ struct DiagramMetrics {
     /// Extra CSS class appended to the root `<svg>` `class` attribute
     /// (empty for regular, `" chord-diagram-compact"` for compact).
     class_extra: &'static str,
+    /// Whether to draw a fret-number label at every fret line across the
+    /// visible window (the absolute fret number `base_fret - 1 + j`).
+    ///
+    /// `true` for the regular size — the full axis subsumes the legacy
+    /// single base-fret label. `false` for the compact size, which keeps
+    /// the minimal single base-fret label so the above-a-lyric layout
+    /// stays uncluttered (see [`DiagramSize::Compact`]).
+    show_fret_numbers: bool,
 }
 
 impl DiagramMetrics {
@@ -406,6 +414,7 @@ impl DiagramMetrics {
             nut_stroke: 3.0,
             line_stroke: 1.0,
             class_extra: "",
+            show_fret_numbers: true,
         }
     }
 
@@ -439,6 +448,10 @@ impl DiagramMetrics {
             nut_stroke: 2.0,
             line_stroke: 0.75,
             class_extra: " chord-diagram-compact",
+            // Compact diagrams sit directly above a lyric line where a full
+            // fret-number axis would add clutter and height; keep the legacy
+            // single base-fret label instead.
+            show_fret_numbers: false,
         }
     }
 
@@ -584,6 +597,7 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
         nut_stroke,
         line_stroke,
         class_extra,
+        show_fret_numbers,
         ..
     } = *m;
 
@@ -619,7 +633,10 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
              stroke=\"black\" stroke-width=\"{nut_stroke}\"/>\n",
             left_margin + grid_w
         ));
-    } else {
+    } else if !show_fret_numbers {
+        // Compact size keeps the legacy single base-fret label. The regular
+        // size draws the full fret-number axis below, which already labels
+        // the first visible fret, so the standalone label would duplicate it.
         svg.push_str(&format!(
             "<text x=\"{}\" y=\"{}\" text-anchor=\"end\" \
              font-family=\"sans-serif\" font-size=\"{label_font}\">{}</text>\n",
@@ -627,6 +644,25 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
             nut_y + cell_h / 2.0 + text_v_center,
             data.base_fret
         ));
+    }
+
+    // Fret-number axis: label every fret line in the visible window with its
+    // absolute fret number (`base_fret - 1 + j`), so fret line 0 is the
+    // nut/open position (labelled 0 when the diagram starts at the nut). The
+    // labels sit left of the grid, right-anchored inside the existing left
+    // margin, so the diagram's bounding box is unchanged. A `fret-number`
+    // class is emitted so consumers can restyle or hide the axis via CSS.
+    if show_fret_numbers {
+        for j in 0..=num_frets {
+            let fret_number = data.base_fret as i32 - 1 + j as i32;
+            let y = nut_y + j as f32 * cell_h + text_v_center;
+            svg.push_str(&format!(
+                "<text x=\"{}\" y=\"{y}\" text-anchor=\"end\" \
+                 font-family=\"sans-serif\" font-size=\"{label_font}\" \
+                 class=\"fret-number\">{fret_number}</text>\n",
+                left_margin - 4.0,
+            ));
+        }
     }
 
     // Fretboard position-marker inlays (faint dots between the
@@ -765,6 +801,7 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
         nut_stroke,
         line_stroke,
         class_extra,
+        show_fret_numbers,
         ..
     } = *m;
 
@@ -814,7 +851,10 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
              stroke=\"black\" stroke-width=\"{nut_stroke}\"/>\n",
             top_margin + grid_h
         ));
-    } else {
+    } else if !show_fret_numbers {
+        // Compact size keeps the legacy single base-fret label above the
+        // first fret column. The regular size draws the full fret-number axis
+        // below the grid, which already labels the first visible fret.
         svg.push_str(&format!(
             "<text x=\"{}\" y=\"{}\" text-anchor=\"middle\" \
              font-family=\"sans-serif\" font-size=\"{label_font}\">{}</text>\n",
@@ -822,6 +862,24 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
             top_margin - 4.0,
             data.base_fret
         ));
+    }
+
+    // Fret-number axis: label every fret line in the visible window with its
+    // absolute fret number (`base_fret - 1 + j`) below the grid, matching the
+    // conventional `0 1 2 3` strip beneath a horizontal fretboard. The labels
+    // sit inside the existing bottom padding so the diagram's bounding box is
+    // unchanged; the `fret-number` class lets consumers restyle/hide them.
+    if show_fret_numbers {
+        let label_y = top_margin + grid_h + label_font;
+        for j in 0..=num_frets {
+            let fret_number = data.base_fret as i32 - 1 + j as i32;
+            let x = nut_x + j as f32 * fret_pitch;
+            svg.push_str(&format!(
+                "<text x=\"{x}\" y=\"{label_y}\" text-anchor=\"middle\" \
+                 font-family=\"sans-serif\" font-size=\"{label_font}\" \
+                 class=\"fret-number\">{fret_number}</text>\n"
+            ));
+        }
     }
 
     // Fretboard position-marker inlays — at the horizontal centre row. The
@@ -3100,5 +3158,133 @@ mod tests {
             "render_svg_with_options(Vertical, Regular) must be byte-identical to \
              render_svg_with_orientation(Vertical)"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fret-number axis (#2602) — every fret line in the visible window is
+    // labelled with its absolute fret number across both orientations.
+    // -----------------------------------------------------------------------
+
+    fn open_c() -> DiagramData {
+        DiagramData {
+            name: "C".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 1,
+            frets: vec![-1, 3, 2, 0, 1, 0],
+            fingers: vec![],
+        }
+    }
+
+    #[test]
+    fn fret_number_axis_vertical_open_position_labels_zero_through_frets_shown() {
+        // base_fret == 1 with 5 visible frets → fret lines 0..=5 are each
+        // labelled with their absolute fret number, the nut being 0.
+        let svg = render_svg_with_orientation(&open_c(), Orientation::Vertical);
+        let count = svg.matches("class=\"fret-number\"").count();
+        assert_eq!(count, 6, "expected 6 fret-line labels (0..=5); got: {svg}");
+        for n in 0..=5 {
+            assert!(
+                svg.contains(&format!("class=\"fret-number\">{n}</text>")),
+                "expected fret-number label {n}; got: {svg}"
+            );
+        }
+    }
+
+    #[test]
+    fn fret_number_axis_horizontal_open_position_sits_below_grid() {
+        // Horizontal axis runs along the bottom of the grid (the `0 1 2 3`
+        // strip under a horizontal fretboard). Labels are centred on each
+        // fret line and middle-anchored.
+        let svg = render_svg_with_orientation(&open_c(), Orientation::Horizontal);
+        let count = svg.matches("class=\"fret-number\"").count();
+        assert_eq!(count, 6, "expected 6 fret-line labels (0..=5); got: {svg}");
+        // The leftmost label (0) is centred on the nut column at x = LEFT_MARGIN.
+        assert!(
+            svg.contains(
+                "<text x=\"20\" y=\"120\" text-anchor=\"middle\" \
+                 font-family=\"sans-serif\" font-size=\"10\" class=\"fret-number\">0</text>"
+            ),
+            "expected nut-column label 0 at x=20 y=120; got: {svg}"
+        );
+    }
+
+    #[test]
+    fn fret_number_axis_offset_by_base_fret() {
+        // A barre window starting at base_fret 7 labels the fret WIRES it
+        // spans: line 0 is the wire behind the window (6), and the visible
+        // frets 7..=11 follow. The single legacy base-fret label is gone —
+        // the axis subsumes it — so `7` appears exactly once.
+        let data = DiagramData {
+            name: "Bm".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 7,
+            frets: vec![-1, 1, 3, 3, 2, 1],
+            fingers: vec![],
+        };
+        for orientation in [Orientation::Vertical, Orientation::Horizontal] {
+            let svg = render_svg_with_orientation(&data, orientation);
+            for n in 6..=11 {
+                assert!(
+                    svg.contains(&format!("class=\"fret-number\">{n}</text>")),
+                    "expected fret-number label {n} for {orientation:?}; got: {svg}"
+                );
+            }
+            assert_eq!(
+                svg.matches("class=\"fret-number\">7</text>").count(),
+                1,
+                "base-fret 7 must be labelled exactly once for {orientation:?}; got: {svg}"
+            );
+        }
+    }
+
+    #[test]
+    fn fret_number_axis_omitted_in_compact_but_base_label_kept() {
+        // Compact diagrams (above-a-lyric) suppress the full axis to stay
+        // uncluttered, but must keep the legacy single base-fret label so a
+        // high-position compact diagram still shows where it sits.
+        let data = DiagramData {
+            name: "Bm".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret: 7,
+            frets: vec![-1, 1, 3, 3, 2, 1],
+            fingers: vec![],
+        };
+        for orientation in [Orientation::Vertical, Orientation::Horizontal] {
+            let svg = render_svg_with_options(&data, orientation, DiagramSize::Compact);
+            assert!(
+                !svg.contains("class=\"fret-number\""),
+                "compact must not draw the full fret-number axis for {orientation:?}; got: {svg}"
+            );
+            assert!(
+                svg.contains(">7</text>"),
+                "compact must keep the single base-fret label 7 for {orientation:?}; got: {svg}"
+            );
+        }
+    }
+
+    #[test]
+    fn fret_number_axis_does_not_grow_the_bounding_box() {
+        // The axis is laid out inside the existing margins / bottom padding,
+        // so adding it must not change either SVG's width or height. These
+        // are the historical dimensions for a 6-string, 5-fret diagram.
+        let extract = |svg: &str, attr: &str| -> f32 {
+            let needle = format!("{attr}=\"");
+            let i = svg.find(&needle).unwrap() + needle.len();
+            let j = svg[i..].find('"').unwrap();
+            svg[i..i + j].parse().unwrap()
+        };
+        let data = open_c();
+        let v = render_svg_with_orientation(&data, Orientation::Vertical);
+        assert_eq!(extract(&v, "width"), 120.0);
+        assert_eq!(extract(&v, "height"), 160.0);
+        let h = render_svg_with_orientation(&data, Orientation::Horizontal);
+        assert_eq!(extract(&h, "width"), 140.0);
+        assert_eq!(extract(&h, "height"), 130.0);
     }
 }

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -3308,18 +3308,18 @@ mod tests {
         let v = render_svg_with_orientation(&data, Orientation::Vertical);
         assert_eq!(extract(&v, "width"), 120.0);
         assert_eq!(extract(&v, "height"), 160.0);
+        let v_ys = label_ys(&v);
         assert!(
-            label_ys(&v).iter().all(|&y| y <= 160.0),
-            "vertical fret-number labels overflow the frame: {:?}",
-            label_ys(&v)
+            v_ys.iter().all(|&y| y <= 160.0),
+            "vertical fret-number labels overflow the frame: {v_ys:?}"
         );
         let h = render_svg_with_orientation(&data, Orientation::Horizontal);
         assert_eq!(extract(&h, "width"), 140.0);
         assert_eq!(extract(&h, "height"), 130.0);
+        let h_ys = label_ys(&h);
         assert!(
-            label_ys(&h).iter().all(|&y| y <= 130.0),
-            "horizontal fret-number labels overflow the frame: {:?}",
-            label_ys(&h)
+            h_ys.iter().all(|&y| y <= 130.0),
+            "horizontal fret-number labels overflow the frame: {h_ys:?}"
         );
     }
 

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -87,6 +87,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -87,6 +87,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>

--- a/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
+++ b/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
@@ -87,6 +87,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
@@ -115,6 +121,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -91,6 +91,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
@@ -115,6 +121,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -86,7 +86,12 @@ img { max-width: 100%; height: auto; }
 </header>
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Bm</text>
-<text x="30" y="26" text-anchor="middle" font-family="sans-serif" font-size="10">2</text>
+<text x="20" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="40" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="60" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="80" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="100" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<text x="120" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">6</text>
 <circle cx="50" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="90" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
@@ -115,6 +120,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
 <line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="3"/>
+<text x="20" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="40" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="60" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="80" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="100" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="120" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="70" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="110" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
@@ -87,6 +87,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="98" viewBox="0 0 140 98" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">C</text>
 <line x1="20" y1="30" x2="20" y2="78" stroke="black" stroke-width="3"/>
+<text x="20" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="40" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="60" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="80" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="100" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="120" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="70" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="110" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
@@ -107,6 +113,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="98" viewBox="0 0 140 98" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">F</text>
 <line x1="20" y1="30" x2="20" y2="78" stroke="black" stroke-width="3"/>
+<text x="20" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="40" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="60" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="80" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="100" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="120" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="70" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="110" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -91,6 +91,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
 <line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="3"/>
+<text x="20" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="40" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="60" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="80" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="100" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="120" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="70" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="110" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
@@ -115,6 +121,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
 <line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="3"/>
+<text x="20" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="40" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="60" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="80" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="100" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="120" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="70" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="110" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -91,6 +91,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
@@ -115,6 +121,12 @@ img { max-width: 100%; height: auto; }
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
 <line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
+<text x="16" y="33" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">0</text>
+<text x="16" y="53" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="16" y="73" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="16" y="93" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="16" y="113" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="16" y="133" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
 <circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
 <line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -1861,20 +1861,26 @@ fn render_chord_diagram_pdf_vertical(
 
     let grid_top = top_y - 15.0; // below the name
 
-    // Nut line (thick for open position)
+    // Nut line (thick for open position). When the diagram starts above
+    // fret 1 the full fret-number axis below already labels the first
+    // visible fret, so no separate base-fret label is drawn.
     if data.base_fret == 1 {
         doc.line_at(base_x, grid_top, base_x + grid_w, grid_top, 2.0);
-    } else {
-        // Show fret number, clamping x to >= 0 to prevent off-page rendering.
-        let fret_label = format!("{}fr", data.base_fret);
-        let fret_label_x = (base_x - 16.0).max(0.0);
-        doc.text_at(
-            &fret_label,
-            Font::Helvetica,
-            6.0,
-            fret_label_x,
-            grid_top - cell_h / 2.0,
-        );
+    }
+
+    // Fret-number axis: label every fret line in the visible window with its
+    // absolute fret number (`base_fret - 1 + j`), matching the SVG renderer.
+    // Right-aligned in the left margin (clamped to x >= 0 to stay on-page) so
+    // 1- and 2-digit numbers sit a consistent gap from the grid.
+    for j in 0..=num_frets {
+        let fret_number = i64::from(data.base_fret) - 1 + j as i64;
+        let label = fret_number.to_string();
+        // Approx Helvetica digit advance at font size 6 (~0.556 em).
+        let label_w = label.len() as f32 * 6.0 * 0.556;
+        let label_x = (base_x - 3.0 - label_w).max(0.0);
+        let y = grid_top - j as f32 * cell_h;
+        // Baseline-centre the label on the fret line.
+        doc.text_at(&label, Font::Helvetica, 6.0, label_x, y - 2.0);
     }
 
     // Vertical lines (strings)
@@ -1969,17 +1975,19 @@ fn render_chord_diagram_pdf_horizontal(
     let nut_x = base_x;
     if data.base_fret == 1 {
         doc.line_at(nut_x, grid_top, nut_x, grid_bottom, 2.0);
-    } else {
-        // Bare base-fret label above the first fret column. Anchored at
-        // the midpoint of the first fret cell along the fret axis.
-        let fret_label = format!("{}fr", data.base_fret);
-        doc.text_at(
-            &fret_label,
-            Font::Helvetica,
-            6.0,
-            nut_x + fret_pitch / 2.0 - 4.0,
-            grid_top + 4.0,
-        );
+    }
+
+    // Fret-number axis: label every fret line in the visible window with its
+    // absolute fret number (`base_fret - 1 + j`) below the grid, matching the
+    // SVG renderer's `0 1 2 3` strip beneath a horizontal fretboard. Centred
+    // on each fret line within the existing bottom budget of `total_h`.
+    for j in 0..=num_frets {
+        let fret_number = i64::from(data.base_fret) - 1 + j as i64;
+        let label = fret_number.to_string();
+        // Approx Helvetica digit advance at font size 6 (~0.556 em).
+        let label_w = label.len() as f32 * 6.0 * 0.556;
+        let x = nut_x + j as f32 * fret_pitch - label_w / 2.0;
+        doc.text_at(&label, Font::Helvetica, 6.0, x, grid_bottom - 7.0);
     }
 
     // Horizontal lines (strings).
@@ -5614,6 +5622,32 @@ mod chord_diagram_pdf_tests {
         assert!(content.contains("Am"));
         // Should contain circle drawing operations (Bezier curves)
         assert!(content.contains(" c "));
+    }
+
+    #[test]
+    fn diagram_pdf_renders_full_fret_number_axis_and_drops_legacy_label() {
+        // #2602: a high-position barre (base-fret 7, 5 visible frets) labels
+        // every fret line 6..=11 along the axis, in both orientations, and the
+        // legacy "{N}fr" single label is gone (the axis subsumes it). The PDF
+        // content stream is uncompressed, so the `(N) Tj` text operators are
+        // directly assertable.
+        for cfg in ["", "{+config.diagrams.orientation: horizontal}\n"] {
+            let input =
+                format!("{cfg}{{define: Bm base-fret 7 frets x 1 3 3 2 1}}\n{{diagrams}}\n[Bm]Hi");
+            let song = chordsketch_chordpro::parse(&input).unwrap();
+            let bytes = render_song(&song);
+            let content = String::from_utf8_lossy(&bytes);
+            for n in 6..=11 {
+                assert!(
+                    content.contains(&format!("({n}) Tj")),
+                    "expected fret-axis label {n} for cfg={cfg:?}"
+                );
+            }
+            assert!(
+                !content.contains("fr) Tj"),
+                "legacy '{{N}}fr' base-fret label must be gone for cfg={cfg:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/render-pdf/src/lib.rs
+++ b/crates/render-pdf/src/lib.rs
@@ -1793,11 +1793,15 @@ fn render_chord_diagram_pdf(
 ) {
     use chordsketch_chordpro::chord_diagram::Orientation;
 
-    // Guard: mirror render_svg bounds checks for strings and frets_shown.
+    // Guard: mirror render_svg bounds checks for strings, frets_shown, and
+    // base_fret (a public field a direct caller can set out of range, which
+    // would otherwise produce a negative or absurd fret-axis label).
     if data.strings < chordsketch_chordpro::chord_diagram::MIN_STRINGS
         || data.strings > chordsketch_chordpro::chord_diagram::MAX_STRINGS
         || data.frets_shown < chordsketch_chordpro::chord_diagram::MIN_FRETS_SHOWN
         || data.frets_shown > chordsketch_chordpro::chord_diagram::MAX_FRETS_SHOWN
+        || data.base_fret < 1
+        || data.base_fret > chordsketch_chordpro::chord_diagram::MAX_BASE_FRET
     {
         return;
     }
@@ -1873,7 +1877,7 @@ fn render_chord_diagram_pdf_vertical(
     // Right-aligned in the left margin (clamped to x >= 0 to stay on-page) so
     // 1- and 2-digit numbers sit a consistent gap from the grid.
     for j in 0..=num_frets {
-        let fret_number = i64::from(data.base_fret) - 1 + j as i64;
+        let fret_number = data.base_fret as i32 - 1 + j as i32;
         let label = fret_number.to_string();
         // Approx Helvetica digit advance at font size 6 (~0.556 em).
         let label_w = label.len() as f32 * 6.0 * 0.556;
@@ -1982,7 +1986,7 @@ fn render_chord_diagram_pdf_horizontal(
     // SVG renderer's `0 1 2 3` strip beneath a horizontal fretboard. Centred
     // on each fret line within the existing bottom budget of `total_h`.
     for j in 0..=num_frets {
-        let fret_number = i64::from(data.base_fret) - 1 + j as i64;
+        let fret_number = data.base_fret as i32 - 1 + j as i32;
         let label = fret_number.to_string();
         // Approx Helvetica digit advance at font size 6 (~0.556 em).
         let label_w = label.len() as f32 * 6.0 * 0.556;
@@ -5648,6 +5652,42 @@ mod chord_diagram_pdf_tests {
                 "legacy '{{N}}fr' base-fret label must be gone for cfg={cfg:?}"
             );
         }
+    }
+
+    #[test]
+    fn pdf_diagram_rejects_out_of_range_base_fret() {
+        // Sister to the SVG renderer's `render_rejects_out_of_range_base_fret`.
+        // `base_fret` is a public field; an out-of-range value must draw
+        // nothing (early return) rather than emit a negative/absurd fret-axis
+        // label. The cursor y is the observable: the guard returns before
+        // `advance_y`, so it stays put.
+        use chordsketch_chordpro::chord_diagram::{DiagramData, MAX_BASE_FRET, Orientation};
+        let make = |base_fret: u32| DiagramData {
+            name: "X".to_string(),
+            display_name: None,
+            strings: 6,
+            frets_shown: 5,
+            base_fret,
+            frets: vec![-1, 0, 2, 2, 1, 0],
+            fingers: vec![],
+        };
+        for bad in [0u32, MAX_BASE_FRET + 1] {
+            for orientation in [Orientation::Vertical, Orientation::Horizontal] {
+                let mut doc = PdfDocument::new();
+                let y_before = doc.y();
+                render_chord_diagram_pdf(&make(bad), &mut doc, orientation);
+                assert_eq!(
+                    doc.y(),
+                    y_before,
+                    "out-of-range base_fret {bad} must draw nothing ({orientation:?})"
+                );
+            }
+        }
+        // Sanity: a valid base_fret DOES advance the cursor.
+        let mut doc = PdfDocument::new();
+        let y_before = doc.y();
+        render_chord_diagram_pdf(&make(1), &mut doc, Orientation::Vertical);
+        assert_ne!(doc.y(), y_before, "valid diagram must advance the cursor");
     }
 
     #[test]

--- a/crates/render-pdf/tests/fixtures/define-display-transposed/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/define-display-transposed/expected.pdf
@@ -24,7 +24,7 @@ endobj
 << /Type /Page /Parent 2 0 R /Contents 9 0 R >>
 endobj
 9 0 obj
-<< /Length 1397 >>
+<< /Length 1607 >>
 stream
 BT
 /F2 18 Tf
@@ -40,6 +40,36 @@ q
 2 w
 56 749 m 106 749 l S
 Q
+BT
+/F1 6 Tf
+49.66 747 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+49.66 735 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+49.66 723 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+49.66 711 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+49.66 699 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+49.66 687 Td
+(5) Tj
+ET
 q
 0.5 w
 56 749 m 56 689 l S
@@ -137,9 +167,9 @@ xref
 0000000653 00000 n 
 0000000748 00000 n 
 0000000811 00000 n 
-0000002260 00000 n 
+0000002470 00000 n 
 trailer
 << /Size 11 /Root 1 0 R /Info 10 0 R >>
 startxref
-2392
+2602
 %%EOF

--- a/crates/render-pdf/tests/fixtures/define-display/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/define-display/expected.pdf
@@ -24,7 +24,7 @@ endobj
 << /Type /Page /Parent 2 0 R /Contents 9 0 R >>
 endobj
 9 0 obj
-<< /Length 1385 >>
+<< /Length 1595 >>
 stream
 BT
 /F2 18 Tf
@@ -40,6 +40,36 @@ q
 2 w
 56 749 m 106 749 l S
 Q
+BT
+/F1 6 Tf
+49.66 747 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+49.66 735 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+49.66 723 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+49.66 711 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+49.66 699 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+49.66 687 Td
+(5) Tj
+ET
 q
 0.5 w
 56 749 m 56 689 l S
@@ -137,9 +167,9 @@ xref
 0000000653 00000 n 
 0000000748 00000 n 
 0000000811 00000 n 
-0000002248 00000 n 
+0000002458 00000 n 
 trailer
 << /Size 11 /Root 1 0 R /Info 10 0 R >>
 startxref
-2332
+2542
 %%EOF

--- a/crates/render-pdf/tests/fixtures/define-with-diagrams/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/define-with-diagrams/expected.pdf
@@ -24,7 +24,7 @@ endobj
 << /Type /Page /Parent 2 0 R /Contents 9 0 R >>
 endobj
 9 0 obj
-<< /Length 2763 >>
+<< /Length 3183 >>
 stream
 BT
 /F2 18 Tf
@@ -40,6 +40,36 @@ q
 2 w
 56 749 m 106 749 l S
 Q
+BT
+/F1 6 Tf
+49.66 747 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+49.66 735 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+49.66 723 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+49.66 711 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+49.66 699 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+49.66 687 Td
+(5) Tj
+ET
 q
 0.5 w
 56 749 m 56 689 l S
@@ -121,6 +151,36 @@ q
 2 w
 56 634 m 106 634 l S
 Q
+BT
+/F1 6 Tf
+49.66 632 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+49.66 620 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+49.66 608 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+49.66 596 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+49.66 584 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+49.66 572 Td
+(5) Tj
+ET
 q
 0.5 w
 56 634 m 56 574 l S
@@ -195,9 +255,9 @@ xref
 0000000653 00000 n 
 0000000748 00000 n 
 0000000811 00000 n 
-0000003626 00000 n 
+0000004046 00000 n 
 trailer
 << /Size 11 /Root 1 0 R /Info 10 0 R >>
 startxref
-3742
+4162
 %%EOF

--- a/crates/render-pdf/tests/fixtures/diagrams-grid/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/diagrams-grid/expected.pdf
@@ -24,7 +24,7 @@ endobj
 << /Type /Page /Parent 2 0 R /Contents 9 0 R >>
 endobj
 9 0 obj
-<< /Length 2642 >>
+<< /Length 3062 >>
 stream
 BT
 /F2 18 Tf
@@ -55,6 +55,36 @@ q
 2 w
 56 723 m 106 723 l S
 Q
+BT
+/F1 6 Tf
+49.66 721 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+49.66 709 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+49.66 697 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+49.66 685 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+49.66 673 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+49.66 661 Td
+(5) Tj
+ET
 q
 0.5 w
 56 723 m 56 663 l S
@@ -124,6 +154,36 @@ q
 2 w
 56 634 m 106 634 l S
 Q
+BT
+/F1 6 Tf
+49.66 632 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+49.66 620 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+49.66 608 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+49.66 596 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+49.66 584 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+49.66 572 Td
+(5) Tj
+ET
 q
 0.5 w
 56 634 m 56 574 l S
@@ -198,9 +258,9 @@ xref
 0000000653 00000 n 
 0000000748 00000 n 
 0000000811 00000 n 
-0000003505 00000 n 
+0000003925 00000 n 
 trailer
 << /Size 11 /Root 1 0 R /Info 10 0 R >>
 startxref
-3637
+4057
 %%EOF

--- a/crates/render-pdf/tests/fixtures/diagrams-horizontal-barre/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/diagrams-horizontal-barre/expected.pdf
@@ -24,7 +24,7 @@ endobj
 << /Type /Page /Parent 2 0 R /Contents 9 0 R >>
 endobj
 9 0 obj
-<< /Length 2561 >>
+<< /Length 2951 >>
 stream
 BT
 /F2 18 Tf
@@ -38,8 +38,33 @@ BT
 ET
 BT
 /F1 6 Tf
-58 753 Td
-(2fr) Tj
+54.33 692 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+66.33 692 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+78.33 692 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+90.33 692 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+102.33 692 Td
+(5) Tj
+ET
+BT
+/F1 6 Tf
+114.33 692 Td
+(6) Tj
 ET
 q
 0.5 w
@@ -119,6 +144,36 @@ q
 2 w
 56 644 m 56 594 l S
 Q
+BT
+/F1 6 Tf
+54.33 587 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+66.33 587 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+78.33 587 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+90.33 587 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+102.33 587 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+114.33 587 Td
+(5) Tj
+ET
 q
 0.5 w
 56 644 m 116 644 l S
@@ -196,9 +251,9 @@ xref
 0000000653 00000 n 
 0000000748 00000 n 
 0000000811 00000 n 
-0000003424 00000 n 
+0000003814 00000 n 
 trailer
 << /Size 11 /Root 1 0 R /Info 10 0 R >>
 startxref
-3604
+3994
 %%EOF

--- a/crates/render-pdf/tests/fixtures/diagrams-horizontal-ukulele/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/diagrams-horizontal-ukulele/expected.pdf
@@ -24,7 +24,7 @@ endobj
 << /Type /Page /Parent 2 0 R /Contents 9 0 R >>
 endobj
 9 0 obj
-<< /Length 2080 >>
+<< /Length 2504 >>
 stream
 BT
 /F2 18 Tf
@@ -40,6 +40,36 @@ q
 2 w
 56 749 m 56 719 l S
 Q
+BT
+/F1 6 Tf
+54.33 712 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+66.33 712 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+78.33 712 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+90.33 712 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+102.33 712 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+114.33 712 Td
+(5) Tj
+ET
 q
 0.5 w
 56 749 m 116 749 l S
@@ -96,6 +126,36 @@ q
 2 w
 56 690 m 56 660 l S
 Q
+BT
+/F1 6 Tf
+54.33 653 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+66.33 653 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+78.33 653 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+90.33 653 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+102.33 653 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+114.33 653 Td
+(5) Tj
+ET
 q
 0.5 w
 56 690 m 116 690 l S
@@ -174,9 +234,9 @@ xref
 0000000653 00000 n 
 0000000748 00000 n 
 0000000811 00000 n 
-0000002943 00000 n 
+0000003367 00000 n 
 trailer
 << /Size 11 /Root 1 0 R /Info 10 0 R >>
 startxref
-3087
+3511
 %%EOF

--- a/crates/render-pdf/tests/fixtures/diagrams-horizontal/expected.pdf
+++ b/crates/render-pdf/tests/fixtures/diagrams-horizontal/expected.pdf
@@ -24,7 +24,7 @@ endobj
 << /Type /Page /Parent 2 0 R /Contents 9 0 R >>
 endobj
 9 0 obj
-<< /Length 2619 >>
+<< /Length 3043 >>
 stream
 BT
 /F2 18 Tf
@@ -55,6 +55,36 @@ q
 2 w
 56 723 m 56 673 l S
 Q
+BT
+/F1 6 Tf
+54.33 666 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+66.33 666 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+78.33 666 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+90.33 666 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+102.33 666 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+114.33 666 Td
+(5) Tj
+ET
 q
 0.5 w
 56 723 m 116 723 l S
@@ -124,6 +154,36 @@ q
 2 w
 56 644 m 56 594 l S
 Q
+BT
+/F1 6 Tf
+54.33 587 Td
+(0) Tj
+ET
+BT
+/F1 6 Tf
+66.33 587 Td
+(1) Tj
+ET
+BT
+/F1 6 Tf
+78.33 587 Td
+(2) Tj
+ET
+BT
+/F1 6 Tf
+90.33 587 Td
+(3) Tj
+ET
+BT
+/F1 6 Tf
+102.33 587 Td
+(4) Tj
+ET
+BT
+/F1 6 Tf
+114.33 587 Td
+(5) Tj
+ET
 q
 0.5 w
 56 644 m 116 644 l S
@@ -198,9 +258,9 @@ xref
 0000000653 00000 n 
 0000000748 00000 n 
 0000000811 00000 n 
-0000003482 00000 n 
+0000003906 00000 n 
 trailer
 << /Size 11 /Root 1 0 R /Info 10 0 R >>
 startxref
-3618
+4042
 %%EOF

--- a/docs/adr/0030-chord-diagram-fret-number-axis.md
+++ b/docs/adr/0030-chord-diagram-fret-number-axis.md
@@ -1,0 +1,109 @@
+# 0030. Chord diagrams label the full visible fret range by default
+
+- **Status**: Accepted
+- **Date**: 2026-06-15
+
+## Context
+
+ChordSketch renders fretted chord diagrams (the end-of-song `{diagrams}` grid
+and `{define}` shapes) as SVG (`crates/chordpro/src/chord_diagram.rs`, the
+single source for the CLI HTML output, the wasm bundle, the React
+`<ChordDiagram>`, and the VS Code / desktop previews) and, independently, as
+vector graphics in the PDF renderer (`crates/render-pdf`).
+
+Before this decision a diagram labelled **only its base fret**: a single
+integer drawn beside the grid when `base_fret > 1`, and nothing at all at the
+open position. Conventional guitar chord charts instead label **every fret
+line in the visible window** — `0 1 2 3 …`, where `0` marks the nut / open
+position — so a reader can immediately tell which frets the shape spans
+without counting cells. The canonical reference is the horizontal
+Japanese-tablature layout, which prints the `0 1 2 3` strip directly beneath
+the fretboard.
+
+The two surfaces also disagreed on the legacy label's spelling: the SVG
+renderer drew a bare integer (`7`) while the PDF renderer drew `7fr`. Any
+fix to the labelling had to reconcile that drift as well.
+
+## Decision
+
+Draw a **fret-number axis** on every regular-size fretted diagram: one label
+per fret line across the full visible window, showing the absolute fret
+number `base_fret - 1 + j` for fret line `j ∈ 0..=frets_shown`. Fret line `0`
+is the nut, so an open-position diagram reads `0 1 2 3 …` and a window that
+starts higher up reads e.g. `6 7 8 9 10 11` for `base_fret = 7`.
+
+- **Default-on, no opt-out knob.** The axis is part of the standard diagram,
+  not gated behind a directive or config value. The `0 1 2 3` strip is what
+  the requested reference shows, and the ChordPro spec defines no
+  diagram-labelling knob to hang an opt-out on. A `fret-number` CSS class is
+  emitted on each SVG label so a consumer that wants to hide or restyle the
+  axis can do so in CSS without an API change.
+- **The axis subsumes the legacy single base-fret label** at the regular
+  size. The standalone label is no longer drawn there because the axis
+  already labels the first visible fret; keeping both would duplicate it.
+- **Compact diagrams keep the legacy single label.** The compact layout
+  (`{diagrams: inline}` / `{diagrams: hover}`, ADR-0027) sits directly above
+  a lyric line where a full axis would add clutter and height, so it retains
+  the minimal single base-fret label and does **not** draw the axis.
+- **Layout stays inside the existing margins / padding.** The axis is placed
+  in the left gutter (vertical) or the existing bottom padding (horizontal),
+  so the SVG and PDF bounding boxes are unchanged. This keeps page flow and
+  the horizontal "wider than tall" aspect invariant intact.
+- **Parity across surfaces.** The SVG change reaches HTML, wasm, and React
+  through the shared renderer; the PDF renderer gains the identical axis in
+  both orientations, which also retires the `7fr` vs `7` drift in favour of
+  the bare-integer spelling everywhere.
+
+## Rationale
+
+The request is literally "display all fret numbers for the range the diagram
+shows," and the reference image renders the axis unconditionally. Gating it
+behind a directive would mean the default output still does not match the
+reference, defeating the purpose; an opt-out belongs in CSS (cheap, no new
+parse surface) rather than a new spec-adjacent directive value (which would
+need parsing, validation, and propagation across every renderer and binding).
+
+Labelling fret **lines** (not cells) is what makes the open position read
+`0` at the nut, matching the reference exactly. The same uniform rule
+(`base_fret - 1 + j`) then labels the fret wires a shifted window spans, which
+is internally consistent and needs no special-casing on `base_fret`.
+
+## Consequences
+
+- Every diagram consumer's default output changes: the CLI HTML, PDF, wasm,
+  React `<ChordDiagram>`, VS Code preview, and desktop app now show the axis.
+  Diagram golden snapshots (HTML + PDF) were regenerated in the same change.
+- The bounding box is unchanged, so downstream layout that depends on diagram
+  dimensions is unaffected.
+- A consumer that preferred the old minimal labelling can hide the axis with
+  `.chord-diagram .fret-number { display: none }`; there is no Rust-level
+  opt-out, which is an accepted limitation until one is requested.
+- The ASCII text renderer (`render_ascii`) is intentionally **not** changed:
+  its single-line-per-chord format already prints absolute fret numbers per
+  string and carries no fret grid to hang an axis on. This is recorded as a
+  deliberate deferral, not an omission.
+
+## Alternatives considered
+
+- **Config / directive opt-in (`{diagrams: fretnumbers}` or a config key).**
+  Rejected: it leaves the default output not matching the reference, and adds
+  parse + validation + propagation surface across every renderer and binding
+  for a facet the spec does not define. CSS hiding covers the opt-out need.
+- **Label cells instead of fret lines.** Rejected: cell labelling cannot show
+  `0` at the nut, so it would not match the reference for the common
+  open-position case.
+- **Only show the axis for the open position (`base_fret == 1`).** Rejected:
+  positional diagrams benefit most from knowing which frets the window spans,
+  and a uniform rule is simpler than branching on `base_fret`.
+- **A CSS `transform: scale()` shrink for compact rather than suppressing the
+  axis.** Rejected for the same legibility reason ADR-0027 already records.
+
+## References
+
+- Issue #2602 — show fret-number labels for the full visible range.
+- ADR-0026 — horizontal chord-diagram default string order (reader-view).
+- ADR-0027 — inline / hover compact chord diagrams (the compact layout that
+  keeps the legacy single label).
+- `.claude/rules/renderer-parity.md`, `.claude/rules/fix-propagation.md` —
+  the sister-site obligations this change follows across SVG / HTML / PDF /
+  React.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,3 +107,4 @@ ADR's Status line to `Superseded by ADR-NNNN`.
 | [0027](0027-inline-hover-compact-chord-diagrams.md) | Inline / hover chord diagrams use a dedicated compact layout (chordsketch `{diagrams: inline}` / `{diagrams: hover}` extension; not a CSS scale) | Accepted (2026-05-31) |
 | [0028](0028-shared-directive-catalog.md) | Shared directive catalog in `chordsketch-chordpro` is the single source of truth for directive-name + value completion across LSP / web / playground | Accepted (2026-05-31) |
 | [0029](0029-react-ui-primitives-package.md) | Design-system React primitives live in a wasm-free `@chordsketch/react-ui`; `@chordsketch/react` stays domain-only and does not re-export them | Accepted (2026-06-01) |
+| [0030](0030-chord-diagram-fret-number-axis.md) | Chord diagrams label the full visible fret range (`0 1 2 3 …`) by default across SVG / HTML / PDF; the axis subsumes the legacy single base-fret label, compact keeps it | Accepted (2026-06-15) |


### PR DESCRIPTION
## What

Chord diagrams now label **every fret line in the visible window** with its
absolute fret number (`base_fret - 1 + j` for fret line `j ∈ 0..=frets_shown`),
so an open-position shape reads `0 1 2 3 …` with `0` at the nut, and a window
starting higher up reads e.g. `6 7 8 9 10 11` for `base_fret = 7`. Previously a
diagram labelled only its base fret (a single integer when `base_fret > 1`).

- **SVG renderer** (`crates/chordpro/src/chord_diagram.rs`) — the single source
  feeding the CLI HTML output, the wasm bundle, the React `<ChordDiagram>`, and
  the VS Code / desktop previews. Axis added in both orientations with a
  `fret-number` CSS class so consumers can restyle or hide it. The axis subsumes
  the legacy single base-fret label at the regular size; the compact size
  (`{diagrams: inline}` / `hover`) keeps the minimal single label to stay
  uncluttered above a lyric.
- **PDF renderer** (`crates/render-pdf`) — identical axis in both orientations.
  This also retires a pre-existing label drift: the PDF renderer used to print
  `7fr` while the SVG renderer printed a bare `7`; both now print the bare
  integer.
- Labels are laid out inside the existing margins / bottom padding, so the SVG
  and PDF bounding boxes are unchanged.

## Why

Standard chord charts label the full fret range so a reader can tell which frets
a shape spans at a glance; the requested reference (the horizontal
Japanese-tablature layout) prints the `0 1 2 3` strip beneath the fretboard.
This is a visible default-rendering change for every diagram consumer, so it is
recorded in **ADR-0030** (default-on, no opt-out knob — hideable via CSS;
compact carve-out; ASCII deferral).

## Test results

- New unit tests: 6 in the SVG renderer (open position, high `base_fret`,
  compact suppression, bounding-box-fit, out-of-range `base_fret` guard) and 2
  in the PDF renderer (axis content + dropped legacy label; `base_fret` guard).
- HTML (8) and PDF (7) diagram golden snapshots regenerated and reviewed.
- `cargo test` green for `chordsketch-chordpro`, `render-html`, `render-pdf`,
  `render-text`, and the CLI; `cargo fmt --check`, `cargo clippy`, and
  `RUSTDOCFLAGS="-D warnings" cargo doc` clean on the changed crates.

## Review summary

Four review passes (correctness, security, general, project-specific) found no
High/Medium/Low findings. The Nit-level findings were all resolved in-PR:

- **Defensive input** — `DiagramData.base_fret` is public, so a direct caller
  could pass `0` and get a `-1` axis label. Added a `base_fret` range guard at
  the render boundary in both the SVG and PDF renderers (sister-site), mirroring
  the existing `strings` / `frets_shown` checks, plus tests.
- **Sister-site idiom** — aligned the PDF axis arithmetic on `i32` to match the
  SVG renderer.
- **Comments / tests** — refreshed the now-stale nut/base-fret comments and
  strengthened the bounding-box test to assert labels fall within the frame.

### Sister-site audit

- Renderers (text / HTML / PDF / React-JSX): HTML, wasm, and React
  `<ChordDiagram>` inherit the axis through the shared SVG renderer (React
  injects the wasm SVG; no separate JSX diagram drawing). PDF got the identical
  axis directly. ASCII (`render_ascii`) is intentionally unchanged — its
  single-line-per-chord format already prints absolute fret numbers per string
  and carries no fret grid to label (recorded as a deliberate deferral in
  ADR-0030).
- The `base_fret` guard and the dropped legacy label were applied to both the
  SVG and PDF renderers in the same change.

## Deferred

- ASCII text renderer: no fret-number axis (justification above; per-string
  absolute fret numbers already present).

Closes #2602

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWpka58raocwzm7mtjmmHc)_