### PR TITLE
Show "Insert chord" only in the idle footer state

### DIFF
--- a/design-system/ui_kits/web/editor-chord-footer.html
+++ b/design-system/ui_kits/web/editor-chord-footer.html
@@ -170,8 +170,9 @@ body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875
     </div>
     <div class="cins__spacer"></div>
     <div class="cins__actions">
+      <!-- Editing an existing chord: Remove only. Insert is idle-only
+           (see the "New chord" state below) — #2646. -->
       <button class="cins__remove">Remove chord</button>
-      <button class="cins__insert">Insert chord</button>
     </div>
   </section>
 

--- a/packages/react/src/use-chord-editor.ts
+++ b/packages/react/src/use-chord-editor.ts
@@ -331,9 +331,11 @@ export function useChordEditor({
     canRight,
     onChange,
     onNudge,
-    // Insert needs a caret to target; offer it only once the editor has
-    // reported a caret position and editing is not gated.
-    onInsert: editable && caret != null ? onInsert : undefined,
+    // Insert builds a NEW chord at the caret, so it belongs to the idle
+    // state only — when the caret is ON a chord the footer offers Remove
+    // instead (inserting there would duplicate the selected chord). Needs
+    // a caret to target and editing not gated.
+    onInsert: editable && caret != null && caretChord == null ? onInsert : undefined,
     onRemove: caretChord != null ? onRemove : undefined,
     note: editable ? undefined : 'Clear transpose / capo to edit chords.',
   };

--- a/packages/react/tests/use-chord-editor.test.tsx
+++ b/packages/react/tests/use-chord-editor.test.tsx
@@ -62,10 +62,16 @@ describe('useChordEditor', () => {
     expect(latest.inspectorProps.selected).toBe(true);
     expect(latest.inspectorProps.chordName).toBe('G');
     expect(latest.chordSelection).toMatchObject({ line: 1, offset: 0, ordinal: 0 });
-    // Caret in the lyrics deselects.
+    // Insert is idle-only: while a chord is selected the footer offers
+    // Remove, not Insert (#2646).
+    expect(latest.inspectorProps.onInsert).toBeUndefined();
+    expect(latest.inspectorProps.onRemove).toBeTypeOf('function');
+    // Caret in the lyrics deselects — and Insert becomes available again.
     caretTo(5); // inside "Almost"
     expect(latest.inspectorProps.selected).toBe(false);
     expect(latest.chordSelection).toBeNull();
+    expect(latest.inspectorProps.onInsert).toBeTypeOf('function');
+    expect(latest.inspectorProps.onRemove).toBeUndefined();
   });
 
   test('editing the selected chord rewrites it in source and keeps it selected', () => {


### PR DESCRIPTION
## What

Show the "Insert chord" button **only when the caret is not on a chord** (the idle /
"New chord" footer state). When a chord is selected ("Editing chord"), the footer now
offers only "Remove chord".

`useChordEditor` gates `onInsert` on `caretChord == null` (in addition to the existing
"editable + caret present" conditions). The `<ChordInspector>` component stays generic
(it renders Insert iff `onInsert` is provided); the hook decides.

## Why

Insert builds a *new* chord at the caret. While a chord is selected the caret sits inside
that chord's bracket, so inserting there snaps past `]` and duplicates the selected chord
next to itself — confusing. Insert therefore belongs to the idle state only.

## Test results

- `@chordsketch/react`: 817 vitest tests pass; `tsc --noEmit` clean. The hook test now
  asserts `onInsert` is `undefined` while a chord is selected (and present + `onRemove`
  absent in idle).

## Review summary

Single-behavior follow-up to #2644. No new public API; `onInsert` was already idle-capable.
The design-system reference page (`editor-chord-footer.html`) editing-state actions row
drops the Insert button to match.

## Sister-site audit

No rendering surface, AST node, or sanitizer touched — renderer-parity / sanitizer rules
not triggered. The uncontrolled in-pane `<ChordSheet>` inspector never wired `onInsert`
(no caret), so it is unaffected.

## Deferred

None.

Closes #2646

https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8GLqK7GLKbLnBbsn2ufJ6)_