### PR TITLE
Add a BPM-synced blinking beat dot to the animated metronome glyph

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1258,7 +1258,9 @@ h2 { font-family: \"Noto Sans JP\", system-ui, -apple-system, sans-serif; font-w
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: __LINE_FLEX_WRAP__; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: \"Roboto\", system-ui, -apple-system, \"Helvetica Neue\", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }
@@ -4541,6 +4543,16 @@ Verse text\n\
         assert!(
             html.contains("140 BPM"),
             "expected '140 BPM' in inline marker; got: {html}"
+        );
+        // The BPM-synced beat dot and its keyframe ship with the
+        // glyph (the dot's blink reuses `--cs-metronome-period`).
+        assert!(
+            html.contains("music-glyph--metronome__beat"),
+            "expected beat-dot circle + CSS rule; got: {html}"
+        );
+        assert!(
+            html.contains("@keyframes cs-metronome-beat"),
+            "expected beat keyframe in embedded stylesheet; got: {html}"
         );
     }
 

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -4554,6 +4554,18 @@ Verse text\n\
             html.contains("@keyframes cs-metronome-beat"),
             "expected beat keyframe in embedded stylesheet; got: {html}"
         );
+        // Phase-sync invariant: the beat blink MUST be driven by the
+        // same `--cs-metronome-period` custom property as the swing,
+        // so the flash peak coincides with the rod reaching an
+        // extreme on every beat. A regression that hardcodes the
+        // beat's animation duration would silently desync the flash
+        // from the tick without tripping the presence checks above.
+        assert!(
+            html.contains(
+                ".music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period"
+            ),
+            "beat blink must reuse --cs-metronome-period for phase sync; got: {html}"
+        );
     }
 
     #[test]

--- a/crates/render-html/src/music_glyphs.rs
+++ b/crates/render-html/src/music_glyphs.rs
@@ -349,14 +349,23 @@ fn write_flat(s: &mut String, cx: f32, cy: f32) {
 /// Emit an inline SVG mini metronome glyph with the pendulum
 /// animation duration derived from `bpm`. The `--cs-metronome-
 /// period` CSS custom property is set on the root `<svg>` so
-/// the stylesheet's `@keyframes cs-metronome-swing` rule (in
-/// the embedded `<style>` block) reads it without runtime JS.
+/// the stylesheet's `@keyframes cs-metronome-swing` and
+/// `@keyframes cs-metronome-beat` rules (in the embedded
+/// `<style>` block) read it without runtime JS.
 ///
 /// Geometry: the rod is modelled as an INVERTED pendulum mounted
 /// on a pivot at `(9, 19)` near the base of the triangular body,
 /// with the weight bead near the top of the rod — a real
 /// mechanical Wittner metronome, not a hanging-clock pendulum.
 /// The pivot point is fixed; the rod sweeps wiper-style.
+///
+/// A static beat dot sits in the top-left corner *inside* the
+/// existing viewBox (so the icon height is unchanged) and pulses
+/// flash-then-decay once per beat. Its blink shares the same
+/// `--cs-metronome-period` as the swing, so the dot is at full
+/// brightness exactly when the rod reaches an extreme (the
+/// audible tick). The dot is a sibling of the pendulum group, so
+/// it does NOT swing — only its opacity animates.
 #[must_use]
 pub fn metronome_svg(bpm_raw: &str) -> String {
     let bpm: f32 = bpm_raw.trim().parse::<f32>().unwrap_or(60.0);
@@ -400,6 +409,8 @@ pub fn metronome_svg(bpm_raw: &str) -> String {
         "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 4 18 18\" \
          width=\"18\" height=\"18\" class=\"music-glyph music-glyph--metronome\" \
          style=\"--cs-metronome-period:{:.3}s\" role=\"img\" aria-label=\"{}\">\
+         <circle class=\"music-glyph--metronome__beat\" cx=\"2.4\" cy=\"6.2\" \
+         r=\"1.5\" fill=\"currentColor\"/>\
          <path d=\"M 3 21 L 15 21 L 12.5 5 L 5.5 5 Z\" fill=\"none\" \
          stroke=\"currentColor\" stroke-width=\"0.9\" stroke-linejoin=\"round\"/>\
          <circle cx=\"9\" cy=\"19\" r=\"0.7\" fill=\"currentColor\"/>\
@@ -625,6 +636,33 @@ mod tests {
         assert!(
             svg.contains("<line x1=\"9\" y1=\"19\" x2=\"9\" y2=\"7\""),
             "rod must extend upward from base pivot; got: {svg}"
+        );
+    }
+
+    #[test]
+    fn metronome_svg_emits_beat_dot() {
+        let svg = metronome_svg("120");
+        // The beat dot is present, sits in the top-left corner, and
+        // carries the `__beat` class the stylesheet animates.
+        assert!(
+            svg.contains(
+                "<circle class=\"music-glyph--metronome__beat\" cx=\"2.4\" cy=\"6.2\" r=\"1.5\""
+            ),
+            "expected top-left beat dot circle; got: {svg}"
+        );
+        // The beat dot must be a SIBLING of the pendulum group, not
+        // inside it — otherwise it would swing with the rod instead
+        // of staying put. Assert the dot appears before the
+        // pendulum group's opening tag.
+        let beat = svg
+            .find("music-glyph--metronome__beat")
+            .expect("beat dot present");
+        let pendulum = svg
+            .find("music-glyph--metronome__pendulum")
+            .expect("pendulum group present");
+        assert!(
+            beat < pendulum,
+            "beat dot must be emitted outside (before) the pendulum group; got: {svg}"
         );
     }
 

--- a/crates/render-html/src/music_glyphs.rs
+++ b/crates/render-html/src/music_glyphs.rs
@@ -383,7 +383,6 @@ pub fn metronome_svg(bpm_raw: &str) -> String {
     let period = (60.0 / safe_bpm).clamp(0.05, 5.0);
 
     // Use the validated numeric BPM in the accessible name —
-    // Use the validated numeric BPM in the accessible name —
     // not the raw `bpm_raw` string — so a `{tempo: <script>}`
     // payload doesn't reach screen readers AND so a future
     // refactor that moves the string into a non-escaping

--- a/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
+++ b/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
+++ b/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/chord-alignment/expected.html
+++ b/crates/render-html/tests/fixtures/chord-alignment/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
+++ b/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/comments/expected.html
+++ b/crates/render-html/tests/fixtures/comments/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
+++ b/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/directives-and-sections/expected.html
+++ b/crates/render-html/tests/fixtures/directives-and-sections/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/empty-lines/expected.html
+++ b/crates/render-html/tests/fixtures/empty-lines/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/full-song/expected.html
+++ b/crates/render-html/tests/fixtures/full-song/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
+++ b/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/image-directive/expected.html
+++ b/crates/render-html/tests/fixtures/image-directive/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/metadata-header/expected.html
+++ b/crates/render-html/tests/fixtures/metadata-header/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/minimal-song/expected.html
+++ b/crates/render-html/tests/fixtures/minimal-song/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/page-control-directives/expected.html
+++ b/crates/render-html/tests/fixtures/page-control-directives/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/svg-section/expected.html
+++ b/crates/render-html/tests/fixtures/svg-section/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
+++ b/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Grid Trailing Colon</title>
+<title>Tempo Glyph</title>
 <style>
 body { font-family: "Noto Sans JP", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-size: 1rem; line-height: 1.6875; color: #0A0A0B; max-width: 720px; margin: 2em auto; padding: 0 1em; }
 h1 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 1.875rem; letter-spacing: -0.02em; color: #0A0A0B; margin-bottom: 0.2em; }
@@ -84,13 +84,11 @@ img { max-width: 100%; height: auto; }
 <body>
 <article class="song">
 <header class="song-header">
-<h1>Grid Trailing Colon</h1>
+<h1>Tempo Glyph</h1>
 </header>
-<div class="empty-line" aria-hidden="true"></div>
-<section class="grid">
-<h3 class="section-label">Grid</h3>
-<div class="grid-line"><span class="grid-barline grid-barline--repeat-start" aria-label="repeat start"><span class="grid-barline__line grid-barline__line--thick"></span><span class="grid-barline__line"></span><span class="grid-barline__dots"><span></span><span></span></span></span><span class="grid-bar" data-beats="2"><span class="grid-beat"><span class="grid-chord">C7</span></span><span class="grid-beat"></span></span><span class="grid-barline" aria-hidden="true"></span><span class="grid-bar" data-beats="2"><span class="grid-beat grid-beat--percent1" aria-label="repeat previous bar"><span class="grid-percent" aria-hidden="true">%</span></span><span class="grid-beat"></span></span><span class="grid-barline grid-barline--repeat-both" aria-label="repeat end and start"><span class="grid-barline__dots"><span></span><span></span></span><span class="grid-barline__line grid-barline__line--thick"></span><span class="grid-barline__line grid-barline__line--thick"></span><span class="grid-barline__dots"><span></span><span></span></span></span><span class="grid-bar" data-beats="2"><span class="grid-beat"><span class="grid-chord">G7</span></span><span class="grid-beat"></span></span><span class="grid-barline" aria-hidden="true"></span><span class="grid-row__comment">% .</span></div>
-</section>
+<div class="line"><span class="chord-block"><span class="chord">G</span><span class="lyrics">Start the song</span></span></div>
+<span class="meta-inline meta-inline--tempo"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 4 18 18" width="18" height="18" class="music-glyph music-glyph--metronome" style="--cs-metronome-period:0.500s" role="img" aria-label="Metronome at 120 BPM"><circle class="music-glyph--metronome__beat" cx="2.4" cy="6.2" r="1.5" fill="currentColor"/><path d="M 3 21 L 15 21 L 12.5 5 L 5.5 5 Z" fill="none" stroke="currentColor" stroke-width="0.9" stroke-linejoin="round"/><circle cx="9" cy="19" r="0.7" fill="currentColor"/><g class="music-glyph--metronome__pendulum"><line x1="9" y1="19" x2="9" y2="7" stroke="currentColor" stroke-width="0.9" stroke-linecap="round"/><circle cx="9" cy="9" r="1.1" fill="currentColor"/></g></svg><span class="meta-inline__value">120 BPM <span class="meta-inline__marking">(Allegro)</span></span></span>
+<div class="line"><span class="chord-block"><span class="chord">C</span><span class="lyrics">Pick up the pace</span></span></div>
 </article>
 </body>
 </html>

--- a/crates/render-html/tests/fixtures/tempo-inline-glyph/input.cho
+++ b/crates/render-html/tests/fixtures/tempo-inline-glyph/input.cho
@@ -1,0 +1,4 @@
+{title: Tempo Glyph}
+[G]Start the song
+{tempo: 120}
+[C]Pick up the pace

--- a/crates/render-html/tests/fixtures/text-before-chord/expected.html
+++ b/crates/render-html/tests/fixtures/text-before-chord/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
@@ -28,7 +28,9 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+@media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
 .chord { font-family: "Roboto", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif; font-weight: 700; color: #BD1642; font-size: 1rem; letter-spacing: 0.01em; line-height: 1; min-height: 1em; }

--- a/packages/react/src/music-glyphs.tsx
+++ b/packages/react/src/music-glyphs.tsx
@@ -636,6 +636,14 @@ export function tempoMarkingFor(bpm: number): string | null {
  * the rod arrives at the opposite extreme every `60/bpm`
  * seconds — exactly one beat at the requested BPM.
  *
+ * A static beat dot sits in the top-left corner *inside* the
+ * existing viewBox (so the icon height is unchanged) and pulses
+ * flash-then-decay once per beat. Its blink shares the same
+ * `--cs-metronome-period` as the swing, so the dot is at full
+ * brightness exactly when the rod reaches an extreme (the
+ * audible tick). The dot is a sibling of the pendulum group, so
+ * it does NOT swing — only its opacity animates.
+ *
  * The animation is gated on
  * `@media (prefers-reduced-motion: reduce)` so users who opt out
  * of motion see a static icon.
@@ -702,6 +710,12 @@ export function MetronomeGlyph({
       aria-hidden={ariaHidden ?? undefined}
       aria-label={ariaHidden ? undefined : `Metronome at ${safeBpm} BPM`}
     >
+      {/* Beat dot — static, top-left corner inside the existing
+          viewBox so the icon height is unchanged. A sibling of the
+          pendulum group (NOT inside it), so it stays put while only
+          its opacity animates (flash → decay) via the
+          `cs-metronome-beat` keyframe in the stylesheet. */}
+      <circle className="music-glyph--metronome__beat" cx={2.4} cy={6.2} r={1.5} fill="currentColor" />
       {/* Triangular body — narrow top, wide base. */}
       <path
         d="M 3 21 L 15 21 L 12.5 5 L 5.5 5 Z"

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -682,10 +682,39 @@
     transform: rotate(28deg);
   }
 }
+
+/* Beat dot — a static LED in the top-left corner that flashes
+   once per beat. It shares `--cs-metronome-period` with the
+   swing, so it reaches full brightness exactly when the rod
+   hits an extreme (the audible tick), then decays before the
+   next beat. `ease-out` shapes the decay; the keyframe holds a
+   brief peak (0–8%) for a crisp "pop". Non-`alternate` so each
+   beat re-triggers the flash from full brightness. */
+.chordsketch-sheet__content .music-glyph--metronome__beat {
+  animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite;
+}
+@keyframes cs-metronome-beat {
+  0% {
+    opacity: 1;
+  }
+  8% {
+    opacity: 1;
+  }
+  60% {
+    opacity: 0.12;
+  }
+  100% {
+    opacity: 0.12;
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   .chordsketch-sheet__content .music-glyph--metronome__pendulum {
     animation: none;
     transform: rotate(0deg);
+  }
+  .chordsketch-sheet__content .music-glyph--metronome__beat {
+    animation: none;
+    opacity: 1;
   }
 }
 

--- a/packages/react/tests/music-glyphs.test.tsx
+++ b/packages/react/tests/music-glyphs.test.tsx
@@ -269,6 +269,24 @@ describe('<MetronomeGlyph>', () => {
       'Metronome at 120 BPM',
     );
   });
+
+  // The beat dot is a sibling of the pendulum group so it stays
+  // put (only its opacity animates) while the rod swings. If a
+  // regression nests it inside `.music-glyph--metronome__pendulum`
+  // it would swing with the rod, breaking the "static LED" intent.
+  test('emits a static top-left beat dot outside the swinging pendulum group', () => {
+    const { container } = render(<MetronomeGlyph bpm={120} />);
+    const svg = container.querySelector('svg.music-glyph--metronome');
+    const beat = svg?.querySelector('circle.music-glyph--metronome__beat');
+    expect(beat).not.toBeNull();
+    // Top-left corner inside the existing viewBox.
+    expect(beat?.getAttribute('cx')).toBe('2.4');
+    expect(beat?.getAttribute('cy')).toBe('6.2');
+    // The dot must NOT be a descendant of the pendulum group.
+    expect(
+      svg?.querySelector('.music-glyph--metronome__pendulum .music-glyph--metronome__beat'),
+    ).toBeNull();
+  });
 });
 
 describe('<TimeSignatureGlyph>', () => {

--- a/packages/react/tests/music-glyphs.test.tsx
+++ b/packages/react/tests/music-glyphs.test.tsx
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
 import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 
@@ -286,6 +290,31 @@ describe('<MetronomeGlyph>', () => {
     expect(
       svg?.querySelector('.music-glyph--metronome__pendulum .music-glyph--metronome__beat'),
     ).toBeNull();
+  });
+
+  // Phase-sync invariant (sister-site to the render-html assertion
+  // in `crates/render-html/src/lib.rs`): the beat blink and the
+  // pendulum swing MUST both be driven by `--cs-metronome-period`.
+  // That shared property is what guarantees the flash peaks exactly
+  // when the rod reaches an extreme (the tick). The blink lives in
+  // styles.css (not inline), so assert it against the stylesheet
+  // source rather than the rendered DOM. A regression that gives the
+  // beat a hardcoded duration would desync the flash from the tick
+  // without failing the DOM-level tests above.
+  test('beat blink and swing share --cs-metronome-period in styles.css', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8');
+    expect(css).toContain('@keyframes cs-metronome-beat');
+    expect(css).toMatch(
+      /\.music-glyph--metronome__beat\s*\{\s*animation:\s*cs-metronome-beat var\(--cs-metronome-period/,
+    );
+    expect(css).toMatch(
+      /\.music-glyph--metronome__pendulum\s*\{[^}]*animation:\s*cs-metronome-swing var\(--cs-metronome-period/,
+    );
+    // Reduced-motion must disable the blink and pin a visible dot.
+    expect(css).toMatch(
+      /prefers-reduced-motion: reduce[\s\S]*\.music-glyph--metronome__beat\s*\{\s*animation:\s*none;\s*opacity:\s*1;/,
+    );
   });
 });
 


### PR DESCRIPTION
## What

Adds a small blinking "beat" dot to the animated `{tempo}` metronome
glyph. The dot flashes once per beat, in sync with the swinging pendulum
reaching each extreme (the audible tick), and decays before the next
beat.

- The dot sits in the **top-left corner inside the existing**
  `viewBox="0 4 18 18"`, so the icon's intrinsic height is unchanged —
  no downstream shrink of surrounding layout.
- Colour is `currentColor` (theme-aware), matching the rest of the glyph.
- Blink shape is **flash → decay**, shaped by `ease-out` + the
  `cs-metronome-beat` keyframe.
- The dot is a **sibling of the pendulum group**, so it stays put while
  only its opacity animates (it does not swing with the rod).
- `prefers-reduced-motion: reduce` disables the blink, leaving a static
  visible dot.

## Why

The metronome already swings with tempo; a beat-synced LED makes the
"this is BPM N" signal readable at a glance even when the swing is subtle
at the small inline size. The blink reuses the existing
`--cs-metronome-period` custom property, so the swing and the blink share
a single source of timing truth — there is no second BPM derivation that
could drift out of sync.

## Test results

- `cargo test` (default members): all pass, including the new
  `metronome_svg_emits_beat_dot` unit test and the extended
  `test_inline_meta_marker_for_tempo` assertions.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `@chordsketch/react` `npm test`: 663 pass (incl. the new
  beat-dot test); `npm run typecheck`: clean.
- Golden fixtures regenerated via `UPDATE_GOLDEN=1`; new
  `tempo-inline-glyph` fixture locks the full inline metronome SVG
  markup with the beat dot.

## Sister-site audit

Per `.claude/rules/renderer-parity.md` and `fix-propagation.md`, the
metronome glyph renders on exactly two surfaces, both updated here:

- `crates/render-html/src/music_glyphs.rs::metronome_svg` + the embedded
  stylesheet in `crates/render-html/src/lib.rs`.
- `packages/react/src/music-glyphs.tsx::MetronomeGlyph` + the matching
  rules in `packages/react/src/styles.css`.

`chordsketch-render-text` and `chordsketch-render-pdf` intentionally
render a textual tempo label (`Tempo: N`) rather than the animated glyph
— the existing sister-site comment in `render-pdf/src/lib.rs` documents
this — so they are out of scope for the glyph change.

## Review summary

Self-reviewed for renderer parity, reduced-motion handling, and
timing-source single-truth. No new dependencies.

Closes #2610

---
_Generated by [Claude Code](https://claude.ai/code/session_019LcEC9A9bQHp2rWuyS13Hr)_