### PR TITLE
Add click-to-focus + nudge buttons and arrow-key chord movement

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -582,6 +582,9 @@ shorthand (no Unicode translation; the SVG renderer handles that).
 | `renderChordproAst` | Atom | Function | AST → JSX walker (powers `<ChordSheet format="html">`). |
 | `applyChordReposition` | Atom | Function | Apply a drag-to-reposition event to a ChordPro source. |
 | `lyricsOffsetToSourceColumn` | Atom | Function | Lyrics-offset → source-column helper for drag UX. |
+| `sourceColumnToLyricsOffset` | Atom | Function | Source-column → lyrics-offset helper (inverse of the above). |
+| `nudgeChordPosition` | Atom | Function | Destination offset/ordinal for a one-step chord nudge. |
+| `findChordByOffsetOrdinal` | Atom | Function | Re-locate a selected chord by `(offset, ordinal)` after a nudge re-render. |
 | `useDebounced` | Atom | Hook | General-purpose debouncer used by `<ChordTextarea>`. |
 | `<MetronomeButton>` | Atom | Component | Clickable `{tempo}` metronome icon; ticks audibly at the BPM (speaker cursor on hover). |
 | `useMetronome` | Atom | Hook | Web Audio metronome state (`start` / `stop` / `toggle` / `isRunning` / `isPlaying` / `supported`). |

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useRef, useState } from 'react';
 import type { HTMLAttributes, ReactNode } from 'react';
 
 import { renderChordproAst } from './chordpro-jsx';
+import type { ChordSelection } from './chordpro-jsx';
 import type { ChordRepositionEvent } from './chord-source-edit';
 import type {
   ChordDiagramInstrument,
@@ -306,6 +308,41 @@ function ChordSheetAstBranch({
   );
   const errorNode = error !== null && errorFallback !== null ? errorFallback(error) : null;
 
+  // Click-to-focus + nudge selection state (#2614). Owned here so it
+  // survives the re-render a nudge triggers (the nudge mutates source,
+  // which re-parses the AST and recreates the chord span); the walker
+  // re-locates the selected chord by its (offset, ordinal) identity.
+  // Only meaningful when `onChordReposition` is wired — otherwise the
+  // chords never become interactive, so the state simply stays null.
+  const [chordSelection, setChordSelection] = useState<ChordSelection | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  // Clear the selection when the user presses down anywhere that is
+  // not a chord / nudge control belonging to THIS sheet. Clicking a
+  // chord re-selects via that chord's own handler, so we keep the
+  // selection only for presses on this sheet's own `.chord` /
+  // `.chord-nudge`; presses elsewhere — empty space, the editor, or
+  // even another sheet instance's chords — clear it. Scoped to when a
+  // selection is active so there is no idle global listener.
+  useEffect(() => {
+    if (chordSelection == null) return;
+    const onPointerDown = (event: PointerEvent): void => {
+      const target = event.target as Node | null;
+      const root = contentRef.current;
+      if (
+        root != null &&
+        target != null &&
+        root.contains(target) &&
+        (target as HTMLElement).closest?.('.chord, .chord-nudge')
+      ) {
+        return;
+      }
+      setChordSelection(null);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [chordSelection]);
+
   if (ast === null) {
     return (
       <div {...divProps} className={wrapperClass} aria-busy={loading || undefined}>
@@ -324,7 +361,7 @@ function ChordSheetAstBranch({
   return (
     <div {...divProps} className={wrapperClass} aria-busy={loading || undefined}>
       {errorNode}
-      <div className="chordsketch-sheet__content">
+      <div className="chordsketch-sheet__content" ref={contentRef}>
         {renderChordproAst(ast, {
           transposedKey,
           transposedKeyDirectives,
@@ -338,6 +375,8 @@ function ChordSheetAstBranch({
           caretColumn,
           caretLineLength,
           onChordReposition,
+          chordSelection,
+          setChordSelection,
         })}
       </div>
     </div>

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -327,13 +327,19 @@ function ChordSheetAstBranch({
   useEffect(() => {
     if (chordSelection == null) return;
     const onPointerDown = (event: PointerEvent): void => {
-      const target = event.target as Node | null;
+      const node = event.target as Node | null;
+      // Resolve to the nearest Element: a pointer event's target can be
+      // a non-Element node (e.g. the chord name's Text node) which has
+      // no `closest`, and treating that as "outside" would clear the
+      // selection the instant the user presses on the chord glyph.
+      const el =
+        node instanceof Element ? node : (node?.parentElement ?? null);
       const root = contentRef.current;
       if (
         root != null &&
-        target != null &&
-        root.contains(target) &&
-        (target as HTMLElement).closest?.('.chord, .chord-nudge')
+        el != null &&
+        root.contains(el) &&
+        el.closest('.chord, .chord-nudge')
       ) {
         return;
       }

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -5,7 +5,19 @@
  * user did (drag from line A column X → drop at line B
  * lyrics-offset Y); the consumer applies the event to the
  * ChordPro source string via `applyChordReposition` and
- * dispatches the result into its editor. The capo helpers
+ * dispatches the result into its editor.
+ *
+ * The same `ChordRepositionEvent` pipeline backs the
+ * click-to-focus + nudge interaction (#2614): tapping a chord
+ * selects it, and the ◀ / ▶ buttons (or the keyboard arrow
+ * keys) move it one lyric character at a time. The pure offset
+ * math for that gesture lives here — {@link nudgeChordPosition}
+ * computes the destination lyrics offset + disambiguation
+ * ordinal, {@link findChordByOffsetOrdinal} re-locates the
+ * selected chord after a re-render, and
+ * {@link sourceColumnToLyricsOffset} is the inverse of
+ * {@link lyricsOffsetToSourceColumn} — so the interaction logic
+ * has unit coverage independent of the DOM. The capo helpers
  * (`readCapo` / `setCapoInSource`) round-trip a `{capo: N}`
  * directive through the source so the `<Capo>` control stays
  * a thin wrapper over the document — no parallel state.
@@ -273,4 +285,117 @@ export function applyChordReposition(
   caretOffset += targetColumn + insertBracket.length;
 
   return { text: lines.join('\n'), caretOffset };
+}
+
+/**
+ * Map a 0-indexed source column on a ChordPro line back to the
+ * lyrics-character offset at that column — the inverse of
+ * {@link lyricsOffsetToSourceColumn}.
+ *
+ * Counts the visible lyric characters strictly before `column`,
+ * treating chord brackets (`[...]`) as zero-width (consistent
+ * with the lyrics-offset convention used throughout this
+ * module). A `column` that points at a `[` therefore yields the
+ * offset of the chord that opens there — i.e. the number of
+ * lyric characters preceding it.
+ *
+ * `column` is clamped to `[0, line.length]`. A bracket that
+ * straddles `column` (an unterminated `[`, or `column` landing
+ * inside `[...]`) counts the characters consumed up to `column`
+ * as lyrics, which keeps the function total for malformed input
+ * rather than throwing.
+ */
+export function sourceColumnToLyricsOffset(line: string, column: number): number {
+  const limit = Math.max(0, Math.min(column, line.length));
+  let lyricsCount = 0;
+  let i = 0;
+  while (i < limit) {
+    if (line[i] === '[') {
+      const close = line.indexOf(']', i);
+      // A bracket that closes before `limit` is skipped whole
+      // (zero-width). One that is unterminated or extends past
+      // `limit` cannot be a complete chord within the counted
+      // range, so fall through and count its characters as
+      // lyrics — mirrors lyricsOffsetToSourceColumn's malformed-
+      // bracket bail-out.
+      if (close !== -1 && close < limit) {
+        i = close + 1;
+        continue;
+      }
+    }
+    lyricsCount++;
+    i++;
+  }
+  return lyricsCount;
+}
+
+/** Destination of a single-step chord nudge, returned by
+ * {@link nudgeChordPosition}. */
+export interface NudgedChordPosition {
+  /** New 0-indexed lyrics offset for the moved chord. */
+  offset: number;
+  /** Index of the moved chord among chords sharing `offset` on
+   * the destination line, in left-to-right order. The nudged
+   * chord always lands AFTER any chord already at `offset` (see
+   * {@link lyricsOffsetToSourceColumn}, which skips leading
+   * brackets), so this equals the count of other chords already
+   * at `offset`. Used to disambiguate stacked chords like
+   * `[A][B]word` when re-locating the selection after the move. */
+  ordinal: number;
+}
+
+/**
+ * Compute where a chord lands when nudged one lyric character in
+ * `direction`, for the click-to-focus + arrow-key interaction
+ * (#2614).
+ *
+ * @param currentOffset the chord's current 0-indexed lyrics
+ *   offset (lyric characters before its `[` bracket).
+ * @param otherOffsets the lyrics offsets of every OTHER chord on
+ *   the same line (the moved chord excluded). Used only to
+ *   compute the destination ordinal.
+ * @param totalLyrics the total visible lyric characters on the
+ *   line. A chord may legitimately sit at `offset === totalLyrics`
+ *   (a trailing chord after the last lyric), so that bound is
+ *   inclusive.
+ * @param direction `-1` to move left, `+1` to move right.
+ * @returns the destination offset + ordinal, or `null` when the
+ *   move would push the chord off either end of the line (the
+ *   caller disables the corresponding button).
+ */
+export function nudgeChordPosition(
+  currentOffset: number,
+  otherOffsets: readonly number[],
+  totalLyrics: number,
+  direction: -1 | 1,
+): NudgedChordPosition | null {
+  const offset = currentOffset + direction;
+  if (offset < 0 || offset > totalLyrics) return null;
+  const ordinal = otherOffsets.reduce((n, o) => (o === offset ? n + 1 : n), 0);
+  return { offset, ordinal };
+}
+
+/**
+ * Find the index, into a line's left-to-right list of chord
+ * lyrics offsets, of the chord identified by `(offset, ordinal)`
+ * — the `ordinal`-th chord (0-indexed) whose offset equals
+ * `offset`.
+ *
+ * Returns `-1` when no such chord exists, e.g. when the source
+ * changed out from under a stale selection. Callers treat `-1`
+ * as "selection no longer resolves" and render no controls.
+ */
+export function findChordByOffsetOrdinal(
+  offsets: readonly number[],
+  offset: number,
+  ordinal: number,
+): number {
+  let seen = 0;
+  for (let i = 0; i < offsets.length; i++) {
+    if (offsets[i] === offset) {
+      if (seen === ordinal) return i;
+      seen++;
+    }
+  }
+  return -1;
 }

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -24,8 +24,24 @@
 // `DANGEROUS_URI_SCHEMES` here in the same PR per
 // `.claude/rules/sanitizer-security.md` §"Security Asymmetry".
 
-import { Fragment, cloneElement, isValidElement, useId, useMemo, useState } from 'react';
-import type { CSSProperties, DragEvent as ReactDragEvent, JSX, ReactNode } from 'react';
+import {
+  Fragment,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type {
+  CSSProperties,
+  DragEvent as ReactDragEvent,
+  JSX,
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from 'react';
 
 import { ChordDiagram } from './chord-diagram';
 
@@ -58,6 +74,10 @@ import type {
   ChordDiagramInstrument,
   ChordDiagramOrientation,
 } from './use-chord-diagram';
+import {
+  findChordByOffsetOrdinal,
+  nudgeChordPosition,
+} from './chord-source-edit';
 import type { ChordRepositionEvent } from './chord-source-edit';
 
 // ---- Sanitiser helpers --------------------------------------------
@@ -1544,6 +1564,58 @@ export function caretPlacement(
 
 // ---- Lyrics line ---------------------------------------------------
 
+/**
+ * Identifies the chord currently selected for the click-to-focus +
+ * nudge interaction (#2614). The selection is deliberately
+ * decoupled from DOM focus: a nudge mutates the ChordPro source,
+ * which re-parses and re-renders the line, removing and recreating
+ * the chord span. Tying selection to the span's blur would drop it
+ * on every nudge. Instead the selection is controlled state that
+ * survives the re-render, and DOM focus is driven programmatically
+ * from it.
+ *
+ * `nonce` is a monotonic user-action counter bumped on every
+ * select / nudge. The auto-focus effect (in {@link LyricsLine})
+ * re-focuses the chord span only when the nonce changes, so an
+ * incidental re-render — e.g. the user typing elsewhere in the
+ * document — never steals DOM focus into the preview.
+ */
+export interface ChordSelection {
+  /** 1-indexed source line of the selected chord. */
+  line: number;
+  /** 0-indexed lyrics offset (lyric characters before the chord's
+   * `[` bracket). */
+  offset: number;
+  /** Index among chords sharing `offset` on `line`, left-to-right.
+   * Disambiguates stacked chords like `[A][B]word`. */
+  ordinal: number;
+  /** Monotonic user-action counter; see the interface doc. */
+  nonce: number;
+}
+
+/**
+ * Drag-and-drop + click-to-nudge context threaded to each
+ * chord-bearing lyrics line. Carries the per-line source number,
+ * the reposition callback the consumer wires, and the shared
+ * selection state used by the nudge interaction.
+ */
+interface ChordRepositionContext {
+  sourceLine: number;
+  onChordReposition: (event: ChordRepositionEvent) => void;
+  /** Click-to-focus + nudge wiring (#2614). `null` when the
+   * consumer wired only drag-and-drop (`onChordReposition` without
+   * selection state) — drag works, but chords are not clickable
+   * toggle buttons and no nudge controls appear. `<ChordSheet>`
+   * always provides this when `onChordReposition` is set. */
+  nudge: {
+    /** Current selection (may belong to a different line, or be
+     * `null` when nothing is selected). */
+    selected: ChordSelection | null;
+    /** Replace the selection. `null` clears it. */
+    setSelected: (next: ChordSelection | null) => void;
+  } | null;
+}
+
 function renderLyricsLine(
   line: ChordproLyricsLine,
   key: number,
@@ -1555,11 +1627,8 @@ function renderLyricsLine(
   lyricsOverride: CSSProperties | null = null,
   /** Caret placement for the in-preview marker. */
   caret: CaretPlacement | null = null,
-  /** Chord drag-and-drop context. */
-  reposition: {
-    sourceLine: number;
-    onChordReposition: (event: ChordRepositionEvent) => void;
-  } | null = null,
+  /** Chord drag-and-drop + click-to-nudge context. */
+  reposition: ChordRepositionContext | null = null,
   /** Inline / hover diagram config (ADR-0027); `null` keeps the
    * plain chord-name rendering. */
   diagrams: LyricsDiagramConfig | null = null,
@@ -1583,10 +1652,7 @@ interface LyricsLineProps {
   fmt: FormattingState;
   lyricsOverride: CSSProperties | null;
   caret: CaretPlacement | null;
-  reposition: {
-    sourceLine: number;
-    onChordReposition: (event: ChordRepositionEvent) => void;
-  } | null;
+  reposition: ChordRepositionContext | null;
   /** Class name applied to the root `.line` div. `pushElement`
    * threads `line line--active` here when the line matches
    * `activeSourceLine`; otherwise the caller passes `"line"`. */
@@ -1765,6 +1831,148 @@ function LyricsLine({
     return layout;
   }, [line.segments]);
 
+  // ---- Click-to-focus + nudge state (#2614) ----------------------
+  // Chord-bearing segments in left-to-right order, paired with the
+  // lyrics offset of each chord. This is the coordinate space the
+  // nudge math (`chord-source-edit`) operates in.
+  const chordSegments = useMemo(() => {
+    const out: Array<{ segmentIdx: number; offset: number }> = [];
+    line.segments.forEach((seg, i) => {
+      if (seg.chord) out.push({ segmentIdx: i, offset: segmentLayout[i].lyricsOffsetStart });
+    });
+    return out;
+  }, [line.segments, segmentLayout]);
+  const chordOffsets = useMemo(() => chordSegments.map((c) => c.offset), [chordSegments]);
+  const totalLyrics = useMemo(
+    () => line.segments.reduce((n, s) => n + s.text.length, 0),
+    [line.segments],
+  );
+
+  const nudgeCtx = reposition?.nudge ?? null;
+  const selected = nudgeCtx?.selected ?? null;
+  const isSelectedLine =
+    reposition != null && selected != null && selected.line === reposition.sourceLine;
+  // Re-locate the selected chord on every render: a nudge mutates
+  // the source, which re-parses into different segments, so the
+  // chord's segment index is NOT stable — only its (offset, ordinal)
+  // identity is. `-1` means the selection no longer resolves (e.g.
+  // the source was edited out from under a stale selection); the
+  // line then renders no controls.
+  const focusedChordIdx =
+    isSelectedLine && selected != null
+      ? findChordByOffsetOrdinal(chordOffsets, selected.offset, selected.ordinal)
+      : -1;
+  const focusedSegmentIdx = focusedChordIdx >= 0 ? chordSegments[focusedChordIdx].segmentIdx : -1;
+  // Availability depends only on the line bounds, so the empty
+  // `otherOffsets` argument (used solely for the destination
+  // ordinal) is fine here.
+  const canNudgeLeft =
+    focusedChordIdx >= 0 &&
+    selected != null &&
+    nudgeChordPosition(selected.offset, [], totalLyrics, -1) !== null;
+  const canNudgeRight =
+    focusedChordIdx >= 0 &&
+    selected != null &&
+    nudgeChordPosition(selected.offset, [], totalLyrics, 1) !== null;
+
+  // DOM focus is driven programmatically from the selection so it
+  // survives the nudge re-render (the old chord span is destroyed
+  // and a new one created at the moved position). The ref points at
+  // whichever chord span is currently selected; the effect focuses
+  // it when the selection nonce advances (a user select / nudge)
+  // and the segment has resolved — never on an incidental re-render.
+  const focusedSpanRef = useRef<HTMLSpanElement | null>(null);
+  const handledNonceRef = useRef<number>(-1);
+  useEffect(() => {
+    if (!isSelectedLine || selected == null || focusedSegmentIdx < 0) return;
+    if (selected.nonce === handledNonceRef.current) return;
+    handledNonceRef.current = selected.nonce;
+    focusedSpanRef.current?.focus();
+  }, [isSelectedLine, focusedSegmentIdx, selected]);
+
+  // Toggle the selection for the chord in `segmentIdx`. Clicking
+  // the already-selected chord clears the selection.
+  const toggleSelect = (segmentIdx: number): void => {
+    if (!reposition || !nudgeCtx) return;
+    const offset = segmentLayout[segmentIdx].lyricsOffsetStart;
+    let ordinal = 0;
+    for (const c of chordSegments) {
+      if (c.segmentIdx === segmentIdx) break;
+      if (c.offset === offset) ordinal++;
+    }
+    const cur = nudgeCtx.selected;
+    const isSame =
+      cur != null &&
+      cur.line === reposition.sourceLine &&
+      cur.offset === offset &&
+      cur.ordinal === ordinal;
+    nudgeCtx.setSelected(
+      isSame
+        ? null
+        : {
+            line: reposition.sourceLine,
+            offset,
+            ordinal,
+            nonce: (cur?.nonce ?? 0) + 1,
+          },
+    );
+  };
+
+  // Move the selected chord one lyric character in `direction`.
+  // Reuses the drag-and-drop `onChordReposition` pipeline so the
+  // source mutation goes through the exact same `applyChordReposition`
+  // path, then advances the selection to the chord's new position so
+  // it stays selected for the next tap / key press.
+  const nudge = (direction: -1 | 1): void => {
+    if (!reposition || !nudgeCtx || focusedChordIdx < 0 || selected == null) return;
+    const otherOffsets = chordOffsets.filter((_, idx) => idx !== focusedChordIdx);
+    const dest = nudgeChordPosition(selected.offset, otherOffsets, totalLyrics, direction);
+    if (!dest) return;
+    const moved = chordSegments[focusedChordIdx];
+    const seg = line.segments[moved.segmentIdx];
+    const layout = segmentLayout[moved.segmentIdx];
+    reposition.onChordReposition({
+      fromLine: reposition.sourceLine,
+      fromColumn: layout.chordSourceColumn,
+      fromLength: layout.chordBracketLength,
+      toLine: reposition.sourceLine,
+      toLyricsOffset: dest.offset,
+      chord: seg.chord?.name ?? '',
+      copy: false,
+    });
+    nudgeCtx.setSelected({
+      line: reposition.sourceLine,
+      offset: dest.offset,
+      ordinal: dest.ordinal,
+      nonce: selected.nonce + 1,
+    });
+  };
+
+  // Keyboard control for a chord span. Enter / Space toggles the
+  // selection of that chord; once selected, ArrowLeft / ArrowRight
+  // nudge it and Escape clears the selection.
+  const chordKeyHandler =
+    (segmentIdx: number) => (event: ReactKeyboardEvent<HTMLSpanElement>): void => {
+      if (!reposition || !nudgeCtx) return;
+      const { key } = event;
+      if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+        event.preventDefault();
+        toggleSelect(segmentIdx);
+        return;
+      }
+      if (segmentIdx !== focusedSegmentIdx) return;
+      if (key === 'ArrowLeft') {
+        event.preventDefault();
+        nudge(-1);
+      } else if (key === 'ArrowRight') {
+        event.preventDefault();
+        nudge(1);
+      } else if (key === 'Escape') {
+        event.preventDefault();
+        nudgeCtx.setSelected(null);
+      }
+    };
+
   const lineHasChords = line.segments.some((s) => s.chord !== null);
   const chordStyle = elementStyleToCss(fmt.chord);
   const textStyle = lyricsOverride ?? elementStyleToCss(fmt.text);
@@ -1910,14 +2118,48 @@ function LyricsLine({
           dropTarget && dropTarget.segmentIdx === i
             ? dropTarget.charOffset
             : null;
+        // Click-to-focus + nudge wiring (#2614). Every real chord
+        // span becomes a toggle button that selects the chord; the
+        // selected one shows the ◀ / ▶ nudge controls and takes the
+        // auto-focus ref + keyboard handler. Off unless the consumer
+        // wired `onChordReposition`.
+        const isRealChord = segment.chord != null;
+        const isFocusedChord =
+          reposition != null && isRealChord && i === focusedSegmentIdx;
+        const chordInteractiveProps =
+          reposition && nudgeCtx && isRealChord
+            ? {
+                tabIndex: 0,
+                role: 'button' as const,
+                'aria-pressed': isFocusedChord,
+                onClick: (e: ReactMouseEvent) => {
+                  e.stopPropagation();
+                  toggleSelect(i);
+                },
+                onKeyDown: chordKeyHandler(i),
+              }
+            : null;
         return (
-          <span key={i} className="chord-block">
+          <span
+            key={i}
+            className={isFocusedChord ? 'chord-block chord-block--selected' : 'chord-block'}
+          >
             {segment.chord ? (
               diagrams &&
               (diagrams.mode === 'inline' || diagrams.mode === 'hover') ? (
                 // chordsketch inline / hover diagram above the lyric
                 // (ADR-0027). `<ChordCell>` is a component so its
                 // `useChordDiagram` hook can run per chord.
+                //
+                // The click-to-nudge controls (#2614) are NOT wired
+                // into this branch: in inline / hover diagram mode the
+                // chord cell is dedicated to the diagram interaction
+                // (the inline diagram replaces the name; the hover
+                // popover claims focus / hover), so a nudge toolbar
+                // there would collide with it. Drag-to-reposition still
+                // works here. This is a deliberate interaction
+                // limitation, not a renderer-parity gap — the nudge UI
+                // is React-only and has no Rust-renderer sibling.
                 <ChordCell
                   mode={diagrams.mode}
                   chord={segment.chord}
@@ -1930,9 +2172,11 @@ function LyricsLine({
                 />
               ) : (
                 <span
-                  className="chord"
+                  className={isFocusedChord ? 'chord chord--selected' : 'chord'}
                   style={chordStyle ?? undefined}
+                  ref={isFocusedChord ? focusedSpanRef : undefined}
                   {...(chordDragProps ?? {})}
+                  {...(chordInteractiveProps ?? {})}
                 >
                   {chordMarker}
                   {renderChord(segment.chord)}
@@ -1951,10 +2195,75 @@ function LyricsLine({
             <span className="lyrics" style={textStyle ?? undefined}>
               {renderLyricsTextWithChars(segment, caretCharOffset, dropCharOffset)}
             </span>
+            {isFocusedChord ? (
+              <NudgeControls
+                chordName={segment.chord?.name ?? ''}
+                canLeft={canNudgeLeft}
+                canRight={canNudgeRight}
+                onNudge={nudge}
+              />
+            ) : null}
           </span>
         );
       })}
     </div>
+  );
+}
+
+/**
+ * The ◀ / ▶ toolbar shown next to the selected chord (#2614).
+ * Each press nudges the chord one lyric character via the `onNudge`
+ * callback. Rendered as a sibling of the chord span inside the
+ * `.chord-block` (not a child of the chord's `role="button"` span,
+ * which must not contain interactive descendants) and positioned
+ * by CSS above the chord.
+ *
+ * The buttons stop their click from bubbling to the chord toggle
+ * (which would deselect) and cancel any drag the press might start,
+ * so tapping a button only nudges.
+ */
+function NudgeControls(props: {
+  chordName: string;
+  canLeft: boolean;
+  canRight: boolean;
+  onNudge: (direction: -1 | 1) => void;
+}): JSX.Element {
+  const { chordName, canLeft, canRight, onNudge } = props;
+  const stopDrag = (e: ReactMouseEvent): void => e.stopPropagation();
+  const cancelDrag = (e: ReactDragEvent): void => e.preventDefault();
+  return (
+    <span className="chord-nudge" role="group" aria-label={`Move chord ${chordName}`}>
+      <button
+        type="button"
+        className="chord-nudge__btn chord-nudge__btn--left"
+        aria-label={`Move chord ${chordName} left`}
+        disabled={!canLeft}
+        draggable={false}
+        onMouseDown={stopDrag}
+        onDragStart={cancelDrag}
+        onClick={(e) => {
+          e.stopPropagation();
+          onNudge(-1);
+        }}
+      >
+        <span aria-hidden="true">‹</span>
+      </button>
+      <button
+        type="button"
+        className="chord-nudge__btn chord-nudge__btn--right"
+        aria-label={`Move chord ${chordName} right`}
+        disabled={!canRight}
+        draggable={false}
+        onMouseDown={stopDrag}
+        onDragStart={cancelDrag}
+        onClick={(e) => {
+          e.stopPropagation();
+          onNudge(1);
+        }}
+      >
+        <span aria-hidden="true">›</span>
+      </button>
+    </span>
   );
 }
 
@@ -2613,6 +2922,24 @@ export interface RenderChordproAstOptions {
    * elements take no drop handlers.
    */
   onChordReposition?: (event: ChordRepositionEvent) => void;
+  /**
+   * Click-to-focus + nudge selection state (#2614). When provided
+   * alongside {@link onChordReposition}, each rendered `.chord`
+   * becomes a toggle button: clicking (tapping) it selects the
+   * chord and reveals ◀ / ▶ controls plus ArrowLeft / ArrowRight
+   * keyboard support that move the chord one lyric character at a
+   * time. The nudge reuses the `onChordReposition` pipeline, so the
+   * consumer mutates source exactly as it does for drag-and-drop.
+   *
+   * `<ChordSheet>` manages this state internally; direct
+   * `renderChordproAst` callers that want the nudge interaction must
+   * own a `useState<ChordSelection | null>` and pass both halves.
+   * Omitting `setChordSelection` leaves drag-and-drop working but
+   * disables click-to-nudge.
+   */
+  chordSelection?: ChordSelection | null;
+  /** Setter paired with {@link chordSelection}; see its docs. */
+  setChordSelection?: (next: ChordSelection | null) => void;
 }
 
 /**
@@ -3512,6 +3839,14 @@ interface WalkContext {
    */
   onChordReposition?: (event: ChordRepositionEvent) => void;
   /**
+   * Click-to-focus + nudge selection state + setter (#2614),
+   * forwarded from `RenderChordproAstOptions`. Both must be present
+   * for the nudge interaction; `setChordSelection` undefined leaves
+   * drag-and-drop working but disables click-to-nudge.
+   */
+  chordSelection?: ChordSelection | null;
+  setChordSelection?: (next: ChordSelection | null) => void;
+  /**
    * Diagram state (visibility / mode / instrument / position) resolved
    * once over the whole song. The per-line chord-block renderer reads
    * this to decide inline / hover rendering above the lyrics (ADR-0027),
@@ -4096,7 +4431,16 @@ function renderLine(ctx: WalkContext, line: ChordproLine, key: number): void {
       // via `cloneElement` — the component forwards those onto
       // its root `.line` div.
       const repositionCtx = ctx.onChordReposition
-        ? { sourceLine, onChordReposition: ctx.onChordReposition }
+        ? {
+            sourceLine,
+            onChordReposition: ctx.onChordReposition,
+            nudge: ctx.setChordSelection
+              ? {
+                  selected: ctx.chordSelection ?? null,
+                  setSelected: ctx.setChordSelection,
+                }
+              : null,
+          }
         : null;
       pushElement(
         ctx,
@@ -4192,6 +4536,8 @@ export function renderChordproAst(
         : null,
     transposedKeyDirectives: options.transposedKeyDirectives ?? {},
     onChordReposition: options.onChordReposition,
+    chordSelection: options.chordSelection,
+    setChordSelection: options.setChordSelection,
     diagramsState: options.chordDiagrams ? resolveDiagramsState(song) : null,
     diagramDefines: options.chordDiagrams ? collectDefines(song) : undefined,
     chordDiagramsInstrument: options.chordDiagrams?.instrument,

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1977,7 +1977,7 @@ function LyricsLine({
     (segmentIdx: number) => (event: ReactKeyboardEvent<HTMLSpanElement>): void => {
       if (!reposition || !nudgeCtx) return;
       const { key } = event;
-      if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+      if (key === 'Enter' || key === ' ') {
         event.preventDefault();
         toggleSelect(segmentIdx);
         return;

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1884,7 +1884,21 @@ function LyricsLine({
   const focusedSpanRef = useRef<HTMLSpanElement | null>(null);
   const handledNonceRef = useRef<number>(-1);
   useEffect(() => {
-    if (!isSelectedLine || selected == null || focusedSegmentIdx < 0) return;
+    // When this line is not (or no longer) the selected line, reset
+    // the handled-nonce so a FUTURE selection of this line refocuses
+    // even if its nonce repeats a previously-handled value — the
+    // per-selection nonce restarts at 1 after a full deselect
+    // (`cur` is null in `toggleSelect`), so without this reset a
+    // select → deselect → reselect-the-same-chord cycle could match
+    // the stale handled value and skip the programmatic refocus.
+    // Do NOT reset while the segment is merely unresolved mid-reparse
+    // (isSelectedLine true, focusedSegmentIdx < 0) — that transient
+    // must still refocus once the new AST lands.
+    if (!isSelectedLine) {
+      handledNonceRef.current = -1;
+      return;
+    }
+    if (selected == null || focusedSegmentIdx < 0) return;
     if (selected.nonce === handledNonceRef.current) return;
     handledNonceRef.current = selected.nonce;
     focusedSpanRef.current?.focus();
@@ -1924,6 +1938,14 @@ function LyricsLine({
   // path, then advances the selection to the chord's new position so
   // it stays selected for the next tap / key press.
   const nudge = (direction: -1 | 1): void => {
+    // `focusedChordIdx < 0` guards the brief window after a nudge when
+    // the selection has advanced but the source has not finished
+    // re-parsing (the host applies `onChordReposition` → new source →
+    // async AST). Dropping the press here is deliberate and safe:
+    // the move's `fromColumn` / `fromLength` are read from the CURRENT
+    // (stale) AST, so acting before the re-parse lands would target
+    // the wrong source span. A held arrow key may therefore skip a
+    // repeat; a normal tap (interval ≫ one render cycle) never does.
     if (!reposition || !nudgeCtx || focusedChordIdx < 0 || selected == null) return;
     const otherOffsets = chordOffsets.filter((_, idx) => idx !== focusedChordIdx);
     const dest = nudgeChordPosition(selected.offset, otherOffsets, totalLyrics, direction);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -60,7 +60,7 @@ export {
 // `format="html"` branch — exposed at the package boundary so
 // custom consumers can drive their own React tree off the same
 // AST without the `<ChordSheet>` shell.
-export { renderChordproAst } from './chordpro-jsx';
+export { renderChordproAst, type ChordSelection } from './chordpro-jsx';
 export {
   useChordproAst,
   type ChordproAstResult,
@@ -142,11 +142,15 @@ export {
   TRANSPOSE_MAX,
   TRANSPOSE_MIN,
   applyChordReposition,
+  findChordByOffsetOrdinal,
   lyricsOffsetToSourceColumn,
+  nudgeChordPosition,
   readCapo,
   setCapoInSource,
+  sourceColumnToLyricsOffset,
   type ChordRepositionEvent,
   type ChordRepositionResult,
+  type NudgedChordPosition,
 } from './chord-source-edit';
 
 // iReal Pro surface (#2473 / #2505 / #2527 / ADR-0020). Mirrors the

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1387,6 +1387,69 @@
   cursor: grabbing;
 }
 
+/* Click-to-focus + nudge controls (#2614). When chord
+   repositioning is enabled each real chord is a toggle button;
+   tapping it selects the chord and reveals a small ◀ / ▶ toolbar
+   so it can be moved one lyric character at a time — the
+   touch-friendly complement to drag-to-reposition. */
+.chordsketch-sheet__content .chord[role='button'] {
+  cursor: pointer;
+}
+.chordsketch-sheet__content .chord--selected {
+  outline: 2px solid var(--cs-crimson-500, #bd1642);
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+/* The chord-block becomes the positioning context for the
+   absolutely-positioned toolbar only while a chord inside it is
+   selected, so unselected blocks keep static flow. */
+.chordsketch-sheet__content .chord-block--selected {
+  position: relative;
+}
+.chordsketch-sheet__content .chord-nudge {
+  position: absolute;
+  /* Sit above the chord row. */
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 3px;
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--cs-surface, #fff);
+  border: 1px solid var(--cs-crimson-500, #bd1642);
+  border-radius: 6px;
+  box-shadow: var(--cs-elevation-popover, 0 2px 6px rgba(0, 0, 0, 0.18));
+  z-index: 5;
+  white-space: nowrap;
+  user-select: none;
+}
+.chordsketch-sheet__content .chord-nudge__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Touch-friendly target — the feature exists for taps where a
+     precise drag is hard (#2614). */
+  min-width: 1.75rem;
+  min-height: 1.75rem;
+  padding: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--cs-crimson-500, #bd1642);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.chordsketch-sheet__content .chord-nudge__btn:hover:not(:disabled) {
+  background: var(--cs-crimson-50, rgba(189, 22, 66, 0.1));
+}
+.chordsketch-sheet__content .chord-nudge__btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
 /* Per-character span inside a `.lyrics` row. Plain wrapper so
    the renderer can highlight a single character with a drop-
    target outline; styling otherwise inherits from `.lyrics`. */

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1449,6 +1449,11 @@
   opacity: 0.35;
   cursor: default;
 }
+.chordsketch-sheet__content .chord-nudge__btn:focus-visible {
+  outline: 2px solid var(--cs-crimson-500, #bd1642);
+  outline-offset: 1px;
+  border-radius: 4px;
+}
 
 /* Per-character span inside a `.lyrics` row. Plain wrapper so
    the renderer can highlight a single character with a drop-

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { ChordSheet } from '../src/index';
@@ -445,6 +445,114 @@ describe('<ChordSheet>', () => {
     diagramWrappers.forEach((wrapper) => {
       expect(wrapper.getAttribute('data-orientation')).toBe('horizontal');
     });
+  });
+
+  // ---------------------------------------------------------------------
+  // Click-to-focus + nudge (#2614). End-to-end through <ChordSheet>:
+  // the selection state + outside-click clearing live in the AST branch
+  // component, which the renderChordproAst-level tests can't exercise.
+  // ---------------------------------------------------------------------
+
+  // A stub returning a single chord-bearing line `[Am]hi`.
+  function chordStub(): StubRenderer {
+    const songAst = JSON.stringify({
+      metadata: {
+        title: null,
+        subtitles: [],
+        artists: [],
+        composers: [],
+        lyricists: [],
+        album: null,
+        year: null,
+        key: null,
+        tempo: null,
+        time: null,
+        capo: null,
+        sortTitle: null,
+        sortArtist: null,
+        arrangers: [],
+        copyright: null,
+        duration: null,
+        tags: [],
+        custom: [],
+      },
+      lines: [
+        {
+          kind: 'lyrics',
+          value: {
+            segments: [
+              { chord: { name: 'Am', detail: null, display: null }, text: 'hi', spans: [] },
+            ],
+          },
+        },
+      ],
+    });
+    return {
+      ...makeStub(),
+      parseChordproWithWarnings: vi.fn(() => ({
+        ast: songAst,
+        warnings: [],
+        transposedKey: undefined,
+      })),
+    };
+  }
+
+  test('onChordReposition enables click-to-focus nudge controls', async () => {
+    const onChordReposition = vi.fn();
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={onChordReposition}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    // No controls until the chord is clicked.
+    expect(container.querySelector('.chord-nudge')).toBeNull();
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    // Controls appear; the right button moves Am one char into "hi".
+    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    fireEvent.click(container.querySelector('.chord-nudge__btn--right') as HTMLElement);
+    expect(onChordReposition).toHaveBeenCalledTimes(1);
+    expect(onChordReposition.mock.calls[0][0]).toMatchObject({
+      fromLine: 1,
+      toLine: 1,
+      toLyricsOffset: 1,
+      chord: 'Am',
+      copy: false,
+    });
+  });
+
+  test('pressing down outside the sheet clears the chord selection', async () => {
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    // Pointer down on the document body (outside any chord) clears it.
+    fireEvent.pointerDown(document.body);
+    expect(container.querySelector('.chord-nudge')).toBeNull();
+  });
+
+  test('chords stay inert when onChordReposition is not provided', async () => {
+    const { container } = render(
+      <ChordSheet source="[Am]hi" astWasmLoader={makeAstLoader(chordStub())} />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.chord')).not.toBeNull();
+    });
+    const chord = container.querySelector('.chord') as HTMLElement;
+    expect(chord.getAttribute('role')).toBeNull();
+    expect(chord.getAttribute('draggable')).toBeNull();
   });
 
   test('omits chordDiagrams option when chordDiagramsInstrument is unset', async () => {

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -543,6 +543,34 @@ describe('<ChordSheet>', () => {
     expect(container.querySelector('.chord-nudge')).toBeNull();
   });
 
+  test('pressing on the chord glyph (text node) does not clear the selection', async () => {
+    // A pointer event can target the chord name's Text node, which has
+    // no `closest`. The outside-click listener must resolve to the
+    // nearest Element before testing membership, otherwise pressing the
+    // glyph would clear the selection it is trying to act on.
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    // The chord name renders as a direct Text-node child of `.chord`.
+    const chordSpan = container.querySelector('.chord--selected') as HTMLElement;
+    const textNode = Array.from(chordSpan.childNodes).find(
+      (n) => n.nodeType === Node.TEXT_NODE,
+    );
+    expect(textNode).toBeDefined();
+    fireEvent.pointerDown(textNode as Node);
+    // Selection survives — the press resolved to the `.chord` element.
+    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+  });
+
   test('chords stay inert when onChordReposition is not provided', async () => {
     const { container } = render(
       <ChordSheet source="[Am]hi" astWasmLoader={makeAstLoader(chordStub())} />,

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -6,9 +6,12 @@ import {
   TRANSPOSE_MAX,
   TRANSPOSE_MIN,
   applyChordReposition,
+  findChordByOffsetOrdinal,
   lyricsOffsetToSourceColumn,
+  nudgeChordPosition,
   readCapo,
   setCapoInSource,
+  sourceColumnToLyricsOffset,
 } from '../src/chord-source-edit';
 
 describe('lyricsOffsetToSourceColumn', () => {
@@ -333,5 +336,167 @@ describe('setCapoInSource', () => {
     for (const value of [0, 1, 5, 7, 12]) {
       expect(readCapo(setCapoInSource(source, value))).toBe(value);
     }
+  });
+});
+
+describe('sourceColumnToLyricsOffset', () => {
+  test('chord-less line: column === lyrics offset', () => {
+    expect(sourceColumnToLyricsOffset('Hello world', 0)).toBe(0);
+    expect(sourceColumnToLyricsOffset('Hello world', 3)).toBe(3);
+    expect(sourceColumnToLyricsOffset('Hello world', 11)).toBe(11);
+  });
+
+  test('clamps out-of-range columns', () => {
+    expect(sourceColumnToLyricsOffset('hi', 99)).toBe(2);
+    expect(sourceColumnToLyricsOffset('hi', -5)).toBe(0);
+  });
+
+  test('chord bracket is zero-width to the lyrics offset', () => {
+    // `[Am]Hello` — a column at the chord's `[` (col 0) precedes no
+    // lyric, so offset 0.
+    expect(sourceColumnToLyricsOffset('[Am]Hello', 0)).toBe(0);
+    // Column 4 is the start of "Hello", still 0 lyrics consumed.
+    expect(sourceColumnToLyricsOffset('[Am]Hello', 4)).toBe(0);
+    // Column 7 is between "Hel" and "lo" → 3 lyric chars before it.
+    expect(sourceColumnToLyricsOffset('[Am]Hello', 7)).toBe(3);
+  });
+
+  test('is the inverse of lyricsOffsetToSourceColumn for in-range offsets', () => {
+    const line = '[Am]Hel[G]lo world';
+    for (let offset = 0; offset <= 11; offset++) {
+      const col = lyricsOffsetToSourceColumn(line, offset);
+      // Round-trips back to the same offset (brackets are skipped on
+      // the way out, so the column lands at a lyric boundary).
+      expect(sourceColumnToLyricsOffset(line, col)).toBe(offset);
+    }
+  });
+
+  test('malformed (unterminated) bracket counts as lyrics within range', () => {
+    // No closing `]` before the column → characters count as lyrics
+    // rather than throwing.
+    expect(sourceColumnToLyricsOffset('[Am Hello', 5)).toBe(5);
+  });
+});
+
+describe('nudgeChordPosition', () => {
+  test('moves right one lyric character', () => {
+    expect(nudgeChordPosition(0, [], 5, 1)).toEqual({ offset: 1, ordinal: 0 });
+  });
+
+  test('moves left one lyric character', () => {
+    expect(nudgeChordPosition(3, [], 5, -1)).toEqual({ offset: 2, ordinal: 0 });
+  });
+
+  test('returns null at the left edge (cannot move before offset 0)', () => {
+    expect(nudgeChordPosition(0, [], 5, -1)).toBeNull();
+  });
+
+  test('returns null at the right edge (cannot move past line end)', () => {
+    // A trailing chord legitimately sits at offset === totalLyrics,
+    // so moving right from there is out of bounds.
+    expect(nudgeChordPosition(5, [], 5, 1)).toBeNull();
+  });
+
+  test('allows landing exactly on the line-end offset', () => {
+    expect(nudgeChordPosition(4, [], 5, 1)).toEqual({ offset: 5, ordinal: 0 });
+  });
+
+  test('destination ordinal counts chords already at the destination offset', () => {
+    // Two other chords sit at offset 2; the moved chord lands AFTER
+    // them (lyricsOffsetToSourceColumn skips leading brackets), so its
+    // ordinal among same-offset chords is 2.
+    expect(nudgeChordPosition(1, [2, 2, 4], 5, 1)).toEqual({ offset: 2, ordinal: 2 });
+  });
+});
+
+describe('findChordByOffsetOrdinal', () => {
+  test('finds the single chord at an offset', () => {
+    expect(findChordByOffsetOrdinal([0, 3, 5], 3, 0)).toBe(1);
+  });
+
+  test('disambiguates stacked chords by ordinal', () => {
+    // Three chords share offset 2 ([A][B][C]word). ordinal picks which.
+    expect(findChordByOffsetOrdinal([2, 2, 2, 5], 2, 0)).toBe(0);
+    expect(findChordByOffsetOrdinal([2, 2, 2, 5], 2, 1)).toBe(1);
+    expect(findChordByOffsetOrdinal([2, 2, 2, 5], 2, 2)).toBe(2);
+  });
+
+  test('returns -1 when the selection no longer resolves', () => {
+    expect(findChordByOffsetOrdinal([0, 3], 3, 1)).toBe(-1);
+    expect(findChordByOffsetOrdinal([0, 3], 9, 0)).toBe(-1);
+  });
+});
+
+describe('nudge integration: nudgeChordPosition + applyChordReposition', () => {
+  // Helper mirroring how the React walker turns a nudge into a
+  // ChordRepositionEvent + applies it to the source. Proves the pure
+  // offset math composes with the source transform end to end.
+  function nudgeSource(
+    source: string,
+    fromLine: number,
+    fromColumn: number,
+    chordName: string,
+    currentOffset: number,
+    otherOffsets: number[],
+    totalLyrics: number,
+    direction: -1 | 1,
+  ): string | null {
+    const dest = nudgeChordPosition(currentOffset, otherOffsets, totalLyrics, direction);
+    if (!dest) return null;
+    const { text } = applyChordReposition(source, {
+      fromLine,
+      fromColumn,
+      fromLength: chordName.length + 2,
+      toLine: fromLine,
+      toLyricsOffset: dest.offset,
+      chord: chordName,
+      copy: false,
+    });
+    return text;
+  }
+
+  test('nudging a leading chord right moves it one character into the lyric', () => {
+    // `[Am]Hello`: Am at column 0, offset 0, line has 5 lyric chars.
+    expect(nudgeSource('[Am]Hello', 1, 0, 'Am', 0, [], 5, 1)).toBe('H[Am]ello');
+  });
+
+  test('nudging a mid-lyric chord left moves it one character back', () => {
+    // `H[Am]ello`: Am at column 1, offset 1.
+    expect(nudgeSource('H[Am]ello', 1, 1, 'Am', 1, [], 5, -1)).toBe('[Am]Hello');
+  });
+
+  test('nudging right onto an occupied offset lands after the existing chord', () => {
+    // `[A]H[B]ello`: move A (col 0, offset 0) right to offset 1, where
+    // B already sits. A re-inserts after B → `[B]` then `[A]` at the
+    // same lyric position is NOT the case here (different offsets);
+    // verify the source transform: removing [A] gives `H[B]ello`,
+    // inserting [A] at offset 1 lands after [B].
+    expect(nudgeSource('[A]H[B]ello', 1, 0, 'A', 0, [1], 5, 1)).toBe('H[B][A]ello');
+  });
+
+  test('repeated right nudges walk the chord across the lyric', () => {
+    let src = '[Am]Hello';
+    let offset = 0;
+    let col = 0;
+    for (let step = 1; step <= 3; step++) {
+      const dest = nudgeChordPosition(offset, [], 5, 1);
+      expect(dest).not.toBeNull();
+      const { text } = applyChordReposition(src, {
+        fromLine: 1,
+        fromColumn: col,
+        fromLength: 4,
+        toLine: 1,
+        toLyricsOffset: dest!.offset,
+        chord: 'Am',
+        copy: false,
+      });
+      src = text;
+      offset = dest!.offset;
+      // After re-insertion the new column is offset + (chars consumed
+      // by lyrics before it); recompute via the helper.
+      col = lyricsOffsetToSourceColumn(src.replace('[Am]', ''), offset);
+    }
+    // Am started before "H", three right steps → before the second "l".
+    expect(src).toBe('Hel[Am]lo');
   });
 });

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -1,8 +1,11 @@
 import { fireEvent, render } from '@testing-library/react';
+import { useState } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { renderChordproAst } from '../src/chordpro-jsx';
+import type { ChordSelection } from '../src/chordpro-jsx';
 import type { ChordproSong } from '../src/chordpro-ast';
+import type { ChordRepositionEvent } from '../src/chord-source-edit';
 
 // Empty metadata helper — every metadata field has to be present
 // to satisfy the strict ChordproMetadata shape, even on tests that
@@ -3756,6 +3759,232 @@ describe('renderChordproAst', () => {
     }
   });
 });
+describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
+  // Harness that owns the selection state the way <ChordSheet>
+  // does, so clicking / keying a chord re-renders with the updated
+  // selection and the nudge controls appear. The AST is fixed
+  // (onReposition is a spy; we assert the emitted event rather than
+  // re-parsing a mutated source), which is enough to cover the UI
+  // wiring and event contract — the source transform itself is
+  // covered by the chord-source-edit unit tests.
+  function Harness({
+    ast,
+    onReposition,
+  }: {
+    ast: ChordproSong;
+    onReposition: (event: ChordRepositionEvent) => void;
+  }): JSX.Element {
+    const [selected, setSelected] = useState<ChordSelection | null>(null);
+    return (
+      <>
+        {renderChordproAst(ast, {
+          onChordReposition: onReposition,
+          chordSelection: selected,
+          setChordSelection: setSelected,
+        })}
+      </>
+    );
+  }
+
+  // `[Am]Hello [G]World` — Am at offset 0, G at offset 6, 11 lyric
+  // chars total.
+  function twoChordAst(): ChordproSong {
+    return {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'lyrics',
+          value: {
+            segments: [
+              { chord: { name: 'Am', detail: null, display: null }, text: 'Hello ', spans: [] },
+              { chord: { name: 'G', detail: null, display: null }, text: 'World', spans: [] },
+            ],
+          },
+        },
+      ],
+    };
+  }
+
+  test('no nudge controls until a chord is clicked', () => {
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
+    expect(container.querySelector('.chord-nudge')).toBeNull();
+    // Chords are toggle buttons when the feature is fully wired.
+    const chord = container.querySelector('.chord') as HTMLElement;
+    expect(chord.getAttribute('role')).toBe('button');
+    expect(chord.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('clicking a chord selects it and reveals two nudge buttons', () => {
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
+    const chord = container.querySelector('.chord') as HTMLElement;
+    fireEvent.click(chord);
+    const nudge = container.querySelector('.chord-nudge');
+    expect(nudge).not.toBeNull();
+    expect(nudge?.querySelectorAll('button').length).toBe(2);
+    // The selected chord reflects aria-pressed.
+    const selectedChord = container.querySelector('.chord--selected') as HTMLElement;
+    expect(selectedChord.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('right button emits a reposition event moving the chord one lyric char', () => {
+    const onReposition = vi.fn();
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={onReposition} />);
+    // Select Am (offset 0).
+    fireEvent.click(container.querySelector('.chord') as HTMLElement);
+    const right = container.querySelector('.chord-nudge__btn--right') as HTMLElement;
+    fireEvent.click(right);
+    expect(onReposition).toHaveBeenCalledTimes(1);
+    expect(onReposition.mock.calls[0][0]).toMatchObject({
+      fromLine: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      toLine: 1,
+      toLyricsOffset: 1,
+      chord: 'Am',
+      copy: false,
+    });
+  });
+
+  test('left button is disabled for a chord at the line start', () => {
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
+    fireEvent.click(container.querySelector('.chord') as HTMLElement);
+    const left = container.querySelector('.chord-nudge__btn--left') as HTMLButtonElement;
+    const right = container.querySelector('.chord-nudge__btn--right') as HTMLButtonElement;
+    expect(left.disabled).toBe(true);
+    expect(right.disabled).toBe(false);
+  });
+
+  test('right button is disabled for a trailing chord at the line end', () => {
+    // `Hi[Am]` — Am at offset 2 === totalLyrics, so it cannot move right.
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'lyrics',
+          value: {
+            segments: [
+              { chord: null, text: 'Hi', spans: [] },
+              { chord: { name: 'Am', detail: null, display: null }, text: '', spans: [] },
+            ],
+          },
+        },
+      ],
+    };
+    const { container } = render(<Harness ast={ast} onReposition={vi.fn()} />);
+    // The real chord is the second .chord span (first is the trailing
+    // segment's — actually the chord-less leading segment has no chord
+    // span on a chord-bearing line unless lineHasChords; click the
+    // role=button chord).
+    const chordButton = container.querySelector(".chord[role='button']") as HTMLElement;
+    fireEvent.click(chordButton);
+    const left = container.querySelector('.chord-nudge__btn--left') as HTMLButtonElement;
+    const right = container.querySelector('.chord-nudge__btn--right') as HTMLButtonElement;
+    expect(right.disabled).toBe(true);
+    expect(left.disabled).toBe(false);
+  });
+
+  test('ArrowRight on the selected chord emits a reposition event', () => {
+    const onReposition = vi.fn();
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={onReposition} />);
+    const chord = container.querySelector('.chord') as HTMLElement;
+    fireEvent.click(chord);
+    const selectedChord = container.querySelector('.chord--selected') as HTMLElement;
+    fireEvent.keyDown(selectedChord, { key: 'ArrowRight' });
+    expect(onReposition).toHaveBeenCalledTimes(1);
+    expect(onReposition.mock.calls[0][0]).toMatchObject({
+      toLyricsOffset: 1,
+      chord: 'Am',
+    });
+  });
+
+  test('Enter selects a chord via the keyboard', () => {
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
+    const chord = container.querySelector('.chord') as HTMLElement;
+    fireEvent.keyDown(chord, { key: 'Enter' });
+    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+  });
+
+  test('Escape clears the selection', () => {
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
+    fireEvent.click(container.querySelector('.chord') as HTMLElement);
+    const selectedChord = container.querySelector('.chord--selected') as HTMLElement;
+    fireEvent.keyDown(selectedChord, { key: 'Escape' });
+    expect(container.querySelector('.chord-nudge')).toBeNull();
+  });
+
+  test('clicking the selected chord again toggles the selection off', () => {
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
+    const chord = container.querySelector('.chord') as HTMLElement;
+    fireEvent.click(chord);
+    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    // Click the (now selected) chord again.
+    fireEvent.click(container.querySelector('.chord--selected') as HTMLElement);
+    expect(container.querySelector('.chord-nudge')).toBeNull();
+  });
+
+  test('nudge advances the selection (does not clear it) and bumps the nonce', () => {
+    // Controlled render: a fixed selection + spy setter so we can
+    // assert exactly what the nudge writes back — proving the button
+    // moves the selection forward rather than the chord toggle
+    // clearing it. (The stateful Harness can't show this because its
+    // AST is not re-parsed, so the moved-to offset resolves to no
+    // chord and the controls naturally disappear.)
+    const onReposition = vi.fn();
+    const setChordSelection = vi.fn();
+    const { container } = render(
+      renderChordproAst(twoChordAst(), {
+        onChordReposition: onReposition,
+        chordSelection: { line: 1, offset: 0, ordinal: 0, nonce: 3 },
+        setChordSelection,
+      }),
+    );
+    const right = container.querySelector('.chord-nudge__btn--right') as HTMLElement;
+    fireEvent.click(right);
+    expect(onReposition).toHaveBeenCalledTimes(1);
+    expect(setChordSelection).toHaveBeenCalledTimes(1);
+    // Non-null move to offset 1, nonce advanced — NOT a deselect.
+    expect(setChordSelection.mock.calls[0][0]).toEqual({
+      line: 1,
+      offset: 1,
+      ordinal: 0,
+      nonce: 4,
+    });
+  });
+
+  test('clicking a chord writes the selection with an advanced nonce', () => {
+    // Controlled render proving the toggle's write shape: selecting G
+    // (offset 6) from a clean state.
+    const setChordSelection = vi.fn();
+    const { container } = render(
+      renderChordproAst(twoChordAst(), {
+        onChordReposition: vi.fn(),
+        chordSelection: null,
+        setChordSelection,
+      }),
+    );
+    const chords = container.querySelectorAll(".chord[role='button']");
+    fireEvent.click(chords[1] as HTMLElement); // G
+    expect(setChordSelection).toHaveBeenCalledWith({
+      line: 1,
+      offset: 6,
+      ordinal: 0,
+      nonce: 1,
+    });
+  });
+
+  test('without setChordSelection, chords are not toggle buttons (drag-only)', () => {
+    const { container } = render(
+      renderChordproAst(twoChordAst(), { onChordReposition: vi.fn() }),
+    );
+    const chord = container.querySelector('.chord') as HTMLElement;
+    // Drag still wired…
+    expect(chord.getAttribute('draggable')).toBe('true');
+    // …but no click-to-nudge toggle semantics.
+    expect(chord.getAttribute('role')).toBeNull();
+    expect(container.querySelector('.chord-nudge')).toBeNull();
+  });
+});
+
 describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
   // A song with N `{diagrams: …}` directive lines + one chord-bearing
   // lyric line. The `<ChordDiagram>` mounted by inline / hover lazily

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3897,6 +3897,33 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     });
   });
 
+  test('reselecting a chord after deselect restores DOM focus (nonce reset)', () => {
+    // jsdom's fireEvent.click does NOT natively focus the element, so
+    // any DOM focus the chord span gains here came from the
+    // programmatic auto-focus effect. This guards the nonce-reset fix:
+    // after a full deselect the per-selection nonce restarts at 1, and
+    // without resetting the handled-nonce the reselect would match the
+    // stale handled value and skip the refocus. To isolate the
+    // programmatic refocus we explicitly drop DOM focus between the
+    // deselect and the reselect (simulating focus moving elsewhere),
+    // since the chord's DOM node otherwise survives the deselect and
+    // keeps focus on its own.
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
+    const chord = () => container.querySelector(".chord[role='button']") as HTMLElement;
+    fireEvent.click(chord());
+    const selected = container.querySelector('.chord--selected') as HTMLElement;
+    expect(document.activeElement).toBe(selected);
+    // Deselect via Escape, then move DOM focus away.
+    fireEvent.keyDown(selected, { key: 'Escape' });
+    expect(container.querySelector('.chord-nudge')).toBeNull();
+    (document.activeElement as HTMLElement | null)?.blur();
+    expect(document.activeElement).not.toBe(chord());
+    // Reselect the same chord — the effect must refocus it despite the
+    // per-selection nonce restarting at 1.
+    fireEvent.click(chord());
+    expect(document.activeElement).toBe(container.querySelector('.chord--selected'));
+  });
+
   test('Enter selects a chord via the keyboard', () => {
     const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
     const chord = container.querySelector('.chord') as HTMLElement;


### PR DESCRIPTION
## What

Extends the React chord drag-to-reposition feature so a chord can also be moved **one lyric character at a time** without a precise drag gesture — the touch-friendly complement to drag-and-drop.

- Clicking (tapping) a `.chord` (when `onChordReposition` is wired) selects it — the chord becomes a `role="button"` toggle with `aria-pressed` — and reveals ◀ / ▶ nudge controls. Each press moves the chord one lyric character.
- `ArrowLeft` / `ArrowRight` move the focused chord; `Enter` / `Space` select; `Escape` and pressing down outside the chord clear the selection; clicking the selected chord again toggles it off.
- The selection follows the chord across nudges (it is re-located by its `(offset, ordinal)` identity on every re-render, since the chord's segment index is not stable after a move), so repeated taps keep working. DOM focus is driven programmatically from a selection nonce so it survives the nudge re-render while an incidental re-render (typing elsewhere) never steals focus into the preview.
- Out-of-range directions disable the corresponding button (a chord at line start can't go left; at line end can't go right).

## Why

On touch devices a fine-grained drag is hard. Buttons + arrow keys let the user fine-tune chord placement one step at a time. Closes #2614.

## Design

- The gesture reuses the existing `ChordRepositionEvent` → `applyChordReposition` pipeline, so every consumer already wiring `onChordReposition` (playground split view, etc.) gets the feature with **no new public prop**. `<ChordSheet>` owns the selection `useState` internally and clears it via a scoped outside-pointerdown listener.
- Pure offset math lives in `chord-source-edit.ts` (DOM-free, unit-tested): `sourceColumnToLyricsOffset` (inverse of `lyricsOffsetToSourceColumn`), `nudgeChordPosition` (destination offset + disambiguation ordinal), `findChordByOffsetOrdinal` (re-locate the selection after a nudge). New exports are added to the package index + README API table.
- The nudge controls render as a sibling of the chord span inside `.chord-block` (not a child of the `role="button"` span, which must not contain interactive descendants) and are positioned by CSS above the chord.

## Test results

- `npm test` (vitest): **695 passed** (was 662; +33 new across `chord-source-edit.test.ts`, `chordpro-jsx.test.tsx`, `chord-sheet.test.tsx`).
- `npm run typecheck` (tsc --noEmit): clean.
- `npm run build` (tsup ESM + CJS + d.ts): success.

## Review summary

- Sister-site audit: the chord-reposition interaction exists **only** in the React JSX walker; the Rust text/HTML/PDF renderers are static output with no interaction surface, so there is no sister site to propagate to. Documented in code.
- Accessibility: chords are focusable toggle buttons with `aria-pressed`; nudge controls are real `<button>`s with `aria-label`s and a `role="group"` wrapper.

## Deferred

- Inline / hover chord-diagram mode (`{diagrams: inline|hover}`) keeps **drag-only** — the diagram (inline replacement / hover popover) claims the chord cell, so a nudge toolbar there would collide. This is a deliberate interaction limitation (documented in `chordpro-jsx.tsx`), not a renderer-parity gap: the nudge UI is React-only and has no Rust-renderer sibling.

Closes #2614

https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6)_