### PR TITLE
Dock chord inspector to bottom + add jazz tension presets

### DIFF
--- a/packages/react/src/chord-inspector.tsx
+++ b/packages/react/src/chord-inspector.tsx
@@ -1,7 +1,10 @@
 // Floating chord-editor inspector for the ChordPro preview (#2622).
 //
-// A left-docked, non-modal panel that appears when a chord is selected
-// in the preview. It edits the selected chord's root, accidental, type
+// A bottom-docked, non-modal panel that appears when a chord is selected
+// in the preview (#2630 moved it from a top-left overlay to a bottom
+// sheet so it no longer covers the lyrics / chord being edited; the
+// parent scrolls the selected chord into view above the dock). It edits
+// the selected chord's root, accidental, type
 // (a quality+extension preset or free-form suffix), and optional slash
 // bass, and hosts the relocated ◀ / ▶ "move one lyric character"
 // controls plus delete. It is the ChordPro sibling of the iReal Pro

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -523,6 +523,30 @@ function ChordSheetAstBranch({
     if (!sourceEditable && chordSelection != null) setChordSelection(null);
   }, [sourceEditable, chordSelection]);
 
+  // Keep the selected chord visible above the bottom-docked inspector
+  // (#2630). The dock pins to the bottom of the scrollport, so a chord
+  // near the bottom would otherwise sit under it. When the selection
+  // changes — a new chord, or a nudge that relocates it — scroll the
+  // active `.chord--selected` badge to the centre of the scrollport,
+  // above the dock. Keyed on `chordSelection`, which is stable across
+  // in-place text edits (they keep the same (line, offset, ordinal)
+  // coordinates), so typing in the inspector does not re-scroll.
+  useEffect(() => {
+    if (!sourceEditable || chordSelection == null) return;
+    const root = contentRef.current;
+    if (root == null) return;
+    const raf = requestAnimationFrame(() => {
+      const target = root.querySelector('.chord--selected');
+      if (target == null || typeof target.scrollIntoView !== 'function') return;
+      const reduce =
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      target.scrollIntoView({ block: 'center', behavior: reduce ? 'auto' : 'smooth' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [chordSelection, sourceEditable]);
+
   if (ast === null) {
     return (
       <div {...divProps} className={wrapperClass} aria-busy={loading || undefined}>

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -512,7 +512,7 @@ export const CHORD_TYPE_PRESETS: readonly ChordTypePreset[] = [
   { id: 'm7b5', label: 'm7♭5', text: 'm7b5' },
   { id: 'dim7', label: 'dim7', text: 'dim7' },
   { id: '7b5', label: '7♭5', text: '7b5' },
-  { id: 'aug7', label: '7♯5', text: '7#5' },
+  { id: '7s5', label: '7♯5', text: '7#5' },
   // Extended
   { id: '9', label: '9', text: '9' },
   { id: 'maj9', label: 'maj9', text: 'maj9' },

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -492,20 +492,48 @@ export interface ChordTypePreset {
  * qualities remain reachable through the free-form suffix field.
  */
 export const CHORD_TYPE_PRESETS: readonly ChordTypePreset[] = [
+  // Triads / basics
   { id: 'maj', label: 'maj', text: '' },
   { id: 'min', label: 'min', text: 'm' },
+  { id: '5', label: '5', text: '5' },
+  { id: 'aug', label: 'aug', text: 'aug' },
+  { id: 'dim', label: 'dim', text: 'dim' },
+  // Sixth family
+  { id: '6', label: '6', text: '6' },
+  { id: 'm6', label: 'm6', text: 'm6' },
+  // `6/9` is written `69` so the suffix carries no `/` (which the
+  // source-edit guard reserves for the slash-bass split).
+  { id: '69', label: '6/9', text: '69' },
+  // Sevenths
   { id: '7', label: '7', text: '7' },
   { id: 'maj7', label: 'maj7', text: 'maj7' },
   { id: 'm7', label: 'm7', text: 'm7' },
+  { id: 'mMaj7', label: 'mMaj7', text: 'mMaj7' },
   { id: 'm7b5', label: 'm7♭5', text: 'm7b5' },
-  { id: 'dim', label: 'dim', text: 'dim' },
   { id: 'dim7', label: 'dim7', text: 'dim7' },
-  { id: 'aug', label: 'aug', text: 'aug' },
+  { id: '7b5', label: '7♭5', text: '7b5' },
+  { id: 'aug7', label: '7♯5', text: '7#5' },
+  // Extended
+  { id: '9', label: '9', text: '9' },
+  { id: 'maj9', label: 'maj9', text: 'maj9' },
+  { id: 'm9', label: 'm9', text: 'm9' },
+  { id: '11', label: '11', text: '11' },
+  { id: 'm11', label: 'm11', text: 'm11' },
+  { id: '13', label: '13', text: '13' },
+  { id: 'm13', label: 'm13', text: 'm13' },
+  { id: 'add9', label: 'add9', text: 'add9' },
+  { id: 'add11', label: 'add11', text: 'add11' },
+  // Altered dominants
+  { id: '7b9', label: '7♭9', text: '7b9' },
+  { id: '7s9', label: '7♯9', text: '7#9' },
+  { id: '7s11', label: '7♯11', text: '7#11' },
+  { id: '7b13', label: '7♭13', text: '7b13' },
+  { id: 'alt', label: 'alt', text: '7alt' },
+  // Suspended
   { id: 'sus2', label: 'sus2', text: 'sus2' },
   { id: 'sus4', label: 'sus4', text: 'sus4' },
-  { id: '6', label: '6', text: '6' },
-  { id: '9', label: '9', text: '9' },
-  { id: 'add9', label: 'add9', text: 'add9' },
+  { id: '7sus4', label: '7sus4', text: '7sus4' },
+  { id: '9sus4', label: '9sus4', text: '9sus4' },
 ];
 
 /** Quality enum values mirrored from `ChordproChordQuality` — kept as a

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -398,10 +398,11 @@
   line-height: 1.6875;
   color: var(--cs-ink-1000, #0a0a0b);
   padding: 2em 1.5em;
-  /* Positioning anchor for the left-docked chord-editor inspector
-     (#2622). The inspector is `position: absolute` against this
-     wrapper so it floats at the content's top-left and does NOT track
-     the selected chord's position. */
+  /* Positioning anchor + sticky containing block for the bottom-docked
+     chord-editor inspector (#2622, re-docked in #2630). The inspector is
+     `position: sticky; bottom` and rendered as this wrapper's last flow
+     child, so it pins to the bottom of the scrollport while the content
+     is in view and does NOT track (or cover) the selected chord. */
   position: relative;
 }
 
@@ -1487,12 +1488,26 @@
    content. Does NOT track the selected chord — it stays put while the
    user edits root / type / bass and steps the chord left / right. */
 .chordsketch-sheet__content .chordsketch-sheet__cins {
-  position: absolute;
-  left: var(--cs-sp-4, 1rem);
-  top: var(--cs-sp-4, 1rem);
+  /* Bottom-docked sheet (#2630): the pre-#2630 `position: absolute;
+     left/top` overlay sat at the content's top-left and covered the
+     lyrics / chord being edited. A `position: sticky; bottom` element,
+     rendered as the LAST flow child of `.chordsketch-sheet__content`,
+     pins to the bottom of the scrollport while the content is in view —
+     so the panel stays reachable as the user scrolls but never tracks
+     (or covers) the selected chord, which the parent scrolls into view
+     above the dock. */
+  position: sticky;
+  bottom: var(--cs-sp-4, 1rem);
   z-index: 6;
-  width: 17rem;
-  max-width: calc(100% - 2rem);
+  /* Centred reading-column cap on wide panes; full width on narrow. */
+  width: 100%;
+  max-width: 34rem;
+  margin-inline: auto;
+  margin-top: var(--cs-sp-4, 1rem);
+  /* Cap height so a long chip list scrolls internally instead of
+     filling the viewport and re-covering the content. */
+  max-height: min(60vh, 32rem);
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: var(--cs-sp-4, 1rem);
@@ -1500,12 +1515,12 @@
   background: var(--cs-surface, #fff);
   border: 1px solid var(--cs-border-strong, #d4d1d6);
   border-radius: var(--cs-r-3, 8px);
-  box-shadow: var(--cs-e-2, 0 4px 12px rgba(10, 10, 11, 0.08));
+  box-shadow: var(--cs-e-3, 0 10px 30px rgba(10, 10, 11, 0.16));
   font-family: var(--cs-font-latin, "Inter", system-ui, sans-serif);
   animation: chordsketch-cins-pop var(--cs-dur-2, 200ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1));
 }
 @keyframes chordsketch-cins-pop {
-  from { opacity: 0; transform: translateY(4px) scale(0.99); }
+  from { opacity: 0; transform: translateY(12px) scale(0.99); }
   to { opacity: 1; transform: none; }
 }
 @media (prefers-reduced-motion: reduce) {
@@ -1588,6 +1603,14 @@
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
+  /* The expanded jazz preset set (#2630) is long; cap the chip area to
+     a few rows and scroll within it so the docked sheet stays compact
+     and Root / inputs / move / footer remain visible without scrolling
+     the whole panel. */
+  max-height: 8.5rem;
+  overflow-y: auto;
+  /* Room for the scrollbar so the rightmost chips aren't clipped. */
+  padding-right: 2px;
 }
 .chordsketch-sheet__content .chordsketch-sheet__cins-chip {
   appearance: none;

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -531,7 +531,7 @@ describe('chordSuffixFromQuality', () => {
   test('the expanded jazz tension / quality set is present (#2630)', () => {
     const suffixes = new Set(CHORD_TYPE_PRESETS.map((p) => p.text));
     // Extended + altered families added in #2630.
-    for (const t of ['maj9', 'm9', '11', 'm11', '13', 'm13', 'add11', '7b9', '7#9', '7#11', '7b13', '7alt', '69', 'm6', 'mMaj7', '7sus4', '9sus4']) {
+    for (const t of ['7b5', '7#5', 'maj9', 'm9', '11', 'm11', '13', 'm13', 'add11', '7b9', '7#9', '7#11', '7b13', '7alt', '69', 'm6', 'mMaj7', '7sus4', '9sus4']) {
       expect(suffixes.has(t)).toBe(true);
     }
   });

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -527,6 +527,29 @@ describe('chordSuffixFromQuality', () => {
     expect(suffixes.has('m7')).toBe(true);
     expect(suffixes.has('maj7')).toBe(true);
   });
+
+  test('the expanded jazz tension / quality set is present (#2630)', () => {
+    const suffixes = new Set(CHORD_TYPE_PRESETS.map((p) => p.text));
+    // Extended + altered families added in #2630.
+    for (const t of ['maj9', 'm9', '11', 'm11', '13', 'm13', 'add11', '7b9', '7#9', '7#11', '7b13', '7alt', '69', 'm6', 'mMaj7', '7sus4', '9sus4']) {
+      expect(suffixes.has(t)).toBe(true);
+    }
+  });
+
+  test('every preset text builds a valid chord token (no forbidden / structural chars)', () => {
+    // A chip selection feeds `text` straight into buildChordName as the
+    // suffix; if any preset carried a `/` or a structural char the edit
+    // would throw and silently drop. Guards the `69` (not `6/9`) choice.
+    for (const preset of CHORD_TYPE_PRESETS) {
+      expect(() => buildChordName({ root: 'C', suffix: preset.text })).not.toThrow();
+      expect(buildChordName({ root: 'C', suffix: preset.text })).toBe(`C${preset.text}`);
+    }
+  });
+
+  test('preset ids are unique', () => {
+    const ids = CHORD_TYPE_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
 });
 
 describe('buildChordName', () => {


### PR DESCRIPTION
## What

Follow-up to #2626 / #2627. Fixes the chord-editor inspector's two reported problems in the `@chordsketch/react` preview:

- **It no longer covers the content.** The inspector was a `position: absolute; left/top` overlay against `.chordsketch-sheet__content`, so it always sat at the content's top-left and covered the lyrics / chord being edited. It is now a **bottom-docked sheet** (`position: sticky; bottom`, rendered as the content wrapper's last flow child): it pins to the bottom of the scrollport while content is in view and never tracks or covers the selection. The panel design itself is unchanged.
- **The selected chord is scrolled into view above the dock.** When the selection changes (a new chord, or a nudge that relocates it) the parent scrolls the active `.chord--selected` badge to the centre of the scrollport. Keyed on `chordSelection`, which is stable across in-place text edits (same `(line, offset, ordinal)`), so typing in the inspector does not re-scroll. Respects `prefers-reduced-motion`; guarded for SSR / jsdom (`matchMedia` + `scrollIntoView` typeof checks).
- **Height is capped.** The sheet caps at `min(60vh, 32rem)` and the Type chip list caps at a few rows with internal scroll, so the expanded preset list never refills the viewport and re-covers the content.

- **Jazz tensions added.** `CHORD_TYPE_PRESETS` previously stopped at `9` / `add9`. Added the extended + altered + sus families: `5` (power), `m6`, `6/9`, `mMaj7`, `7♭5`, `7♯5`, `maj9`, `m9`, `11`, `m11`, `13`, `m13`, `add11`, `7♭9`, `7♯9`, `7♯11`, `7♭13`, `alt`, `7sus4`, `9sus4`. `6/9` is stored as the suffix `69` so it carries no `/` (the source-edit guard reserves `/` for the slash-bass split).

## Why

The inspector overlay covered exactly the region the user was editing, making it unusable; and the preset chips lacked the tensions needed for real lead-sheet work. UI direction (bottom dock + full jazz tension set) confirmed with the maintainer before implementation.

## Test results

- `npm test` (vitest): **763 passed** (+4: expanded-preset presence, every-preset-builds-a-valid-token guard, unique-id guard). `npm run typecheck` clean; `npm run build` clean.
- The pre-existing "Maximum update depth exceeded" test-harness warning is unrelated (5 occurrences with and without this change).

## Review summary

- Sister-site audit: chord editing is a React-only interaction layer; the Rust renderers are static output with no interaction surface — no sister site.
- Accessibility: unchanged control semantics (real buttons/inputs, `aria-pressed`, `role="group"`, Escape closes, design-system focus ring). The dock follows scroll rather than trapping focus.

## Deferred

- None.

Closes #2630

https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6)_