### PR TITLE
Harden chord editor: correct transpose gate, guard reposition, dedup layout

### DIFF
--- a/packages/playground/tests-e2e/chord-inspector.spec.ts
+++ b/packages/playground/tests-e2e/chord-inspector.spec.ts
@@ -1,0 +1,83 @@
+// Smoke coverage for the chord-editor inspector mount path in the
+// ChordPro playground (#2622 / #2626 / #2630).
+//
+// Per `.claude/rules/playground-smoke.md`, a new React component mount
+// site reached only at runtime in a real browser needs an end-to-end
+// spec: the in-process vitest suites stub the wasm boundary, so the
+// only thing proving the inspector actually mounts in the deployed
+// bundle is loading the page and selecting a chord. The pre-#2630
+// inspector was a top-left overlay that covered the lyrics; #2630
+// re-docked it to the bottom, so this spec also asserts the rendered
+// lyrics stay visible while the inspector is open (the "does not cover
+// content" contract) and that the expanded jazz-tension chips shipped.
+//
+// Assertions are structural (selectors / visibility), and every test
+// registers a `pageerror` listener asserting `[]` so a JS exception
+// during select / edit fails the test even if the DOM still renders.
+
+import { expect, test, type Page } from '@playwright/test';
+
+function trackPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('pageerror', (err) => errors.push(String(err)));
+  return errors;
+}
+
+test.describe('chord-editor inspector (ChordPro playground)', () => {
+  test('selecting a chord mounts the bottom-docked inspector without covering the lyrics', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    const preview = page.locator('.pane.preview');
+    // In split view the preview chords are selectable buttons. Assert
+    // the affordance is present first so a later miss is a real signal.
+    const chord = preview.locator(".chord[role='button']").first();
+    await expect(chord).toBeVisible();
+
+    // No inspector until a chord is selected.
+    await expect(preview.locator('.chordsketch-sheet__cins')).toHaveCount(0);
+
+    await chord.click();
+
+    // The inspector mounts on selection — this is the integration the
+    // stubbed unit suites cannot observe.
+    const inspector = preview.locator('.chordsketch-sheet__cins');
+    await expect(inspector).toBeVisible();
+    // The selected chord paints as a solid badge.
+    await expect(preview.locator('.chord--selected')).toBeVisible();
+
+    // Bottom-dock contract (#2630): the inspector does NOT replace or
+    // cover the content — a sample lyric stays visible alongside it.
+    await expect(inspector).toBeVisible();
+    await expect(preview).toContainText('sweet');
+
+    expect(errors).toEqual([]);
+  });
+
+  test('the inspector exposes the expanded jazz-tension chips and edits without error (#2630)', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    const preview = page.locator('.pane.preview');
+    await preview.locator(".chord[role='button']").first().click();
+    await expect(preview.locator('.chordsketch-sheet__cins')).toBeVisible();
+
+    // A tension chip added in #2630 (would be absent if the expanded
+    // preset set regressed). `maj9` is one of the new extended entries.
+    const maj9 = preview.locator('.chordsketch-sheet__cins-chip', { hasText: /^maj9$/ });
+    await expect(maj9).toHaveCount(1);
+
+    // Picking it rewrites the selected chord through the source-as-truth
+    // edit pipeline; the editor source should now contain a `maj9` chord.
+    await maj9.click();
+    await expect(page.locator('.cm-editor')).toContainText('maj9');
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -8,9 +8,10 @@ import type { ChordproChord, ChordproSong } from './chordpro-ast';
 import {
   buildChordName,
   buildChordNudge,
+  chordLayoutForLine,
+  chordSourceEditableUnderTranspose,
   findChordByOffsetOrdinal,
   nudgeChordPosition,
-  readCapo,
 } from './chord-source-edit';
 import type {
   ChordDeleteTarget,
@@ -245,27 +246,26 @@ function resolveSelectedChord(ast: ChordproSong, selection: ChordSelection): Res
   const line = ast.lines[selection.line - 1];
   if (!line || line.kind !== 'lyrics') return null;
   const segments = line.value.segments;
-  let srcCol = 0;
-  let lyricsCount = 0;
+  // Shared layout helper — single source of truth for the chord
+  // coordinate space (the JSX walker uses the same helper for drag /
+  // nudge targeting, so the two cannot drift). See chordLayoutForLine.
+  const { layout, totalLyrics: lyricsCount } = chordLayoutForLine(segments);
   const chords: Array<{
     sourceColumn: number;
     bracketLength: number;
     offset: number;
     chord: ChordproChord;
   }> = [];
-  for (const seg of segments) {
-    const bracketLen = seg.chord ? (seg.chord.name?.length ?? 0) + 2 : 0;
+  segments.forEach((seg, i) => {
     if (seg.chord) {
       chords.push({
-        sourceColumn: srcCol,
-        bracketLength: bracketLen,
-        offset: lyricsCount,
+        sourceColumn: layout[i].sourceColumn,
+        bracketLength: layout[i].bracketLength,
+        offset: layout[i].lyricsOffsetStart,
         chord: seg.chord,
       });
     }
-    srcCol += bracketLen + seg.text.length;
-    lyricsCount += seg.text.length;
-  }
+  });
   const offsets = chords.map((c) => c.offset);
   const idx = findChordByOffsetOrdinal(offsets, selection.offset, selection.ordinal);
   if (idx < 0) return null;
@@ -508,11 +508,11 @@ function ChordSheetAstBranch({
   // any `{capo: N}` into the effective transpose (ADR-0023) — so under
   // a non-zero effective transpose `chord.name` is the TRANSPOSED
   // spelling, and editing by source coordinates would write the wrong
-  // chord / miscompute columns. Gate the whole interaction off in that
-  // case (it would otherwise silently corrupt the song). `effective =
-  // transpose − capo`; coincidental cancellation (e.g. transpose +2 with
-  // `{capo: 2}`) is genuinely a no-op transpose, so editing is safe.
-  const sourceEditable = (transpose ?? 0) - readCapo(source) === 0;
+  // chord / miscompute columns. The gate mirrors the core's
+  // `effective_transpose` capo semantics exactly (1..=24 accept-or-zero,
+  // NOT the `<Capo>` control's 0..=12 display clamp), so a hand-edited
+  // `{capo: 18}` cannot fool the gate into editing a transposed AST.
+  const sourceEditable = chordSourceEditableUnderTranspose(source, transpose);
   const repositionCb = sourceEditable ? onChordReposition : undefined;
   const editCb = sourceEditable ? onChordEdit : undefined;
   const deleteCb = sourceEditable ? onChordDelete : undefined;

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -51,6 +51,13 @@ const CAPO_DIRECTIVE_RE = /\{capo:\s*(-?\d+)\s*\}\s*\n?/;
 // inside the lyrics.
 const CAPO_ANCHOR_RE = /^(\{(?:title|subtitle|artist|key|tempo|time)[^}]*\}\s*\n)+/;
 
+/** Characters that would corrupt the ChordPro source structure when
+ * interpolated into a `[chord]` token. Shared by every chord-writing
+ * helper so the editor surface cannot inject directives / brackets /
+ * line breaks. `/` is intentionally allowed — it is the slash-chord
+ * separator. */
+const CHORD_FORBIDDEN_RE = /[[\]{}<>\n\r]/;
+
 function clampInt(n: number, min: number, max: number): number {
   if (Number.isNaN(n)) return min;
   if (n < min) return min;
@@ -608,13 +615,6 @@ export function buildChordNudge(params: {
 // token from those parts and splice it back over the original
 // `[chord]` at a known source position — the same source-as-truth
 // model the reposition pipeline uses (no parallel chord state).
-
-/** Characters that would corrupt the ChordPro source structure when
- * interpolated into a `[chord]` token. Shared by every chord-writing
- * helper so the editor surface cannot inject directives / brackets /
- * line breaks. `/` is intentionally allowed — it is the slash-chord
- * separator. */
-const CHORD_FORBIDDEN_RE = /[[\]{}<>\n\r]/;
 
 /** A chord-type preset offered as a chip in the editor. `text` is the
  * ChordPro suffix written after the root (+ accidental) — e.g. `"m7"`

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -81,6 +81,56 @@ export function readCapo(source: string): number {
 }
 
 /**
+ * Read the capo value the **core renderer / parser** folds into the
+ * effective transpose for `source`, mirroring
+ * `Metadata::capo_validated` (`crates/chordpro/src/ast.rs`): only a
+ * `{capo: N}` with `N ∈ 1..=24` contributes; anything else (absent,
+ * out of range, non-integer, negative) contributes `0`.
+ *
+ * This is deliberately NOT {@link readCapo}: that helper clamps into
+ * `[CAPO_MIN, CAPO_MAX]` (0..=12) so the `<Capo>` control never shows a
+ * value its `+` / `−` buttons cannot emit. Reusing that display clamp
+ * for the edit-safety gate is a bug — a hand-edited `{capo: 18}` would
+ * clamp to `12` here while the core transposes the AST by `18`, so the
+ * gate would (wrongly) think the rendered chords still match the raw
+ * source and enable source-coordinate editing on a transposed AST,
+ * corrupting the song. The gate must mirror the core's `1..=24`
+ * accept-or-zero semantics exactly, with no clamping.
+ *
+ * @see chordSourceEditableUnderTranspose for the gate that consumes this.
+ */
+export function capoTransposeOffset(source: string): number {
+  const match = source.match(CAPO_DIRECTIVE_RE);
+  if (!match) return 0;
+  const n = parseInt(match[1], 10);
+  if (!Number.isInteger(n) || n < 1 || n > 24) return 0;
+  return n;
+}
+
+/**
+ * Whether source-coordinate chord editing is safe for `source` under a
+ * given CLI `transpose`. Editing rewrites the raw `[chord]` tokens by
+ * source column, but the wasm parse path transposes the AST in place —
+ * folding `{capo}` into the effective transpose (ADR-0023) — so under a
+ * non-zero **effective** transpose the rendered chord names are the
+ * transposed spelling, not the raw source, and editing by source
+ * coordinates would corrupt the song.
+ *
+ * Effective transpose mirrors the core's `effective_transpose(0, cli,
+ * capo)`: `cli_transpose − capoTransposeOffset(source)`. Editing is safe
+ * exactly when that is `0` (including coincidental cancellation such as
+ * `transpose +2` with `{capo: 2}`, a genuine no-op transpose). The file
+ * `{transpose}` directive is intentionally excluded because the wasm
+ * parse path itself does not fold it (see `do_parse_chordpro`).
+ */
+export function chordSourceEditableUnderTranspose(
+  source: string,
+  transpose: number | undefined,
+): boolean {
+  return (transpose ?? 0) - capoTransposeOffset(source) === 0;
+}
+
+/**
  * Round-trip a capo value into a ChordPro source string.
  *
  * - When `capo === 0`, any existing `{capo: N}` directive is
@@ -144,6 +194,16 @@ export interface ChordRepositionEvent {
   /** Copy vs move semantics. `true` keeps the original bracket
    * in place; `false` removes it. */
   copy: boolean;
+  /** Optional optimistic-concurrency guard for the `from` span,
+   * mirroring {@link ChordEditEvent.expected}. When provided on a
+   * move (`copy: false`), the reposition is a no-op (source returned
+   * unchanged) if the live source at `[fromColumn, fromColumn +
+   * fromLength)` is not `[expected]`. This prevents a stale or
+   * drifted span (e.g. a column miscomputed across an escaped
+   * special — see {@link chordLayoutForLine}) from removing the
+   * wrong bracket and corrupting the song. Omitted on copies (no
+   * removal happens) and ignored then. */
+  expected?: string;
 }
 
 /** Return value of {@link applyChordReposition}. */
@@ -235,7 +295,12 @@ export function applyChordReposition(
   if (typeof evt.chord !== 'string' || evt.chord.length === 0) {
     throw new Error('chord must be a non-empty string');
   }
-  if (/[\[\]{}<\n\r]/.test(evt.chord)) {
+  // Shared structural denylist with buildChordName / applyChordEdit /
+  // applyChordDelete (one constant for every chord-writing helper, so a
+  // future denylist change cannot reach only some of them — the
+  // sister-site divergence `.claude/rules/fix-propagation.md` warns
+  // about; previously this site inlined a near-copy that omitted `>`).
+  if (CHORD_FORBIDDEN_RE.test(evt.chord)) {
     throw new Error(
       `chord ${JSON.stringify(evt.chord)} contains forbidden character ` +
         '(brackets, braces, angle bracket, newline / carriage return)',
@@ -259,6 +324,19 @@ export function applyChordReposition(
         `from range [${evt.fromColumn}, ${evt.fromColumn + evt.fromLength}) ` +
           `exceeds line length ${lineText.length}`,
       );
+    }
+    // Optimistic-concurrency guard (parity with applyChordEdit /
+    // applyChordDelete): if the caller told us which token to expect at
+    // the `from` span and the live source no longer matches — a stale
+    // event, or a column drifted across an escaped special — no-op
+    // instead of removing the wrong bracket and corrupting the song.
+    if (
+      evt.expected !== undefined &&
+      lineText.slice(evt.fromColumn, evt.fromColumn + evt.fromLength) !== `[${evt.expected}]`
+    ) {
+      let caret = 0;
+      for (let i = 0; i < lineIdx; i++) caret += lines[i].length + 1;
+      return { text: source, caretOffset: caret + evt.fromColumn };
     }
     lines[lineIdx] =
       lineText.slice(0, evt.fromColumn) + lineText.slice(evt.fromColumn + evt.fromLength);
@@ -327,6 +405,65 @@ export function sourceColumnToLyricsOffset(line: string, column: number): number
     i++;
   }
   return lyricsCount;
+}
+
+/** One entry of {@link chordLayoutForLine}, parallel to the input
+ * segment list (one per segment, in order). */
+export interface SegmentLayout {
+  /** 0-indexed source column of this segment's `[` opening bracket
+   * (only meaningful when the segment carries a chord). */
+  sourceColumn: number;
+  /** Source-column span of this segment's `[chord]` including both
+   * brackets (`name.length + 2`), or `0` when the segment has no
+   * chord. */
+  bracketLength: number;
+  /** 0-indexed lyrics offset at which this segment's text begins —
+   * i.e. the lyrics offset of the segment's chord, if any. */
+  lyricsOffsetStart: number;
+}
+
+/** Minimal structural shape of a parsed lyrics segment, kept local so
+ * this module stays free of an AST-type import. */
+interface LayoutSegment {
+  text: string;
+  chord?: { name?: string | null } | null;
+}
+
+/**
+ * Compute the source-column / lyrics-offset layout of a lyrics line's
+ * segments — the single source of truth for the chord-coordinate space
+ * shared by the JSX walker (drag / nudge / drop targeting) and
+ * `resolveSelectedChord` (inspector selection → source coordinates).
+ *
+ * Both surfaces previously walked `line.segments` with byte-identical
+ * accumulation; keeping two copies risked silent desync (a future
+ * change to bracket-length math applied to one and not the other would
+ * resolve the wrong chord — exactly the sister-site hazard
+ * `.claude/rules/fix-propagation.md` warns about). This is also the one
+ * place a future fix for escaped-special column drift (see #2634) must
+ * land: the reconstruction below derives columns from post-lex
+ * `seg.text`, which has lost the backslash of an escaped `\[` / `\]` /
+ * `\{` etc., so a chord after such an escape gets a column that is too
+ * small. Edit / delete / reposition all guard against the resulting
+ * stale span via their `expected` token, so a drift produces a safe
+ * no-op rather than corruption until the AST carries real source spans.
+ *
+ * @returns one {@link SegmentLayout} per input segment (same order) and
+ *   the line's total visible lyric-character count.
+ */
+export function chordLayoutForLine(
+  segments: ReadonlyArray<LayoutSegment>,
+): { layout: SegmentLayout[]; totalLyrics: number } {
+  const layout: SegmentLayout[] = [];
+  let sourceColumn = 0;
+  let lyricsOffset = 0;
+  for (const seg of segments) {
+    const bracketLength = seg.chord ? (seg.chord.name?.length ?? 0) + 2 : 0;
+    layout.push({ sourceColumn, bracketLength, lyricsOffsetStart: lyricsOffset });
+    sourceColumn += bracketLength + seg.text.length;
+    lyricsOffset += seg.text.length;
+  }
+  return { layout, totalLyrics: lyricsOffset };
 }
 
 /** Destination of a single-step chord nudge, returned by
@@ -453,6 +590,11 @@ export function buildChordNudge(params: {
       toLyricsOffset: dest.offset,
       chord: params.chordName,
       copy: false,
+      // A nudge moves a chord in place, so the token at the `from`
+      // span is exactly the chord being moved — guard the removal
+      // against that, so a stale / drifted span no-ops instead of
+      // corrupting (parity with the edit / delete guards).
+      expected: params.chordName,
     },
     offset: dest.offset,
     ordinal: dest.ordinal,
@@ -491,6 +633,20 @@ export interface ChordTypePreset {
  * its root). The set is deliberately small and common; arbitrary
  * qualities remain reachable through the free-form suffix field.
  */
+// Sister surface: the iReal Pro chord editor's `QUALITY_OPTIONS`
+// (`ireal-bar-grid-popover.tsx`). The two lists are INTENTIONALLY not
+// identical and are NOT bound by `.claude/rules/fix-propagation.md`'s
+// "keep sister sites in lockstep": iReal models quality as a closed
+// `IrealChordQuality['kind']` enum (a finite set the iReal AST can
+// represent), whereas a ChordPro chord is free-form text, so this list
+// is an open palette of common shorthands the user can extend via the
+// free-form suffix field. New entries here do NOT require a matching
+// `QUALITY_OPTIONS` entry and vice versa.
+//
+// `id` is a stable React key / test selector only (never emitted into
+// the chord text); it avoids `#` and `/` (spelled `s` / written as the
+// `69` text) so it is safe as a DOM id / attribute selector. `text` is
+// the literal ChordPro suffix written after the root (+ accidental).
 export const CHORD_TYPE_PRESETS: readonly ChordTypePreset[] = [
   // Triads / basics
   { id: 'maj', label: 'maj', text: '' },
@@ -547,8 +703,12 @@ export type ChordQualityName = 'major' | 'minor' | 'diminished' | 'augmented';
  * `(minor, "7")` → `"m7"`, `(major, "maj7")` → `"maj7"`,
  * `(diminished, null)` → `"dim"`, `(major, null)` → `""`.
  *
- * The editor uses it to pre-select the matching {@link CHORD_TYPE_PRESETS}
- * chip and to seed the free-form suffix field from the selected chord.
+ * Standalone quality→suffix utility exposed for external hosts that
+ * resolve a chord from a parser quality + extension split. The bundled
+ * inspector does NOT use it — it derives parts from the raw chord name
+ * via `partsFromRawName` so editing stays transpose-safe (it must never
+ * read the transposed `chord.detail`). Kept as public API for consumers
+ * driving the editor from a structured chord rather than a raw name.
  */
 export function chordSuffixFromQuality(
   quality: ChordQualityName,

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -75,6 +75,7 @@ import type {
 } from './use-chord-diagram';
 import {
   buildChordNudge,
+  chordLayoutForLine,
   findChordByOffsetOrdinal,
 } from './chord-source-edit';
 import type { ChordRepositionEvent } from './chord-source-edit';
@@ -1809,26 +1810,19 @@ function LyricsLine({
   // Pre-walk segments to record per-chord source columns and
   // per-segment lyrics-offset starts. Memoised so dragover-driven
   // re-renders don't re-walk on every event.
-  const segmentLayout = useMemo(() => {
-    const layout: Array<{
-      chordSourceColumn: number;
-      chordBracketLength: number;
-      lyricsOffsetStart: number;
-    }> = [];
-    let srcCol = 0;
-    let lyricsCount = 0;
-    for (const seg of line.segments) {
-      const bracketLen = seg.chord ? (seg.chord.name?.length ?? 0) + 2 : 0;
-      layout.push({
-        chordSourceColumn: srcCol,
-        chordBracketLength: bracketLen,
-        lyricsOffsetStart: lyricsCount,
-      });
-      srcCol += bracketLen + seg.text.length;
-      lyricsCount += seg.text.length;
-    }
-    return layout;
-  }, [line.segments]);
+  const segmentLayout = useMemo(
+    () =>
+      // Single source of truth for the chord coordinate space, shared
+      // with `resolveSelectedChord` (chord-sheet) so the two cannot
+      // drift — see chordLayoutForLine. Mapped to this component's
+      // existing field names to keep downstream call sites unchanged.
+      chordLayoutForLine(line.segments).layout.map((l) => ({
+        chordSourceColumn: l.sourceColumn,
+        chordBracketLength: l.bracketLength,
+        lyricsOffsetStart: l.lyricsOffsetStart,
+      })),
+    [line.segments],
+  );
 
   // ---- Click-to-focus + nudge state (#2614) ----------------------
   // Chord-bearing segments in left-to-right order, paired with the
@@ -2060,6 +2054,10 @@ function LyricsLine({
           toLyricsOffset: segLayout.lyricsOffsetStart + target.charOffset,
           chord: payload.chord,
           copy: event.altKey,
+          // Guard the move's removal against the dragged chord's own
+          // token, so a stale / drifted `from` span no-ops instead of
+          // corrupting (copy removes nothing, so no guard needed).
+          expected: event.altKey ? undefined : payload.chord,
         });
       }
     : undefined;
@@ -2337,6 +2335,9 @@ function buildLyricsDropProps(
         toLyricsOffset: lyricsOffsetStart + charOffset,
         chord: payload.chord,
         copy: event.altKey,
+        // Guard the move's removal against the dragged chord's own
+        // token (copy removes nothing, so no guard needed).
+        expected: event.altKey ? undefined : payload.chord,
       });
     },
   };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -147,6 +147,9 @@ export {
   applyChordReposition,
   buildChordName,
   buildChordNudge,
+  capoTransposeOffset,
+  chordLayoutForLine,
+  chordSourceEditableUnderTranspose,
   chordSuffixFromQuality,
   findChordByOffsetOrdinal,
   lyricsOffsetToSourceColumn,
@@ -163,6 +166,7 @@ export {
   type ChordRepositionResult,
   type ChordTypePreset,
   type NudgedChordPosition,
+  type SegmentLayout,
 } from './chord-source-edit';
 
 // Chord-editor inspector (#2622). The floating, design-system-styled

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -599,6 +599,54 @@ describe('<ChordSheet>', () => {
     });
   });
 
+  test('selecting a chord scrolls it into view; typing in the inspector does not re-scroll (#2631)', async () => {
+    // jsdom does not implement scrollIntoView; define it as a spy so the
+    // effect's `typeof … === 'function'` guard passes and we can count
+    // calls. Restore afterwards so the global stays clean for other tests.
+    const original = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
+    const spy = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: spy,
+    });
+    try {
+      const { container } = render(
+        <ChordSheet
+          source="[Am]hi"
+          astWasmLoader={makeAstLoader(chordStub())}
+          onChordReposition={vi.fn()}
+          onChordEdit={vi.fn()}
+        />,
+      );
+      await waitFor(() => {
+        expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+      });
+      // No selection yet → the effect early-returns, nothing scrolled.
+      expect(spy).not.toHaveBeenCalled();
+
+      fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+      // Selection set → the selected badge is scrolled into view (rAF).
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+      const selected = container.querySelector('.chord--selected');
+      expect(spy.mock.instances[0]).toBe(selected);
+      expect(spy.mock.calls[0][0]).toMatchObject({ block: 'center' });
+
+      // Typing in the free-form suffix field is an in-place edit: the
+      // selection coordinates (line, offset, ordinal) are unchanged, so
+      // the scroll effect (keyed on chordSelection) must NOT re-fire.
+      const input = container.querySelector(
+        '.chordsketch-sheet__cins-row2 .chordsketch-sheet__cins-input',
+      ) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'm7' } });
+      await Promise.resolve();
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      if (original) Object.defineProperty(Element.prototype, 'scrollIntoView', original);
+      else delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+    }
+  });
+
   test('the inspector ◀ button is disabled for a chord at the line start', async () => {
     const { container } = render(
       <ChordSheet

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -10,6 +10,10 @@ import {
   applyChordEdit,
   applyChordReposition,
   buildChordName,
+  buildChordNudge,
+  capoTransposeOffset,
+  chordLayoutForLine,
+  chordSourceEditableUnderTranspose,
   chordSuffixFromQuality,
   findChordByOffsetOrdinal,
   lyricsOffsetToSourceColumn,
@@ -711,5 +715,160 @@ describe('applyChordEdit / applyChordDelete — expected-token guard', () => {
       expected: 'Am',
     });
     expect(text).toBe('hi');
+  });
+});
+
+describe('capoTransposeOffset (mirrors core capo_validated 1..=24)', () => {
+  test('returns 0 when no {capo} directive is present', () => {
+    expect(capoTransposeOffset('{title: T}\nLa la')).toBe(0);
+  });
+
+  test('returns the value verbatim for 1..=24 (NO display clamp to 12)', () => {
+    expect(capoTransposeOffset('{capo: 1}\n')).toBe(1);
+    expect(capoTransposeOffset('{capo: 12}\n')).toBe(12);
+    // The bug this guards: readCapo clamps 13..24 down to 12; the gate
+    // must use the real value the core transposes by.
+    expect(capoTransposeOffset('{capo: 13}\n')).toBe(13);
+    expect(capoTransposeOffset('{capo: 24}\n')).toBe(24);
+    expect(readCapo('{capo: 18}\n')).toBe(12); // sanity: readCapo DOES clamp
+    expect(capoTransposeOffset('{capo: 18}\n')).toBe(18); // gate does not
+  });
+
+  test('returns 0 for out-of-range / malformed / negative (core treats as unset)', () => {
+    expect(capoTransposeOffset('{capo: 0}\n')).toBe(0);
+    expect(capoTransposeOffset('{capo: 25}\n')).toBe(0);
+    expect(capoTransposeOffset('{capo: 300}\n')).toBe(0);
+    expect(capoTransposeOffset('{capo: -3}\n')).toBe(0);
+  });
+});
+
+describe('chordSourceEditableUnderTranspose', () => {
+  test('editable when effective transpose is zero', () => {
+    expect(chordSourceEditableUnderTranspose('La la', 0)).toBe(true);
+    expect(chordSourceEditableUnderTranspose('La la', undefined)).toBe(true);
+    // Coincidental cancellation is a genuine no-op transpose.
+    expect(chordSourceEditableUnderTranspose('{capo: 2}\nLa', 2)).toBe(true);
+  });
+
+  test('NOT editable when a transpose or capo shifts the rendered chords', () => {
+    expect(chordSourceEditableUnderTranspose('La la', 3)).toBe(false);
+    expect(chordSourceEditableUnderTranspose('{capo: 5}\nLa', 0)).toBe(false);
+  });
+
+  test('regression: capo 13..24 is not clamped, so the gate stays correct', () => {
+    // Pre-fix, readCapo(13)=12 made `12 - 12 === 0` → editing enabled on
+    // a transposed AST (core effective = 12 - 13 = -1). Must be false now.
+    expect(chordSourceEditableUnderTranspose('{capo: 13}\nLa', 12)).toBe(false);
+    // And the genuine no-op at capo 18 / transpose 18 stays editable.
+    expect(chordSourceEditableUnderTranspose('{capo: 18}\nLa', 18)).toBe(true);
+  });
+});
+
+describe('chordLayoutForLine', () => {
+  test('chord-less line: every segment column equals its lyrics offset', () => {
+    const { layout, totalLyrics } = chordLayoutForLine([{ text: 'Hello' }]);
+    expect(layout).toEqual([{ sourceColumn: 0, bracketLength: 0, lyricsOffsetStart: 0 }]);
+    expect(totalLyrics).toBe(5);
+  });
+
+  test('accounts for bracket width when accumulating source columns', () => {
+    // Source: `[C]do[Am]re` → seg0 {C,"do"}, seg1 {Am,"re"}.
+    const { layout, totalLyrics } = chordLayoutForLine([
+      { text: 'do', chord: { name: 'C' } },
+      { text: 're', chord: { name: 'Am' } },
+    ]);
+    expect(layout).toEqual([
+      { sourceColumn: 0, bracketLength: 3, lyricsOffsetStart: 0 }, // [C]
+      { sourceColumn: 5, bracketLength: 4, lyricsOffsetStart: 2 }, // [Am] after `[C]do`
+    ]);
+    expect(totalLyrics).toBe(4);
+  });
+
+  test('matches the column applyChordEdit expects (round-trips with the editor)', () => {
+    const segs = [{ text: 'hi', chord: { name: 'Am' } }];
+    const { layout } = chordLayoutForLine(segs);
+    const source = '[Am]hi';
+    expect(source.slice(layout[0].sourceColumn, layout[0].sourceColumn + layout[0].bracketLength)).toBe(
+      '[Am]',
+    );
+  });
+});
+
+describe('applyChordReposition — expected-token guard (parity with edit/delete)', () => {
+  test('move no-ops when the live `from` span no longer matches `expected`', () => {
+    // Stale/drifted span: source has `[C]` at col 0 but the event expects `[Am]`.
+    const before = '[C]hi';
+    const { text } = applyChordReposition(before, {
+      fromLine: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      toLine: 1,
+      toLyricsOffset: 2,
+      chord: 'Am',
+      copy: false,
+      expected: 'Am',
+    });
+    expect(text).toBe(before); // unchanged — no corruption
+  });
+
+  test('move applies when `expected` matches the live span', () => {
+    const { text } = applyChordReposition('[Am]hi', {
+      fromLine: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      toLine: 1,
+      toLyricsOffset: 2,
+      chord: 'Am',
+      copy: false,
+      expected: 'Am',
+    });
+    expect(text).toBe('hi[Am]');
+  });
+
+  test('copy ignores `expected` (nothing is removed)', () => {
+    const { text } = applyChordReposition('hi', {
+      fromLine: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      toLine: 1,
+      toLyricsOffset: 0,
+      chord: 'Am',
+      copy: true,
+      expected: 'whatever',
+    });
+    expect(text).toBe('[Am]hi');
+  });
+
+  test('shares the structural denylist with the other writers (rejects `>`)', () => {
+    // Pre-fix, applyChordReposition inlined a denylist that omitted `>`.
+    expect(() =>
+      applyChordReposition('hi', {
+        fromLine: 1,
+        fromColumn: 0,
+        fromLength: 0,
+        toLine: 1,
+        toLyricsOffset: 0,
+        chord: 'A>',
+        copy: true,
+      }),
+    ).toThrow(/forbidden/);
+  });
+});
+
+describe('buildChordNudge sets the expected-token guard on its move event', () => {
+  test('expected equals the moved chord name', () => {
+    const result = buildChordNudge({
+      sourceLine: 1,
+      chordName: 'Am7',
+      sourceColumn: 0,
+      bracketLength: 5,
+      currentOffset: 0,
+      otherOffsets: [],
+      totalLyrics: 4,
+      direction: 1,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.event.expected).toBe('Am7');
+    expect(result!.event.copy).toBe(false);
   });
 });


### PR DESCRIPTION
## What

A four-lens review (correctness, security, simplification, project-rule compliance) of the chord-editor inspector subsystem shipped in #2627 / #2631 surfaced two **High** findings and several Low/Nit items. All are fixed here at root cause.

### High — transpose-safety gate diverged from the core's capo semantics
`sourceEditable` re-derived the effective transpose using `readCapo`, which clamps `{capo}` into the `<Capo>` control's `[0,12]` display range. The core (`Metadata::capo_validated`, `crates/chordpro/src/ast.rs`) accepts `1..=24` and folds that exact value into the AST transpose. So a hand-edited `{capo: 13}` with `transpose: 12` computed `0` in React (editing **enabled**) while the core transposed the AST by `-1` — source-coordinate editing of a transposed AST then corrupts the song.
- Added `capoTransposeOffset` (mirrors `capo_validated`: `1..=24` accept-or-zero, **no clamp**) and `chordSourceEditableUnderTranspose`; the gate now uses them. `readCapo` stays the `<Capo>` control's display helper (its clamp is correct there).

### High — chord reposition could remove the wrong bracket
Drag and nudge flow through `applyChordReposition`, which — unlike `applyChordEdit` / `applyChordDelete` — had no `expected` optimistic-concurrency guard, so a stale or column-drifted `from` span corrupted the source.
- Added the optional `expected` guard (move-only; copies remove nothing), threaded it from `buildChordNudge` and both walker drop emitters, and shared the structural denylist `CHORD_FORBIDDEN_RE` across all chord-writing helpers (it also adds the previously-missing `>` that the reposition inline copy omitted — a sanitizer asymmetry per `sanitizer-security.md`).

### Medium — duplicated coordinate walk (fix-propagation hazard)
The JSX walker's `segmentLayout` and `resolveSelectedChord` walked segments with byte-identical accumulation that had to stay in lockstep. Extracted one `chordLayoutForLine` helper both consume — and the single home for the eventual #2634 source-span fix.

### Low / Nit
- `CHORD_TYPE_PRESETS`: documented it as an intentionally-open palette (not bound to the iReal `QUALITY_OPTIONS` enum) and the `id` convention (sister-site note per `fix-propagation.md`).
- `chordSuffixFromQuality`: corrected the docstring (the inspector uses `partsFromRawName`, not this helper) and kept it as a standalone public utility.
- Exported the new public helpers (`capoTransposeOffset`, `chordSourceEditableUnderTranspose`, `chordLayoutForLine`, `SegmentLayout`).

## Why

The inspector subsystem merged without these being caught; the transpose gate and the reposition guard are genuine song-corruption vectors. Per `root-cause-fixes.md` the fixes target the right layer (gate mirrors core capo semantics; the guard is the same mechanism edit/delete already use; the layout walk is unified rather than re-copied).

## Test results

- vitest: **778 passed** (+15): capo-gate range incl. the `13..24` regression, the reposition `expected` guard + `>` denylist, `chordLayoutForLine`, `buildChordNudge` expected, and a scroll-on-select / no-rescroll-on-type effect test. `npm run typecheck` and `npm run build` clean.
- New Playwright smoke `packages/playground/tests-e2e/chord-inspector.spec.ts` (per `playground-smoke.md`): asserts the inspector mounts on chord-select, the lyrics stay visible (bottom-dock "does not cover content" contract), the expanded jazz-tension chips shipped, and no uncaught page errors. **Could not be run locally** (the sandbox has no `@chordsketch/wasm` installed and no Playwright browsers, network-restricted); `playground-smoke.yml` exercises it in CI. DOM assumptions were verified against the playground source (split is the default view, so `onChordEdit` is wired; chords are `role="button"`; edits flow to `.cm-editor`).

## Review summary

- Sister-site audit: unified the three chord-writing denylists onto `CHORD_FORBIDDEN_RE`; chord editing remains a React-only interaction layer (no Rust renderer sister). React JSX walker chord escaping parity with the Rust HTML renderer was confirmed unchanged.

## Deferred

- **Escaped-special source-column drift (root cause)** — tracked in **#2634**. The complete fix carries real source spans through the AST JSON (Rust + wasm), which is only runtime-effective after a published `@chordsketch/wasm` release (ADR-0008). The `expected` guard added here turns the drift from corruption into a safe no-op meanwhile, so this is not closed by this PR.
- **`CLAUDE.md` `@chordsketch/react` row** does not yet mention the chord inspector / `onChordEdit` / `onChordDelete` (pre-existing since #2614). Per `parallel-work.md`'s Shared Files Policy and `doc-maintenance.md`, `CLAUDE.md` is updated via a dedicated docs PR, not a feature branch — to be done separately.
- **`.cins*` CSS font-sizes** use raw rems where `--cs-fs-*` tokens exist; left as-is because the block matches the file's dominant raw-rem style (53 raw vs 4 tokenised), so tokenising only this block would create local inconsistency — a file-wide tokenisation is a separate refactor.

Refs #2627, #2631, #2634

https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6)_