### PR TITLE
Flash the metronome beat dot at the center crossing, not the extremes

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1258,7 +1258,7 @@ h2 { font-family: \"Noto Sans JP\", system-ui, -apple-system, sans-serif; font-w
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: __LINE_FLEX_WRAP__; margin: 0.1em 0; }
@@ -4556,15 +4556,23 @@ Verse text\n\
         );
         // Phase-sync invariant: the beat blink MUST be driven by the
         // same `--cs-metronome-period` custom property as the swing,
-        // so the flash peak coincides with the rod reaching an
-        // extreme on every beat. A regression that hardcodes the
-        // beat's animation duration would silently desync the flash
-        // from the tick without tripping the presence checks above.
+        // so the flash stays locked to the swing on every beat. A
+        // regression that hardcodes the beat's animation duration
+        // would silently desync the flash without tripping the
+        // presence checks above.
         assert!(
             html.contains(
                 ".music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period"
             ),
             "beat blink must reuse --cs-metronome-period for phase sync; got: {html}"
+        );
+        // Center-crossing phase: a `-period/2` animation-delay shifts
+        // the flash peak from the rod's extremes to its center
+        // crossing. A regression that drops the delay would move the
+        // flash back to the extremes.
+        assert!(
+            html.contains("animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5)"),
+            "beat flash must be phase-shifted to the center crossing; got: {html}"
         );
     }
 

--- a/crates/render-html/src/music_glyphs.rs
+++ b/crates/render-html/src/music_glyphs.rs
@@ -362,10 +362,11 @@ fn write_flat(s: &mut String, cx: f32, cy: f32) {
 /// A static beat dot sits in the top-left corner *inside* the
 /// existing viewBox (so the icon height is unchanged) and pulses
 /// flash-then-decay once per beat. Its blink shares the same
-/// `--cs-metronome-period` as the swing, so the dot is at full
-/// brightness exactly when the rod reaches an extreme (the
-/// audible tick). The dot is a sibling of the pendulum group, so
-/// it does NOT swing — only its opacity animates.
+/// `--cs-metronome-period` as the swing, and a `-period/2`
+/// `animation-delay` phase-shifts the flash so the dot is at full
+/// brightness when the rod passes through the center (vertical),
+/// not at the extremes. The dot is a sibling of the pendulum
+/// group, so it does NOT swing — only its opacity animates.
 #[must_use]
 pub fn metronome_svg(bpm_raw: &str) -> String {
     let bpm: f32 = bpm_raw.trim().parse::<f32>().unwrap_or(60.0);

--- a/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
+++ b/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
+++ b/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/chord-alignment/expected.html
+++ b/crates/render-html/tests/fixtures/chord-alignment/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
+++ b/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/comments/expected.html
+++ b/crates/render-html/tests/fixtures/comments/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
+++ b/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/directives-and-sections/expected.html
+++ b/crates/render-html/tests/fixtures/directives-and-sections/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/empty-lines/expected.html
+++ b/crates/render-html/tests/fixtures/empty-lines/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/full-song/expected.html
+++ b/crates/render-html/tests/fixtures/full-song/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
+++ b/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/image-directive/expected.html
+++ b/crates/render-html/tests/fixtures/image-directive/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/metadata-header/expected.html
+++ b/crates/render-html/tests/fixtures/metadata-header/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/minimal-song/expected.html
+++ b/crates/render-html/tests/fixtures/minimal-song/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/page-control-directives/expected.html
+++ b/crates/render-html/tests/fixtures/page-control-directives/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/svg-section/expected.html
+++ b/crates/render-html/tests/fixtures/svg-section/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
+++ b/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/text-before-chord/expected.html
+++ b/crates/render-html/tests/fixtures/text-before-chord/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
@@ -28,7 +28,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
 @keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }

--- a/packages/react/src/music-glyphs.tsx
+++ b/packages/react/src/music-glyphs.tsx
@@ -664,10 +664,12 @@ export function metronomePeriodCss(bpm: number): string {
  * A static beat dot sits in the top-left corner *inside* the
  * existing viewBox (so the icon height is unchanged) and pulses
  * flash-then-decay once per beat. Its blink shares the same
- * `--cs-metronome-period` as the swing, so the dot is at full
- * brightness exactly when the rod reaches an extreme (the
- * audible tick). The dot is a sibling of the pendulum group, so
- * it does NOT swing — only its opacity animates.
+ * `--cs-metronome-period` as the swing, and a `-period/2`
+ * `animation-delay` (applied in the stylesheet) phase-shifts the
+ * flash so the dot is at full brightness when the rod passes
+ * through the center (vertical), not at the extremes. The dot is
+ * a sibling of the pendulum group, so it does NOT swing — only
+ * its opacity animates.
  *
  * The animation is gated on
  * `@media (prefers-reduced-motion: reduce)` so users who opt out

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -685,13 +685,16 @@
 
 /* Beat dot — a static LED in the top-left corner that flashes
    once per beat. It shares `--cs-metronome-period` with the
-   swing, so it reaches full brightness exactly when the rod
-   hits an extreme (the audible tick), then decays before the
-   next beat. `ease-out` shapes the decay; the keyframe holds a
-   brief peak (0–8%) for a crisp "pop". Non-`alternate` so each
-   beat re-triggers the flash from full brightness. */
+   swing, and a `-period/2` `animation-delay` phase-shifts the
+   flash so it reaches full brightness when the rod passes
+   through the center (vertical), not at the extremes, then
+   decays before the next beat. `ease-out` shapes the decay; the
+   keyframe holds a brief peak (0–8%) for a crisp "pop".
+   Non-`alternate` so each beat re-triggers the flash from full
+   brightness. */
 .chordsketch-sheet__content .music-glyph--metronome__beat {
   animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite;
+  animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5);
 }
 @keyframes cs-metronome-beat {
   0% {

--- a/packages/react/tests/music-glyphs.test.tsx
+++ b/packages/react/tests/music-glyphs.test.tsx
@@ -296,19 +296,24 @@ describe('<MetronomeGlyph>', () => {
 
   // Phase-sync invariant (sister-site to the render-html assertion
   // in `crates/render-html/src/lib.rs`): the beat blink and the
-  // pendulum swing MUST both be driven by `--cs-metronome-period`.
-  // That shared property is what guarantees the flash peaks exactly
-  // when the rod reaches an extreme (the tick). The blink lives in
+  // pendulum swing MUST both be driven by `--cs-metronome-period`,
+  // and a `-period/2` animation-delay phase-shifts the flash to the
+  // rod's center crossing (not its extremes). The blink lives in
   // styles.css (not inline), so assert it against the stylesheet
   // source rather than the rendered DOM. A regression that gives the
-  // beat a hardcoded duration would desync the flash from the tick
-  // without failing the DOM-level tests above.
+  // beat a hardcoded duration would desync the flash from the swing,
+  // and one that drops the delay would move the flash back to the
+  // extremes — neither would fail the DOM-level tests above.
   test('beat blink and swing share --cs-metronome-period in styles.css', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8');
     expect(css).toContain('@keyframes cs-metronome-beat');
     expect(css).toMatch(
       /\.music-glyph--metronome__beat\s*\{\s*animation:\s*cs-metronome-beat var\(--cs-metronome-period/,
+    );
+    // The `-period/2` delay that puts the flash on the center crossing.
+    expect(css).toMatch(
+      /\.music-glyph--metronome__beat\s*\{[^}]*animation-delay:\s*calc\(var\(--cs-metronome-period, 1s\) \* -0\.5\)/,
     );
     expect(css).toMatch(
       /\.music-glyph--metronome__pendulum\s*\{[^}]*animation:\s*cs-metronome-swing var\(--cs-metronome-period/,


### PR DESCRIPTION
## What

Phase-shifts the BPM-synced metronome beat dot (from #2613) so its flash
peaks when the pendulum **passes through the center** (vertical) rather
than when it reaches the **extremes**.

A `-period/2` `animation-delay` on `.music-glyph--metronome__beat` moves
the existing flash→decay keyframe by half a beat. The keyframe shape and
the beat rate (one flash per `period`) are unchanged — only the phase
moves. The delay reuses the same `--cs-metronome-period` custom property
the swing and the blink already share, so the timing still has a single
source of truth.

## Why

Design preference: the flash reads more naturally when it lands on the
rod's center crossing than on the turn-arounds at the extremes.

## Test results

- `cargo test -p chordsketch-render-html`: pass (incl. the extended
  `test_inline_meta_marker_for_tempo` asserting the `-period/2` delay).
- `cargo clippy -p chordsketch-render-html`: clean. `cargo fmt --check`:
  clean.
- `@chordsketch/react` `npx vitest run tests/music-glyphs.test.tsx`: 65
  pass (incl. the styles.css delay assertion); `npm run typecheck`: clean.
- Golden fixtures regenerated via `UPDATE_GOLDEN=1`.

## Sister-site audit

Per `.claude/rules/renderer-parity.md`, the beat dot renders on the two
glyph surfaces, both updated identically:

- `crates/render-html/src/lib.rs` embedded stylesheet.
- `packages/react/src/styles.css`.

render-text / render-pdf render a textual tempo label, not the glyph, so
they remain out of scope. Reduced-motion path unchanged (static visible
dot; `animation: none` resets the delay).

## Review summary

Self-reviewed for renderer parity, phase correctness (`-period/2` aligns
the keyframe peak with the symmetric swing's center crossing), and
reduced-motion handling. No new dependencies.

Closes #2620

---
_Generated by [Claude Code](https://claude.ai/code/session_019LcEC9A9bQHp2rWuyS13Hr)_