### PR TITLE
Fix Homebrew formula install smoke for Homebrew 6.0 (tap trust + Linux sandbox)

### DIFF
--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -453,6 +453,25 @@ jobs:
         run: |
           set -euo pipefail
           brew tap koedame/tap
+          # Homebrew's tap-trust feature (gated by
+          # HOMEBREW_REQUIRE_TAP_TRUST, shipped on the bleeding-edge
+          # setup-homebrew@master this job pins) refuses to load
+          # formulae from a third-party tap until the tap is explicitly
+          # trusted, failing with "Refusing to load formula ... from
+          # untrusted tap". Trust our own tap so the documented
+          # `brew install` below runs. `brew trust` is non-interactive
+          # under CI (Homebrew auto-detects CI=true), so it records the
+          # trust without prompting.
+          #
+          # The enforcement is NOT yet the stable default — upstream
+          # users must opt in via `export HOMEBREW_REQUIRE_TAP_TRUST=1`
+          # (https://github.com/Homebrew/brew/issues/22551) — so the
+          # README's user-facing `brew install chordsketch` still works
+          # on released Homebrew without this step, and the README is
+          # intentionally left unchanged. Watch signal: when tap-trust
+          # becomes the stable default, the README install instructions
+          # must add a `brew trust koedame/tap` line (tracked in #2606).
+          brew trust koedame/tap
           brew install chordsketch
           chordsketch --version
 

--- a/.github/workflows/readme-smoke.yml
+++ b/.github/workflows/readme-smoke.yml
@@ -472,6 +472,21 @@ jobs:
           # becomes the stable default, the README install instructions
           # must add a `brew trust koedame/tap` line (tracked in #2606).
           brew trust koedame/tap
+          # Homebrew 6.0 (tagged on the master this job tracks) makes the
+          # Linux build sandbox mandatory and requires a rootless `bwrap`
+          # (Bubblewrap) on PATH. GitHub's ubuntu runner ships neither,
+          # and Homebrew cannot install the `bubblewrap` formula to
+          # satisfy it because that install itself would need the sandbox
+          # — a bootstrap deadlock ("Bubblewrap is required to use the
+          # Linux sandbox but was not found"). Disable the Linux sandbox,
+          # exactly as Homebrew's own error recommends as the final
+          # workaround. This is safe here: the sandbox guards against
+          # malicious formula build scripts, and we are installing our
+          # own trusted formula (which built fine before Homebrew 6.0).
+          # Like the trust gate above, this enforcement is bleeding-edge
+          # only, so the README's documented `brew install chordsketch`
+          # is unaffected for end users on released Homebrew.
+          export HOMEBREW_NO_SANDBOX_LINUX=1
           brew install chordsketch
           chordsketch --version
 


### PR DESCRIPTION
## What

Make the `Homebrew` formula-install smoke job in
`.github/workflows/readme-smoke.yml` survive Homebrew 6.0's two new
bleeding-edge enforcements (both arriving via the
`Homebrew/actions/setup-homebrew@master` pin):

1. `brew trust koedame/tap` — clears the **tap-trust** gate.
2. `export HOMEBREW_NO_SANDBOX_LINUX=1` — clears the mandatory **Linux
   build sandbox** that requires a rootless `bwrap`.

## Why

This job has been **red on `main` since 2026-06-12** (readme-smoke runs
1584, 1585, 1595…), unrelated to product code. It pins
`setup-homebrew@master`, which ships bleeding-edge Homebrew (now tagged
`6.0.0`/`6.0.1`), and each new 6.0 enforcement breaks the install in turn:

**1. Tap trust.** Homebrew refuses to load formulae from a third-party tap
until trusted:

```
Refusing to load formula koedame/tap/chordsketch from untrusted tap koedame/tap.
```

Fixed with `brew trust koedame/tap` (trusts our **own** tap rather than
disabling the feature globally; non-interactive under CI). Confirmed
working — the job log now prints `Trusted tap: koedame/tap` and proceeds.

**2. Linux sandbox.** Homebrew 6.0 makes the Linux build sandbox mandatory
and requires a rootless `bwrap` (Bubblewrap) on PATH. The runner ships
neither, and Homebrew can't install the `bubblewrap` formula to satisfy it
because that install itself needs the sandbox — a bootstrap deadlock:

```
Bubblewrap is required to use the Linux sandbox but was not found.
...
As a final workaround, disable the Linux sandbox:
  export HOMEBREW_NO_SANDBOX_LINUX=1
```

Fixed with `HOMEBREW_NO_SANDBOX_LINUX=1`, exactly as Homebrew's error
recommends. Safe here: the sandbox guards against malicious formula build
scripts, and we install our own trusted formula (which built fine before
Homebrew 6.0).

### Why the README is not changed

Both enforcements are bleeding-edge Homebrew 6.0 behaviours that are **not
the stable default** — `HOMEBREW_REQUIRE_TAP_TRUST` must be opted into
upstream ([Homebrew/brew#22551](https://github.com/Homebrew/brew/issues/22551)).
End users running the documented `brew install chordsketch` on released
Homebrew are unaffected, so the README install instructions remain correct.
The workflow comments record the watch signal: when these become stable
defaults, the README must be updated.

### Scope

- The `Homebrew Cask (macOS)` job is **not** modified — it is green on the
  same runs where the formula job is red (cask installs are not subject to
  these formula-path gates on the current Homebrew). No speculative change
  to a passing job.
- README and the readme-sync snapshot are untouched (these are
  CI-environment prerequisites, not documented user commands), so no
  `.github/snapshots/readme-commands.txt` drift.

## Test results

- Workflow YAML validates (`yaml.safe_load`).
- Functional verification is the `Homebrew` job turning green on this PR's
  CI (tap-trust step already confirmed passing in the prior run).

## Review summary

Root-cause fixes for each enforcement (trust the specific tap; apply the
Homebrew-sanctioned sandbox workaround) rather than globally disabling
security. No sister-site defect: the only other `brew tap koedame/tap`
site is the cask job, which has no current defect.

Closes #2606