### PR TITLE
Hold the metronome beat-dot LED static while the {tempo} chip is playing

### DIFF
--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -780,6 +780,23 @@
 .chordsketch-sheet__content button.meta-inline--interactive.is-playing .meta-inline__value {
   color: inherit;
 }
+/* While the metronome is actually playing, hold the decorative
+   beat-dot LED static. The dot is a DISCRETE per-beat flash on the
+   always-on `cs-metronome-beat` CSS clock, which cannot lock to the
+   Web Audio metronome, so during playback it drifts against the real
+   audible tick and reads as a stuttering off-beat double-tick.
+   The CONTINUOUS cues — the pendulum swing (`cs-metronome-swing`) and
+   the frame pulse (`cs-tempo-frame`) — are deliberately left running:
+   their motion is ambient rather than a discrete tick, so the same
+   clock drift is imperceptible and they keep signalling the running
+   tempo. (Do NOT extend this freeze to those two on a "they drift
+   too" reading — the discrete-vs-continuous distinction is the whole
+   point.) The resting full-opacity dot matches the reduced-motion
+   treatment. */
+.chordsketch-sheet__content button.meta-inline--interactive.is-playing .music-glyph--metronome__beat {
+  animation: none;
+  opacity: 1;
+}
 @keyframes cs-tempo-frame {
   0%,
   100% {

--- a/packages/react/tests/metronome-button.test.tsx
+++ b/packages/react/tests/metronome-button.test.tsx
@@ -184,4 +184,27 @@ describe('<MetronomeButton>', () => {
     expect(rule).not.toBeNull();
     expect(rule?.[0]).toContain('box-sizing: border-box;');
   });
+
+  // While the metronome is playing, the decorative beat-dot LED must
+  // stop blinking: it is a discrete per-beat flash on an independent
+  // CSS clock that drifts against the real audible tick (the
+  // continuous swing / frame pulse stay running — see the stylesheet
+  // comment). The animation is a CSS property jsdom does not compute,
+  // so assert it against the stylesheet source like the box-sizing
+  // test above.
+  test('holds the beat-dot LED static while playing', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8').replace(
+      /\/\*[\s\S]*?\*\//g,
+      '',
+    );
+    // The playing-state rule that targets the beat dot must turn its
+    // animation off and rest it at full opacity.
+    const rule = css.match(
+      /button\.meta-inline--interactive\.is-playing \.music-glyph--metronome__beat \{[^}]*\}/,
+    );
+    expect(rule).not.toBeNull();
+    expect(rule?.[0]).toContain('animation: none;');
+    expect(rule?.[0]).toContain('opacity: 1;');
+  });
 });


### PR DESCRIPTION
## What

While the interactive `{tempo}` chip (`<MetronomeButton>`) is actively playing, hold its decorative beat-dot LED static instead of letting it keep flashing. The continuous cues — the pendulum swing (`cs-metronome-swing`) and the frame pulse (`cs-tempo-frame`) — keep running; only the discrete per-beat dot flash is frozen, resting at full opacity (matching the existing reduced-motion treatment). The idle (not-playing) animation is unchanged.

Implemented as a single CSS rule in `packages/react/src/styles.css` keyed on `button.meta-inline--interactive.is-playing .music-glyph--metronome__beat`, which outranks the always-on `cs-metronome-beat` rule on both specificity (0,4,1 vs 0,2,0) and source order.

## Why

The beat dot is a discrete per-beat flash driven by an always-on CSS animation. That CSS clock cannot lock to the Web Audio metronome, so during playback the dot drifts against the real audible tick and reads as a stuttering off-beat double-tick. The pendulum swing and frame pulse share the same clock-drift property but are *continuous/ambient* motion, where the drift is imperceptible — so the freeze is applied only to the discrete dot. The stylesheet comment records this discrete-vs-continuous distinction explicitly so the freeze is not later mis-extended to the swing or frame pulse.

## Test results

- `npm test` in `packages/react`: 764 passed (35 files), including a new assertion in `tests/metronome-button.test.tsx` that the playing-state rule sets `animation: none; opacity: 1;` on the beat dot. The CSS animation is a property jsdom does not compute, so the test matches against the stylesheet source — the established pattern in that file (mirrors the box-sizing test).
- `npm run typecheck`: clean.

## Review summary

Reviewed in parallel under four lenses (general code review, security, project-rule compliance, UX/design):

- **Code review**: no findings — selector correctly targets the dot; the override wins on specificity and source order; `opacity: 1` matches the reduced-motion resting state; the test regex uniquely matches the new rule.
- **Security**: no findings — purely declarative static CSS, no `url()`/`data:`/dynamic interpolation, no user input, no sanitizer-parity surface; the test path derives from `import.meta.url` only.
- **UX/design**: surfaced that the original rationale ("CSS drift competes with the audible beat") applied equally to the still-running swing and frame pulse. Resolved at the root by correcting the rationale to the principled discrete-vs-continuous distinction (rather than over-scoping by also freezing the swing, which would make the playing glyph look dead).

## Sister-site audit

The interactive playing state (`.is-playing`, set by `useMetronome`'s Web Audio playback) exists only in the React surface — confirmed `is-playing` appears solely in `packages/react/**` and `packages/playground/tests-e2e/`. The Rust HTML renderer (`crates/render-html/src/lib.rs`, `music_glyphs.rs`) emits a static, JS-free chip with no `<button>`, click handler, or playback concept, so there is no sister-site to propagate this change to (per `.claude/rules/fix-propagation.md` / `renderer-parity.md`). The existing playground Playwright smoke (`tests-e2e/metronome.spec.ts`) already covers the `is-playing` toggle path; no new smoke is required under `.claude/rules/playground-smoke.md` (no new mount site / format toggle / mount-sequence / wasm-surface change).

## Deferred

None.

Closes #2632


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGQ9TGjeYYqdWQtxoKvAbf)_