### PR TITLE
Extinguish the metronome beat-dot LED during playback

### DIFF
--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -780,22 +780,29 @@
 .chordsketch-sheet__content button.meta-inline--interactive.is-playing .meta-inline__value {
   color: inherit;
 }
-/* While the metronome is actually playing, hold the decorative
-   beat-dot LED static. The dot is a DISCRETE per-beat flash on the
+/* While the metronome is actually playing, extinguish the decorative
+   beat-dot LED entirely. The dot is a DISCRETE per-beat flash on the
    always-on `cs-metronome-beat` CSS clock, which cannot lock to the
    Web Audio metronome, so during playback it drifts against the real
-   audible tick and reads as a stuttering off-beat double-tick.
+   audible tick and reads as a stuttering off-beat double-tick. Once
+   the user is hearing the real beat, the dot has no honest job left —
+   so it is turned off (`opacity: 0`) rather than frozen lit, which
+   would leave a static indicator implying a per-beat cue it no longer
+   carries.
    The CONTINUOUS cues — the pendulum swing (`cs-metronome-swing`) and
    the frame pulse (`cs-tempo-frame`) — are deliberately left running:
    their motion is ambient rather than a discrete tick, so the same
    clock drift is imperceptible and they keep signalling the running
-   tempo. (Do NOT extend this freeze to those two on a "they drift
-   too" reading — the discrete-vs-continuous distinction is the whole
-   point.) The resting full-opacity dot matches the reduced-motion
-   treatment. */
+   tempo. (Do NOT extend this to those two on a "they drift too"
+   reading — the discrete-vs-continuous distinction is the whole
+   point.) `opacity: 0` keeps the SVG circle in layout, so the glyph's
+   size is unchanged; the dot reappears (idle blink, or reduced-motion
+   static) the moment playback stops. This rule sits outside the
+   reduced-motion media block and outranks it on specificity, so the
+   dot is off during playback regardless of the motion preference. */
 .chordsketch-sheet__content button.meta-inline--interactive.is-playing .music-glyph--metronome__beat {
   animation: none;
-  opacity: 1;
+  opacity: 0;
 }
 @keyframes cs-tempo-frame {
   0%,

--- a/packages/react/tests/metronome-button.test.tsx
+++ b/packages/react/tests/metronome-button.test.tsx
@@ -186,25 +186,27 @@ describe('<MetronomeButton>', () => {
   });
 
   // While the metronome is playing, the decorative beat-dot LED must
-  // stop blinking: it is a discrete per-beat flash on an independent
-  // CSS clock that drifts against the real audible tick (the
+  // be extinguished (not just frozen): it is a discrete per-beat flash
+  // on an independent CSS clock that drifts against the real audible
+  // tick, so once the real beat is audible the dot is turned off
+  // entirely rather than left as a static lit indicator (the
   // continuous swing / frame pulse stay running — see the stylesheet
   // comment). The animation is a CSS property jsdom does not compute,
   // so assert it against the stylesheet source like the box-sizing
   // test above.
-  test('holds the beat-dot LED static while playing', () => {
+  test('extinguishes the beat-dot LED while playing', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8').replace(
       /\/\*[\s\S]*?\*\//g,
       '',
     );
     // The playing-state rule that targets the beat dot must turn its
-    // animation off and rest it at full opacity.
+    // animation off and set it fully transparent (extinguished).
     const rule = css.match(
       /button\.meta-inline--interactive\.is-playing \.music-glyph--metronome__beat \{[^}]*\}/,
     );
     expect(rule).not.toBeNull();
     expect(rule?.[0]).toContain('animation: none;');
-    expect(rule?.[0]).toContain('opacity: 1;');
+    expect(rule?.[0]).toContain('opacity: 0;');
   });
 });


### PR DESCRIPTION
## What

While the `{tempo}` chip's metronome is playing, set the decorative beat-dot LED to `opacity: 0` (extinguished) instead of `opacity: 1` (frozen lit, the state #2633 left it in). The pendulum swing and frame pulse keep running. When playback stops the dot reappears (idle blink, or reduced-motion static).

Single CSS rule in `packages/react/src/styles.css` keyed on `button.meta-inline--interactive.is-playing .music-glyph--metronome__beat`, plus the matching test assertion.

## Why

The beat dot is a discrete per-beat flash on an always-on CSS clock that cannot lock to the Web Audio metronome. #2633 stopped it from blinking during playback by freezing it lit, but a static lit dot still reads as a per-beat indicator it no longer honestly provides — once the user hears the real beat, the dot has no job left. Turning it off entirely is the more honest resting state: the audible tick is the per-beat cue, and the continuous swing + frame pulse remain as ambient tempo indicators (their CSS-clock drift is imperceptible because they are continuous, not discrete — the discrete-vs-continuous distinction is documented in the stylesheet comment).

`opacity: 0` keeps the SVG `<circle>` in layout, so the glyph size is unchanged (no layout shift). The rule sits outside the `prefers-reduced-motion` media block and outranks it on specificity (0,4,1 vs 0,2,0), so the dot is off during playback in both normal-motion and reduced-motion contexts.

## Test results

- `npm test` in `packages/react`: 779 passed (35 files), including the updated `tests/metronome-button.test.tsx` assertion that the playing-state rule sets `animation: none; opacity: 0;` on the beat dot (stylesheet-source assertion — jsdom does not compute animations; same pattern as the box-sizing test).
- `npm run typecheck`: clean.

## Review summary

Reviewed in parallel under four lenses (code/UX, security, project-rule compliance) before opening — all returned no findings:

- **Code/UX**: specificity confirmed (0,4,1) wins over both the always-on `cs-metronome-beat` rule and the reduced-motion rule in both motion contexts; `opacity: 0` hides the dot with zero layout shift; idle-blink / playing-off state model is coherent and matches the requested scope; test matches the right rule and regresses on a revert to `opacity: 1`.
- **Security**: purely declarative static CSS, no dynamic/user-controlled value, no sanitizer-parity surface.
- **Project-rule**: React-only (the `.is-playing` playback state has no Rust sister-site — the HTML renderer emits a static, JS-free chip); test follows the established pattern; no new playground smoke triggered; CLAUDE.md / README describe only the frame pulse, so no doc update needed.

## Sister-site audit

`.is-playing` is set only by `useMetronome`'s Web Audio playback and appears solely under `packages/react/**` (and the playground e2e). The Rust HTML renderer (`crates/render-html/src/lib.rs`, `music_glyphs.rs`) emits a static chip with no `<button>` / click handler / playback state, so there is no sister-site to propagate to (per `.claude/rules/fix-propagation.md` / `renderer-parity.md`). Existing `tests-e2e/metronome.spec.ts` covers the `is-playing` toggle path; no new smoke required.

## Deferred

None.

Closes #2640


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGQ9TGjeYYqdWQtxoKvAbf)_