### PR TITLE
Add floating chord-editor inspector with solid-badge active state

### DIFF
--- a/packages/playground/src/chordpro/main.tsx
+++ b/packages/playground/src/chordpro/main.tsx
@@ -20,9 +20,13 @@ import {
   RendererPreview,
   ChordSourceArea,
   applyChordReposition,
+  applyChordEdit,
+  applyChordDelete,
   readCapo,
   setCapoInSource,
   type ChordRepositionEvent,
+  type ChordEditEvent,
+  type ChordDeleteTarget,
   type ChordSourceAreaHandle,
   loadChordproCatalog,
   type DirectiveCatalogEntry,
@@ -635,6 +639,35 @@ function PlaygroundApp(): JSX.Element {
     });
   }, []);
 
+  // In-place chord edit (#2622): the left-docked inspector emits a
+  // ChordEditEvent (source coordinates + new chord token); apply it the
+  // same functional-updater way as reposition so concurrent edits read
+  // the latest source, and restore the caret after the new chord.
+  const handleChordEdit = useCallback((event: ChordEditEvent) => {
+    setSource((current) => {
+      try {
+        const { text, caretOffset } = applyChordEdit(current, event);
+        queueMicrotask(() => editorRef.current?.setCaret(caretOffset));
+        return text;
+      } catch {
+        return current;
+      }
+    });
+  }, []);
+
+  // Chord delete (#2622): remove the [chord] token the inspector targets.
+  const handleChordDelete = useCallback((target: ChordDeleteTarget) => {
+    setSource((current) => {
+      try {
+        const { text, caretOffset } = applyChordDelete(current, target);
+        queueMicrotask(() => editorRef.current?.setCaret(caretOffset));
+        return text;
+      } catch {
+        return current;
+      }
+    });
+  }, []);
+
   // Capo source change: use the functional-updater form of `setSource`
   // so rapid consecutive Capo clicks always read the latest state, not
   // the stale `source` prop captured by the render cycle that set up the
@@ -892,6 +925,11 @@ function PlaygroundApp(): JSX.Element {
                 onChordReposition={
                   view === 'split' ? handleChordReposition : undefined
                 }
+                /* Chord editing (#2622): the inspector edits/deletes the
+                   ChordPro source, so — like reposition — gate it on
+                   split view where the editor is mounted and visible. */
+                onChordEdit={view === 'split' ? handleChordEdit : undefined}
+                onChordDelete={view === 'split' ? handleChordDelete : undefined}
               />
             </div>
           </section>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -585,6 +585,12 @@ shorthand (no Unicode translation; the SVG renderer handles that).
 | `sourceColumnToLyricsOffset` | Atom | Function | Source-column → lyrics-offset helper (inverse of the above). |
 | `nudgeChordPosition` | Atom | Function | Destination offset/ordinal for a one-step chord nudge. |
 | `findChordByOffsetOrdinal` | Atom | Function | Re-locate a selected chord by `(offset, ordinal)` after a nudge re-render. |
+| `<ChordInspector>` | Atom | Component | Floating chord-editor panel (root / accidental / type chips / `/bass` / move) `<ChordSheet>` opens on chord select when `onChordEdit` is wired. |
+| `buildChordName` | Atom | Function | Assemble a chord token (`root`+accidental+suffix+`/bass`) for the editor. |
+| `applyChordEdit` | Atom | Function | Apply an in-place `ChordEditEvent` (rewrite a chord token) to the source. |
+| `applyChordDelete` | Atom | Function | Remove a chord token from the source (inspector "Remove chord"). |
+| `chordSuffixFromQuality` | Atom | Function | Reconstruct a chord suffix from parsed quality + extension. |
+| `CHORD_TYPE_PRESETS` | Atom | Const | The chord-type chips (`maj`/`min`/`7`/`maj7`/`m7`/…) the inspector offers. |
 | `useDebounced` | Atom | Hook | General-purpose debouncer used by `<ChordTextarea>`. |
 | `<MetronomeButton>` | Atom | Component | Interactive `{tempo}` chip; the whole pill toggles an audible metronome at the BPM (speaker cursor on hover, frame pulses while playing). |
 | `useMetronome` | Atom | Hook | Web Audio metronome state (`start` / `stop` / `toggle` / `isRunning` / `isPlaying` / `supported`). |

--- a/packages/react/src/chord-inspector.tsx
+++ b/packages/react/src/chord-inspector.tsx
@@ -1,0 +1,237 @@
+// Floating chord-editor inspector for the ChordPro preview (#2622).
+//
+// A left-docked, non-modal panel that appears when a chord is selected
+// in the preview. It edits the selected chord's root, accidental, type
+// (a quality+extension preset or free-form suffix), and optional slash
+// bass, and hosts the relocated ◀ / ▶ "move one lyric character"
+// controls plus delete. It is the ChordPro sibling of the iReal Pro
+// `<IrealBarPopover>` chord-row editor, and like that surface it is
+// purely presentational: the parent owns the chord parts and the source
+// mutation (via `chord-source-edit`'s `buildChordName` / `applyChordEdit`
+// / `applyChordDelete`), so there is no parallel chord state here.
+
+import type { JSX, KeyboardEvent as ReactKeyboardEvent } from 'react';
+
+import {
+  CHORD_TYPE_PRESETS,
+  type ChordParts,
+} from './chord-source-edit';
+
+/** Root letters offered in the segmented control, C-major order. */
+const ROOT_NOTES = ['C', 'D', 'E', 'F', 'G', 'A', 'B'] as const;
+
+/** Accidental options: natural / sharp / flat, mapped to the source
+ * characters {@link ChordParts.accidental} carries. */
+const ACCIDENTALS: ReadonlyArray<{ value: '' | '#' | 'b'; label: string; aria: string }> = [
+  { value: '', label: '♮', aria: 'Natural' },
+  { value: '#', label: '♯', aria: 'Sharp' },
+  { value: 'b', label: '♭', aria: 'Flat' },
+];
+
+/** Props for {@link ChordInspector}. Controlled: the parent supplies the
+ * current parts + bounds and receives every edit through the callbacks. */
+export interface ChordInspectorProps {
+  /** The selected chord's display name for the header, e.g. `"Am7"`. */
+  chordName: string;
+  /** Current root letter `A`–`G`. */
+  root: string;
+  /** Current root accidental. */
+  accidental: '' | '#' | 'b';
+  /** Current quality+extension suffix (e.g. `"m7"`, `""` for major). */
+  suffix: string;
+  /** Current slash-bass token without the leading `/` (e.g. `"G"`), or
+   * empty for no slash. */
+  bass: string;
+  /** Whether the chord can move one lyric character left / right. */
+  canLeft: boolean;
+  canRight: boolean;
+  /** Fired with the full updated parts on any root / accidental / type /
+   * suffix / bass change. The parent rebuilds the chord token and writes
+   * it back to source. */
+  onChange: (parts: ChordParts) => void;
+  /** Fired when a move button is pressed. `-1` = left, `+1` = right. */
+  onNudge: (direction: -1 | 1) => void;
+  /** Remove the chord (delete its `[chord]` token). Omit to hide the
+   * "Remove chord" button (e.g. when no delete handler is wired). */
+  onRemove?: () => void;
+  /** Close the inspector (deselect). */
+  onClose: () => void;
+}
+
+/**
+ * The chord-editor inspector panel. Renders design-system-styled
+ * controls keyed off `.chordsketch-sheet__cins*` classes (see
+ * `styles.css`). Not a modal — the sheet stays interactive while it is
+ * open — so it does not trap focus; Escape closes it.
+ */
+export function ChordInspector(props: ChordInspectorProps): JSX.Element {
+  const { chordName, root, accidental, suffix, bass, canLeft, canRight } = props;
+
+  const emit = (patch: Partial<ChordParts>): void => {
+    props.onChange({ root, accidental, suffix, bass, ...patch });
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      props.onClose();
+    }
+  };
+
+  return (
+    <div
+      className="chordsketch-sheet__cins"
+      role="group"
+      aria-label={`Edit chord ${chordName || '(empty)'}`}
+      onKeyDown={onKeyDown}
+    >
+      <div className="chordsketch-sheet__cins-head">
+        <div>
+          <div className="chordsketch-sheet__cins-eyebrow">Editing chord</div>
+          <div className="chordsketch-sheet__cins-name">{chordName || '—'}</div>
+        </div>
+        <button
+          type="button"
+          className="chordsketch-sheet__cins-close"
+          aria-label="Close chord editor"
+          onClick={props.onClose}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="chordsketch-sheet__cins-group">
+        <span className="chordsketch-sheet__cins-label">Root</span>
+        <div
+          className="chordsketch-sheet__cins-seg"
+          role="group"
+          aria-label="Root note"
+        >
+          {ROOT_NOTES.map((note) => (
+            <button
+              key={note}
+              type="button"
+              aria-pressed={root === note}
+              onClick={() => emit({ root: note })}
+            >
+              {note}
+            </button>
+          ))}
+        </div>
+        <div
+          className="chordsketch-sheet__cins-seg"
+          role="group"
+          aria-label="Accidental"
+        >
+          {ACCIDENTALS.map((acc) => (
+            <button
+              key={acc.aria}
+              type="button"
+              aria-label={acc.aria}
+              aria-pressed={accidental === acc.value}
+              onClick={() => emit({ accidental: acc.value })}
+            >
+              {acc.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="chordsketch-sheet__cins-group">
+        <span className="chordsketch-sheet__cins-label">Type</span>
+        <div
+          className="chordsketch-sheet__cins-chips"
+          role="group"
+          aria-label="Chord type"
+        >
+          {CHORD_TYPE_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              className="chordsketch-sheet__cins-chip"
+              aria-pressed={suffix === preset.text}
+              onClick={() => emit({ suffix: preset.text })}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="chordsketch-sheet__cins-row2">
+        <label className="chordsketch-sheet__cins-field">
+          <span className="chordsketch-sheet__cins-label">Quality / ext.</span>
+          <input
+            className="chordsketch-sheet__cins-input"
+            value={suffix}
+            placeholder="m7, sus4…"
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            onChange={(e) => emit({ suffix: e.target.value })}
+          />
+        </label>
+        <label className="chordsketch-sheet__cins-field">
+          <span className="chordsketch-sheet__cins-label">/ Bass</span>
+          <input
+            className="chordsketch-sheet__cins-input"
+            value={bass}
+            placeholder="G, F#…"
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            onChange={(e) => emit({ bass: e.target.value })}
+          />
+        </label>
+      </div>
+
+      <div className="chordsketch-sheet__cins-divider" />
+
+      <div className="chordsketch-sheet__cins-group">
+        <span className="chordsketch-sheet__cins-label">Move one step</span>
+        <div className="chordsketch-sheet__cins-move">
+          <button
+            type="button"
+            className="chordsketch-sheet__cins-movebtn"
+            aria-label="Move chord left"
+            disabled={!canLeft}
+            onClick={() => props.onNudge(-1)}
+          >
+            ◀
+          </button>
+          <span className="chordsketch-sheet__cins-movelbl">lyric position</span>
+          <button
+            type="button"
+            className="chordsketch-sheet__cins-movebtn"
+            aria-label="Move chord right"
+            disabled={!canRight}
+            onClick={() => props.onNudge(1)}
+          >
+            ▶
+          </button>
+        </div>
+      </div>
+
+      <div className="chordsketch-sheet__cins-footer">
+        {props.onRemove ? (
+          <button
+            type="button"
+            className="chordsketch-sheet__cins-remove"
+            onClick={props.onRemove}
+          >
+            Remove chord
+          </button>
+        ) : (
+          <span />
+        )}
+        <button
+          type="button"
+          className="chordsketch-sheet__cins-done"
+          onClick={props.onClose}
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -532,6 +532,10 @@ function ChordSheetAstBranch({
             accidental={resolvedChord.parts.accidental}
             suffix={resolvedChord.parts.suffix}
             bass={resolvedChord.parts.bass}
+            // `[]` for otherOffsets: availability depends only on
+            // the line bounds; otherOffsets is used solely to compute
+            // the destination ordinal (not the null/non-null result),
+            // so an empty list is fine for the can-move check.
             canLeft={
               nudgeChordPosition(resolvedChord.currentOffset, [], resolvedChord.totalLyrics, -1) !==
               null

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -10,6 +10,7 @@ import {
   buildChordNudge,
   findChordByOffsetOrdinal,
   nudgeChordPosition,
+  readCapo,
 } from './chord-source-edit';
 import type {
   ChordDeleteTarget,
@@ -116,6 +117,12 @@ export interface ChordSheetProps extends Omit<HTMLAttributes<HTMLDivElement>, 'c
    * `applyChordEdit` (exported from this package). Omit to render the
    * inspector read-only / without the edit controls taking effect.
    *
+   * Disabled (along with selection / drag) while an effective transpose
+   * is active (a non-zero `transpose`, or a `{capo}` in the source):
+   * the rendered chords are then the transposed spelling, not the raw
+   * source, so source-coordinate editing would corrupt the song. Clear
+   * the transpose / capo to edit.
+   *
    * Only consumed by `format="html"`.
    */
   onChordEdit?: (event: ChordEditEvent) => void;
@@ -208,7 +215,12 @@ function partsFromRawName(name: string): ResolvedChord['parts'] {
   const head = slash >= 0 ? name.slice(0, slash) : name;
   const bass = slash >= 0 ? name.slice(slash + 1) : '';
   const hasRoot = /^[A-G]/.test(head);
-  const root = hasRoot ? head[0] : 'C';
+  // Rootless / non-standard names (e.g. `N.C.`) yield an empty root so
+  // a stray chip click → buildChordName(empty root) throws and the
+  // edit is dropped, rather than defaulting to `C` and corrupting the
+  // token. The chord stays selectable (badge + move), just not
+  // root/type-editable until the user sets a root.
+  const root = hasRoot ? head[0] : '';
   let rest = hasRoot ? head.slice(1) : head;
   let accidental: '' | '#' | 'b' = '';
   if (rest[0] === '#') {
@@ -490,6 +502,27 @@ function ChordSheetAstBranch({
     [ast, chordSelection],
   );
 
+  // Source-coordinate editing (selection / drag / nudge / inspector)
+  // is only valid when the chords the walker renders match the raw
+  // source. The wasm parse path transposes the AST in place — folding
+  // any `{capo: N}` into the effective transpose (ADR-0023) — so under
+  // a non-zero effective transpose `chord.name` is the TRANSPOSED
+  // spelling, and editing by source coordinates would write the wrong
+  // chord / miscompute columns. Gate the whole interaction off in that
+  // case (it would otherwise silently corrupt the song). `effective =
+  // transpose − capo`; coincidental cancellation (e.g. transpose +2 with
+  // `{capo: 2}`) is genuinely a no-op transpose, so editing is safe.
+  const sourceEditable = (transpose ?? 0) - readCapo(source) === 0;
+  const repositionCb = sourceEditable ? onChordReposition : undefined;
+  const editCb = sourceEditable ? onChordEdit : undefined;
+  const deleteCb = sourceEditable ? onChordDelete : undefined;
+  // Drop a stale selection if the user applies a transpose / capo while
+  // a chord is selected, so no badge / inspector lingers on a chord the
+  // user can no longer safely edit.
+  useEffect(() => {
+    if (!sourceEditable && chordSelection != null) setChordSelection(null);
+  }, [sourceEditable, chordSelection]);
+
   if (ast === null) {
     return (
       <div {...divProps} className={wrapperClass} aria-busy={loading || undefined}>
@@ -521,11 +554,11 @@ function ChordSheetAstBranch({
           activeSourceLine,
           caretColumn,
           caretLineLength,
-          onChordReposition,
-          chordSelection,
-          setChordSelection,
+          onChordReposition: repositionCb,
+          chordSelection: repositionCb ? chordSelection : null,
+          setChordSelection: repositionCb ? setChordSelection : undefined,
         })}
-        {resolvedChord && onChordEdit ? (
+        {resolvedChord && editCb ? (
           <ChordInspector
             chordName={resolvedChord.chordName}
             root={resolvedChord.parts.root}
@@ -549,15 +582,17 @@ function ChordSheetAstBranch({
               try {
                 chord = buildChordName(parts);
               } catch {
-                // Invalid parts (the inspector only ever produces valid
-                // ones); ignore rather than corrupt the source.
+                // Invalid parts (e.g. a rootless chord whose root is
+                // empty — buildChordName throws); ignore rather than
+                // corrupt the source.
                 return;
               }
-              onChordEdit({
+              editCb({
                 line: resolvedChord.sourceLine,
                 fromColumn: resolvedChord.sourceColumn,
                 fromLength: resolvedChord.bracketLength,
                 chord,
+                expected: resolvedChord.chordName,
               });
             }}
             onNudge={(direction) => {
@@ -571,8 +606,8 @@ function ChordSheetAstBranch({
                 totalLyrics: resolvedChord.totalLyrics,
                 direction,
               });
-              if (!result || !onChordReposition) return;
-              onChordReposition(result.event);
+              if (!result || !repositionCb) return;
+              repositionCb(result.event);
               setChordSelection((prev) => ({
                 line: resolvedChord.sourceLine,
                 offset: result.offset,
@@ -581,12 +616,13 @@ function ChordSheetAstBranch({
               }));
             }}
             onRemove={
-              onChordDelete
+              deleteCb
                 ? () => {
-                    onChordDelete({
+                    deleteCb({
                       line: resolvedChord.sourceLine,
                       fromColumn: resolvedChord.sourceColumn,
                       fromLength: resolvedChord.bracketLength,
+                      expected: resolvedChord.chordName,
                     });
                     setChordSelection(null);
                   }

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -8,7 +8,6 @@ import type { ChordproChord, ChordproSong } from './chordpro-ast';
 import {
   buildChordName,
   buildChordNudge,
-  chordSuffixFromQuality,
   findChordByOffsetOrdinal,
   nudgeChordPosition,
 } from './chord-source-edit';
@@ -197,14 +196,13 @@ interface ResolvedChord {
   totalLyrics: number;
 }
 
-function accidentalChar(a: 'sharp' | 'flat' | null | undefined): '' | '#' | 'b' {
-  return a === 'sharp' ? '#' : a === 'flat' ? 'b' : '';
-}
-
-/** Best-effort split of a raw chord name into editor parts when the
- * parser produced no structured `detail` (lenient / non-standard
- * chords). Keeps the chord round-trippable: `root + accidental +
- * suffix (+ /bass)` reassembles the original name. */
+/** Split a raw chord name into editor parts. Used for ALL chords (not
+ * just detail-less ones): the source carries the RAW name (`chord.name`),
+ * whereas a transposed render exposes the transposed pitch via
+ * `chord.detail` / `chord.display`. Editing must rewrite the raw source
+ * chord, so deriving parts from the raw name keeps editing correct even
+ * under a non-zero transpose. The split is round-trippable —
+ * `root + accidental + suffix (+ /bass)` reassembles the original name. */
 function partsFromRawName(name: string): ResolvedChord['parts'] {
   const slash = name.indexOf('/');
   const head = slash >= 0 ? name.slice(0, slash) : name;
@@ -260,17 +258,9 @@ function resolveSelectedChord(ast: ChordproSong, selection: ChordSelection): Res
   const idx = findChordByOffsetOrdinal(offsets, selection.offset, selection.ordinal);
   if (idx < 0) return null;
   const target = chords[idx];
-  const detail = target.chord.detail;
-  const parts: ResolvedChord['parts'] = detail
-    ? {
-        root: detail.root,
-        accidental: accidentalChar(detail.rootAccidental),
-        suffix: chordSuffixFromQuality(detail.quality, detail.extension),
-        bass: detail.bassNote
-          ? `${detail.bassNote.note}${accidentalChar(detail.bassNote.accidental)}`
-          : '',
-      }
-    : partsFromRawName(target.chord.name ?? '');
+  // Derive parts from the RAW name (transpose-safe — see
+  // partsFromRawName). `detail` is intentionally not used here.
+  const parts = partsFromRawName(target.chord.name ?? '');
   return {
     chordName: target.chord.name ?? '',
     parts,

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -1,9 +1,23 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { HTMLAttributes, ReactNode } from 'react';
 
+import { ChordInspector } from './chord-inspector';
 import { renderChordproAst } from './chordpro-jsx';
 import type { ChordSelection } from './chordpro-jsx';
-import type { ChordRepositionEvent } from './chord-source-edit';
+import type { ChordproChord, ChordproSong } from './chordpro-ast';
+import {
+  buildChordName,
+  buildChordNudge,
+  chordSuffixFromQuality,
+  findChordByOffsetOrdinal,
+  nudgeChordPosition,
+} from './chord-source-edit';
+import type {
+  ChordDeleteTarget,
+  ChordEditEvent,
+  ChordParts,
+  ChordRepositionEvent,
+} from './chord-source-edit';
 import type {
   ChordDiagramInstrument,
   ChordDiagramOrientation,
@@ -95,6 +109,26 @@ export interface ChordSheetProps extends Omit<HTMLAttributes<HTMLDivElement>, 'c
    */
   onChordReposition?: (event: ChordRepositionEvent) => void;
   /**
+   * Optional callback enabling in-place chord editing via the
+   * left-docked inspector (#2622). When set (alongside
+   * `onChordReposition`, which enables selection), clicking a chord
+   * opens an editor for its root / accidental / type / bass; each
+   * change emits a {@link ChordEditEvent} the consumer applies with
+   * `applyChordEdit` (exported from this package). Omit to render the
+   * inspector read-only / without the edit controls taking effect.
+   *
+   * Only consumed by `format="html"`.
+   */
+  onChordEdit?: (event: ChordEditEvent) => void;
+  /**
+   * Optional callback enabling the inspector's "Remove chord" action
+   * (#2622). Receives the chord token's source coordinates; apply it
+   * with `applyChordDelete`. Omit to hide the remove button.
+   *
+   * Only consumed by `format="html"`.
+   */
+  onChordDelete?: (target: ChordDeleteTarget) => void;
+  /**
    * Configuration preset name (e.g. `"guitar"`, `"ukulele"`) or an
    * inline RRJSON configuration string.
    */
@@ -148,6 +182,107 @@ export interface ChordSheetProps extends Omit<HTMLAttributes<HTMLDivElement>, 'c
   astWasmLoader?: ChordproWasmLoader;
 }
 
+/** The selected chord resolved out of the AST into the coordinates +
+ * parts the inspector needs. `null` when the selection no longer maps
+ * to a chord (e.g. the source was edited out from under it). */
+interface ResolvedChord {
+  /** Raw chord name for the inspector header. */
+  chordName: string;
+  parts: { root: string; accidental: '' | '#' | 'b'; suffix: string; bass: string };
+  sourceLine: number;
+  sourceColumn: number;
+  bracketLength: number;
+  currentOffset: number;
+  otherOffsets: number[];
+  totalLyrics: number;
+}
+
+function accidentalChar(a: 'sharp' | 'flat' | null | undefined): '' | '#' | 'b' {
+  return a === 'sharp' ? '#' : a === 'flat' ? 'b' : '';
+}
+
+/** Best-effort split of a raw chord name into editor parts when the
+ * parser produced no structured `detail` (lenient / non-standard
+ * chords). Keeps the chord round-trippable: `root + accidental +
+ * suffix (+ /bass)` reassembles the original name. */
+function partsFromRawName(name: string): ResolvedChord['parts'] {
+  const slash = name.indexOf('/');
+  const head = slash >= 0 ? name.slice(0, slash) : name;
+  const bass = slash >= 0 ? name.slice(slash + 1) : '';
+  const hasRoot = /^[A-G]/.test(head);
+  const root = hasRoot ? head[0] : 'C';
+  let rest = hasRoot ? head.slice(1) : head;
+  let accidental: '' | '#' | 'b' = '';
+  if (rest[0] === '#') {
+    accidental = '#';
+    rest = rest.slice(1);
+  } else if (rest[0] === 'b') {
+    accidental = 'b';
+    rest = rest.slice(1);
+  }
+  return { root, accidental, suffix: rest, bass };
+}
+
+/**
+ * Resolve the current {@link ChordSelection} against the AST into the
+ * selected chord's source coordinates + editable parts. Recomputes the
+ * selected line's chord layout (source columns + lyrics offsets) the
+ * same way the JSX walker does, then locates the chord by its
+ * `(offset, ordinal)` identity. Returns `null` when the line is not a
+ * lyrics line or the selection no longer resolves.
+ */
+function resolveSelectedChord(ast: ChordproSong, selection: ChordSelection): ResolvedChord | null {
+  const line = ast.lines[selection.line - 1];
+  if (!line || line.kind !== 'lyrics') return null;
+  const segments = line.value.segments;
+  let srcCol = 0;
+  let lyricsCount = 0;
+  const chords: Array<{
+    sourceColumn: number;
+    bracketLength: number;
+    offset: number;
+    chord: ChordproChord;
+  }> = [];
+  for (const seg of segments) {
+    const bracketLen = seg.chord ? (seg.chord.name?.length ?? 0) + 2 : 0;
+    if (seg.chord) {
+      chords.push({
+        sourceColumn: srcCol,
+        bracketLength: bracketLen,
+        offset: lyricsCount,
+        chord: seg.chord,
+      });
+    }
+    srcCol += bracketLen + seg.text.length;
+    lyricsCount += seg.text.length;
+  }
+  const offsets = chords.map((c) => c.offset);
+  const idx = findChordByOffsetOrdinal(offsets, selection.offset, selection.ordinal);
+  if (idx < 0) return null;
+  const target = chords[idx];
+  const detail = target.chord.detail;
+  const parts: ResolvedChord['parts'] = detail
+    ? {
+        root: detail.root,
+        accidental: accidentalChar(detail.rootAccidental),
+        suffix: chordSuffixFromQuality(detail.quality, detail.extension),
+        bass: detail.bassNote
+          ? `${detail.bassNote.note}${accidentalChar(detail.bassNote.accidental)}`
+          : '',
+      }
+    : partsFromRawName(target.chord.name ?? '');
+  return {
+    chordName: target.chord.name ?? '',
+    parts,
+    sourceLine: selection.line,
+    sourceColumn: target.sourceColumn,
+    bracketLength: target.bracketLength,
+    currentOffset: target.offset,
+    otherOffsets: offsets.filter((_, i) => i !== idx),
+    totalLyrics: lyricsCount,
+  };
+}
+
 function defaultErrorFallback(error: Error): ReactNode {
   return (
     <div role="alert" className="chordsketch-sheet__error">
@@ -196,6 +331,8 @@ export function ChordSheet({
   caretColumn,
   caretLineLength,
   onChordReposition,
+  onChordEdit,
+  onChordDelete,
   className,
   ...divProps
 }: ChordSheetProps): JSX.Element {
@@ -230,6 +367,8 @@ export function ChordSheet({
       caretColumn={caretColumn}
       caretLineLength={caretLineLength}
       onChordReposition={onChordReposition}
+      onChordEdit={onChordEdit}
+      onChordDelete={onChordDelete}
       wrapperClass={wrapperClass}
       divProps={divProps}
     />
@@ -290,6 +429,8 @@ function ChordSheetAstBranch({
   caretColumn,
   caretLineLength,
   onChordReposition,
+  onChordEdit,
+  onChordDelete,
   wrapperClass,
   divProps,
 }: BranchProps & {
@@ -300,6 +441,8 @@ function ChordSheetAstBranch({
   caretColumn: number | undefined;
   caretLineLength: number | undefined;
   onChordReposition: ((event: ChordRepositionEvent) => void) | undefined;
+  onChordEdit: ((event: ChordEditEvent) => void) | undefined;
+  onChordDelete: ((target: ChordDeleteTarget) => void) | undefined;
 }): JSX.Element {
   const { ast, loading, error, transposedKey, transposedKeyDirectives } = useChordproAst(
     source,
@@ -339,7 +482,7 @@ function ChordSheetAstBranch({
         root != null &&
         el != null &&
         root.contains(el) &&
-        el.closest('.chord, .chord-nudge')
+        el.closest('.chord, .chordsketch-sheet__cins')
       ) {
         return;
       }
@@ -348,6 +491,14 @@ function ChordSheetAstBranch({
     document.addEventListener('pointerdown', onPointerDown);
     return () => document.removeEventListener('pointerdown', onPointerDown);
   }, [chordSelection]);
+
+  // Resolve the selection into the selected chord's coordinates + parts
+  // for the inspector. Recomputed whenever the AST (a re-parse after an
+  // edit / nudge) or the selection changes.
+  const resolvedChord = useMemo(
+    () => (ast && chordSelection ? resolveSelectedChord(ast, chordSelection) : null),
+    [ast, chordSelection],
+  );
 
   if (ast === null) {
     return (
@@ -384,6 +535,72 @@ function ChordSheetAstBranch({
           chordSelection,
           setChordSelection,
         })}
+        {resolvedChord && onChordEdit ? (
+          <ChordInspector
+            chordName={resolvedChord.chordName}
+            root={resolvedChord.parts.root}
+            accidental={resolvedChord.parts.accidental}
+            suffix={resolvedChord.parts.suffix}
+            bass={resolvedChord.parts.bass}
+            canLeft={
+              nudgeChordPosition(resolvedChord.currentOffset, [], resolvedChord.totalLyrics, -1) !==
+              null
+            }
+            canRight={
+              nudgeChordPosition(resolvedChord.currentOffset, [], resolvedChord.totalLyrics, 1) !==
+              null
+            }
+            onChange={(parts: ChordParts) => {
+              let chord: string;
+              try {
+                chord = buildChordName(parts);
+              } catch {
+                // Invalid parts (the inspector only ever produces valid
+                // ones); ignore rather than corrupt the source.
+                return;
+              }
+              onChordEdit({
+                line: resolvedChord.sourceLine,
+                fromColumn: resolvedChord.sourceColumn,
+                fromLength: resolvedChord.bracketLength,
+                chord,
+              });
+            }}
+            onNudge={(direction) => {
+              const result = buildChordNudge({
+                sourceLine: resolvedChord.sourceLine,
+                chordName: resolvedChord.chordName,
+                sourceColumn: resolvedChord.sourceColumn,
+                bracketLength: resolvedChord.bracketLength,
+                currentOffset: resolvedChord.currentOffset,
+                otherOffsets: resolvedChord.otherOffsets,
+                totalLyrics: resolvedChord.totalLyrics,
+                direction,
+              });
+              if (!result || !onChordReposition) return;
+              onChordReposition(result.event);
+              setChordSelection((prev) => ({
+                line: resolvedChord.sourceLine,
+                offset: result.offset,
+                ordinal: result.ordinal,
+                nonce: (prev?.nonce ?? 0) + 1,
+              }));
+            }}
+            onRemove={
+              onChordDelete
+                ? () => {
+                    onChordDelete({
+                      line: resolvedChord.sourceLine,
+                      fromColumn: resolvedChord.sourceColumn,
+                      fromLength: resolvedChord.bracketLength,
+                    });
+                    setChordSelection(null);
+                  }
+                : undefined
+            }
+            onClose={() => setChordSelection(null)}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -399,3 +399,294 @@ export function findChordByOffsetOrdinal(
   }
   return -1;
 }
+
+/** Result of {@link buildChordNudge}: the reposition event to fire plus
+ * the chord's new `(offset, ordinal)` so the caller can advance the
+ * selection to track the moved chord. */
+export interface ChordNudgeResult {
+  event: ChordRepositionEvent;
+  offset: number;
+  ordinal: number;
+}
+
+/**
+ * Build the reposition event + advanced selection coordinates for
+ * moving one chord one lyric character in `direction`. Shared by the
+ * keyboard arrow path (in the JSX walker) and the inspector's ◀ / ▶
+ * buttons so both produce identical moves (one source of nudge logic).
+ *
+ * Returns `null` when the move is out of bounds (the caller disables
+ * the control / drops the key press).
+ */
+export function buildChordNudge(params: {
+  /** 1-indexed source line the chord lives on (move is same-line). */
+  sourceLine: number;
+  /** Chord name written back into the source, e.g. `"Am7"`. */
+  chordName: string;
+  /** 0-indexed source column of the chord's `[`. */
+  sourceColumn: number;
+  /** Source-column span of `[chord]` (`name.length + 2`). */
+  bracketLength: number;
+  /** The chord's current lyrics offset. */
+  currentOffset: number;
+  /** Lyrics offsets of every OTHER chord on the line (for the
+   * destination ordinal). */
+  otherOffsets: readonly number[];
+  /** Total visible lyric characters on the line. */
+  totalLyrics: number;
+  /** `-1` left, `+1` right. */
+  direction: -1 | 1;
+}): ChordNudgeResult | null {
+  const dest = nudgeChordPosition(
+    params.currentOffset,
+    params.otherOffsets,
+    params.totalLyrics,
+    params.direction,
+  );
+  if (!dest) return null;
+  return {
+    event: {
+      fromLine: params.sourceLine,
+      fromColumn: params.sourceColumn,
+      fromLength: params.bracketLength,
+      toLine: params.sourceLine,
+      toLyricsOffset: dest.offset,
+      chord: params.chordName,
+      copy: false,
+    },
+    offset: dest.offset,
+    ordinal: dest.ordinal,
+  };
+}
+
+// ---- Chord editing (#2622) -----------------------------------------
+// The click-to-focus inspector (#2614 follow-up) edits the selected
+// chord in place: root, accidental, type (quality + extension), and an
+// optional slash bass. The pure helpers below build the ChordPro chord
+// token from those parts and splice it back over the original
+// `[chord]` at a known source position — the same source-as-truth
+// model the reposition pipeline uses (no parallel chord state).
+
+/** Characters that would corrupt the ChordPro source structure when
+ * interpolated into a `[chord]` token. Shared by every chord-writing
+ * helper so the editor surface cannot inject directives / brackets /
+ * line breaks. `/` is intentionally allowed — it is the slash-chord
+ * separator. */
+const CHORD_FORBIDDEN_RE = /[[\]{}<>\n\r]/;
+
+/** A chord-type preset offered as a chip in the editor. `text` is the
+ * ChordPro suffix written after the root (+ accidental) — e.g. `"m7"`
+ * for A minor 7 → `Am7`. `id` is a stable key; `label` is the chip
+ * face (may contain display accidentals like `♭`). */
+export interface ChordTypePreset {
+  id: string;
+  label: string;
+  text: string;
+}
+
+/**
+ * The curated chord-type presets the editor chips expose, in display
+ * order. Each maps to the canonical ChordPro suffix the parser
+ * round-trips. `maj` is the empty suffix (a bare major triad is just
+ * its root). The set is deliberately small and common; arbitrary
+ * qualities remain reachable through the free-form suffix field.
+ */
+export const CHORD_TYPE_PRESETS: readonly ChordTypePreset[] = [
+  { id: 'maj', label: 'maj', text: '' },
+  { id: 'min', label: 'min', text: 'm' },
+  { id: '7', label: '7', text: '7' },
+  { id: 'maj7', label: 'maj7', text: 'maj7' },
+  { id: 'm7', label: 'm7', text: 'm7' },
+  { id: 'm7b5', label: 'm7♭5', text: 'm7b5' },
+  { id: 'dim', label: 'dim', text: 'dim' },
+  { id: 'dim7', label: 'dim7', text: 'dim7' },
+  { id: 'aug', label: 'aug', text: 'aug' },
+  { id: 'sus2', label: 'sus2', text: 'sus2' },
+  { id: 'sus4', label: 'sus4', text: 'sus4' },
+  { id: '6', label: '6', text: '6' },
+  { id: '9', label: '9', text: '9' },
+  { id: 'add9', label: 'add9', text: 'add9' },
+];
+
+/** Quality enum values mirrored from `ChordproChordQuality` — kept as a
+ * plain string union so this module stays free of an AST-type import. */
+export type ChordQualityName = 'major' | 'minor' | 'diminished' | 'augmented';
+
+/**
+ * Reconstruct the chord suffix (the text after the root + accidental,
+ * before any `/bass`) from a parsed quality + extension. This is the
+ * inverse of how the parser splits a chord, so it round-trips: e.g.
+ * `(minor, "7")` → `"m7"`, `(major, "maj7")` → `"maj7"`,
+ * `(diminished, null)` → `"dim"`, `(major, null)` → `""`.
+ *
+ * The editor uses it to pre-select the matching {@link CHORD_TYPE_PRESETS}
+ * chip and to seed the free-form suffix field from the selected chord.
+ */
+export function chordSuffixFromQuality(
+  quality: ChordQualityName,
+  extension: string | null,
+): string {
+  const base =
+    quality === 'minor'
+      ? 'm'
+      : quality === 'diminished'
+        ? 'dim'
+        : quality === 'augmented'
+          ? 'aug'
+          : ''; // major
+  return `${base}${extension ?? ''}`;
+}
+
+/** The component parts the chord editor manipulates. */
+export interface ChordParts {
+  /** Root note letter `A`–`G` (uppercase). */
+  root: string;
+  /** Root accidental: `''` (natural), `'#'` (sharp), or `'b'` (flat). */
+  accidental?: '' | '#' | 'b';
+  /** Quality + extension suffix written after the root, e.g. `'m7'`,
+   * `'maj7'`, `'sus4'`. Empty for a bare major triad. */
+  suffix?: string;
+  /** Optional slash-bass token (without the leading `/`), e.g. `'G'`,
+   * `'F#'`. Empty / omitted = no slash. */
+  bass?: string;
+}
+
+/**
+ * Build a ChordPro chord token body (the text that goes inside the
+ * `[...]`, without the brackets) from its parts.
+ *
+ * `root + accidental + suffix + (bass ? "/" + bass : "")`.
+ *
+ * Throws if the root is not a single `A`–`G` letter, if the accidental
+ * is not one of `''` / `'#'` / `'b'`, or if `suffix` / `bass` contain a
+ * character that would break the ChordPro source structure (brackets,
+ * braces, angle brackets, slash inside the suffix, newlines). The throw
+ * is defense-in-depth — the editor UI only ever produces valid parts —
+ * mirroring {@link applyChordReposition}'s chord-name guard.
+ */
+export function buildChordName(parts: ChordParts): string {
+  const { root } = parts;
+  if (typeof root !== 'string' || !/^[A-G]$/.test(root)) {
+    throw new Error(`chord root must be a single A-G letter, got ${JSON.stringify(root)}`);
+  }
+  const accidental = parts.accidental ?? '';
+  if (accidental !== '' && accidental !== '#' && accidental !== 'b') {
+    throw new Error(`chord accidental must be '', '#', or 'b', got ${JSON.stringify(accidental)}`);
+  }
+  const suffix = parts.suffix ?? '';
+  // The suffix sits before the slash, so it must not itself contain a
+  // `/` (that would create a spurious bass split) on top of the shared
+  // structural denylist.
+  if (CHORD_FORBIDDEN_RE.test(suffix) || suffix.includes('/')) {
+    throw new Error(`chord suffix ${JSON.stringify(suffix)} contains a forbidden character`);
+  }
+  const bass = parts.bass ?? '';
+  if (CHORD_FORBIDDEN_RE.test(bass) || bass.includes('/')) {
+    throw new Error(`chord bass ${JSON.stringify(bass)} contains a forbidden character`);
+  }
+  return `${root}${accidental}${suffix}${bass ? `/${bass}` : ''}`;
+}
+
+/** Describes an in-place chord edit in source-coordinate terms. */
+export interface ChordEditEvent {
+  /** 1-indexed source line of the chord being edited. */
+  line: number;
+  /** 0-indexed source column of the original `[` opening bracket. */
+  fromColumn: number;
+  /** Source-column span of the original `[chord]`, including both
+   * brackets (`oldName.length + 2`). */
+  fromLength: number;
+  /** New chord token body (without brackets), e.g. `"Am7"`. Build it
+   * with {@link buildChordName}. */
+  chord: string;
+}
+
+/**
+ * Apply an in-place chord edit: replace the `[chord]` token at
+ * `(line, fromColumn)` spanning `fromLength` columns with
+ * `[evt.chord]`, returning the updated source plus a caret offset
+ * pointing just past the rewritten bracket.
+ *
+ * Throws if `line` / the column span is out of range, or if
+ * `evt.chord` is empty or contains a structurally dangerous character
+ * (same guard as {@link applyChordReposition}).
+ */
+export function applyChordEdit(source: string, evt: ChordEditEvent): ChordRepositionResult {
+  if (typeof evt.chord !== 'string' || evt.chord.length === 0) {
+    throw new Error('chord must be a non-empty string');
+  }
+  if (CHORD_FORBIDDEN_RE.test(evt.chord)) {
+    throw new Error(
+      `chord ${JSON.stringify(evt.chord)} contains forbidden character ` +
+        '(brackets, braces, angle bracket, newline / carriage return)',
+    );
+  }
+  const lines = source.split('\n');
+  const lineIdx = evt.line - 1;
+  if (lineIdx < 0 || lineIdx >= lines.length) {
+    throw new Error(`line ${evt.line} out of range (lines: ${lines.length})`);
+  }
+  const lineText = lines[lineIdx];
+  if (evt.fromColumn < 0 || evt.fromColumn + evt.fromLength > lineText.length) {
+    throw new Error(
+      `edit range [${evt.fromColumn}, ${evt.fromColumn + evt.fromLength}) ` +
+        `exceeds line length ${lineText.length}`,
+    );
+  }
+  const insertBracket = `[${evt.chord}]`;
+  lines[lineIdx] =
+    lineText.slice(0, evt.fromColumn) + insertBracket + lineText.slice(evt.fromColumn + evt.fromLength);
+
+  let caretOffset = 0;
+  for (let i = 0; i < lineIdx; i++) {
+    caretOffset += lines[i].length + 1; // +1 for the `\n`
+  }
+  caretOffset += evt.fromColumn + insertBracket.length;
+
+  return { text: lines.join('\n'), caretOffset };
+}
+
+/** Identifies a chord token to delete, in source coordinates. */
+export interface ChordDeleteTarget {
+  /** 1-indexed source line. */
+  line: number;
+  /** 0-indexed source column of the `[` opening bracket. */
+  fromColumn: number;
+  /** Source-column span of `[chord]`, including both brackets. */
+  fromLength: number;
+}
+
+/**
+ * Delete the `[chord]` token at `(line, fromColumn)` spanning
+ * `fromLength` columns, returning the updated source plus a caret
+ * offset at the deletion point. The lyric text the chord annotated is
+ * left untouched; only the bracketed chord is removed.
+ *
+ * Throws if `line` or the column span is out of range.
+ */
+export function applyChordDelete(
+  source: string,
+  evt: ChordDeleteTarget,
+): ChordRepositionResult {
+  const lines = source.split('\n');
+  const lineIdx = evt.line - 1;
+  if (lineIdx < 0 || lineIdx >= lines.length) {
+    throw new Error(`line ${evt.line} out of range (lines: ${lines.length})`);
+  }
+  const lineText = lines[lineIdx];
+  if (evt.fromColumn < 0 || evt.fromColumn + evt.fromLength > lineText.length) {
+    throw new Error(
+      `delete range [${evt.fromColumn}, ${evt.fromColumn + evt.fromLength}) ` +
+        `exceeds line length ${lineText.length}`,
+    );
+  }
+  lines[lineIdx] = lineText.slice(0, evt.fromColumn) + lineText.slice(evt.fromColumn + evt.fromLength);
+
+  let caretOffset = 0;
+  for (let i = 0; i < lineIdx; i++) {
+    caretOffset += lines[i].length + 1;
+  }
+  caretOffset += evt.fromColumn;
+
+  return { text: lines.join('\n'), caretOffset };
+}

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -599,6 +599,13 @@ export interface ChordEditEvent {
   /** New chord token body (without brackets), e.g. `"Am7"`. Build it
    * with {@link buildChordName}. */
   chord: string;
+  /** Optional optimistic-concurrency guard: the chord token body
+   * expected at the target span. When provided, the edit is a no-op
+   * (source returned unchanged) if the current source there is not
+   * `[expected]` — this prevents a stale event (built against an
+   * older source that has not finished re-parsing) from splicing at
+   * the wrong span. Omit to skip the check. */
+  expected?: string;
 }
 
 /**
@@ -633,6 +640,18 @@ export function applyChordEdit(source: string, evt: ChordEditEvent): ChordReposi
         `exceeds line length ${lineText.length}`,
     );
   }
+  // Optimistic-concurrency guard: if the caller told us what token to
+  // expect at the span and the live source no longer matches (a stale
+  // event from an edit whose re-parse hasn't landed), no-op instead of
+  // splicing at the wrong place. Caret stays at the target column.
+  if (
+    evt.expected !== undefined &&
+    lineText.slice(evt.fromColumn, evt.fromColumn + evt.fromLength) !== `[${evt.expected}]`
+  ) {
+    let caret = 0;
+    for (let i = 0; i < lineIdx; i++) caret += lines[i].length + 1;
+    return { text: source, caretOffset: caret + evt.fromColumn };
+  }
   const insertBracket = `[${evt.chord}]`;
   lines[lineIdx] =
     lineText.slice(0, evt.fromColumn) + insertBracket + lineText.slice(evt.fromColumn + evt.fromLength);
@@ -654,6 +673,10 @@ export interface ChordDeleteTarget {
   fromColumn: number;
   /** Source-column span of `[chord]`, including both brackets. */
   fromLength: number;
+  /** Optional optimistic-concurrency guard — see
+   * {@link ChordEditEvent.expected}. When the live source at the span
+   * is not `[expected]`, the delete is a no-op. */
+  expected?: string;
 }
 
 /**
@@ -679,6 +702,14 @@ export function applyChordDelete(
       `delete range [${evt.fromColumn}, ${evt.fromColumn + evt.fromLength}) ` +
         `exceeds line length ${lineText.length}`,
     );
+  }
+  if (
+    evt.expected !== undefined &&
+    lineText.slice(evt.fromColumn, evt.fromColumn + evt.fromLength) !== `[${evt.expected}]`
+  ) {
+    let caret = 0;
+    for (let i = 0; i < lineIdx; i++) caret += lines[i].length + 1;
+    return { text: source, caretOffset: caret + evt.fromColumn };
   }
   lines[lineIdx] = lineText.slice(0, evt.fromColumn) + lineText.slice(evt.fromColumn + evt.fromLength);
 

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -74,8 +74,8 @@ import type {
   ChordDiagramOrientation,
 } from './use-chord-diagram';
 import {
+  buildChordNudge,
   findChordByOffsetOrdinal,
-  nudgeChordPosition,
 } from './chord-source-edit';
 import type { ChordRepositionEvent } from './chord-source-edit';
 
@@ -1862,17 +1862,6 @@ function LyricsLine({
       ? findChordByOffsetOrdinal(chordOffsets, selected.offset, selected.ordinal)
       : -1;
   const focusedSegmentIdx = focusedChordIdx >= 0 ? chordSegments[focusedChordIdx].segmentIdx : -1;
-  // Availability depends only on the line bounds, so the empty
-  // `otherOffsets` argument (used solely for the destination
-  // ordinal) is fine here.
-  const canNudgeLeft =
-    focusedChordIdx >= 0 &&
-    selected != null &&
-    nudgeChordPosition(selected.offset, [], totalLyrics, -1) !== null;
-  const canNudgeRight =
-    focusedChordIdx >= 0 &&
-    selected != null &&
-    nudgeChordPosition(selected.offset, [], totalLyrics, 1) !== null;
 
   // DOM focus is driven programmatically from the selection so it
   // survives the nudge re-render (the old chord span is destroyed
@@ -1947,24 +1936,25 @@ function LyricsLine({
     // repeat; a normal tap (interval ≫ one render cycle) never does.
     if (!reposition || !nudgeCtx || focusedChordIdx < 0 || selected == null) return;
     const otherOffsets = chordOffsets.filter((_, idx) => idx !== focusedChordIdx);
-    const dest = nudgeChordPosition(selected.offset, otherOffsets, totalLyrics, direction);
-    if (!dest) return;
     const moved = chordSegments[focusedChordIdx];
     const seg = line.segments[moved.segmentIdx];
     const layout = segmentLayout[moved.segmentIdx];
-    reposition.onChordReposition({
-      fromLine: reposition.sourceLine,
-      fromColumn: layout.chordSourceColumn,
-      fromLength: layout.chordBracketLength,
-      toLine: reposition.sourceLine,
-      toLyricsOffset: dest.offset,
-      chord: seg.chord?.name ?? '',
-      copy: false,
+    const result = buildChordNudge({
+      sourceLine: reposition.sourceLine,
+      chordName: seg.chord?.name ?? '',
+      sourceColumn: layout.chordSourceColumn,
+      bracketLength: layout.chordBracketLength,
+      currentOffset: selected.offset,
+      otherOffsets,
+      totalLyrics,
+      direction,
     });
+    if (!result) return;
+    reposition.onChordReposition(result.event);
     nudgeCtx.setSelected({
       line: reposition.sourceLine,
-      offset: dest.offset,
-      ordinal: dest.ordinal,
+      offset: result.offset,
+      ordinal: result.ordinal,
       nonce: selected.nonce + 1,
     });
   };
@@ -2139,11 +2129,13 @@ function LyricsLine({
           dropTarget && dropTarget.segmentIdx === i
             ? dropTarget.charOffset
             : null;
-        // Click-to-focus + nudge wiring (#2614). Every real chord
-        // span becomes a toggle button that selects the chord; the
-        // selected one shows the ◀ / ▶ nudge controls and takes the
-        // auto-focus ref + keyboard handler. Off unless the consumer
-        // wired `onChordReposition`.
+        // Click-to-focus + nudge wiring (#2614 / #2622). Every real
+        // chord span becomes a toggle button that selects the chord;
+        // the selected one paints as a solid crimson badge, takes the
+        // auto-focus ref + keyboard handler, and opens the left-docked
+        // chord-editor inspector (rendered by the host, not here — see
+        // `ChordSheet`). Off unless the consumer wired
+        // `onChordReposition` + `setChordSelection`.
         const isRealChord = segment.chord != null;
         const isFocusedChord =
           reposition != null && isRealChord && i === focusedSegmentIdx;
@@ -2161,10 +2153,7 @@ function LyricsLine({
               }
             : null;
         return (
-          <span
-            key={i}
-            className={isFocusedChord ? 'chord-block chord-block--selected' : 'chord-block'}
-          >
+          <span key={i} className="chord-block">
             {segment.chord ? (
               diagrams &&
               (diagrams.mode === 'inline' || diagrams.mode === 'hover') ? (
@@ -2216,14 +2205,6 @@ function LyricsLine({
             <span className="lyrics" style={textStyle ?? undefined}>
               {renderLyricsTextWithChars(segment, caretCharOffset, dropCharOffset)}
             </span>
-            {isFocusedChord ? (
-              <NudgeControls
-                chordName={segment.chord?.name ?? ''}
-                canLeft={canNudgeLeft}
-                canRight={canNudgeRight}
-                onNudge={nudge}
-              />
-            ) : null}
           </span>
         );
       })}
@@ -2232,62 +2213,6 @@ function LyricsLine({
 }
 
 /**
- * The ◀ / ▶ toolbar shown next to the selected chord (#2614).
- * Each press nudges the chord one lyric character via the `onNudge`
- * callback. Rendered as a sibling of the chord span inside the
- * `.chord-block` (not a child of the chord's `role="button"` span,
- * which must not contain interactive descendants) and positioned
- * by CSS above the chord.
- *
- * The buttons stop their click from bubbling to the chord toggle
- * (which would deselect) and cancel any drag the press might start,
- * so tapping a button only nudges.
- */
-function NudgeControls(props: {
-  chordName: string;
-  canLeft: boolean;
-  canRight: boolean;
-  onNudge: (direction: -1 | 1) => void;
-}): JSX.Element {
-  const { chordName, canLeft, canRight, onNudge } = props;
-  const stopDrag = (e: ReactMouseEvent): void => e.stopPropagation();
-  const cancelDrag = (e: ReactDragEvent): void => e.preventDefault();
-  return (
-    <span className="chord-nudge" role="group" aria-label={`Move chord ${chordName}`}>
-      <button
-        type="button"
-        className="chord-nudge__btn chord-nudge__btn--left"
-        aria-label={`Move chord ${chordName} left`}
-        disabled={!canLeft}
-        draggable={false}
-        onMouseDown={stopDrag}
-        onDragStart={cancelDrag}
-        onClick={(e) => {
-          e.stopPropagation();
-          onNudge(-1);
-        }}
-      >
-        <span aria-hidden="true">‹</span>
-      </button>
-      <button
-        type="button"
-        className="chord-nudge__btn chord-nudge__btn--right"
-        aria-label={`Move chord ${chordName} right`}
-        disabled={!canRight}
-        draggable={false}
-        onMouseDown={stopDrag}
-        onDragStart={cancelDrag}
-        onClick={(e) => {
-          e.stopPropagation();
-          onNudge(1);
-        }}
-      >
-        <span aria-hidden="true">›</span>
-      </button>
-    </span>
-  );
-}
-
 /**
  * From a dragover/drop event, locate which chord-block segment
  * the pointer is over and the character offset (in lyric

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -139,19 +139,37 @@ export {
 export {
   CAPO_MAX,
   CAPO_MIN,
+  CHORD_TYPE_PRESETS,
   TRANSPOSE_MAX,
   TRANSPOSE_MIN,
+  applyChordDelete,
+  applyChordEdit,
   applyChordReposition,
+  buildChordName,
+  buildChordNudge,
+  chordSuffixFromQuality,
   findChordByOffsetOrdinal,
   lyricsOffsetToSourceColumn,
   nudgeChordPosition,
   readCapo,
   setCapoInSource,
   sourceColumnToLyricsOffset,
+  type ChordDeleteTarget,
+  type ChordEditEvent,
+  type ChordNudgeResult,
+  type ChordParts,
+  type ChordQualityName,
   type ChordRepositionEvent,
   type ChordRepositionResult,
+  type ChordTypePreset,
   type NudgedChordPosition,
 } from './chord-source-edit';
+
+// Chord-editor inspector (#2622). The floating, design-system-styled
+// panel `<ChordSheet>` opens when a chord is selected and `onChordEdit`
+// is wired. Exposed so hosts that render the AST directly can mount it
+// themselves.
+export { ChordInspector, type ChordInspectorProps } from './chord-inspector';
 
 // iReal Pro surface (#2473 / #2505 / #2527 / ADR-0020). Mirrors the
 // ChordPro surface in shape: Tier 1 atom (`<IrealBarGrid>`) +

--- a/packages/react/src/renderer-preview.tsx
+++ b/packages/react/src/renderer-preview.tsx
@@ -2,7 +2,11 @@ import type { HTMLAttributes, ReactNode } from 'react';
 
 import { ChordSheet } from './chord-sheet';
 import { PdfExport } from './pdf-export';
-import type { ChordRepositionEvent } from './chord-source-edit';
+import type {
+  ChordDeleteTarget,
+  ChordEditEvent,
+  ChordRepositionEvent,
+} from './chord-source-edit';
 import type {
   ChordDiagramInstrument,
   ChordDiagramOrientation,
@@ -69,6 +73,17 @@ export interface RendererPreviewProps extends Omit<HTMLAttributes<HTMLDivElement
    */
   onChordReposition?: (event: ChordRepositionEvent) => void;
   /**
+   * Optional in-place chord-edit callback (#2622). Forwarded to
+   * {@link ChordSheet}; see `ChordSheetProps.onChordEdit`. Enables the
+   * left-docked chord-editor inspector. Only consumed by `format="html"`.
+   */
+  onChordEdit?: (event: ChordEditEvent) => void;
+  /**
+   * Optional chord-delete callback (#2622). Forwarded to
+   * {@link ChordSheet}; see `ChordSheetProps.onChordDelete`.
+   */
+  onChordDelete?: (target: ChordDeleteTarget) => void;
+  /**
    * Optional content rendered while the wasm runtime is initialising.
    *
    * Only honoured by the inline `html` / `text` branches — the
@@ -132,6 +147,8 @@ export function RendererPreview({
   caretColumn,
   caretLineLength,
   onChordReposition,
+  onChordEdit,
+  onChordDelete,
   loadingFallback,
   errorFallback,
   wasmLoader,
@@ -170,6 +187,8 @@ export function RendererPreview({
       caretColumn={caretColumn}
       caretLineLength={caretLineLength}
       onChordReposition={onChordReposition}
+      onChordEdit={onChordEdit}
+      onChordDelete={onChordDelete}
       loadingFallback={loadingFallback}
       errorFallback={errorFallback}
       wasmLoader={wasmLoader}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -398,6 +398,11 @@
   line-height: 1.6875;
   color: var(--cs-ink-1000, #0a0a0b);
   padding: 2em 1.5em;
+  /* Positioning anchor for the left-docked chord-editor inspector
+     (#2622). The inspector is `position: absolute` against this
+     wrapper so it floats at the content's top-left and does NOT track
+     the selected chord's position. */
+  position: relative;
 }
 
 /* `.song` is the AST walker's root container. It carries no
@@ -1454,72 +1459,256 @@
   cursor: grabbing;
 }
 
-/* Click-to-focus + nudge controls (#2614). When chord
+/* Click-to-focus chord editing (#2614 / #2622). When chord
    repositioning is enabled each real chord is a toggle button;
-   tapping it selects the chord and reveals a small ◀ / ▶ toolbar
-   so it can be moved one lyric character at a time — the
-   touch-friendly complement to drag-to-reposition. */
+   tapping it selects the chord, which paints it as a solid crimson
+   badge and opens the left-docked chord-editor inspector. */
 .chordsketch-sheet__content .chord[role='button'] {
   cursor: pointer;
 }
+/* Active chord — solid crimson badge (the confirmed treatment).
+   The chord name inverts to white on a filled crimson chip so the
+   selected chord reads unambiguously as "the one being edited". */
 .chordsketch-sheet__content .chord--selected {
-  outline: 2px solid var(--cs-crimson-500, #bd1642);
-  outline-offset: 1px;
-  border-radius: 3px;
+  background: var(--cs-crimson-500, #bd1642);
+  color: var(--cs-fg-on-crimson, #fff);
+  border-radius: var(--cs-r-2, 4px);
+  padding: 1px 5px;
+  /* Keep the chip from nudging the lyric baseline as it appears. */
+  box-shadow: var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
 }
-/* The chord-block becomes the positioning context for the
-   absolutely-positioned toolbar only while a chord inside it is
-   selected, so unselected blocks keep static flow. */
-.chordsketch-sheet__content .chord-block--selected {
-  position: relative;
+.chordsketch-sheet__content .chord--selected:focus-visible {
+  outline: none;
+  box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
 }
-.chordsketch-sheet__content .chord-nudge {
+
+/* ---- Left-docked chord-editor inspector (#2622) ---------------- */
+/* Floating, non-modal panel anchored to the top-left of the preview
+   content. Does NOT track the selected chord — it stays put while the
+   user edits root / type / bass and steps the chord left / right. */
+.chordsketch-sheet__content .chordsketch-sheet__cins {
   position: absolute;
-  /* Sit above the chord row. */
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-bottom: 3px;
-  display: inline-flex;
-  gap: 2px;
-  padding: 2px;
+  left: var(--cs-sp-4, 1rem);
+  top: var(--cs-sp-4, 1rem);
+  z-index: 6;
+  width: 17rem;
+  max-width: calc(100% - 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--cs-sp-4, 1rem);
+  padding: var(--cs-sp-4, 1rem);
   background: var(--cs-surface, #fff);
-  border: 1px solid var(--cs-crimson-500, #bd1642);
-  border-radius: 6px;
-  box-shadow: var(--cs-elevation-popover, 0 2px 6px rgba(0, 0, 0, 0.18));
-  z-index: 5;
-  white-space: nowrap;
-  user-select: none;
+  border: 1px solid var(--cs-border-strong, #d4d1d6);
+  border-radius: var(--cs-r-3, 8px);
+  box-shadow: var(--cs-e-2, 0 4px 12px rgba(10, 10, 11, 0.08));
+  font-family: var(--cs-font-latin, "Inter", system-ui, sans-serif);
+  animation: chordsketch-cins-pop var(--cs-dur-2, 200ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1));
 }
-.chordsketch-sheet__content .chord-nudge__btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  /* Touch-friendly target — the feature exists for taps where a
-     precise drag is hard (#2614). */
-  min-width: 1.75rem;
-  min-height: 1.75rem;
-  padding: 0;
-  font-size: 1.125rem;
+@keyframes chordsketch-cins-pop {
+  from { opacity: 0; transform: translateY(4px) scale(0.99); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chordsketch-sheet__content .chordsketch-sheet__cins { animation: none; }
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--cs-sp-2, 0.5rem);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-eyebrow {
+  font-size: 0.625rem;
   font-weight: 700;
-  line-height: 1;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cs-text-tertiary, #8a8790);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-name {
+  font-family: var(--cs-font-chord, "Roboto", system-ui, sans-serif);
+  font-weight: 900;
+  font-size: 1.75rem;
+  line-height: 1.1;
   color: var(--cs-crimson-500, #bd1642);
-  background: transparent;
-  border: none;
-  border-radius: 4px;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-close {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--cs-border, #e8e6ea);
+  background: var(--cs-surface, #fff);
+  border-radius: var(--cs-r-2, 4px);
+  color: var(--cs-text-secondary, #67646d);
+  font-size: 1rem;
+  line-height: 1;
   cursor: pointer;
 }
-.chordsketch-sheet__content .chord-nudge__btn:hover:not(:disabled) {
-  background: var(--cs-crimson-50, rgba(189, 22, 66, 0.1));
+.chordsketch-sheet__content .chordsketch-sheet__cins-close:hover {
+  background: var(--cs-surface-hover, #f6f4f7);
 }
-.chordsketch-sheet__content .chord-nudge__btn:disabled {
+.chordsketch-sheet__content .chordsketch-sheet__cins-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cs-sp-2, 0.5rem);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--cs-text-strong, #44424a);
+}
+/* segmented (root / accidental) */
+.chordsketch-sheet__content .chordsketch-sheet__cins-seg {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding: 2px;
+  background: var(--cs-ink-100, #f6f4f7);
+  border: 1px solid var(--cs-border, #e8e6ea);
+  border-radius: var(--cs-r-2, 4px);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-seg button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  border-radius: var(--cs-r-1, 2px);
+  padding: 4px 8px;
+  min-width: 30px;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--cs-text-secondary, #67646d);
+  cursor: pointer;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-seg button[aria-pressed='true'] {
+  background: var(--cs-surface, #fff);
+  color: var(--cs-crimson-600, #a30f37);
+  box-shadow: var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
+}
+/* type chips */
+.chordsketch-sheet__content .chordsketch-sheet__cins-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-chip {
+  appearance: none;
+  border: 1px solid var(--cs-border-strong, #d4d1d6);
+  background: var(--cs-surface, #fff);
+  border-radius: var(--cs-r-full, 9999px);
+  padding: 4px 10px;
+  font-family: var(--cs-font-chord, "Roboto", system-ui, sans-serif);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--cs-text-strong, #44424a);
+  cursor: pointer;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-chip:hover {
+  background: var(--cs-surface-hover, #f6f4f7);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-chip[aria-pressed='true'] {
+  background: var(--cs-crimson-500, #bd1642);
+  border-color: var(--cs-crimson-500, #bd1642);
+  color: var(--cs-fg-on-crimson, #fff);
+}
+/* inputs */
+.chordsketch-sheet__content .chordsketch-sheet__cins-row2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--cs-sp-2, 0.5rem);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cs-sp-1, 0.25rem);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-input {
+  width: 100%;
+  height: 32px;
+  border: 1px solid var(--cs-border-strong, #d4d1d6);
+  border-radius: var(--cs-r-2, 4px);
+  background: var(--cs-surface, #fff);
+  padding: 0 var(--cs-sp-2, 0.5rem);
+  font-family: var(--cs-font-chord, "Roboto", system-ui, sans-serif);
+  font-size: 0.875rem;
+  color: var(--cs-text-primary, #0a0a0b);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-input:focus-visible {
+  outline: none;
+  box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-divider {
+  height: 1px;
+  background: var(--cs-border, #e8e6ea);
+  margin: 0 calc(var(--cs-sp-4, 1rem) * -1);
+}
+/* move row (relocated nudge) */
+.chordsketch-sheet__content .chordsketch-sheet__cins-move {
+  display: flex;
+  align-items: center;
+  gap: var(--cs-sp-2, 0.5rem);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-movebtn {
+  flex: 1;
+  height: 34px;
+  border: 1px solid var(--cs-border-strong, #d4d1d6);
+  background: var(--cs-surface, #fff);
+  border-radius: var(--cs-r-2, 4px);
+  font-size: 1rem;
+  color: var(--cs-text-strong, #44424a);
+  cursor: pointer;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-movebtn:hover:not(:disabled) {
+  background: var(--cs-surface-hover, #f6f4f7);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-movebtn:disabled {
   opacity: 0.35;
   cursor: default;
 }
-.chordsketch-sheet__content .chord-nudge__btn:focus-visible {
-  outline: 2px solid var(--cs-crimson-500, #bd1642);
-  outline-offset: 1px;
-  border-radius: 4px;
+.chordsketch-sheet__content .chordsketch-sheet__cins-movelbl {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--cs-text-secondary, #67646d);
+  white-space: nowrap;
+}
+/* footer */
+.chordsketch-sheet__content .chordsketch-sheet__cins-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-remove {
+  appearance: none;
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: var(--cs-r-2, 4px);
+  padding: var(--cs-sp-2, 0.5rem) var(--cs-sp-3, 0.75rem);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--cs-crimson-600, #a30f37);
+  cursor: pointer;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-remove:hover {
+  background: var(--cs-crimson-50, #fdf2f5);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-done {
+  appearance: none;
+  border: 1px solid var(--cs-border-strong, #d4d1d6);
+  background: var(--cs-surface, #fff);
+  border-radius: var(--cs-r-2, 4px);
+  padding: var(--cs-sp-2, 0.5rem) var(--cs-sp-3, 0.75rem);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--cs-text-strong, #44424a);
+  cursor: pointer;
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins-done:hover {
+  background: var(--cs-surface-hover, #f6f4f7);
+}
+.chordsketch-sheet__content .chordsketch-sheet__cins :focus-visible {
+  outline: none;
+  box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
+  border-radius: var(--cs-r-2, 4px);
 }
 
 /* Per-character span inside a `.lyrics` row. Plain wrapper so

--- a/packages/react/tests/chord-inspector.test.tsx
+++ b/packages/react/tests/chord-inspector.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ChordInspector } from '../src/chord-inspector';
+import type { ChordParts } from '../src/chord-source-edit';
+
+function setup(overrides: Partial<Parameters<typeof ChordInspector>[0]> = {}) {
+  const onChange = vi.fn();
+  const onNudge = vi.fn();
+  const onRemove = vi.fn();
+  const onClose = vi.fn();
+  const props = {
+    chordName: 'Am7',
+    root: 'A',
+    accidental: '' as const,
+    suffix: 'm7',
+    bass: '',
+    canLeft: true,
+    canRight: true,
+    onChange,
+    onNudge,
+    onRemove,
+    onClose,
+    ...overrides,
+  };
+  const utils = render(<ChordInspector {...props} />);
+  return { ...utils, onChange, onNudge, onRemove, onClose };
+}
+
+describe('<ChordInspector>', () => {
+  test('header shows the chord name and root/accidental/type reflect the parts', () => {
+    const { container } = setup();
+    expect(container.querySelector('.chordsketch-sheet__cins-name')?.textContent).toBe('Am7');
+    // Root A is pressed; accidental natural is pressed; type m7 chip pressed.
+    const pressedRoot = container.querySelector(
+      '.chordsketch-sheet__cins-seg button[aria-pressed="true"]',
+    );
+    expect(pressedRoot?.textContent).toBe('A');
+    const pressedChip = container.querySelector(
+      '.chordsketch-sheet__cins-chip[aria-pressed="true"]',
+    );
+    expect(pressedChip?.textContent).toBe('m7');
+  });
+
+  test('changing the root emits the full parts with the new root', () => {
+    const { container, onChange } = setup();
+    const segs = container.querySelectorAll('.chordsketch-sheet__cins-seg');
+    const dButton = Array.from(segs[0].querySelectorAll('button')).find(
+      (b) => b.textContent === 'D',
+    ) as HTMLButtonElement;
+    fireEvent.click(dButton);
+    expect(onChange).toHaveBeenCalledWith({ root: 'D', accidental: '', suffix: 'm7', bass: '' });
+  });
+
+  test('choosing an accidental emits the mapped character', () => {
+    const { container, onChange } = setup();
+    const accSeg = container.querySelectorAll('.chordsketch-sheet__cins-seg')[1];
+    const flat = Array.from(accSeg.querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === 'Flat',
+    ) as HTMLButtonElement;
+    fireEvent.click(flat);
+    expect(onChange).toHaveBeenCalledWith({ root: 'A', accidental: 'b', suffix: 'm7', bass: '' });
+  });
+
+  test('a type chip sets the suffix to the preset text', () => {
+    const { container, onChange } = setup();
+    const chips = container.querySelectorAll('.chordsketch-sheet__cins-chip');
+    const maj7 = Array.from(chips).find((c) => c.textContent === 'maj7') as HTMLButtonElement;
+    fireEvent.click(maj7);
+    expect(onChange).toHaveBeenCalledWith({
+      root: 'A',
+      accidental: '',
+      suffix: 'maj7',
+      bass: '',
+    });
+  });
+
+  test('typing in the suffix / bass inputs emits the edited value', () => {
+    const { container, onChange } = setup();
+    const inputs = container.querySelectorAll('.chordsketch-sheet__cins-input');
+    fireEvent.change(inputs[0], { target: { value: 'sus4' } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      root: 'A',
+      accidental: '',
+      suffix: 'sus4',
+      bass: '',
+    });
+    fireEvent.change(inputs[1], { target: { value: 'G' } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      root: 'A',
+      accidental: '',
+      suffix: 'm7',
+      bass: 'G',
+    } satisfies ChordParts);
+  });
+
+  test('move buttons call onNudge and respect the bound flags', () => {
+    const { container, onNudge } = setup({ canLeft: false });
+    const left = container.querySelector('button[aria-label="Move chord left"]') as HTMLButtonElement;
+    const right = container.querySelector(
+      'button[aria-label="Move chord right"]',
+    ) as HTMLButtonElement;
+    expect(left.disabled).toBe(true);
+    fireEvent.click(right);
+    expect(onNudge).toHaveBeenCalledWith(1);
+  });
+
+  test('Escape closes; the close button closes; Remove fires onRemove', () => {
+    const { container, onClose, onRemove } = setup();
+    fireEvent.keyDown(container.querySelector('.chordsketch-sheet__cins') as HTMLElement, {
+      key: 'Escape',
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.click(container.querySelector('.chordsketch-sheet__cins-remove') as HTMLElement);
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    fireEvent.click(container.querySelector('.chordsketch-sheet__cins-close') as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  test('omitting onRemove hides the Remove button', () => {
+    const { container } = setup({ onRemove: undefined });
+    expect(container.querySelector('.chordsketch-sheet__cins-remove')).toBeNull();
+  });
+});

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -620,6 +620,66 @@ describe('<ChordSheet>', () => {
     expect(right.disabled).toBe(false);
   });
 
+  test('edits use the RAW source name, not a transposed detail', async () => {
+    // Guards transpose-safety: under a non-zero transpose the AST chord
+    // exposes the transposed pitch via `detail`, but `chord.name` stays
+    // the raw source token. Editing must rewrite the raw chord. Here the
+    // raw name is "Am" while detail claims root B (as if transposed +2);
+    // picking the "7" chip must write "A7" (raw root A), never "B7".
+    const transposedDetailAst = JSON.stringify({
+      metadata: JSON.parse(astFor('x')).metadata,
+      lines: [
+        {
+          kind: 'lyrics',
+          value: {
+            segments: [
+              {
+                chord: {
+                  name: 'Am',
+                  display: 'Bm',
+                  detail: {
+                    root: 'B',
+                    rootAccidental: null,
+                    quality: 'minor',
+                    extension: null,
+                    bassNote: null,
+                  },
+                },
+                text: 'hi',
+                spans: [],
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const stub: StubRenderer = {
+      ...makeStub(),
+      parseChordproWithWarnings: vi.fn(() => ({
+        ast: transposedDetailAst,
+        warnings: [],
+        transposedKey: undefined,
+      })),
+    };
+    const onChordEdit = vi.fn();
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(stub)}
+        onChordReposition={vi.fn()}
+        onChordEdit={onChordEdit}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    const chips = container.querySelectorAll('.chordsketch-sheet__cins-chip');
+    const seven = Array.from(chips).find((c) => c.textContent === '7') as HTMLButtonElement;
+    fireEvent.click(seven);
+    expect(onChordEdit.mock.calls[0][0].chord).toBe('A7');
+  });
+
   test('the inspector "Remove chord" button fires onChordDelete and deselects', async () => {
     const onChordDelete = vi.fn();
     const { container } = render(

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -487,13 +487,14 @@ describe('<ChordSheet>', () => {
         },
       ],
     });
+    const result = { ast: songAst, warnings: [], transposedKey: undefined };
     return {
       ...makeStub(),
-      parseChordproWithWarnings: vi.fn(() => ({
-        ast: songAst,
-        warnings: [],
-        transposedKey: undefined,
-      })),
+      // Both parse entries return the chord-bearing AST so the stub
+      // works whether or not transpose / config options are passed
+      // (the AST branch uses the options entry when transpose is set).
+      parseChordproWithWarnings: vi.fn(() => result),
+      parseChordproWithWarningsAndOptions: vi.fn(() => result),
     };
   }
 
@@ -566,6 +567,7 @@ describe('<ChordSheet>', () => {
       fromColumn: 0,
       fromLength: 4,
       chord: 'A7',
+      expected: 'Am',
     });
   });
 
@@ -699,7 +701,12 @@ describe('<ChordSheet>', () => {
       '.chordsketch-sheet__cins-remove',
     ) as HTMLButtonElement;
     fireEvent.click(remove);
-    expect(onChordDelete).toHaveBeenCalledWith({ line: 1, fromColumn: 0, fromLength: 4 });
+    expect(onChordDelete).toHaveBeenCalledWith({
+      line: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      expected: 'Am',
+    });
     expect(container.querySelector('.chordsketch-sheet__cins')).toBeNull();
   });
 
@@ -786,6 +793,61 @@ describe('<ChordSheet>', () => {
     fireEvent.pointerDown(textNode as Node);
     // Selection survives — the press resolved to the `.chord` element.
     expect(container.querySelector('.chord--selected')).not.toBeNull();
+  });
+
+  test('a non-zero transpose disables chord selection + the inspector', async () => {
+    // The transposed AST carries transposed chord names, so source-
+    // coordinate editing is unsafe and must be gated off.
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        transpose={2}
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+        onChordDelete={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.chord')).not.toBeNull();
+    });
+    // Chords are not selectable; no badge / inspector / role=button.
+    expect(container.querySelector(".chord[role='button']")).toBeNull();
+    fireEvent.click(container.querySelector('.chord') as HTMLElement);
+    expect(container.querySelector('.chordsketch-sheet__cins')).toBeNull();
+    expect(container.querySelector('.chord--selected')).toBeNull();
+  });
+
+  test('a {capo} in the source disables editing (capo folds into transpose)', async () => {
+    const { container } = render(
+      <ChordSheet
+        source={'{capo: 2}\n[Am]hi'}
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.chord')).not.toBeNull();
+    });
+    expect(container.querySelector(".chord[role='button']")).toBeNull();
+  });
+
+  test('transpose that cancels the capo (net zero) keeps editing enabled', async () => {
+    // transpose +2 with {capo: 2} → effective 0 → names == source → safe.
+    const { container } = render(
+      <ChordSheet
+        source={'{capo: 2}\n[Am]hi'}
+        transpose={2}
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.chord')).not.toBeNull();
+    });
+    expect(container.querySelector(".chord[role='button']")).not.toBeNull();
   });
 
   test('chords stay inert when onChordReposition is not provided', async () => {

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -497,7 +497,10 @@ describe('<ChordSheet>', () => {
     };
   }
 
-  test('onChordReposition enables click-to-focus nudge controls', async () => {
+  test('onChordReposition enables click-to-select + keyboard nudge', async () => {
+    // Without onChordEdit, clicking selects (solid badge) and keyboard
+    // arrows nudge, but the editor inspector is not shown (it is the
+    // chord EDITOR, gated on onChordEdit).
     const onChordReposition = vi.fn();
     const { container } = render(
       <ChordSheet
@@ -509,12 +512,18 @@ describe('<ChordSheet>', () => {
     await waitFor(() => {
       expect(container.querySelector(".chord[role='button']")).not.toBeNull();
     });
-    // No controls until the chord is clicked.
-    expect(container.querySelector('.chord-nudge')).toBeNull();
-    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
-    // Controls appear; the right button moves Am one char into "hi".
-    expect(container.querySelector('.chord-nudge')).not.toBeNull();
-    fireEvent.click(container.querySelector('.chord-nudge__btn--right') as HTMLElement);
+    expect(container.querySelector('.chord--selected')).toBeNull();
+    expect(container.querySelector('.chordsketch-sheet__cins')).toBeNull();
+    const chord = container.querySelector(".chord[role='button']") as HTMLElement;
+    fireEvent.click(chord);
+    // Selected badge, but no inspector (no onChordEdit wired).
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
+    expect(container.querySelector('.chordsketch-sheet__cins')).toBeNull();
+    // Keyboard ArrowRight moves Am one char into "hi".
+    fireEvent.keyDown(
+      container.querySelector('.chord--selected') as HTMLElement,
+      { key: 'ArrowRight' },
+    );
     expect(onChordReposition).toHaveBeenCalledTimes(1);
     expect(onChordReposition.mock.calls[0][0]).toMatchObject({
       fromLine: 1,
@@ -525,22 +534,170 @@ describe('<ChordSheet>', () => {
     });
   });
 
-  test('pressing down outside the sheet clears the chord selection', async () => {
+  test('onChordEdit opens the inspector; a type chip emits a ChordEditEvent', async () => {
+    const onChordReposition = vi.fn();
+    const onChordEdit = vi.fn();
     const { container } = render(
       <ChordSheet
         source="[Am]hi"
         astWasmLoader={makeAstLoader(chordStub())}
-        onChordReposition={vi.fn()}
+        onChordReposition={onChordReposition}
+        onChordEdit={onChordEdit}
       />,
     );
     await waitFor(() => {
       expect(container.querySelector(".chord[role='button']")).not.toBeNull();
     });
     fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
-    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    // Inspector appears with the selected chord in the header.
+    expect(container.querySelector('.chordsketch-sheet__cins')).not.toBeNull();
+    expect(container.querySelector('.chordsketch-sheet__cins-name')?.textContent).toBe('Am');
+    // A type chip emits a ChordEditEvent rewriting the chord at its
+    // source position. Am is detail-less in the stub, so the editor
+    // falls back to raw-name parts (root A, suffix "m"); picking "7"
+    // writes "A7" over the original [Am].
+    const chips = container.querySelectorAll('.chordsketch-sheet__cins-chip');
+    const seven = Array.from(chips).find((c) => c.textContent === '7') as HTMLButtonElement;
+    expect(seven).toBeDefined();
+    fireEvent.click(seven);
+    expect(onChordEdit).toHaveBeenCalledTimes(1);
+    expect(onChordEdit.mock.calls[0][0]).toEqual({
+      line: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      chord: 'A7',
+    });
+  });
+
+  test('the inspector ▶ button moves the chord via the reposition pipeline', async () => {
+    const onChordReposition = vi.fn();
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={onChordReposition}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    const right = container.querySelector(
+      '.chordsketch-sheet__cins-move button[aria-label="Move chord right"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(right);
+    expect(onChordReposition).toHaveBeenCalledTimes(1);
+    expect(onChordReposition.mock.calls[0][0]).toMatchObject({
+      fromLine: 1,
+      toLine: 1,
+      toLyricsOffset: 1,
+      chord: 'Am',
+      copy: false,
+    });
+  });
+
+  test('the inspector ◀ button is disabled for a chord at the line start', async () => {
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    const left = container.querySelector(
+      '.chordsketch-sheet__cins-move button[aria-label="Move chord left"]',
+    ) as HTMLButtonElement;
+    const right = container.querySelector(
+      '.chordsketch-sheet__cins-move button[aria-label="Move chord right"]',
+    ) as HTMLButtonElement;
+    expect(left.disabled).toBe(true);
+    expect(right.disabled).toBe(false);
+  });
+
+  test('the inspector "Remove chord" button fires onChordDelete and deselects', async () => {
+    const onChordDelete = vi.fn();
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+        onChordDelete={onChordDelete}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    const remove = container.querySelector(
+      '.chordsketch-sheet__cins-remove',
+    ) as HTMLButtonElement;
+    fireEvent.click(remove);
+    expect(onChordDelete).toHaveBeenCalledWith({ line: 1, fromColumn: 0, fromLength: 4 });
+    expect(container.querySelector('.chordsketch-sheet__cins')).toBeNull();
+  });
+
+  test('the inspector "Remove" button is hidden when onChordDelete is not wired', async () => {
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    expect(container.querySelector('.chordsketch-sheet__cins')).not.toBeNull();
+    expect(container.querySelector('.chordsketch-sheet__cins-remove')).toBeNull();
+  });
+
+  test('pressing down outside the sheet clears the chord selection', async () => {
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    expect(container.querySelector('.chordsketch-sheet__cins')).not.toBeNull();
     // Pointer down on the document body (outside any chord) clears it.
     fireEvent.pointerDown(document.body);
-    expect(container.querySelector('.chord-nudge')).toBeNull();
+    expect(container.querySelector('.chordsketch-sheet__cins')).toBeNull();
+  });
+
+  test('pressing inside the inspector keeps the selection', async () => {
+    // The outside-click listener must exclude the inspector itself, or
+    // interacting with its controls would deselect mid-edit.
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    const inspector = container.querySelector('.chordsketch-sheet__cins') as HTMLElement;
+    expect(inspector).not.toBeNull();
+    fireEvent.pointerDown(inspector);
+    expect(container.querySelector('.chordsketch-sheet__cins')).not.toBeNull();
   });
 
   test('pressing on the chord glyph (text node) does not clear the selection', async () => {
@@ -559,7 +716,7 @@ describe('<ChordSheet>', () => {
       expect(container.querySelector(".chord[role='button']")).not.toBeNull();
     });
     fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
-    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
     // The chord name renders as a direct Text-node child of `.chord`.
     const chordSpan = container.querySelector('.chord--selected') as HTMLElement;
     const textNode = Array.from(chordSpan.childNodes).find(
@@ -568,7 +725,7 @@ describe('<ChordSheet>', () => {
     expect(textNode).toBeDefined();
     fireEvent.pointerDown(textNode as Node);
     // Selection survives — the press resolved to the `.chord` element.
-    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
   });
 
   test('chords stay inert when onChordReposition is not provided', async () => {

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -5,7 +5,12 @@ import {
   CAPO_MIN,
   TRANSPOSE_MAX,
   TRANSPOSE_MIN,
+  CHORD_TYPE_PRESETS,
+  applyChordDelete,
+  applyChordEdit,
   applyChordReposition,
+  buildChordName,
+  chordSuffixFromQuality,
   findChordByOffsetOrdinal,
   lyricsOffsetToSourceColumn,
   nudgeChordPosition,
@@ -498,5 +503,143 @@ describe('nudge integration: nudgeChordPosition + applyChordReposition', () => {
     }
     // Am started before "H", three right steps → before the second "l".
     expect(src).toBe('Hel[Am]lo');
+  });
+});
+
+describe('chordSuffixFromQuality', () => {
+  test('round-trips parser quality + extension splits', () => {
+    expect(chordSuffixFromQuality('major', null)).toBe('');
+    expect(chordSuffixFromQuality('minor', null)).toBe('m');
+    expect(chordSuffixFromQuality('diminished', null)).toBe('dim');
+    expect(chordSuffixFromQuality('augmented', null)).toBe('aug');
+    expect(chordSuffixFromQuality('minor', '7')).toBe('m7');
+    expect(chordSuffixFromQuality('major', 'maj7')).toBe('maj7');
+    expect(chordSuffixFromQuality('minor', '7b5')).toBe('m7b5');
+    expect(chordSuffixFromQuality('major', 'sus4')).toBe('sus4');
+  });
+
+  test('every suffix-only preset is reachable from a quality+extension split', () => {
+    // Sanity: the presets the chips expose are all valid suffix strings
+    // the parser could produce (so a chip selection round-trips).
+    const suffixes = new Set(CHORD_TYPE_PRESETS.map((p) => p.text));
+    expect(suffixes.has('')).toBe(true); // maj
+    expect(suffixes.has('m')).toBe(true); // min
+    expect(suffixes.has('m7')).toBe(true);
+    expect(suffixes.has('maj7')).toBe(true);
+  });
+});
+
+describe('buildChordName', () => {
+  test('assembles root + accidental + suffix + bass', () => {
+    expect(buildChordName({ root: 'A' })).toBe('A');
+    expect(buildChordName({ root: 'A', suffix: 'm' })).toBe('Am');
+    expect(buildChordName({ root: 'A', accidental: '#', suffix: 'm7' })).toBe('A#m7');
+    expect(buildChordName({ root: 'B', accidental: 'b', suffix: 'maj7' })).toBe('Bbmaj7');
+    expect(buildChordName({ root: 'G', suffix: '7', bass: 'B' })).toBe('G7/B');
+    expect(buildChordName({ root: 'C', bass: 'E' })).toBe('C/E');
+  });
+
+  test('rejects a bad root', () => {
+    expect(() => buildChordName({ root: 'H' })).toThrow(/root/);
+    expect(() => buildChordName({ root: 'Am' })).toThrow(/root/);
+    expect(() => buildChordName({ root: '' })).toThrow(/root/);
+  });
+
+  test('rejects a bad accidental', () => {
+    // @ts-expect-error — exercising the runtime guard with an invalid value
+    expect(() => buildChordName({ root: 'C', accidental: 'x' })).toThrow(/accidental/);
+  });
+
+  test.each([
+    ['m[7'], ['m]7'], ['m{7'], ['m}7'], ['m<7'], ['m\n7'], ['m/7'],
+  ])('rejects a suffix containing a structural character (%s)', (suffix) => {
+    expect(() => buildChordName({ root: 'C', suffix })).toThrow(/suffix/);
+  });
+
+  test('rejects a bass containing a slash or structural character', () => {
+    expect(() => buildChordName({ root: 'C', bass: 'E/G' })).toThrow(/bass/);
+    expect(() => buildChordName({ root: 'C', bass: 'E]' })).toThrow(/bass/);
+  });
+});
+
+describe('applyChordEdit', () => {
+  test('replaces the chord token in place and reports caret after it', () => {
+    // `[Am]Hello` — edit Am (col 0, len 4) → Amaj7.
+    const { text, caretOffset } = applyChordEdit('[Am]Hello', {
+      line: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      chord: 'Amaj7',
+    });
+    expect(text).toBe('[Amaj7]Hello');
+    expect(caretOffset).toBe('[Amaj7]'.length); // 7
+  });
+
+  test('edits a mid-line chord on the correct line, leaving others intact', () => {
+    // line 2: `He[G]llo` — edit G (col 2, len 3) → G7.
+    const before = 'first\nHe[G]llo';
+    const { text, caretOffset } = applyChordEdit(before, {
+      line: 2,
+      fromColumn: 2,
+      fromLength: 3,
+      chord: 'G7',
+    });
+    expect(text).toBe('first\nHe[G7]llo');
+    // line1 "first"(5)+\n = 6, + col 2 ("He") + "[G7]"(4) = 12.
+    expect(caretOffset).toBe(12);
+  });
+
+  test('round-trips buildChordName output through applyChordEdit', () => {
+    const chord = buildChordName({ root: 'D', accidental: 'b', suffix: 'm7', bass: 'F' });
+    expect(chord).toBe('Dbm7/F');
+    const { text } = applyChordEdit('[Am]x', { line: 1, fromColumn: 0, fromLength: 4, chord });
+    expect(text).toBe('[Dbm7/F]x');
+  });
+
+  test('throws on out-of-range line / span and on a forbidden chord', () => {
+    expect(() =>
+      applyChordEdit('a', { line: 5, fromColumn: 0, fromLength: 1, chord: 'C' }),
+    ).toThrow(/line 5 out of range/);
+    expect(() =>
+      applyChordEdit('[Am]', { line: 1, fromColumn: 0, fromLength: 99, chord: 'C' }),
+    ).toThrow(/exceeds line length/);
+    expect(() =>
+      applyChordEdit('[Am]', { line: 1, fromColumn: 0, fromLength: 4, chord: '' }),
+    ).toThrow(/non-empty/);
+    expect(() =>
+      applyChordEdit('[Am]', { line: 1, fromColumn: 0, fromLength: 4, chord: 'C}evil' }),
+    ).toThrow(/forbidden character/);
+  });
+});
+
+describe('applyChordDelete', () => {
+  test('removes the chord token, keeping the lyric', () => {
+    const { text, caretOffset } = applyChordDelete('[Am]Hello', {
+      line: 1,
+      fromColumn: 0,
+      fromLength: 4,
+    });
+    expect(text).toBe('Hello');
+    expect(caretOffset).toBe(0);
+  });
+
+  test('removes a mid-line chord on the correct line', () => {
+    const { text, caretOffset } = applyChordDelete('first\nHe[G]llo', {
+      line: 2,
+      fromColumn: 2,
+      fromLength: 3,
+    });
+    expect(text).toBe('first\nHello');
+    // "first"(5)+\n=6, +2 = 8
+    expect(caretOffset).toBe(8);
+  });
+
+  test('throws on out-of-range line / span', () => {
+    expect(() => applyChordDelete('a', { line: 9, fromColumn: 0, fromLength: 1 })).toThrow(
+      /out of range/,
+    );
+    expect(() => applyChordDelete('[Am]', { line: 1, fromColumn: 0, fromLength: 99 })).toThrow(
+      /exceeds line length/,
+    );
   });
 });

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -679,4 +679,14 @@ describe('applyChordEdit / applyChordDelete — expected-token guard', () => {
     });
     expect(text).toBe('[Cm]hi');
   });
+
+  test('applyChordDelete applies when `expected` matches the live span', () => {
+    const { text } = applyChordDelete('[Am]hi', {
+      line: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      expected: 'Am',
+    });
+    expect(text).toBe('hi');
+  });
 });

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -643,3 +643,40 @@ describe('applyChordDelete', () => {
     );
   });
 });
+
+describe('applyChordEdit / applyChordDelete — expected-token guard', () => {
+  test('applyChordEdit no-ops when the live span no longer matches `expected`', () => {
+    // Stale event: source already advanced from `[C]` to `[Cm]`, but the
+    // event still carries the old span (col 0, len 3) + expected 'C'.
+    const { text } = applyChordEdit('[Cm]hi', {
+      line: 1,
+      fromColumn: 0,
+      fromLength: 3,
+      chord: 'C7',
+      expected: 'C',
+    });
+    // Source unchanged — no `[C7]]hi` corruption.
+    expect(text).toBe('[Cm]hi');
+  });
+
+  test('applyChordEdit applies when `expected` matches the live span', () => {
+    const { text } = applyChordEdit('[C]hi', {
+      line: 1,
+      fromColumn: 0,
+      fromLength: 3,
+      chord: 'C7',
+      expected: 'C',
+    });
+    expect(text).toBe('[C7]hi');
+  });
+
+  test('applyChordDelete no-ops on a stale `expected`', () => {
+    const { text } = applyChordDelete('[Cm]hi', {
+      line: 1,
+      fromColumn: 0,
+      fromLength: 3,
+      expected: 'C',
+    });
+    expect(text).toBe('[Cm]hi');
+  });
+});

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3805,82 +3805,21 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     };
   }
 
-  test('no nudge controls until a chord is clicked', () => {
+  test('chords are toggle buttons; clicking selects (solid badge + aria-pressed)', () => {
     const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
-    expect(container.querySelector('.chord-nudge')).toBeNull();
-    // Chords are toggle buttons when the feature is fully wired.
     const chord = container.querySelector('.chord') as HTMLElement;
+    // Toggle-button semantics when the feature is fully wired.
     expect(chord.getAttribute('role')).toBe('button');
     expect(chord.getAttribute('aria-pressed')).toBe('false');
-  });
-
-  test('clicking a chord selects it and reveals two nudge buttons', () => {
-    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
-    const chord = container.querySelector('.chord') as HTMLElement;
+    // Nothing selected yet.
+    expect(container.querySelector('.chord--selected')).toBeNull();
     fireEvent.click(chord);
-    const nudge = container.querySelector('.chord-nudge');
-    expect(nudge).not.toBeNull();
-    expect(nudge?.querySelectorAll('button').length).toBe(2);
-    // The selected chord reflects aria-pressed.
-    const selectedChord = container.querySelector('.chord--selected') as HTMLElement;
-    expect(selectedChord.getAttribute('aria-pressed')).toBe('true');
-  });
-
-  test('right button emits a reposition event moving the chord one lyric char', () => {
-    const onReposition = vi.fn();
-    const { container } = render(<Harness ast={twoChordAst()} onReposition={onReposition} />);
-    // Select Am (offset 0).
-    fireEvent.click(container.querySelector('.chord') as HTMLElement);
-    const right = container.querySelector('.chord-nudge__btn--right') as HTMLElement;
-    fireEvent.click(right);
-    expect(onReposition).toHaveBeenCalledTimes(1);
-    expect(onReposition.mock.calls[0][0]).toMatchObject({
-      fromLine: 1,
-      fromColumn: 0,
-      fromLength: 4,
-      toLine: 1,
-      toLyricsOffset: 1,
-      chord: 'Am',
-      copy: false,
-    });
-  });
-
-  test('left button is disabled for a chord at the line start', () => {
-    const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
-    fireEvent.click(container.querySelector('.chord') as HTMLElement);
-    const left = container.querySelector('.chord-nudge__btn--left') as HTMLButtonElement;
-    const right = container.querySelector('.chord-nudge__btn--right') as HTMLButtonElement;
-    expect(left.disabled).toBe(true);
-    expect(right.disabled).toBe(false);
-  });
-
-  test('right button is disabled for a trailing chord at the line end', () => {
-    // `Hi[Am]` — Am at offset 2 === totalLyrics, so it cannot move right.
-    const ast: ChordproSong = {
-      metadata: EMPTY_META,
-      lines: [
-        {
-          kind: 'lyrics',
-          value: {
-            segments: [
-              { chord: null, text: 'Hi', spans: [] },
-              { chord: { name: 'Am', detail: null, display: null }, text: '', spans: [] },
-            ],
-          },
-        },
-      ],
-    };
-    const { container } = render(<Harness ast={ast} onReposition={vi.fn()} />);
-    // The real chord is the second .chord span (first is the trailing
-    // segment's — actually the chord-less leading segment has no chord
-    // span on a chord-bearing line unless lineHasChords; click the
-    // role=button chord).
-    const chordButton = container.querySelector(".chord[role='button']") as HTMLElement;
-    fireEvent.click(chordButton);
-    const left = container.querySelector('.chord-nudge__btn--left') as HTMLButtonElement;
-    const right = container.querySelector('.chord-nudge__btn--right') as HTMLButtonElement;
-    expect(right.disabled).toBe(true);
-    expect(left.disabled).toBe(false);
+    // Selected → solid badge + aria-pressed. (The ◀/▶ move controls and
+    // the editor now live in the left-docked inspector, which is
+    // rendered by <ChordSheet>, not the walker — see chord-sheet tests.)
+    const selected = container.querySelector('.chord--selected') as HTMLElement;
+    expect(selected).not.toBeNull();
+    expect(selected.getAttribute('aria-pressed')).toBe('true');
   });
 
   test('ArrowRight on the selected chord emits a reposition event', () => {
@@ -3895,6 +3834,16 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
       toLyricsOffset: 1,
       chord: 'Am',
     });
+  });
+
+  test('ArrowLeft at the line start is a no-op (out of bounds)', () => {
+    const onReposition = vi.fn();
+    const { container } = render(<Harness ast={twoChordAst()} onReposition={onReposition} />);
+    // Select Am at offset 0 — it cannot move left.
+    fireEvent.click(container.querySelector('.chord') as HTMLElement);
+    const selected = container.querySelector('.chord--selected') as HTMLElement;
+    fireEvent.keyDown(selected, { key: 'ArrowLeft' });
+    expect(onReposition).not.toHaveBeenCalled();
   });
 
   test('reselecting a chord after deselect restores DOM focus (nonce reset)', () => {
@@ -3915,7 +3864,7 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     expect(document.activeElement).toBe(selected);
     // Deselect via Escape, then move DOM focus away.
     fireEvent.keyDown(selected, { key: 'Escape' });
-    expect(container.querySelector('.chord-nudge')).toBeNull();
+    expect(container.querySelector('.chord--selected')).toBeNull();
     (document.activeElement as HTMLElement | null)?.blur();
     expect(document.activeElement).not.toBe(chord());
     // Reselect the same chord — the effect must refocus it despite the
@@ -3928,7 +3877,7 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
     const chord = container.querySelector('.chord') as HTMLElement;
     fireEvent.keyDown(chord, { key: 'Enter' });
-    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
   });
 
   test('Escape clears the selection', () => {
@@ -3936,46 +3885,17 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     fireEvent.click(container.querySelector('.chord') as HTMLElement);
     const selectedChord = container.querySelector('.chord--selected') as HTMLElement;
     fireEvent.keyDown(selectedChord, { key: 'Escape' });
-    expect(container.querySelector('.chord-nudge')).toBeNull();
+    expect(container.querySelector('.chord--selected')).toBeNull();
   });
 
   test('clicking the selected chord again toggles the selection off', () => {
     const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
     const chord = container.querySelector('.chord') as HTMLElement;
     fireEvent.click(chord);
-    expect(container.querySelector('.chord-nudge')).not.toBeNull();
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
     // Click the (now selected) chord again.
     fireEvent.click(container.querySelector('.chord--selected') as HTMLElement);
-    expect(container.querySelector('.chord-nudge')).toBeNull();
-  });
-
-  test('nudge advances the selection (does not clear it) and bumps the nonce', () => {
-    // Controlled render: a fixed selection + spy setter so we can
-    // assert exactly what the nudge writes back — proving the button
-    // moves the selection forward rather than the chord toggle
-    // clearing it. (The stateful Harness can't show this because its
-    // AST is not re-parsed, so the moved-to offset resolves to no
-    // chord and the controls naturally disappear.)
-    const onReposition = vi.fn();
-    const setChordSelection = vi.fn();
-    const { container } = render(
-      renderChordproAst(twoChordAst(), {
-        onChordReposition: onReposition,
-        chordSelection: { line: 1, offset: 0, ordinal: 0, nonce: 3 },
-        setChordSelection,
-      }),
-    );
-    const right = container.querySelector('.chord-nudge__btn--right') as HTMLElement;
-    fireEvent.click(right);
-    expect(onReposition).toHaveBeenCalledTimes(1);
-    expect(setChordSelection).toHaveBeenCalledTimes(1);
-    // Non-null move to offset 1, nonce advanced — NOT a deselect.
-    expect(setChordSelection.mock.calls[0][0]).toEqual({
-      line: 1,
-      offset: 1,
-      ordinal: 0,
-      nonce: 4,
-    });
+    expect(container.querySelector('.chord--selected')).toBeNull();
   });
 
   test('clicking a chord writes the selection with an advanced nonce', () => {
@@ -4006,9 +3926,9 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     const chord = container.querySelector('.chord') as HTMLElement;
     // Drag still wired…
     expect(chord.getAttribute('draggable')).toBe('true');
-    // …but no click-to-nudge toggle semantics.
+    // …but no click-to-select toggle semantics.
     expect(chord.getAttribute('role')).toBeNull();
-    expect(container.querySelector('.chord-nudge')).toBeNull();
+    expect(container.querySelector('.chord--selected')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

Follow-up to #2614. Turns the selected-chord experience in the `@chordsketch/react` preview into a proper, design-system-aligned **chord editor**.

- **Active chord** → a **solid crimson-500 filled badge** (white text), replacing the thin outline (confirmed design direction).
- **Floating, left-docked inspector** (`<ChordInspector>`) that opens on chord select and does **not** track the chord:
  - **Root** segmented (C–B) · **Accidental** ♮♯♭ · **Type** preset chips (`maj`/`min`/`7`/`maj7`/`m7`/`m7♭5`/`dim`/`dim7`/`aug`/`sus2`/`sus4`/`6`/`9`/`add9`) · free-form **quality/ext** + **`/bass`** inputs · relocated **◀ / ▶ move** · **Remove chord** · **Done**.
  - Bespoke `.chordsketch-sheet__cins*` classes mirror the iReal Pro `<IrealBarPopover>` chord-edit pattern; all colour/space/radius/elevation/motion/focus come from the design-system tokens. Docked over `.chordsketch-sheet__content` (now `position: relative`).

## Why

On touch, fine editing is hard; a floating editor with discrete controls (root/type/bass + one-step move) is the natural next step after click-to-select (#2614). The maintainer confirmed the UI direction (left-docked inspector · solid badge · preset chips · includes Remove) before implementation. Closes #2626.

## Design

- `<ChordSheet>` owns selection + AST + source and renders the inspector; a resolver maps the `(line, offset, ordinal)` selection to the chord's editable parts + source coordinates.
- The ◀ / ▶ buttons and the keyboard arrows share one `buildChordNudge` helper (single nudge implementation). Edits emit a `ChordEditEvent`, delete emits a `ChordDeleteTarget`; the consumer applies them with `applyChordEdit` / `applyChordDelete` — the same source-as-truth pipeline as reposition, **no parallel chord state**.
- New public props `onChordEdit` / `onChordDelete` on `<ChordSheet>` + `<RendererPreview>`; the playground wires them (split view only). New exports: `<ChordInspector>`, `buildChordName`, `buildChordNudge`, `applyChordEdit`, `applyChordDelete`, `chordSuffixFromQuality`, `CHORD_TYPE_PRESETS`, + supporting types.
- The #2614 floating ◀/▶ toolbar is removed (controls relocated into the inspector); the keyboard nudge path is retained.

## Test results

- `npm test` (vitest): **751 passed** (new: chord-edit source-helper units, `<ChordInspector>` component units, `<ChordSheet>` e2e for select → inspector → edit / nudge / remove). `npm run typecheck` clean; `npm run build` clean. Playground typechecks against the source alias (the only `tsc` errors in a standalone run are `react-ui`'s own uninstalled `react` dep — environmental).

## Review summary

- Sister-site audit: chord editing is a React-only interaction layer; the Rust renderers are static output with no interaction surface — no sister site. Documented.
- Accessibility: chord = `role="button"` toggle with `aria-pressed`; inspector controls are real buttons/inputs with `aria-label`s + a `role="group"`; Escape closes; design-system `--cs-focus-ring` on focus.

## Deferred

- Inline / hover chord-diagram mode keeps drag-only (the diagram claims the chord cell) — unchanged from #2614, documented in `chordpro-jsx.tsx`.

Closes #2626

https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6)_