### PR TITLE
Fix multi-{key} transpose dropping non-primary key pairs in React preview

### DIFF
--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -451,8 +451,7 @@ fn render_bytes_with_warnings_inner(
     let obj = js_sys::Object::new();
     let arr = js_sys::Uint8Array::from(bytes.as_slice());
     js_sys::Reflect::set(&obj, &JsValue::from_str("output"), &arr.into())?;
-    let warnings_js =
-        serde_wasm_bindgen::to_value(&warnings).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let warnings_js = to_js_value(&warnings)?;
     js_sys::Reflect::set(&obj, &JsValue::from_str("warnings"), &warnings_js)?;
     Ok(obj.into())
 }
@@ -478,11 +477,10 @@ fn render_bytes_with_warnings_inner(
         output: Vec<u8>,
         warnings: Vec<String>,
     }
-    serde_wasm_bindgen::to_value(&BytesWithWarnings {
+    to_js_value(&BytesWithWarnings {
         output: bytes,
         warnings,
     })
-    .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 /// Render ChordPro input as HTML and return `{ output, warnings }`.

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -63,6 +63,36 @@ pub fn start() {
     console_error_panic_hook::set_once();
 }
 
+/// Serialize `value` to a `JsValue`, encoding Rust maps
+/// (`BTreeMap` / `HashMap`) as **plain JS objects** (`{ k: v }`)
+/// rather than `serde_wasm_bindgen`'s default ES `Map`.
+///
+/// Every React / TS consumer of this surface indexes map fields
+/// with `obj[key]` — e.g. `transposedKeyDirectives[keyName]` in
+/// `packages/react/src/chordpro-jsx.tsx`. Object-bracket access
+/// returns `undefined` on an ES `Map`, which silently dropped the
+/// transposed pairing for every non-primary `{key:}` directive: a
+/// multi-`{key}` song that was transposed showed the
+/// "Original → Playing" pair for only the song-primary key and
+/// left every other `{key:}` chip unpaired (the bug this helper
+/// fixes). The unit tests never caught it because they hand-build
+/// the map as a plain JS object literal, stubbing the real wasm
+/// boundary.
+///
+/// The flag is behaviour-preserving for map-free payloads (Vecs,
+/// Options, structs are serialized identically either way), so
+/// every JS-object-returning entry point routes through this
+/// helper to keep the surface uniform and to stop the footgun from
+/// silently reappearing the next time a map field is added.
+fn to_js_value<T>(value: &T) -> Result<JsValue, JsValue>
+where
+    T: Serialize + ?Sized,
+{
+    value
+        .serialize(&serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true))
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
 /// JS `console.warn` binding, used by [`crate::flush_warnings`] to
 /// surface render warnings (transpose saturation, chorus recall
 /// limits, deny-listed metadata overrides) to developers in the
@@ -391,7 +421,7 @@ fn render_string_with_warnings_inner(
     let (output, warnings) = render_string_with_warnings_core(input, &opts, render_fn)
         .map_err(|e| JsValue::from_str(&e))?;
     let payload = StringWithWarnings { output, warnings };
-    serde_wasm_bindgen::to_value(&payload).map_err(|e| JsValue::from_str(&e.to_string()))
+    to_js_value(&payload)
 }
 
 /// Bytes-returning render that captures warnings and returns a JS
@@ -823,8 +853,7 @@ pub fn chord_diagram_svg_with_defines_orientation_compact(
 // same `ValidationError[]` shape the NAPI binding already provides.
 #[wasm_bindgen(js_name = validate, skip_typescript)]
 pub fn validate(input: &str) -> Result<JsValue, JsValue> {
-    serde_wasm_bindgen::to_value(&validate_inner(input))
-        .map_err(|e| JsValue::from_str(&e.to_string()))
+    to_js_value(&validate_inner(input))
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -918,8 +947,7 @@ export function chordDiagramSvgWithDefinesOrientationCompact(
 /// defensive path callers can treat as infallible in normal use.
 #[wasm_bindgen(js_name = listDirectives, skip_typescript)]
 pub fn list_directives() -> Result<JsValue, JsValue> {
-    serde_wasm_bindgen::to_value(&do_list_directives())
-        .map_err(|e| JsValue::from_str(&e.to_string()))
+    to_js_value(&do_list_directives())
 }
 
 /// Return the allowed value set for an enum-valued directive (alias-aware),
@@ -931,8 +959,7 @@ pub fn list_directives() -> Result<JsValue, JsValue> {
 /// Returns a `JsValue` error string only if serialisation fails.
 #[wasm_bindgen(js_name = directiveValueOptions, skip_typescript)]
 pub fn directive_value_options(name: &str) -> Result<JsValue, JsValue> {
-    serde_wasm_bindgen::to_value(&do_directive_value_options(name))
-        .map_err(|e| JsValue::from_str(&e.to_string()))
+    to_js_value(&do_directive_value_options(name))
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -1075,13 +1102,12 @@ pub fn parse_chordpro_with_options(input: &str, options: JsValue) -> Result<Stri
 pub fn parse_chordpro_with_warnings(input: &str) -> Result<JsValue, JsValue> {
     let (ast, warnings, transposed_key, transposed_key_directives) =
         do_parse_chordpro(input, None).map_err(|e| JsValue::from_str(&e))?;
-    serde_wasm_bindgen::to_value(&ParseChordproResult {
+    to_js_value(&ParseChordproResult {
         ast,
         warnings,
         transposed_key,
         transposed_key_directives,
     })
-    .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 /// Same as [`parse_chordpro_with_warnings`] but threads the
@@ -1097,13 +1123,12 @@ pub fn parse_chordpro_with_warnings_and_options(
     let opts = deserialize_options(options)?;
     let (ast, warnings, transposed_key, transposed_key_directives) =
         do_parse_chordpro(input, Some(&opts)).map_err(|e| JsValue::from_str(&e))?;
-    serde_wasm_bindgen::to_value(&ParseChordproResult {
+    to_js_value(&ParseChordproResult {
         ast,
         warnings,
         transposed_key,
         transposed_key_directives,
     })
-    .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 /// Convert a ChordPro source string into an `irealb://` URL
@@ -1121,7 +1146,7 @@ pub fn parse_chordpro_with_warnings_and_options(
 #[wasm_bindgen(js_name = convertChordproToIrealb)]
 pub fn convert_chordpro_to_irealb(input: &str) -> Result<JsValue, JsValue> {
     let payload = do_convert_chordpro_to_irealb(input).map_err(|e| JsValue::from_str(&e))?;
-    serde_wasm_bindgen::to_value(&payload).map_err(|e| JsValue::from_str(&e.to_string()))
+    to_js_value(&payload)
 }
 
 /// Convert an `irealb://` URL into rendered ChordPro text
@@ -1139,7 +1164,7 @@ pub fn convert_chordpro_to_irealb(input: &str) -> Result<JsValue, JsValue> {
 #[wasm_bindgen(js_name = convertIrealbToChordproText)]
 pub fn convert_irealb_to_chordpro_text(input: &str) -> Result<JsValue, JsValue> {
     let payload = do_convert_irealb_to_chordpro_text(input).map_err(|e| JsValue::from_str(&e))?;
-    serde_wasm_bindgen::to_value(&payload).map_err(|e| JsValue::from_str(&e.to_string()))
+    to_js_value(&payload)
 }
 
 /// Render an `irealb://` URL as an iReal Pro-style SVG chart

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1896,7 +1896,8 @@ mod wasm_tests {
     use super::bindings::{
         chord_diagram_svg, chord_diagram_svg_with_defines,
         chord_diagram_svg_with_defines_orientation, chord_diagram_svg_with_orientation,
-        parse_irealb, render_html, render_html_with_options, render_html_with_warnings,
+        parse_chordpro_with_warnings, parse_chordpro_with_warnings_and_options, parse_irealb,
+        render_html, render_html_with_options, render_html_with_warnings,
         render_html_with_warnings_and_options, render_ireal_svg, render_text,
         render_text_with_options, render_text_with_warnings, render_text_with_warnings_and_options,
         serialize_irealb, start, validate, version,
@@ -1908,11 +1909,80 @@ mod wasm_tests {
         render_pdf_with_warnings, render_pdf_with_warnings_and_options,
     };
 
-    use js_sys::{Array, Reflect};
+    use js_sys::{Array, Map, Reflect};
     use wasm_bindgen::{JsCast, JsValue};
     use wasm_bindgen_test::wasm_bindgen_test;
 
     const MINIMAL_INPUT: &str = "{title: Test}\n[C]Hello";
+
+    /// Regression for the multi-`{key}` transpose bug: every
+    /// `{key:}` directive in a transposed song must reach JS in the
+    /// `transposedKeyDirectives` field as a **plain object**, not an
+    /// ES `Map`.
+    ///
+    /// `serde_wasm_bindgen` serializes Rust maps as ES `Map` by
+    /// default, but the React JSX walker reads
+    /// `transposedKeyDirectives[keyName]` with plain-object bracket
+    /// access — which returns `undefined` on a `Map`. The symptom
+    /// was that a multi-`{key}` song showed the "Original → Playing"
+    /// pair for only the song-primary key (the one that still
+    /// resolved via the `soundingKey` fallback) and left every
+    /// other `{key:}` chip unpaired. The native unit tests in this
+    /// crate never caught it because they call `do_parse_chordpro`
+    /// directly and the React unit tests hand-build the map as a
+    /// plain JS object literal — only the real wasm boundary, under
+    /// `wasm-pack test --node`, exercises the serialization. See the
+    /// `to_js_value` helper in `bindings.rs`.
+    #[wasm_bindgen_test]
+    fn parse_chordpro_transposed_key_directives_is_plain_object() {
+        let opts = js_sys::Object::new();
+        Reflect::set(&opts, &"transpose".into(), &JsValue::from(2)).unwrap();
+        let v =
+            parse_chordpro_with_warnings_and_options("{key: G}\n[G]a\n{key: D}\n[D]b", opts.into())
+                .unwrap();
+        let map = Reflect::get(&v, &"transposedKeyDirectives".into()).unwrap();
+        assert!(
+            map.is_object(),
+            "transposedKeyDirectives must be a JS object (got {map:?})"
+        );
+        assert!(
+            !map.is_instance_of::<Map>(),
+            "transposedKeyDirectives must NOT be an ES Map — the React walker \
+             indexes it with object-bracket access, which is undefined on a Map"
+        );
+        // `Reflect::get` mirrors the `obj[key]` access the walker
+        // performs. Every transposed `{key:}` value must resolve:
+        // G + 2 = A, D + 2 = E.
+        let g = Reflect::get(&map, &"G".into()).unwrap();
+        assert_eq!(
+            g.as_string().as_deref(),
+            Some("A"),
+            "transposedKeyDirectives['G'] must be A"
+        );
+        let d = Reflect::get(&map, &"D".into()).unwrap();
+        assert_eq!(
+            d.as_string().as_deref(),
+            Some("E"),
+            "transposedKeyDirectives['D'] must be E (the mid-song key the \
+             Map-vs-object bug silently dropped)"
+        );
+    }
+
+    /// Same guarantee for the no-options entry point. The lean
+    /// `@chordsketch/wasm` bundle's `parseChordproWithWarnings`
+    /// never carries a transpose offset, so the map is empty and the
+    /// field is omitted entirely — assert it is absent (or, if
+    /// present, still a plain object) rather than an ES `Map`.
+    #[wasm_bindgen_test]
+    fn parse_chordpro_with_warnings_no_transpose_omits_key_directives() {
+        let v = parse_chordpro_with_warnings("{key: G}\n[G]a\n{key: D}\n[D]b").unwrap();
+        let map = Reflect::get(&v, &"transposedKeyDirectives".into()).unwrap();
+        // No transpose → no pairs to surface → field omitted.
+        assert!(
+            map.is_undefined(),
+            "transposedKeyDirectives must be omitted with no transpose (got {map:?})"
+        );
+    }
 
     /// `render_html_with_options` accepts a real JS object and produces
     /// HTML containing the rendered title. Exercises the

--- a/packages/playground/tests-e2e/multi-key-transpose.spec.ts
+++ b/packages/playground/tests-e2e/multi-key-transpose.spec.ts
@@ -1,0 +1,88 @@
+// Smoke verification for the multi-`{key}` transpose integration.
+//
+// Regression guard for the Map-vs-object serialization bug: the wasm
+// `parseChordproWithWarningsAndOptions` entry point returns
+// `transposedKeyDirectives` (every `{key:}` directive's transposed
+// value). `serde_wasm_bindgen` serializes Rust maps as ES `Map` by
+// default, but the React JSX walker indexes the field with
+// plain-object bracket access (`transposedKeyDirectives[keyName]`),
+// which is `undefined` on a `Map`. The symptom was that a transposed
+// song with several `{key:}` directives rendered the
+// "Original → Playing" pair for only the song-primary key and left
+// every other key chip unpaired.
+//
+// This is precisely the integration class `.claude/rules/playground-
+// smoke.md` exists for: the React unit tests hand-build the map as a
+// plain JS object literal and the Rust unit tests call the parser
+// directly, so neither layer ever observes the real wasm boundary.
+// Only loading the deployed bundle in a browser proves the map
+// crosses the boundary in a shape the walker can read.
+//
+// Structural assertions only (DOM class names + text content), per
+// the playground-smoke authoring guidance.
+
+import { expect, test, type Page } from "@playwright/test";
+
+const MULTI_KEY_SOURCE = [
+  "{title: Multi Key Transpose}",
+  "{key: G}",
+  "[G]first section in G",
+  "{key: D}",
+  "[D]second section in D",
+  "{key: A}",
+  "[A]third section in A",
+].join("\n");
+
+async function setSource(page: Page, text: string): Promise<void> {
+  // Mirror the replace-the-sample dance used by the other specs:
+  // wait for CodeMirror to claim keyboard focus before select-all +
+  // delete, otherwise the type APPENDS to the bundled sample.
+  const editor = page.locator(".cm-content");
+  await editor.waitFor({ state: "visible" });
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Backspace");
+  await page.keyboard.type(text);
+}
+
+test.describe("multi-{key} transpose", () => {
+  test("every {key} directive renders an Original → Playing pair after transpose", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto("chordpro/", { waitUntil: "networkidle" });
+    await setSource(page, MULTI_KEY_SOURCE);
+
+    // Drive a +2 transpose through the performance toolbar.
+    const transposeGroup = page.getByRole("group", { name: "Transpose" });
+    await transposeGroup
+      .getByRole("combobox", { name: "Transpose" })
+      .selectOption("2");
+
+    // All THREE `{key}` directives must surface the paired
+    // "Original → Playing" marker. Before the fix only the
+    // song-primary key paired (the `soundingKey` fallback), so this
+    // count was 1 while the other two stayed plain `.meta-inline--key`
+    // chips. `toHaveCount` auto-retries past the preview debounce.
+    const pairs = page.locator(".meta-inline--key-pair");
+    await expect(pairs).toHaveCount(3);
+
+    // Spot-check the transposed (Playing) values so the assertion
+    // fails if the pairing renders but with the wrong key: each pair's
+    // second `.meta-inline__group` carries the sounding key.
+    // G + 2 = A, D + 2 = E, A + 2 = B.
+    const playing = await pairs.evaluateAll((els) =>
+      els.map(
+        (el) =>
+          el
+            .querySelectorAll(".meta-inline__group")[1]
+            ?.querySelector(".meta-inline__value")?.textContent ?? "",
+      ),
+    );
+    expect(playing).toEqual(["A", "E", "B"]);
+
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

A song with multiple `{key:}` directives that is transposed now renders the "Original → Playing" pair for **every** `{key:}` directive in the React preview, not just the song-primary one.

## Why

`crates/wasm` returns the per-directive `transposedKeyDirectives` map to JS via `serde_wasm_bindgen::to_value`, which serializes Rust maps as an **ES `Map`** by default. The React JSX walker (`packages/react/src/chordpro-jsx.tsx`) reads the field with plain-object bracket access (`transposedKeyDirectives[keyName]`), which returns `undefined` on a `Map`. Every per-directive lookup missed, so the walker fell back to the `soundingKey` channel — which only knows the song-primary key's transposition. The result: a transposed multi-key song paired only one key and left every other `{key:}` chip un-transposed.

This is the integration class `.claude/rules/playground-smoke.md` documents: the Rust unit tests call `do_parse_chordpro` directly (never crossing the wasm boundary) and the React unit tests hand-build the map as a plain JS object literal, so all layers were green and all blind to the real serialization shape.

## How

Root-cause fix at the serialization boundary: a `to_js_value` helper sets `serialize_maps_as_objects(true)` so Rust maps reach JS as plain objects (matching the long-declared `Record<string, string>` TS type). Every JS-object-returning wasm entry point routes through the helper. The flag is behaviour-preserving for map-free payloads (Vecs / Options / structs serialize identically), so the surface stays uniform and a future map field cannot silently regress the same way. No React/TS source change was needed — the walker already consumed the field as an object.

## Sister-site audit

- **Three Rust renderers** (text / HTML / PDF): each recomputes the transposed key per `{key}` directive inline; verified correct for the multi-key case via the CLI (`--format text` / `--format html` with `--transpose`). No change needed.
- **NAPI / FFI bindings**: do not expose `transposed_key_directives` or any equivalent map — the per-directive transposed-key channel is wasm-only (the React preview is its sole consumer). No sister-site fix required.
- **Other wasm map fields**: `transposed_key_directives` is the only map currently serialized to JS; routing all object payloads through `to_js_value` future-proofs the rest.

## Test results

- `cargo test -p chordsketch-wasm` — 78 passed (native unit tests).
- `cargo clippy -p chordsketch-wasm --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- New `wasm-pack test --node` regression (`crates/wasm/src/lib.rs` `wasm_tests`): asserts `transposedKeyDirectives` is a plain object (not an ES `Map`) and each key resolves via object access (`G→A`, `D→E`); plus the no-transpose omission case. Compiles for `wasm32-unknown-unknown`; executed under CI's `wasm.yml`.
- New Playwright smoke (`packages/playground/tests-e2e/multi-key-transpose.spec.ts`): loads a three-`{key}` song, applies +2 transpose, asserts all three chips render the Original → Playing pair with the correct sounding keys and no `pageerror`. Runs under `playground-smoke.yml`.

## Review summary

Self-reviewed against `root-cause-fixes.md` (fixed at the serialization layer, not the consumer), `fix-propagation.md` (sister sites audited above), and `playground-smoke.md` (added the boundary-crossing smoke this bug class requires).

Closes #2628

---
_Generated by [Claude Code](https://claude.ai/code/session_01GU4CDHm9knK9DeWKHYuAui)_