### PR TITLE
Align inline metadata chip heights by pinning box-sizing

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1245,7 +1245,7 @@ h2 { font-family: \"Noto Sans JP\", system-ui, -apple-system, sans-serif; font-w
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: \"JetBrains Mono\", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: \"tnum\" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: \"JetBrains Mono\", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: \"tnum\" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: \"JetBrains Mono\", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: \"tnum\" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }
@@ -4607,6 +4607,42 @@ Verse text\n\
         assert!(
             !html.contains("<span class=\"meta-inline__value\">6/8</span>"),
             "redundant text value should not be emitted alongside the icon; got: {html}"
+        );
+    }
+
+    /// The inline `.meta-inline` chip must pin its box model
+    /// explicitly so the three directive variants line up at the
+    /// same height. On the React surface the `{tempo}` chip is a
+    /// `<button>` (UA default `border-box`) while `{key}` / `{time}`
+    /// are `<span>` (`content-box`); without an explicit
+    /// `box-sizing`, `min-height` + the 1px border made the button
+    /// ~2px shorter, so the pills misaligned (#2624). This renderer
+    /// only emits spans, but its embedded `.meta-inline` rule is the
+    /// sister-site to the React stylesheet (`renderer-parity.md`) and
+    /// must carry the same declaration so the two HTML surfaces stay
+    /// in lockstep.
+    #[test]
+    fn test_meta_inline_chip_pins_box_sizing() {
+        let html = render("{key: D}\n[D]hi");
+        assert!(
+            html.contains(".meta-inline { display: inline-flex;"),
+            "expected the embedded .meta-inline rule; got: {html}"
+        );
+        // The declaration must sit inside the `.meta-inline` rule
+        // block (before its closing brace), not merely anywhere in
+        // the document.
+        let rule_start = html
+            .find(".meta-inline { display: inline-flex;")
+            .expect("meta-inline rule present");
+        let rule_end = html[rule_start..]
+            .find('}')
+            .map(|offset| rule_start + offset)
+            .expect("meta-inline rule is brace-terminated");
+        assert!(
+            html[rule_start..rule_end].contains("box-sizing: border-box;"),
+            "the .meta-inline rule must pin box-sizing: border-box so the span and button \
+             chip variants compute the same height; got: {}",
+            &html[rule_start..rule_end]
         );
     }
 

--- a/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
+++ b/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
+++ b/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/chord-alignment/expected.html
+++ b/crates/render-html/tests/fixtures/chord-alignment/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
+++ b/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/comments/expected.html
+++ b/crates/render-html/tests/fixtures/comments/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
+++ b/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/directives-and-sections/expected.html
+++ b/crates/render-html/tests/fixtures/directives-and-sections/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/empty-lines/expected.html
+++ b/crates/render-html/tests/fixtures/empty-lines/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/full-song/expected.html
+++ b/crates/render-html/tests/fixtures/full-song/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
+++ b/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/image-directive/expected.html
+++ b/crates/render-html/tests/fixtures/image-directive/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/metadata-header/expected.html
+++ b/crates/render-html/tests/fixtures/metadata-header/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/minimal-song/expected.html
+++ b/crates/render-html/tests/fixtures/minimal-song/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/page-control-directives/expected.html
+++ b/crates/render-html/tests/fixtures/page-control-directives/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/svg-section/expected.html
+++ b/crates/render-html/tests/fixtures/svg-section/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
+++ b/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/text-before-chord/expected.html
+++ b/crates/render-html/tests/fixtures/text-before-chord/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
@@ -15,7 +15,7 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .meta--params { display: flex; flex-wrap: wrap; gap: 0.4em; margin: 0.2em 0 0.8em; }
 .meta__chip { display: inline-block; padding: 0.15em 0.6em; border: 1px solid #D4D1D6; border-radius: 4px; background-color: #FAFAFA; color: #2A262E; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; font-feature-settings: "tnum" 1; }
 .meta--supplementary { font-size: 0.75rem; color: #A8A4AD; margin-bottom: 0.4em; }
-.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
+.meta-inline { display: inline-flex; align-items: center; gap: 0.25rem; margin: 0.15em 0.3em 0.15em 0; padding: 0 0.5rem; box-sizing: border-box; min-height: 1.6rem; border-radius: 2px; background-color: #F6F4F7; border: 1px solid #E8E6EA; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.75rem; color: #44424A; line-height: 1.2; letter-spacing: 0.02em; font-feature-settings: "tnum" 1; vertical-align: middle; }
 .meta-inline__label { color: #8A8790; font-weight: 500; }
 .meta-inline__value { color: #0A0A0B; font-weight: 600; }
 .meta-inline__marking { color: #8A8790; font-weight: 400; font-style: italic; }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -520,6 +520,18 @@
   gap: var(--cs-sp-1, 0.25rem);
   margin: 0.15em 0.3em 0.15em 0;
   padding: 0 var(--cs-sp-2, 0.5rem);
+  /* Declare the box model explicitly so the chip's resolved height
+     does not depend on the element type the walker emits. The
+     `{tempo}` chip is a `<button>` (`<MetronomeButton>`), whose UA
+     default is `border-box`, while the `{key}` / `{time}` chips are
+     `<span>` (`content-box`). Without this line, `min-height: 1.6rem`
+     + the 1px border made the button ~2px shorter than the spans, so
+     the pills differed in height and their `vertical-align: middle`
+     midpoints did not align. `border-box` makes `min-height` include
+     the border for every variant, so all three chips are exactly
+     1.6rem tall. Kept in lockstep with the Rust HTML renderer's
+     embedded `.meta-inline` rule (`crates/render-html/src/lib.rs`). */
+  box-sizing: border-box;
   min-height: 1.6rem;
   border-radius: var(--cs-r-1, 2px);
   background-color: var(--cs-ink-100, #f6f4f7);

--- a/packages/react/tests/metronome-button.test.tsx
+++ b/packages/react/tests/metronome-button.test.tsx
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -151,5 +155,33 @@ describe('<MetronomeButton>', () => {
     const glyph = chip.querySelector('.music-glyph--metronome');
     expect(glyph?.getAttribute('aria-hidden')).toBe('true');
     expect(glyph?.getAttribute('role')).toBeNull();
+  });
+
+  // The interactive tempo chip is a `<button>` while the `{key}` /
+  // `{time}` chips (and this chip's own non-interactive fallback) are
+  // `<span>`. A `<button>` defaults to `box-sizing: border-box` and a
+  // `<span>` to `content-box`, so without an explicit declaration on
+  // `.meta-inline` the `min-height: 1.6rem` + 1px border made the
+  // button ~2px shorter than the spans, misaligning the pills (#2624).
+  // The fix pins `box-sizing: border-box` on `.meta-inline` itself so
+  // every variant computes the same height regardless of element type.
+  // Assert it against the stylesheet source — the height delta is a
+  // layout property jsdom does not compute, so the DOM-level tests
+  // above cannot catch a regression here.
+  test('`.meta-inline` pins box-sizing so span and button chips share a height (#2624)', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // Strip CSS comments first — the explanatory comment inside the
+    // rule mentions `{key}` / `{tempo}` / `{time}`, whose braces would
+    // otherwise terminate the `[^}]` rule-block match prematurely.
+    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8').replace(
+      /\/\*[\s\S]*?\*\//g,
+      '',
+    );
+    // The base `.meta-inline` rule (not a `--variant` modifier) must
+    // carry `box-sizing: border-box`. Match the rule block and assert
+    // the declaration lives inside it.
+    const rule = css.match(/\.chordsketch-sheet__content \.meta-inline \{[^}]*\}/);
+    expect(rule).not.toBeNull();
+    expect(rule?.[0]).toContain('box-sizing: border-box;');
   });
 });


### PR DESCRIPTION
## What

Pin `box-sizing: border-box` on the inline `.meta-inline` metadata chip rule so the `{key}`, `{tempo}`, and `{time}` chips line up at the same height in the React `<ChordSheet format="html">` preview. The declaration is added to both HTML surfaces:

- `packages/react/src/styles.css` (React JSX walker surface)
- `crates/render-html/src/lib.rs` embedded stylesheet (Rust HTML renderer surface)

Golden HTML snapshots are regenerated for the embedded-stylesheet change, and regression tests are added on both surfaces.

## Why

The `{tempo}` chip renders as a `<button>` (`<MetronomeButton>`), whose UA-default `box-sizing` is `border-box`, while the `{key}` / `{time}` chips render as `<span>` (`content-box`). With `min-height: 1.6rem` plus a 1px border, the button resolved ~2px shorter than the spans, so the pills differed in height and their `vertical-align: middle` midpoints fell on different lines.

The root cause is that `.meta-inline` left its box model implicit, so the computed height depended on which element type the walker happened to emit. Pinning `box-sizing: border-box` makes `min-height` border-inclusive for every variant, so all three chips are exactly 1.6rem tall regardless of element type. This is a root-cause fix, not a per-element override.

## Test results

- `cargo test -p chordsketch-render-html` — 286 passed (incl. new `test_meta_inline_chip_pins_box_sizing`); golden suite green after regeneration.
- `cargo fmt --check` / `cargo clippy -p chordsketch-render-html --all-targets` — clean.
- React: `vitest run` for `metronome-button` / `music-glyphs` / `chordpro-jsx` — 208 passed (incl. the new stylesheet box-sizing assertion); `tsc --noEmit` clean.

## Review summary

Reviewed for correctness, security, bugs, and project rules. No findings.

## Sister-site audit

Per `renderer-parity.md` / `fix-propagation.md`: the `.meta-inline` base rule is defined in exactly two places — `crates/render-html/src/lib.rs` (embedded CSS) and `packages/react/src/styles.css` — both updated here. The React JSX walker consumes the shared `styles.css`; the text and PDF renderers emit no HTML/CSS, so they carry no `.meta-inline` rule (out of scope). `packages/react/dist/styles.css` is a gitignored build artifact, regenerated on build. No other surface (VS Code extension, desktop, playground, design-system) duplicates this rule. The `button.meta-inline--interactive` rule does not override `box-sizing`, so the button inherits the new `border-box`.

Closes #2624


---
_Generated by [Claude Code](https://claude.ai/code/session_01JtFhV7MUR279VR2T5gxWSZ)_