### PR TITLE
ci(playground): redeploy on any crate change, not just crates/wasm

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -4,7 +4,19 @@ on:
   push:
     branches: [main]
     paths:
-      - 'crates/wasm/**'
+      # The playground ships the wasm bundle built from `crates/wasm`, which
+      # transitively depends on `chordsketch-chordpro` and every renderer
+      # crate. A behaviour change in any of those (e.g. chord-diagram
+      # rendering in `crates/chordpro`) changes the wasm output the deployed
+      # playground serves, but watching only `crates/wasm/**` would not
+      # redeploy and the live playground would go silently stale (issue
+      # #2608: PR #2605's fret-number axis lived in `crates/chordpro` and
+      # never reached the deployed site). Watch every crate so a transitive
+      # change can never leave the deployed playground stale; the extra
+      # redeploys for wasm-irrelevant crates (CLI / LSP / FFI / …) are cheap
+      # and idempotent, and self-maintaining beats an explicit dep list that
+      # the next `crates/wasm` dependency addition would silently outdate.
+      - 'crates/**'
       - 'packages/playground/**'
       - 'packages/npm/**'
       - 'packages/npm-export/**'


### PR DESCRIPTION
## What

Widen `deploy-playground.yml`'s `paths:` filter from `crates/wasm/**` to
`crates/**` so a change in **any** crate the playground's wasm bundle
transitively depends on triggers a redeploy.

## Why

The deployed playground ships the wasm bundle built from `crates/wasm`, which
transitively depends on `chordsketch-chordpro` and every renderer crate. The
filter only watched `crates/wasm/**`, so a behaviour change in a transitive
dependency did not redeploy and the live playground served stale wasm.

Concretely: PR #2605's chord-diagram fret-number axis lives in
`crates/chordpro`, so its merge to `main` did **not** trigger
`deploy-playground` (the last run was for `b4832d49`, which predates the
merge), and the feature never reached the live playground. This is a
recurring staleness class for any renderer/parser change.

A self-maintaining `crates/**` glob is preferred over an explicit
transitive-dependency list: the list would silently outdate the next time
`crates/wasm`'s `Cargo.toml` gains a dependency — the same omission class that
caused this bug. The extra redeploys for wasm-irrelevant crates (CLI / LSP /
FFI / …) are cheap and idempotent.

## Test results

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-playground.yml'))"` parses; `paths` now includes `crates/**`.
- Merging this PR is itself the functional test: the workflow file is in its
  own `paths:` list, so the merge triggers a `deploy-playground` run that
  rebuilds wasm from current `main` (including #2605) and redeploys — bringing
  the fret-number axis to the live playground.

## Review summary

`.github/`-only change (dedicated PR per the shared-files policy). No Rust or
playground source touched; no smoke-suite change required (this does not add a
mount path or format toggle per `.claude/rules/playground-smoke.md`).

Closes #2608

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWpka58raocwzm7mtjmmHc)_