### PR TITLE
Make the metronome beat-dot blink a crisp on/off snap

### DIFF
--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -1258,8 +1258,8 @@ h2 { font-family: \"Noto Sans JP\", system-ui, -apple-system, sans-serif; font-w
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: __LINE_FLEX_WRAP__; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }
@@ -4573,6 +4573,21 @@ Verse text\n\
         assert!(
             html.contains("animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5)"),
             "beat flash must be phase-shifted to the center crossing; got: {html}"
+        );
+        // Crisp on/off blink (no fade): `step-end` makes every keyframe
+        // boundary an instantaneous jump, and the keyframe snaps from
+        // full opacity to 0 with no interpolated dim resting state. A
+        // regression to an eased fade would reintroduce the decaying
+        // glow this blink deliberately avoids.
+        assert!(
+            html.contains("var(--cs-metronome-period, 1s) step-end infinite"),
+            "beat blink must use step-end for an instant on/off snap; got: {html}"
+        );
+        assert!(
+            html.contains(
+                "@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }"
+            ),
+            "beat keyframe must snap from full opacity to 0 with no fade; got: {html}"
         );
     }
 

--- a/crates/render-html/src/music_glyphs.rs
+++ b/crates/render-html/src/music_glyphs.rs
@@ -360,13 +360,13 @@ fn write_flat(s: &mut String, cx: f32, cy: f32) {
 /// The pivot point is fixed; the rod sweeps wiper-style.
 ///
 /// A static beat dot sits in the top-left corner *inside* the
-/// existing viewBox (so the icon height is unchanged) and pulses
-/// flash-then-decay once per beat. Its blink shares the same
-/// `--cs-metronome-period` as the swing, and a `-period/2`
-/// `animation-delay` phase-shifts the flash so the dot is at full
-/// brightness when the rod passes through the center (vertical),
-/// not at the extremes. The dot is a sibling of the pendulum
-/// group, so it does NOT swing — only its opacity animates.
+/// existing viewBox (so the icon height is unchanged) and blinks
+/// crisply on/off once per beat (no fade). Its blink shares the
+/// same `--cs-metronome-period` as the swing, and a `-period/2`
+/// `animation-delay` phase-shifts the flash so the dot switches on
+/// when the rod passes through the center (vertical), not at the
+/// extremes. The dot is a sibling of the pendulum group, so it
+/// does NOT swing — only its opacity animates.
 #[must_use]
 pub fn metronome_svg(bpm_raw: &str) -> String {
     let bpm: f32 = bpm_raw.trim().parse::<f32>().unwrap_or(60.0);

--- a/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
+++ b/crates/render-html/tests/fixtures/capo-transposes-c-to-bb/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
+++ b/crates/render-html/tests/fixtures/capo-with-key-directive/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/chord-alignment/expected.html
+++ b/crates/render-html/tests/fixtures/chord-alignment/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
+++ b/crates/render-html/tests/fixtures/chord-less-and-chord-bearing-mix/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/chords-over-lyrics/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/comments/expected.html
+++ b/crates/render-html/tests/fixtures/comments/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
+++ b/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/directives-and-sections/expected.html
+++ b/crates/render-html/tests/fixtures/directives-and-sections/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/empty-lines/expected.html
+++ b/crates/render-html/tests/fixtures/empty-lines/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/full-song/expected.html
+++ b/crates/render-html/tests/fixtures/full-song/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
+++ b/crates/render-html/tests/fixtures/grid-full-syntax/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-lone-colon/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
+++ b/crates/render-html/tests/fixtures/grid-trailing-colon/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/image-directive/expected.html
+++ b/crates/render-html/tests/fixtures/image-directive/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/metadata-header/expected.html
+++ b/crates/render-html/tests/fixtures/metadata-header/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/minimal-song/expected.html
+++ b/crates/render-html/tests/fixtures/minimal-song/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/page-control-directives/expected.html
+++ b/crates/render-html/tests/fixtures/page-control-directives/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/svg-section/expected.html
+++ b/crates/render-html/tests/fixtures/svg-section/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
+++ b/crates/render-html/tests/fixtures/tempo-inline-glyph/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/text-before-chord/expected.html
+++ b/crates/render-html/tests/fixtures/text-before-chord/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
+++ b/crates/render-html/tests/fixtures/unicode-lyrics/expected.html
@@ -28,8 +28,8 @@ h2 { font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif; font-wei
 .music-glyph--time__bar { display: block; width: 0.9em; height: 1.5px; margin: 0.05em 0; background-color: currentColor; border-radius: 1px; flex-shrink: 0; }
 .music-glyph--metronome__pendulum { transform-origin: 9px 19px; animation: cs-metronome-swing var(--cs-metronome-period, 1s) cubic-bezier(0.55, 0, 0.45, 1) infinite alternate; }
 @keyframes cs-metronome-swing { from { transform: rotate(-28deg); } to { transform: rotate(28deg); } }
-.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
-@keyframes cs-metronome-beat { 0% { opacity: 1; } 8% { opacity: 1; } 60% { opacity: 0.12; } 100% { opacity: 0.12; } }
+.music-glyph--metronome__beat { animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite; animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5); }
+@keyframes cs-metronome-beat { 0% { opacity: 1; } 12% { opacity: 0; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) { .music-glyph--metronome__pendulum { animation: none; transform: rotate(0deg); } .music-glyph--metronome__beat { animation: none; opacity: 1; } }
 .line { display: flex; flex-wrap: wrap; margin: 0.1em 0; }
 .chord-block { display: inline-flex; flex-direction: column; align-items: flex-start; }

--- a/packages/react/src/music-glyphs.tsx
+++ b/packages/react/src/music-glyphs.tsx
@@ -662,14 +662,14 @@ export function metronomePeriodCss(bpm: number): string {
  * seconds — exactly one beat at the requested BPM.
  *
  * A static beat dot sits in the top-left corner *inside* the
- * existing viewBox (so the icon height is unchanged) and pulses
- * flash-then-decay once per beat. Its blink shares the same
- * `--cs-metronome-period` as the swing, and a `-period/2`
+ * existing viewBox (so the icon height is unchanged) and blinks
+ * crisply on/off once per beat (no fade). Its blink shares the
+ * same `--cs-metronome-period` as the swing, and a `-period/2`
  * `animation-delay` (applied in the stylesheet) phase-shifts the
- * flash so the dot is at full brightness when the rod passes
- * through the center (vertical), not at the extremes. The dot is
- * a sibling of the pendulum group, so it does NOT swing — only
- * its opacity animates.
+ * flash so the dot switches on when the rod passes through the
+ * center (vertical), not at the extremes. The dot is a sibling of
+ * the pendulum group, so it does NOT swing — only its opacity
+ * animates.
  *
  * The animation is gated on
  * `@media (prefers-reduced-motion: reduce)` so users who opt out
@@ -736,7 +736,7 @@ export function MetronomeGlyph({
       {/* Beat dot — static, top-left corner inside the existing
           viewBox so the icon height is unchanged. A sibling of the
           pendulum group (NOT inside it), so it stays put while only
-          its opacity animates (flash → decay) via the
+          its opacity animates (a crisp on/off blink) via the
           `cs-metronome-beat` keyframe in the stylesheet. */}
       <circle className="music-glyph--metronome__beat" cx={2.4} cy={6.2} r={1.5} fill="currentColor" />
       {/* Triangular body — narrow top, wide base. */}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -698,28 +698,26 @@
 /* Beat dot — a static LED in the top-left corner that flashes
    once per beat. It shares `--cs-metronome-period` with the
    swing, and a `-period/2` `animation-delay` phase-shifts the
-   flash so it reaches full brightness when the rod passes
-   through the center (vertical), not at the extremes, then
-   decays before the next beat. `ease-out` shapes the decay; the
-   keyframe holds a brief peak (0–8%) for a crisp "pop".
-   Non-`alternate` so each beat re-triggers the flash from full
-   brightness. */
+   flash so it switches on when the rod passes through the center
+   (vertical), not at the extremes. The dot snaps fully on for a
+   brief window then snaps off with no fade: `step-end` makes every
+   keyframe boundary an instantaneous jump, so the dot reads as a
+   crisp on/off blink (a momentary "pop") rather than a decaying
+   glow. Non-`alternate` so each beat re-triggers the flash from
+   off. */
 .chordsketch-sheet__content .music-glyph--metronome__beat {
-  animation: cs-metronome-beat var(--cs-metronome-period, 1s) ease-out infinite;
+  animation: cs-metronome-beat var(--cs-metronome-period, 1s) step-end infinite;
   animation-delay: calc(var(--cs-metronome-period, 1s) * -0.5);
 }
 @keyframes cs-metronome-beat {
   0% {
     opacity: 1;
   }
-  8% {
-    opacity: 1;
-  }
-  60% {
-    opacity: 0.12;
+  12% {
+    opacity: 0;
   }
   100% {
-    opacity: 0.12;
+    opacity: 0;
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/packages/react/tests/music-glyphs.test.tsx
+++ b/packages/react/tests/music-glyphs.test.tsx
@@ -322,6 +322,17 @@ describe('<MetronomeGlyph>', () => {
     expect(css).toMatch(
       /prefers-reduced-motion: reduce[\s\S]*\.music-glyph--metronome__beat\s*\{\s*animation:\s*none;\s*opacity:\s*1;/,
     );
+    // Crisp on/off blink (no fade): the beat dot uses `step-end`
+    // timing so every keyframe boundary is an instantaneous jump,
+    // and the keyframe snaps from full opacity to 0 with no
+    // interpolated dim resting state. A regression to an eased fade
+    // (e.g. `ease-out` decaying to a 0.12 glow) would fail here.
+    expect(css).toMatch(
+      /\.music-glyph--metronome__beat\s*\{\s*animation:\s*cs-metronome-beat var\(--cs-metronome-period, 1s\) step-end infinite;/,
+    );
+    expect(css).toMatch(
+      /@keyframes cs-metronome-beat\s*\{\s*0%\s*\{\s*opacity:\s*1;\s*\}\s*12%\s*\{\s*opacity:\s*0;\s*\}\s*100%\s*\{\s*opacity:\s*0;\s*\}\s*\}/,
+    );
   });
 });
 


### PR DESCRIPTION
## What

Replaces the metronome beat-dot's eased fade with a crisp on/off blink. The
`{tempo}` chip's beat-dot LED previously decayed from full opacity to a dim
`0.12` resting glow each beat (`ease-out`). It now snaps fully on at the rod's
center crossing, holds for a brief flash window, then snaps off with no
interpolation:

- `step-end` timing makes every keyframe boundary an instantaneous jump.
- The keyframe drops the dim resting state and snaps `1 → 0`
  (`0% { opacity: 1 } 12% { opacity: 0 } 100% { opacity: 0 }`).
- The `-period/2` `animation-delay` is unchanged, so the flash stays
  phase-aligned to the pendulum's center crossing.

## Why

The fade read as a decaying glow rather than a discrete per-beat tick. A
hard show/hide switch matches the intent of a metronome blink — a momentary
"pop" — and removes the lingering dim dot between beats.

## Surfaces / sister-site audit

Per `renderer-parity.md` / `fix-propagation.md`, the change is applied to every
surface that emits this animation:

- React JSX walker stylesheet — `packages/react/src/styles.css`
- HTML renderer embedded CSS — `crates/render-html/src/lib.rs`

The text and PDF renderers were checked and emit **no** metronome CSS animation
(`crates/render-text` has no metronome glyph; `crates/render-pdf` paints
`{tempo}` as a static `Tempo: N BPM` text label), so no parity change applies
there. Doc comments updated in lockstep (`music-glyphs.tsx`, `music_glyphs.rs`);
no stale "fade/decay" wording remains.

## Test results

- Regression assertions added on both surfaces that fail if the fade is
  reintroduced:
  - `packages/react/tests/music-glyphs.test.tsx` — asserts `step-end` timing and
    the exact snap keyframe.
  - `crates/render-html/src/lib.rs` — asserts `step-end infinite` and the exact
    snap keyframe string.
- 28 HTML golden fixtures regenerated (`UPDATE_GOLDEN=1`).
- `cargo test -p chordsketch-render-html`: 286 lib + golden tests pass.
- React `npm test`: 784 tests pass; `npm run typecheck` clean.
- `cargo fmt --all --check` and `cargo clippy -p chordsketch-render-html` clean.

## Review summary

Reviewed for correctness, security, and project-rule conventions (renderer
parity, fix-propagation, golden-tests, root-cause, code-style, english-only).
No findings. The change is a static CSS keyframe/timing edit with no user-input
surface and no security implications.

Closes #2642

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgfrR8DWAGRTxpfe9hL5Qa)_