### PR TITLE
Chord inspector: footer panel, sync parse (no flicker), Unicode header, no select reflow

### DIFF
--- a/packages/playground/tests-e2e/chord-inspector.spec.ts
+++ b/packages/playground/tests-e2e/chord-inspector.spec.ts
@@ -1,5 +1,5 @@
 // Smoke coverage for the chord-editor inspector mount path in the
-// ChordPro playground (#2622 / #2626 / #2630).
+// ChordPro playground (#2622 / #2626 / #2630 / #2638).
 //
 // Per `.claude/rules/playground-smoke.md`, a new React component mount
 // site reached only at runtime in a real browser needs an end-to-end
@@ -7,9 +7,12 @@
 // only thing proving the inspector actually mounts in the deployed
 // bundle is loading the page and selecting a chord. The pre-#2630
 // inspector was a top-left overlay that covered the lyrics; #2630
-// re-docked it to the bottom, so this spec also asserts the rendered
-// lyrics stay visible while the inspector is open (the "does not cover
-// content" contract) and that the expanded jazz-tension chips shipped.
+// re-docked it to the bottom; #2638 made it a full-width FOOTER panel
+// (a sibling of `.chordsketch-sheet__content`, not a card inside it)
+// and stopped the selected-chord badge from reflowing the line. This
+// spec asserts the inspector mounts, the lyrics stay visible, the
+// footer is NOT inside the scroll content, selecting a chord does not
+// reflow its neighbours, and the expanded jazz-tension chips shipped.
 //
 // Assertions are structural (selectors / visibility), and every test
 // registers a `pageerror` listener asserting `[]` so a JS exception
@@ -77,6 +80,55 @@ test.describe('chord-editor inspector (ChordPro playground)', () => {
     // edit pipeline; the editor source should now contain a `maj9` chord.
     await maj9.click();
     await expect(page.locator('.cm-editor')).toContainText('maj9');
+
+    expect(errors).toEqual([]);
+  });
+
+  test('selecting a chord does not reflow its neighbours (#2638)', async ({ page }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    const preview = page.locator('.pane.preview');
+    const chords = preview.locator(".chord[role='button']");
+    // The first sample line is `[G]Amazing [G7]grace …`, so chord 0 (G)
+    // and chord 1 (G7) sit on the same line with G7 to the right of G.
+    // Selecting G paints the solid badge; if the badge grew G's box the
+    // way the pre-#2638 padding did, G7 would shift right. The badge now
+    // offsets its padding with an equal negative margin, so G7's x must
+    // not move. x is scroll-invariant (the preview only scrolls
+    // vertically), so this isolates horizontal reflow from the
+    // scroll-into-view the selection also triggers.
+    const second = chords.nth(1);
+    const beforeX = (await second.boundingBox())?.x ?? 0;
+
+    await chords.nth(0).click();
+    await expect(preview.locator('.chord--selected')).toBeVisible();
+
+    const afterX = (await second.boundingBox())?.x ?? 0;
+    // Sub-pixel tolerance; the pre-fix reflow was ~10px.
+    expect(Math.abs(afterX - beforeX)).toBeLessThan(1.5);
+
+    expect(errors).toEqual([]);
+  });
+
+  test('the inspector is a footer below the song, not a card inside the scroll content (#2638)', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    const preview = page.locator('.pane.preview');
+    await preview.locator(".chord[role='button']").first().click();
+    await expect(preview.locator('.chordsketch-sheet__cins')).toBeVisible();
+
+    // The footer is a sibling of `.chordsketch-sheet__content`, NOT a
+    // descendant of it — so it sits below the scrolling song rather than
+    // floating over it as the pre-#2638 dock did.
+    await expect(
+      preview.locator('.chordsketch-sheet__content .chordsketch-sheet__cins'),
+    ).toHaveCount(0);
 
     expect(errors).toEqual([]);
   });

--- a/packages/react/src/chord-inspector.tsx
+++ b/packages/react/src/chord-inspector.tsx
@@ -1,10 +1,11 @@
-// Floating chord-editor inspector for the ChordPro preview (#2622).
+// Footer chord-editor inspector for the ChordPro preview (#2622).
 //
-// A bottom-docked, non-modal panel that appears when a chord is selected
-// in the preview (#2630 moved it from a top-left overlay to a bottom
-// sheet so it no longer covers the lyrics / chord being edited; the
-// parent scrolls the selected chord into view above the dock). It edits
-// the selected chord's root, accidental, type
+// A non-modal panel that appears when a chord is selected in the
+// preview. #2630 moved it from a top-left overlay to a bottom sheet; for
+// #2638 it became a full-width footer below the song (a sibling of
+// `.chordsketch-sheet__content`, not a card floating over it), and the
+// parent scrolls the selected chord into view above it. It edits the
+// selected chord's root, accidental, type
 // (a quality+extension preset or free-form suffix), and optional slash
 // bass, and hosts the relocated ◀ / ▶ "move one lyric character"
 // controls plus delete. It is the ChordPro sibling of the iReal Pro
@@ -34,8 +35,16 @@ const ACCIDENTALS: ReadonlyArray<{ value: '' | '#' | 'b'; label: string; aria: s
 /** Props for {@link ChordInspector}. Controlled: the parent supplies the
  * current parts + bounds and receives every edit through the callbacks. */
 export interface ChordInspectorProps {
-  /** The selected chord's display name for the header, e.g. `"Am7"`. */
+  /** The selected chord's RAW name (as it appears in source), e.g.
+   * `"Bbm7"`. Used as the header fallback when {@link displayName} is
+   * omitted. */
   chordName: string;
+  /** The selected chord's display name with Unicode accidentals (e.g.
+   * `"B♭m7"`), matching how the renderer paints the chord. Shown in the
+   * header so the editor's title agrees with the preview instead of
+   * showing the raw ASCII `b` / `#`. Falls back to {@link chordName}
+   * when omitted. */
+  displayName?: string;
   /** Current root letter `A`–`G`. */
   root: string;
   /** Current root accidental. */
@@ -68,7 +77,10 @@ export interface ChordInspectorProps {
  * open — so it does not trap focus; Escape closes it.
  */
 export function ChordInspector(props: ChordInspectorProps): JSX.Element {
-  const { chordName, root, accidental, suffix, bass, canLeft, canRight } = props;
+  const { chordName, displayName, root, accidental, suffix, bass, canLeft, canRight } = props;
+  // Header / aria title: prefer the Unicode-accidental display name so
+  // the editor's title matches the rendered chord (B♭, not Bb).
+  const titleName = displayName ?? chordName;
 
   const emit = (patch: Partial<ChordParts>): void => {
     props.onChange({ root, accidental, suffix, bass, ...patch });
@@ -85,13 +97,13 @@ export function ChordInspector(props: ChordInspectorProps): JSX.Element {
     <div
       className="chordsketch-sheet__cins"
       role="group"
-      aria-label={`Edit chord ${chordName || '(empty)'}`}
+      aria-label={`Edit chord ${titleName || '(empty)'}`}
       onKeyDown={onKeyDown}
     >
       <div className="chordsketch-sheet__cins-head">
         <div>
           <div className="chordsketch-sheet__cins-eyebrow">Editing chord</div>
-          <div className="chordsketch-sheet__cins-name">{chordName || '—'}</div>
+          <div className="chordsketch-sheet__cins-name">{titleName || '—'}</div>
         </div>
         <button
           type="button"

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { HTMLAttributes, ReactNode } from 'react';
 
 import { ChordInspector } from './chord-inspector';
-import { renderChordproAst } from './chordpro-jsx';
+import { renderChordproAst, unicodeAccidentals } from './chordpro-jsx';
 import type { ChordSelection } from './chordpro-jsx';
 import type { ChordproChord, ChordproSong } from './chordpro-ast';
 import {
@@ -461,6 +461,11 @@ function ChordSheetAstBranch({
   // chords never become interactive, so the state simply stays null.
   const [chordSelection, setChordSelection] = useState<ChordSelection | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
+  // Per-instance root spanning both the song content and the footer
+  // inspector (which is a sibling of `__content`, not inside it). Used
+  // by the outside-click handler so clicking inside this sheet's
+  // inspector does not count as "outside" and clear the selection.
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   // Clear the selection when the user presses down anywhere that is
   // not a chord / nudge control belonging to THIS sheet. Clicking a
@@ -479,7 +484,10 @@ function ChordSheetAstBranch({
       // selection the instant the user presses on the chord glyph.
       const el =
         node instanceof Element ? node : (node?.parentElement ?? null);
-      const root = contentRef.current;
+      // Scope to THIS sheet's subtree (chords in `__content` + the
+      // sibling inspector footer), so a press on a chord or anywhere in
+      // the inspector keeps the selection; anything else clears it.
+      const root = wrapperRef.current;
       if (
         root != null &&
         el != null &&
@@ -563,7 +571,7 @@ function ChordSheetAstBranch({
   // `transposedKey` plumbed through from `parseChordproWithWarnings*`
   // drives the "Original Key X · Play Key Y" header path.
   return (
-    <div {...divProps} className={wrapperClass} aria-busy={loading || undefined}>
+    <div {...divProps} ref={wrapperRef} className={wrapperClass} aria-busy={loading || undefined}>
       {errorNode}
       <div className="chordsketch-sheet__content" ref={contentRef}>
         {renderChordproAst(ast, {
@@ -582,80 +590,84 @@ function ChordSheetAstBranch({
           chordSelection: repositionCb ? chordSelection : null,
           setChordSelection: repositionCb ? setChordSelection : undefined,
         })}
-        {resolvedChord && editCb ? (
-          <ChordInspector
-            chordName={resolvedChord.chordName}
-            root={resolvedChord.parts.root}
-            accidental={resolvedChord.parts.accidental}
-            suffix={resolvedChord.parts.suffix}
-            bass={resolvedChord.parts.bass}
-            // `[]` for otherOffsets: availability depends only on
-            // the line bounds; otherOffsets is used solely to compute
-            // the destination ordinal (not the null/non-null result),
-            // so an empty list is fine for the can-move check.
-            canLeft={
-              nudgeChordPosition(resolvedChord.currentOffset, [], resolvedChord.totalLyrics, -1) !==
-              null
-            }
-            canRight={
-              nudgeChordPosition(resolvedChord.currentOffset, [], resolvedChord.totalLyrics, 1) !==
-              null
-            }
-            onChange={(parts: ChordParts) => {
-              let chord: string;
-              try {
-                chord = buildChordName(parts);
-              } catch {
-                // Invalid parts (e.g. a rootless chord whose root is
-                // empty — buildChordName throws); ignore rather than
-                // corrupt the source.
-                return;
-              }
-              editCb({
-                line: resolvedChord.sourceLine,
-                fromColumn: resolvedChord.sourceColumn,
-                fromLength: resolvedChord.bracketLength,
-                chord,
-                expected: resolvedChord.chordName,
-              });
-            }}
-            onNudge={(direction) => {
-              const result = buildChordNudge({
-                sourceLine: resolvedChord.sourceLine,
-                chordName: resolvedChord.chordName,
-                sourceColumn: resolvedChord.sourceColumn,
-                bracketLength: resolvedChord.bracketLength,
-                currentOffset: resolvedChord.currentOffset,
-                otherOffsets: resolvedChord.otherOffsets,
-                totalLyrics: resolvedChord.totalLyrics,
-                direction,
-              });
-              if (!result || !repositionCb) return;
-              repositionCb(result.event);
-              setChordSelection((prev) => ({
-                line: resolvedChord.sourceLine,
-                offset: result.offset,
-                ordinal: result.ordinal,
-                nonce: (prev?.nonce ?? 0) + 1,
-              }));
-            }}
-            onRemove={
-              deleteCb
-                ? () => {
-                    deleteCb({
-                      line: resolvedChord.sourceLine,
-                      fromColumn: resolvedChord.sourceColumn,
-                      fromLength: resolvedChord.bracketLength,
-                      expected: resolvedChord.chordName,
-                    });
-                    setChordSelection(null);
-                  }
-                : undefined
-            }
-            onClose={() => setChordSelection(null)}
-          />
-        ) : null}
       </div>
+      {resolvedChord && editCb ? (
+        <ChordInspector
+          chordName={resolvedChord.chordName}
+          // Header shows the chord with Unicode accidentals (B♭, not
+          // Bb) so the editor title matches the rendered chord, while
+          // `chordName` stays raw for the source-edit `expected` guard.
+          displayName={unicodeAccidentals(resolvedChord.chordName)}
+          root={resolvedChord.parts.root}
+          accidental={resolvedChord.parts.accidental}
+          suffix={resolvedChord.parts.suffix}
+          bass={resolvedChord.parts.bass}
+          // `[]` for otherOffsets: availability depends only on
+          // the line bounds; otherOffsets is used solely to compute
+          // the destination ordinal (not the null/non-null result),
+          // so an empty list is fine for the can-move check.
+          canLeft={
+            nudgeChordPosition(resolvedChord.currentOffset, [], resolvedChord.totalLyrics, -1) !==
+            null
+          }
+          canRight={
+            nudgeChordPosition(resolvedChord.currentOffset, [], resolvedChord.totalLyrics, 1) !==
+            null
+          }
+          onChange={(parts: ChordParts) => {
+            let chord: string;
+            try {
+              chord = buildChordName(parts);
+            } catch {
+              // Invalid parts (e.g. a rootless chord whose root is
+              // empty — buildChordName throws); ignore rather than
+              // corrupt the source.
+              return;
+            }
+            editCb({
+              line: resolvedChord.sourceLine,
+              fromColumn: resolvedChord.sourceColumn,
+              fromLength: resolvedChord.bracketLength,
+              chord,
+              expected: resolvedChord.chordName,
+            });
+          }}
+          onNudge={(direction) => {
+            const result = buildChordNudge({
+              sourceLine: resolvedChord.sourceLine,
+              chordName: resolvedChord.chordName,
+              sourceColumn: resolvedChord.sourceColumn,
+              bracketLength: resolvedChord.bracketLength,
+              currentOffset: resolvedChord.currentOffset,
+              otherOffsets: resolvedChord.otherOffsets,
+              totalLyrics: resolvedChord.totalLyrics,
+              direction,
+            });
+            if (!result || !repositionCb) return;
+            repositionCb(result.event);
+            setChordSelection((prev) => ({
+              line: resolvedChord.sourceLine,
+              offset: result.offset,
+              ordinal: result.ordinal,
+              nonce: (prev?.nonce ?? 0) + 1,
+            }));
+          }}
+          onRemove={
+            deleteCb
+              ? () => {
+                  deleteCb({
+                    line: resolvedChord.sourceLine,
+                    fromColumn: resolvedChord.sourceColumn,
+                    fromLength: resolvedChord.bracketLength,
+                    expected: resolvedChord.chordName,
+                  });
+                  setChordSelection(null);
+                }
+              : undefined
+          }
+          onClose={() => setChordSelection(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -398,12 +398,6 @@
   line-height: 1.6875;
   color: var(--cs-ink-1000, #0a0a0b);
   padding: 2em 1.5em;
-  /* Positioning anchor + sticky containing block for the bottom-docked
-     chord-editor inspector (#2622, re-docked in #2630). The inspector is
-     `position: sticky; bottom` and rendered as this wrapper's last flow
-     child, so it pins to the bottom of the scrollport while the content
-     is in view and does NOT track (or cover) the selected chord. */
-  position: relative;
 }
 
 /* `.song` is the AST walker's root container. It carries no
@@ -1480,7 +1474,7 @@
 /* Click-to-focus chord editing (#2614 / #2622). When chord
    repositioning is enabled each real chord is a toggle button;
    tapping it selects the chord, which paints it as a solid crimson
-   badge and opens the left-docked chord-editor inspector. */
+   badge and opens the footer chord-editor inspector. */
 .chordsketch-sheet__content .chord[role='button'] {
   cursor: pointer;
 }
@@ -1491,8 +1485,14 @@
   background: var(--cs-crimson-500, #bd1642);
   color: var(--cs-fg-on-crimson, #fff);
   border-radius: var(--cs-r-2, 4px);
-  padding: 1px 5px;
-  /* Keep the chip from nudging the lyric baseline as it appears. */
+  /* The badge needs padding for breathing room, but padding would grow
+     the chord's box and reflow the lyric line + shift neighbouring
+     chords the moment one is selected (#2638). An equal negative margin
+     cancels the padding's layout effect: the border-box paints the chip
+     while the margin-box stays exactly the unselected chord's size, so
+     selecting never moves anything. */
+  padding: 2px 5px;
+  margin: -2px -5px;
   box-shadow: var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
 }
 .chordsketch-sheet__content .chord--selected:focus-visible {
@@ -1500,70 +1500,69 @@
   box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
 }
 
-/* ---- Left-docked chord-editor inspector (#2622) ---------------- */
-/* Floating, non-modal panel anchored to the top-left of the preview
-   content. Does NOT track the selected chord — it stays put while the
-   user edits root / type / bass and steps the chord left / right. */
-.chordsketch-sheet__content .chordsketch-sheet__cins {
-  /* Bottom-docked sheet (#2630): the pre-#2630 `position: absolute;
-     left/top` overlay sat at the content's top-left and covered the
-     lyrics / chord being edited. A `position: sticky; bottom` element,
-     rendered as the LAST flow child of `.chordsketch-sheet__content`,
-     pins to the bottom of the scrollport while the content is in view —
-     so the panel stays reachable as the user scrolls but never tracks
-     (or covers) the selected chord, which the parent scrolls into view
-     above the dock. */
+/* ---- Footer chord-editor inspector (#2622) --------------------- */
+/* Non-modal footer panel below the preview (see the rule below for the
+   sibling-of-`__content` structure). Does NOT track the selected chord
+   — it stays put while the user edits root / type / bass and steps the
+   chord left / right. */
+.chordsketch-sheet .chordsketch-sheet__cins {
+  /* Footer panel (#2638): rendered as a sibling AFTER
+     `.chordsketch-sheet__content` (not inside it), so it is a
+     full-width band below the song rather than a centred card floating
+     over it — the pre-#2638 dock read as a modal. `position: sticky;
+     bottom: 0` pins it to the bottom of the preview scrollport so it
+     stays reachable as the song scrolls, while the selected chord is
+     scrolled into view above it. Being a flow sibling, it reserves its
+     own height, so the last song line is always reachable above it. */
   position: sticky;
-  bottom: var(--cs-sp-4, 1rem);
+  bottom: 0;
   z-index: 6;
-  /* Centred reading-column cap on wide panes; full width on narrow. */
   width: 100%;
-  max-width: 34rem;
-  margin-inline: auto;
-  margin-top: var(--cs-sp-4, 1rem);
   /* Cap height so a long chip list scrolls internally instead of
      filling the viewport and re-covering the content. */
-  max-height: min(60vh, 32rem);
+  max-height: min(55vh, 30rem);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: var(--cs-sp-4, 1rem);
-  padding: var(--cs-sp-4, 1rem);
+  padding: var(--cs-sp-4, 1rem) var(--cs-sp-6, 1.5rem);
   background: var(--cs-surface, #fff);
-  border: 1px solid var(--cs-border-strong, #d4d1d6);
-  border-radius: var(--cs-r-3, 8px);
-  box-shadow: var(--cs-e-3, 0 10px 30px rgba(10, 10, 11, 0.16));
+  /* Footer divider + upward lift, not an all-round card border/shadow. */
+  border: 0;
+  border-top: 1px solid var(--cs-border-strong, #d4d1d6);
+  border-radius: 0;
+  box-shadow: 0 -8px 24px rgba(10, 10, 11, 0.1);
   font-family: var(--cs-font-latin, "Inter", system-ui, sans-serif);
-  animation: chordsketch-cins-pop var(--cs-dur-2, 200ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1));
+  animation: chordsketch-cins-rise var(--cs-dur-2, 200ms) var(--cs-ease-out, cubic-bezier(0.2, 0.8, 0.2, 1));
 }
-@keyframes chordsketch-cins-pop {
-  from { opacity: 0; transform: translateY(12px) scale(0.99); }
+@keyframes chordsketch-cins-rise {
+  from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: none; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .chordsketch-sheet__content .chordsketch-sheet__cins { animation: none; }
+  .chordsketch-sheet .chordsketch-sheet__cins { animation: none; }
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-head {
+.chordsketch-sheet .chordsketch-sheet__cins-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--cs-sp-2, 0.5rem);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-eyebrow {
+.chordsketch-sheet .chordsketch-sheet__cins-eyebrow {
   font-size: 0.625rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--cs-text-tertiary, #8a8790);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-name {
+.chordsketch-sheet .chordsketch-sheet__cins-name {
   font-family: var(--cs-font-chord, "Roboto", system-ui, sans-serif);
   font-weight: 900;
   font-size: 1.75rem;
   line-height: 1.1;
   color: var(--cs-crimson-500, #bd1642);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-close {
+.chordsketch-sheet .chordsketch-sheet__cins-close {
   width: 28px;
   height: 28px;
   border: 1px solid var(--cs-border, #e8e6ea);
@@ -1574,21 +1573,21 @@
   line-height: 1;
   cursor: pointer;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-close:hover {
+.chordsketch-sheet .chordsketch-sheet__cins-close:hover {
   background: var(--cs-surface-hover, #f6f4f7);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-group {
+.chordsketch-sheet .chordsketch-sheet__cins-group {
   display: flex;
   flex-direction: column;
   gap: var(--cs-sp-2, 0.5rem);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-label {
+.chordsketch-sheet .chordsketch-sheet__cins-label {
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--cs-text-strong, #44424a);
 }
 /* segmented (root / accidental) */
-.chordsketch-sheet__content .chordsketch-sheet__cins-seg {
+.chordsketch-sheet .chordsketch-sheet__cins-seg {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 2px;
@@ -1597,7 +1596,7 @@
   border: 1px solid var(--cs-border, #e8e6ea);
   border-radius: var(--cs-r-2, 4px);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-seg button {
+.chordsketch-sheet .chordsketch-sheet__cins-seg button {
   appearance: none;
   border: 0;
   background: transparent;
@@ -1610,13 +1609,13 @@
   color: var(--cs-text-secondary, #67646d);
   cursor: pointer;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-seg button[aria-pressed='true'] {
+.chordsketch-sheet .chordsketch-sheet__cins-seg button[aria-pressed='true'] {
   background: var(--cs-surface, #fff);
   color: var(--cs-crimson-600, #a30f37);
   box-shadow: var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
 }
 /* type chips */
-.chordsketch-sheet__content .chordsketch-sheet__cins-chips {
+.chordsketch-sheet .chordsketch-sheet__cins-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
@@ -1629,7 +1628,7 @@
   /* Room for the scrollbar so the rightmost chips aren't clipped. */
   padding-right: 2px;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-chip {
+.chordsketch-sheet .chordsketch-sheet__cins-chip {
   appearance: none;
   border: 1px solid var(--cs-border-strong, #d4d1d6);
   background: var(--cs-surface, #fff);
@@ -1641,26 +1640,26 @@
   color: var(--cs-text-strong, #44424a);
   cursor: pointer;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-chip:hover {
+.chordsketch-sheet .chordsketch-sheet__cins-chip:hover {
   background: var(--cs-surface-hover, #f6f4f7);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-chip[aria-pressed='true'] {
+.chordsketch-sheet .chordsketch-sheet__cins-chip[aria-pressed='true'] {
   background: var(--cs-crimson-500, #bd1642);
   border-color: var(--cs-crimson-500, #bd1642);
   color: var(--cs-fg-on-crimson, #fff);
 }
 /* inputs */
-.chordsketch-sheet__content .chordsketch-sheet__cins-row2 {
+.chordsketch-sheet .chordsketch-sheet__cins-row2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--cs-sp-2, 0.5rem);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-field {
+.chordsketch-sheet .chordsketch-sheet__cins-field {
   display: flex;
   flex-direction: column;
   gap: var(--cs-sp-1, 0.25rem);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-input {
+.chordsketch-sheet .chordsketch-sheet__cins-input {
   width: 100%;
   height: 32px;
   border: 1px solid var(--cs-border-strong, #d4d1d6);
@@ -1671,22 +1670,24 @@
   font-size: 0.875rem;
   color: var(--cs-text-primary, #0a0a0b);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-input:focus-visible {
+.chordsketch-sheet .chordsketch-sheet__cins-input:focus-visible {
   outline: none;
   box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-divider {
+.chordsketch-sheet .chordsketch-sheet__cins-divider {
   height: 1px;
   background: var(--cs-border, #e8e6ea);
-  margin: 0 calc(var(--cs-sp-4, 1rem) * -1);
+  /* Full-bleed: must match the panel's horizontal padding (--cs-sp-6)
+     so the divider reaches both edges of the footer. */
+  margin: 0 calc(var(--cs-sp-6, 1.5rem) * -1);
 }
 /* move row (relocated nudge) */
-.chordsketch-sheet__content .chordsketch-sheet__cins-move {
+.chordsketch-sheet .chordsketch-sheet__cins-move {
   display: flex;
   align-items: center;
   gap: var(--cs-sp-2, 0.5rem);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-movebtn {
+.chordsketch-sheet .chordsketch-sheet__cins-movebtn {
   flex: 1;
   height: 34px;
   border: 1px solid var(--cs-border-strong, #d4d1d6);
@@ -1696,26 +1697,26 @@
   color: var(--cs-text-strong, #44424a);
   cursor: pointer;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-movebtn:hover:not(:disabled) {
+.chordsketch-sheet .chordsketch-sheet__cins-movebtn:hover:not(:disabled) {
   background: var(--cs-surface-hover, #f6f4f7);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-movebtn:disabled {
+.chordsketch-sheet .chordsketch-sheet__cins-movebtn:disabled {
   opacity: 0.35;
   cursor: default;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-movelbl {
+.chordsketch-sheet .chordsketch-sheet__cins-movelbl {
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--cs-text-secondary, #67646d);
   white-space: nowrap;
 }
 /* footer */
-.chordsketch-sheet__content .chordsketch-sheet__cins-footer {
+.chordsketch-sheet .chordsketch-sheet__cins-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-remove {
+.chordsketch-sheet .chordsketch-sheet__cins-remove {
   appearance: none;
   border: 1px solid transparent;
   background: transparent;
@@ -1727,10 +1728,10 @@
   color: var(--cs-crimson-600, #a30f37);
   cursor: pointer;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-remove:hover {
+.chordsketch-sheet .chordsketch-sheet__cins-remove:hover {
   background: var(--cs-crimson-50, #fdf2f5);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-done {
+.chordsketch-sheet .chordsketch-sheet__cins-done {
   appearance: none;
   border: 1px solid var(--cs-border-strong, #d4d1d6);
   background: var(--cs-surface, #fff);
@@ -1742,10 +1743,10 @@
   color: var(--cs-text-strong, #44424a);
   cursor: pointer;
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins-done:hover {
+.chordsketch-sheet .chordsketch-sheet__cins-done:hover {
   background: var(--cs-surface-hover, #f6f4f7);
 }
-.chordsketch-sheet__content .chordsketch-sheet__cins :focus-visible {
+.chordsketch-sheet .chordsketch-sheet__cins :focus-visible {
   outline: none;
   box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
   border-radius: var(--cs-r-2, 4px);

--- a/packages/react/src/use-chordpro-ast.ts
+++ b/packages/react/src/use-chordpro-ast.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ChordproSong } from './chordpro-ast';
 
@@ -61,11 +61,14 @@ export interface ChordproParseOptions {
 /** Result state returned by {@link useChordproAst}. */
 export interface ChordproAstResult {
   /**
-   * Parsed AST. `null` while WASM is initialising or while the
-   * parse is in flight.
+   * Parsed AST. `null` only while the wasm module is initialising
+   * (or when `skip` is set). Once the module is loaded the AST is
+   * derived synchronously from `source`, so it is never a render
+   * behind the current input.
    */
   ast: ChordproSong | null;
-  /** `true` while WASM is loading or the parse is in flight. */
+  /** `true` only while the wasm module is loading. Parsing itself is
+   * synchronous, so there is no per-parse in-flight window. */
   loading: boolean;
   /**
    * The most recent parse error (WASM init failure, JSON shape
@@ -146,107 +149,132 @@ export function useChordproAst(
   options: ChordproParseOptions = {},
   loader: ChordproWasmLoader = defaultLoader,
 ): ChordproAstResult {
-  const [ast, setAst] = useState<ChordproSong | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const [warnings, setWarnings] = useState<string[]>([]);
-  const [transposedKey, setTransposedKey] = useState<string | null>(null);
-  const [transposedKeyDirectives, setTransposedKeyDirectives] = useState<
-    Record<string, string>
-  >({});
-  // Bumping `retryNonce` forces the effect to re-fire even when
-  // (`source`, `transpose`, `config`) are unchanged — the hook
-  // surface for consumers that hit a transient WASM-init failure
-  // and want to recover without an input change.
+  const { transpose, config, skip = false } = options;
+
+  // The wasm module is loaded once (async); after that, parsing is a
+  // synchronous call. The AST is therefore DERIVED synchronously from
+  // `(parser, source, transpose, config)` in the `useMemo` below rather
+  // than written into state from an async effect. This is what keeps
+  // `source` and `ast` updating in the SAME render: a source change
+  // (e.g. a chord nudge) never leaves the AST a tick behind, which used
+  // to unmount/remount selection-dependent UI for one frame — the chord
+  // inspector flicker (#2638).
+  const [parser, setParser] = useState<ChordproParser | null>(null);
+  const [initError, setInitError] = useState<Error | null>(null);
+  // Bumping `retryNonce` re-fires the load effect after a transient
+  // WASM-init failure even though `(source, transpose, config)` are
+  // unchanged.
   const [retryNonce, setRetryNonce] = useState(0);
 
-  const parserRef = useRef<ChordproParser | null>(null);
   const loaderRef = useRef(loader);
   loaderRef.current = loader;
 
-  const { transpose, config, skip = false } = options;
-
   useEffect(() => {
-    if (skip) {
-      // Caller is signalling the AST will not be consumed — keep
-      // the hook idle so the wasm module is not fetched. Reset
-      // `loading` to `false` so consumers can still inspect the
-      // (`null`) `ast` state without thinking work is in flight.
-      setLoading(false);
-      return;
-    }
+    if (skip || parser !== null) return;
     let cancelled = false;
-
-    const run = async (): Promise<void> => {
-      setLoading(true);
+    void (async () => {
       try {
-        if (parserRef.current === null) {
-          let mod: ChordproParser;
-          try {
-            mod = await loaderRef.current();
-            await mod.default();
-          } catch (initErr) {
-            // WASM init failures (network drop, MIME mismatch,
-            // integrity check) are a different defect class
-            // than parse errors — they can recover on retry,
-            // and they should NOT poison `parserRef`. Log so
-            // the failure is visible in devtools regardless of
-            // whether the consumer renders `error`, then
-            // surface it through the same `error` channel.
-            if (typeof console !== 'undefined') {
-              console.error(
-                '[@chordsketch/react] useChordproAst: failed to load @chordsketch/wasm',
-                initErr,
-              );
-            }
-            throw initErr;
-          }
-          parserRef.current = mod;
-          if (cancelled) return;
-        }
-        const parser = parserRef.current;
-        const hasOptions = transpose !== undefined || config !== undefined;
-        const result = hasOptions
-          ? parser.parseChordproWithWarningsAndOptions(source, { transpose, config })
-          : parser.parseChordproWithWarnings(source);
-        const parsed = JSON.parse(result.ast) as ChordproSong;
+        const mod = await loaderRef.current();
+        await mod.default();
         if (cancelled) return;
-        setAst(parsed);
-        setWarnings(result.warnings);
-        setTransposedKey(result.transposedKey ?? null);
-        setTransposedKeyDirectives(result.transposedKeyDirectives ?? {});
-        setError(null);
+        setParser(() => mod);
+        setInitError(null);
       } catch (e) {
-        if (cancelled) return;
-        const err = e instanceof Error ? e : new Error(String(e));
-        setError(err);
-        // Keep the previous `ast` and `warnings` so half-typed
-        // edits do not blank the preview — consumers render
-        // `error` alongside the stale tree if they want to
-        // surface the issue. Init failures keep `parserRef`
-        // null so the next `run()` re-imports the module
-        // (manual retry via `retry()` or an input change).
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
+        // WASM init failures (network drop, MIME mismatch, integrity
+        // check) recover on retry and must NOT poison `parser`. Log so
+        // the failure is visible in devtools regardless of whether the
+        // consumer renders `error`, then surface it through `error`.
+        if (typeof console !== 'undefined') {
+          console.error(
+            '[@chordsketch/react] useChordproAst: failed to load @chordsketch/wasm',
+            e,
+          );
         }
+        if (!cancelled) setInitError(e instanceof Error ? e : new Error(String(e)));
       }
-    };
-
-    void run();
-
+    })();
     return () => {
       cancelled = true;
     };
-    // `loader` intentionally excluded — see `use-chord-render.ts`
-    // for the identical pattern + rationale (inline loaders would
+    // `loader` intentionally excluded — see `use-chord-render.ts` for
+    // the identical pattern + rationale (inline loaders would
     // invalidate the effect every render).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source, transpose, config, retryNonce, skip]);
+  }, [skip, parser, retryNonce]);
+
+  // Last successfully-committed parse, retained so a transient invalid
+  // edit (or a parse throw) does not blank the preview — consumers
+  // render `error` alongside the stale tree if they want to surface the
+  // issue. It is written ONLY from a post-commit effect (below), never
+  // during render: the `useMemo` factory stays pure so an abandoned
+  // concurrent render (a transition React discards) can never pollute
+  // the cache with an AST that was never committed.
+  const lastGoodRef = useRef<{
+    ast: ChordproSong;
+    warnings: string[];
+    transposedKey: string | null;
+    transposedKeyDirectives: Record<string, string>;
+  } | null>(null);
+
+  const { ast, warnings, transposedKey, transposedKeyDirectives, parseError } = useMemo(() => {
+    if (skip || parser === null) {
+      return {
+        ast: null as ChordproSong | null,
+        warnings: [] as string[],
+        transposedKey: null as string | null,
+        transposedKeyDirectives: {} as Record<string, string>,
+        parseError: null as Error | null,
+      };
+    }
+    try {
+      const hasOptions = transpose !== undefined || config !== undefined;
+      const result = hasOptions
+        ? parser.parseChordproWithWarningsAndOptions(source, { transpose, config })
+        : parser.parseChordproWithWarnings(source);
+      return {
+        ast: JSON.parse(result.ast) as ChordproSong,
+        warnings: result.warnings,
+        transposedKey: result.transposedKey ?? null,
+        transposedKeyDirectives: result.transposedKeyDirectives ?? {},
+        parseError: null as Error | null,
+      };
+    } catch (e) {
+      // Fall back to the last committed good parse so the preview does
+      // not blank on a half-typed edit.
+      const prev = lastGoodRef.current;
+      return {
+        ast: prev?.ast ?? null,
+        warnings: prev?.warnings ?? [],
+        transposedKey: prev?.transposedKey ?? null,
+        transposedKeyDirectives: prev?.transposedKeyDirectives ?? {},
+        parseError: e instanceof Error ? e : new Error(String(e)),
+      };
+    }
+  }, [parser, source, transpose, config, skip]);
+
+  // Remember the last good parse AFTER commit. Running this in an effect
+  // (not in the memo) keeps the cache consistent with what was actually
+  // committed, even if React renders-then-abandons a memo for a source
+  // that never paints.
+  useEffect(() => {
+    if (parseError === null && ast !== null) {
+      lastGoodRef.current = { ast, warnings, transposedKey, transposedKeyDirectives };
+    }
+  }, [ast, warnings, transposedKey, transposedKeyDirectives, parseError]);
 
   const retry = useCallback(() => {
+    // Drop the parser so the load effect re-imports the module, and
+    // bump the nonce so the effect re-fires even when `parser` is
+    // already null (a load that failed before ever setting it).
+    setParser(null);
+    setInitError(null);
     setRetryNonce((n) => n + 1);
   }, []);
+
+  // `loading` is true only while the wasm module itself is loading;
+  // parsing is synchronous, so there is no per-parse in-flight window.
+  const loading = !skip && parser === null && initError === null;
+  const error = initError ?? parseError;
 
   return {
     ast,

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -88,6 +88,48 @@ function makeAstLoader(stub: StubRenderer): ChordproWasmLoader {
   return vi.fn(async () => stub as unknown as Awaited<ReturnType<ChordproWasmLoader>>);
 }
 
+// A stub returning a single chord-bearing line whose chord has the
+// given raw name (e.g. `"Bb"`), so a test can assert how the inspector
+// renders that name.
+function chordNamedStub(name: string): StubRenderer {
+  const songAst = JSON.stringify({
+    metadata: {
+      title: null,
+      subtitles: [],
+      artists: [],
+      composers: [],
+      lyricists: [],
+      album: null,
+      year: null,
+      key: null,
+      tempo: null,
+      time: null,
+      capo: null,
+      sortTitle: null,
+      sortArtist: null,
+      arrangers: [],
+      copyright: null,
+      duration: null,
+      tags: [],
+      custom: [],
+    },
+    lines: [
+      {
+        kind: 'lyrics',
+        value: {
+          segments: [{ chord: { name, detail: null, display: null }, text: 'hi', spans: [] }],
+        },
+      },
+    ],
+  });
+  const result = { ast: songAst, warnings: [], transposedKey: undefined };
+  return {
+    ...makeStub(),
+    parseChordproWithWarnings: vi.fn(() => result),
+    parseChordproWithWarningsAndOptions: vi.fn(() => result),
+  };
+}
+
 describe('<ChordSheet>', () => {
   test('renders HTML output via parseChordpro when no options are set', async () => {
     const stub = makeStub();
@@ -453,50 +495,11 @@ describe('<ChordSheet>', () => {
   // component, which the renderChordproAst-level tests can't exercise.
   // ---------------------------------------------------------------------
 
-  // A stub returning a single chord-bearing line `[Am]hi`.
-  function chordStub(): StubRenderer {
-    const songAst = JSON.stringify({
-      metadata: {
-        title: null,
-        subtitles: [],
-        artists: [],
-        composers: [],
-        lyricists: [],
-        album: null,
-        year: null,
-        key: null,
-        tempo: null,
-        time: null,
-        capo: null,
-        sortTitle: null,
-        sortArtist: null,
-        arrangers: [],
-        copyright: null,
-        duration: null,
-        tags: [],
-        custom: [],
-      },
-      lines: [
-        {
-          kind: 'lyrics',
-          value: {
-            segments: [
-              { chord: { name: 'Am', detail: null, display: null }, text: 'hi', spans: [] },
-            ],
-          },
-        },
-      ],
-    });
-    const result = { ast: songAst, warnings: [], transposedKey: undefined };
-    return {
-      ...makeStub(),
-      // Both parse entries return the chord-bearing AST so the stub
-      // works whether or not transpose / config options are passed
-      // (the AST branch uses the options entry when transpose is set).
-      parseChordproWithWarnings: vi.fn(() => result),
-      parseChordproWithWarningsAndOptions: vi.fn(() => result),
-    };
-  }
+  // A stub returning a single chord-bearing line `[Am]hi` — the
+  // `chordNamedStub('Am')` case (both parse entries return the same
+  // chord-bearing AST so the stub works whether or not transpose /
+  // config options are passed).
+  const chordStub = (): StubRenderer => chordNamedStub('Am');
 
   test('onChordReposition enables click-to-select + keyboard nudge', async () => {
     // Without onChordEdit, clicking selects (solid badge) and keyboard
@@ -927,5 +930,45 @@ describe('<ChordSheet>', () => {
       expect(stub.parseChordproWithWarnings).toHaveBeenCalled();
     });
     expect(container.querySelector('.chord-diagrams-grid')).toBeNull();
+  });
+
+  test('inspector header shows the chord with Unicode accidentals (B♭, not Bb) (#2638)', async () => {
+    const { container } = render(
+      <ChordSheet
+        source="[Bb]hi"
+        astWasmLoader={makeAstLoader(chordNamedStub('Bb'))}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    // Header title matches the rendered chord (♭), not the raw ASCII `b`.
+    expect(container.querySelector('.chordsketch-sheet__cins-name')?.textContent).toBe('B♭');
+  });
+
+  test('inspector is a footer SIBLING of the song content, not inside it (#2638)', async () => {
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    const wrapper = container.querySelector('.chordsketch-sheet');
+    const content = container.querySelector('.chordsketch-sheet__content');
+    const inspector = container.querySelector('.chordsketch-sheet__cins');
+    expect(inspector).not.toBeNull();
+    // Footer panel: within the sheet wrapper, but NOT inside the
+    // scrolling song content (so it sits below the song, not over it).
+    expect(wrapper?.contains(inspector ?? null)).toBe(true);
+    expect(content?.contains(inspector ?? null)).toBe(false);
   });
 });

--- a/packages/react/tests/use-chordpro-ast.test.tsx
+++ b/packages/react/tests/use-chordpro-ast.test.tsx
@@ -1,0 +1,97 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { useChordproAst, type ChordproWasmLoader } from '../src/use-chordpro-ast';
+
+// Minimal parser stub: the AST's `metadata.title` echoes the source so
+// a test can assert which source the visible AST reflects. The real
+// `ChordproSong` shape has many more fields, but the hook only
+// `JSON.parse`s + casts, so a minimal object is sufficient at runtime.
+function parserStub(opts: { throwOn?: string } = {}) {
+  const make = (src: string) => {
+    if (opts.throwOn !== undefined && src === opts.throwOn) {
+      throw new Error('boom');
+    }
+    return {
+      ast: JSON.stringify({ metadata: { title: src }, lines: [] }),
+      warnings: [] as string[],
+      transposedKey: undefined,
+    };
+  };
+  return {
+    default: vi.fn(async () => undefined),
+    parseChordproWithWarnings: vi.fn(make),
+    parseChordproWithWarningsAndOptions: vi.fn(make),
+  };
+}
+
+function Probe({
+  source,
+  loader,
+  skip,
+}: {
+  source: string;
+  loader: ChordproWasmLoader;
+  skip?: boolean;
+}) {
+  const { ast, loading, error } = useChordproAst(source, { skip }, loader);
+  return (
+    <div data-testid="out">
+      {loading ? 'loading' : error ? `error:${ast?.metadata.title ?? 'null'}` : (ast?.metadata.title ?? 'null')}
+    </div>
+  );
+}
+
+describe('useChordproAst — synchronous parse (no AST lag, #2638)', () => {
+  test('parses after the module loads, then re-parses SYNCHRONOUSLY on source change', async () => {
+    const stub = parserStub();
+    const loader: ChordproWasmLoader = vi.fn(
+      async () => stub as unknown as Awaited<ReturnType<ChordproWasmLoader>>,
+    );
+    const { getByTestId, rerender } = render(<Probe source="A" loader={loader} />);
+
+    // Module load is async — the first paint is `loading`.
+    await waitFor(() => expect(getByTestId('out').textContent).toBe('A'));
+
+    // The regression: changing `source` must update `ast` in the SAME
+    // render, with NO async tick. Under the previous async-effect
+    // implementation the AST lagged one render behind `source` (the
+    // chord-inspector flicker). Asserting without `waitFor` — i.e. the
+    // value is correct immediately after the synchronous rerender —
+    // proves the parse is now a synchronous derivation of `source`.
+    rerender(<Probe source="B" loader={loader} />);
+    expect(getByTestId('out').textContent).toBe('B');
+
+    rerender(<Probe source="C" loader={loader} />);
+    expect(getByTestId('out').textContent).toBe('C');
+  });
+
+  test('keeps the last good AST and surfaces an error when a parse throws', async () => {
+    const stub = parserStub({ throwOn: 'BAD' });
+    const loader: ChordproWasmLoader = vi.fn(
+      async () => stub as unknown as Awaited<ReturnType<ChordproWasmLoader>>,
+    );
+    const { getByTestId, rerender } = render(<Probe source="GOOD" loader={loader} />);
+    await waitFor(() => expect(getByTestId('out').textContent).toBe('GOOD'));
+
+    // A throwing parse must not blank the preview: the previous AST is
+    // retained and `error` is set.
+    rerender(<Probe source="BAD" loader={loader} />);
+    expect(getByTestId('out').textContent).toBe('error:GOOD');
+
+    // Recovering to a valid source clears the error synchronously.
+    rerender(<Probe source="OK" loader={loader} />);
+    expect(getByTestId('out').textContent).toBe('OK');
+  });
+
+  test('skip holds the AST null and never invokes the loader', async () => {
+    const stub = parserStub();
+    const loader: ChordproWasmLoader = vi.fn(
+      async () => stub as unknown as Awaited<ReturnType<ChordproWasmLoader>>,
+    );
+    const { getByTestId } = render(<Probe source="A" loader={loader} skip />);
+    // skip => not loading, ast null, loader untouched.
+    await waitFor(() => expect(getByTestId('out').textContent).toBe('null'));
+    expect(loader).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Fixes the four chord-editor inspector issues reported on the `@chordsketch/react` preview (#2638), each at root cause.

### 1. Move-button flicker → synchronous parse
`useChordproAst` parsed inside an **async effect**, so `ast` lagged the `source` prop by a render. A nudge batches `setSource` (host) + `setChordSelection` (advanced) into one render, but the stale `ast` made `resolveSelectedChord` return null there → the inspector unmounted for a frame, then remounted. The wasm parse call is synchronous; only module load is async. Reworked the hook to **load the module once (async) and derive the AST synchronously via `useMemo`**, so `source` and `ast` update in the same render and selection UI never unmounts mid-update. The last-good-AST fallback (keep the preview from blanking on a half-typed edit) is now written from a **post-commit effect**, not in the memo, so an abandoned concurrent render can't pollute the cache.

### 2. `Bb` vs `B♭` → Unicode header
Added an optional `displayName` to `<ChordInspector>`; the header/aria title now shows `unicodeAccidentals(name)` (the same helper the JSX walker paints chords with), while `chordName` stays **raw** for the source-edit `expected` guard.

### 3. Modal-looking panel → footer
The inspector is now a **full-width footer**: rendered as a sibling **after** `.chordsketch-sheet__content` (not inside it), sticky to the bottom of the preview scrollport, with a top divider instead of an all-round card border/shadow. CSS re-scoped to `.chordsketch-sheet`; the outside-click handler scopes to a wrapper ref covering both the song content and the footer.

### 4. Selected-chord reflow → padding offset by negative margin
`.chord--selected` added padding with no compensating margin, growing the box and reflowing the line. The padding is now cancelled by an equal negative margin, so the badge paints without changing the chord's layout box.

## Why

All four are user-visible defects in a young surface; the fixes target the right layer (the AST should be a synchronous derivation of source, not async state; the badge must not alter layout geometry; the panel is a structural sibling, not a positioned overlay) rather than papering over symptoms.

## Test results

- vitest: **784 passed** (+8): synchronous-parse / stale-on-error / skip for `useChordproAst`; Unicode header + footer-sibling structure for `<ChordSheet>`; `npm run typecheck` + `npm run build` clean.
- Playwright (`packages/playground/tests-e2e/chord-inspector.spec.ts`, runs in CI): the inspector mounts as a footer **not** inside the scroll content, and **selecting a chord does not reflow its same-line neighbour** (x-position invariant within 1.5px; the pre-fix reflow was ~10px). Could not run Playwright locally (sandbox has no `@chordsketch/wasm` install / browsers); CI's `playground-smoke.yml` exercises it.

## Review summary

- Reviewed across four lenses (correctness, security, simplification, project-rule). Security: clean. Correctness: one Low (render-phase `lastGoodRef` write) — **fixed** by moving the cache write to a post-commit effect. Remaining Low/Nit (stale comments, full-bleed divider margin tracking the new padding token, test-stub dedup, spec header) all resolved.
- Sister-site: chord editing + the `unicodeAccidentals` display are React-only; no Rust renderer / JSX-walker sanitiser or rendering contract changed. `use-chord-render.ts` keeps its async pattern intentionally (it produces a display string, not an AST consumed by selection UI, so the flicker class doesn't apply).

## Deferred

- `CLAUDE.md` `@chordsketch/react` row still doesn't enumerate the chord inspector (pre-existing since #2614); per the Shared Files Policy / `doc-maintenance.md` that belongs in a dedicated docs PR.

Closes #2638

https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6)_