### PR TITLE
Watch Vite-aliased React packages in deploy-playground paths filter

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -20,6 +20,18 @@ on:
       - 'packages/playground/**'
       - 'packages/npm/**'
       - 'packages/npm-export/**'
+      # The playground build pulls these workspace packages directly from
+      # their SOURCE via Vite aliases (see `packages/playground/
+      # vite.config.ts`: `@chordsketch/react` → `../react/src`, etc.), not
+      # from a published/built copy. A change under any of them therefore
+      # changes the bundle the deployed site serves, so — by the same
+      # reasoning as the `crates/**` block above — they must be watched or
+      # the live playground goes silently stale (PR #2633's
+      # `packages/react/src/styles.css` metronome change merged without a
+      # redeploy because none of these were listed; issue #2636).
+      - 'packages/react/**'
+      - 'packages/react-ui/**'
+      - 'packages/ui-irealb-editor/**'
       # The docs SSG reads `docs/sdk/**` from disk at build time (see
       # `packages/playground/scripts/build-docs-static.mjs`), so Markdown
       # edits under that tree must trigger a redeploy or the deployed


### PR DESCRIPTION
## What

Add `packages/react/**`, `packages/react-ui/**`, and `packages/ui-irealb-editor/**` to the `deploy-playground.yml` push `paths:` filter, with a comment explaining the rationale.

## Why

The playground build pulls these three workspace packages directly from their **source** via Vite aliases (`packages/playground/vite.config.ts`: `@chordsketch/react` → `../react/src`, `@chordsketch/react-ui` → `../react-ui/src`, `@chordsketch/ui-irealb-editor` → `../ui-irealb-editor/...`), not from a published/built copy. A change under any of them therefore changes the bundle the deployed site serves.

The `paths:` filter did not watch them, so a change touching only those packages merged to `main` without triggering a redeploy, and the live playground (chordsketch.koeda.me) went silently stale. Confirmed: PR #2633 (a `packages/react/src/styles.css`-only metronome change) and #2631 both merged without a `deploy-playground` run — the most recent run before this fix was `f6e7bf8` (#2627) at 14:58Z, while #2633 merged at 16:14Z.

This is the same class of bug as #2608, which the workflow's own `crates/**` comment already cites. The fix mirrors that rationale.

## Test results

- `python3 -c "import yaml; ..."` parses the workflow and confirms the `paths:` list now contains all three new globs.
- Merging this PR is itself the end-to-end test: the workflow file is in its own watch list, so the squash-merge triggers a `deploy-playground` run that rebuilds from current `main` (which includes #2633's metronome change), proving the stale-deploy path is closed.

## Review summary

- CI-config-only change; no Rust/TS source touched. The added globs match the exact set of source packages Vite-aliases into the playground build (`react`, `react-ui`, `ui-irealb-editor`); `npm` / `npm-export` were already covered.

## Sister-site audit

Checked the other two source packages the playground aliases (`react-ui`, `ui-irealb-editor`) — both added in the same commit, not just the one #2633 touched, so the gap is closed for the whole aliased set rather than only the symptom path. No other workflow gates the playground deploy.

## Deferred

None.

Closes #2636

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGQ9TGjeYYqdWQtxoKvAbf)_