### PR TITLE
Select the dropped chord after a drag-and-drop reposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `@chordsketch/react`: dragging a chord in the `<ChordSheet>`
+  preview and dropping it now leaves the moved chord **selected**, so
+  it can be nudged or edited without a second click — matching the
+  keyboard-nudge gesture, which already advanced the selection. The
+  standalone walker reports the moved chord's new
+  `(line, offset, ordinal)` after the drop; the controlled
+  `useChordEditor` path lands the editor caret inside the moved
+  bracket (which also fixes the preview keyboard nudge dropping the
+  selection in that mode). New pure helper `repositionedChordOrdinal`
+  backs the disambiguation-ordinal math. (#2651)
+
 - **Inline `{key}` directive now follows the active transpose
   offset across all three Rust renderers, preserving modal
   qualifiers, extensions, and slash-bass notes (#2522).** Before

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@chordsketch/react",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chordsketch/react",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@chordsketch/wasm": "^0.5.0",
+        "@codemirror/autocomplete": "^6.18.0",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.12.3",
         "@codemirror/search": "^6.7.0",

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -544,6 +544,47 @@ export function findChordByOffsetOrdinal(
   return -1;
 }
 
+/**
+ * Compute the disambiguation ordinal a chord occupies after a
+ * drag-and-drop reposition lands it at `destinationOffset` on the
+ * destination line — so the consumer can keep the dropped chord selected
+ * (parity with the nudge path, which advances the selection to the moved
+ * chord via {@link buildChordNudge}'s returned `ordinal`).
+ *
+ * The dropped chord always lands AFTER any chords already sitting at
+ * `destinationOffset` — {@link lyricsOffsetToSourceColumn} skips leading
+ * `[...]` brackets at the target lyric position — so its ordinal is the
+ * count of OTHER chords sharing that offset in the re-parsed source.
+ *
+ * Moving a chord shifts only bracket columns, never the zero-width lyrics
+ * offsets of the other chords, so this count can be taken against the
+ * pre-move layout. The only adjustment is the dragged chord itself: on a
+ * same-line move it is removed from the destination line before the
+ * re-insert, so it must be excluded from the count via `removedIndex`. On
+ * a cross-line move or a copy nothing is removed from the destination
+ * line, so every current chord there counts (`removedIndex < 0`).
+ *
+ * @param destinationOffset the lyrics offset the chord lands at (the
+ *   event's `toLyricsOffset`, expected within `[0, totalLyrics]`).
+ * @param destinationChordOffsets lyrics offsets of every chord currently
+ *   on the destination line (pre-move layout), in source order.
+ * @param removedIndex index into `destinationChordOffsets` of the dragged
+ *   chord when the move removes it from the destination line (same-line
+ *   move); `-1` for a cross-line move or a copy.
+ */
+export function repositionedChordOrdinal(
+  destinationOffset: number,
+  destinationChordOffsets: readonly number[],
+  removedIndex: number,
+): number {
+  let ordinal = 0;
+  for (let i = 0; i < destinationChordOffsets.length; i++) {
+    if (i === removedIndex) continue;
+    if (destinationChordOffsets[i] === destinationOffset) ordinal++;
+  }
+  return ordinal;
+}
+
 /** Result of {@link buildChordNudge}: the reposition event to fire plus
  * the chord's new `(offset, ordinal)` so the caller can advance the
  * selection to track the moved chord. */

--- a/packages/react/src/chord-source-edit.ts
+++ b/packages/react/src/chord-source-edit.ts
@@ -225,6 +225,31 @@ export interface ChordRepositionResult {
 }
 
 /**
+ * Caret offset landing just inside the `[` of the `[chord]` bracket an
+ * apply-helper ({@link applyChordReposition} / {@link applyChordInsert})
+ * just wrote. Those helpers return {@link ChordRepositionResult.caretOffset}
+ * pointing just PAST the bracket (`… + insertBracket.length`); this backs up
+ * over `]` and the chord name to the position right after `[`.
+ *
+ * Editor surfaces use it to keep the just-moved / just-inserted chord
+ * selected: the caret-driven selection re-resolves onto a chord only while
+ * the caret sits inside its brackets — a caret past the `]` lands in the
+ * lyrics and deselects it. Kept beside the helpers it inverts so the
+ * forward and reverse caret conventions cannot drift apart (a single
+ * change to where the apply-helpers place `caretOffset` updates both).
+ *
+ * @param chordName the chord body written between the brackets (without
+ *   the brackets), e.g. `"Am7"` — its length plus the two brackets is the
+ *   span backed over.
+ */
+export function caretInsideWrittenBracket(
+  result: ChordRepositionResult,
+  chordName: string,
+): number {
+  return result.caretOffset - (chordName.length + 2) + 1;
+}
+
+/**
  * Map a lyrics-character offset on a ChordPro source line to
  * the source column where a new `[chord]` should be inserted.
  *
@@ -515,8 +540,21 @@ export function nudgeChordPosition(
 ): NudgedChordPosition | null {
   const offset = currentOffset + direction;
   if (offset < 0 || offset > totalLyrics) return null;
-  const ordinal = otherOffsets.reduce((n, o) => (o === offset ? n + 1 : n), 0);
-  return { offset, ordinal };
+  return { offset, ordinal: ordinalAtOffset(offset, otherOffsets) };
+}
+
+/**
+ * Count the chords whose lyrics offset equals `offset` — the
+ * disambiguation ordinal a chord inserted there receives, since a
+ * freshly written `[chord]` always lands AFTER any chords already at
+ * the offset ({@link lyricsOffsetToSourceColumn} skips leading
+ * brackets). Single source of the "ordinal = chords already at this
+ * offset" rule shared by {@link nudgeChordPosition} and
+ * {@link repositionedChordOrdinal}; `offsets` must already exclude the
+ * chord being placed.
+ */
+function ordinalAtOffset(offset: number, offsets: readonly number[]): number {
+  return offsets.reduce((n, o) => (o === offset ? n + 1 : n), 0);
 }
 
 /**
@@ -577,12 +615,13 @@ export function repositionedChordOrdinal(
   destinationChordOffsets: readonly number[],
   removedIndex: number,
 ): number {
-  let ordinal = 0;
-  for (let i = 0; i < destinationChordOffsets.length; i++) {
-    if (i === removedIndex) continue;
-    if (destinationChordOffsets[i] === destinationOffset) ordinal++;
-  }
-  return ordinal;
+  // Exclude the dragged chord on a same-line move, then count the
+  // remaining chords at the offset — the shared ordinal rule.
+  const others =
+    removedIndex < 0
+      ? destinationChordOffsets
+      : destinationChordOffsets.filter((_, i) => i !== removedIndex);
+  return ordinalAtOffset(destinationOffset, others);
 }
 
 /** Result of {@link buildChordNudge}: the reposition event to fire plus

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -77,6 +77,7 @@ import {
   buildChordNudge,
   chordLayoutForLine,
   findChordByOffsetOrdinal,
+  repositionedChordOrdinal,
 } from './chord-source-edit';
 import type { ChordRepositionEvent } from './chord-source-edit';
 
@@ -2046,12 +2047,21 @@ function LyricsLine({
         setDropTarget(null);
         if (!target) return;
         const segLayout = segmentLayout[target.segmentIdx];
+        // The chord lands at this lyrics offset. Clamp to the line's
+        // total so a drop past the last character resolves to the same
+        // trailing offset `applyChordReposition` snaps it to — keeping
+        // the post-drop selection on the chord rather than at a phantom
+        // offset that would fail to re-resolve.
+        const toLyricsOffset = Math.min(
+          segLayout.lyricsOffsetStart + target.charOffset,
+          totalLyrics,
+        );
         reposition.onChordReposition({
           fromLine: payload.fromLine,
           fromColumn: payload.fromColumn,
           fromLength: payload.fromLength,
           toLine: reposition.sourceLine,
-          toLyricsOffset: segLayout.lyricsOffsetStart + target.charOffset,
+          toLyricsOffset,
           chord: payload.chord,
           copy: event.altKey,
           // Guard the move's removal against the dragged chord's own
@@ -2059,6 +2069,30 @@ function LyricsLine({
           // corrupting (copy removes nothing, so no guard needed).
           expected: event.altKey ? undefined : payload.chord,
         });
+        // Keep the dropped chord selected (parity with the keyboard
+        // nudge, which advances the selection to the moved chord). The
+        // consumer applies `onChordReposition` → new source → re-parse;
+        // the walker then re-locates this chord by its (offset, ordinal)
+        // identity. A copy or a cross-line move removes nothing from this
+        // (destination) line, so every current chord at the offset
+        // counts; a same-line move excludes the dragged chord, located
+        // by its source column. `nudgeCtx` is absent in drag-only mode
+        // (no selection state wired) — then there is nothing to select.
+        if (nudgeCtx) {
+          const isSameLineMove = !event.altKey && payload.fromLine === reposition.sourceLine;
+          const removedIndex = isSameLineMove
+            ? chordSegments.findIndex(
+                (c) => segmentLayout[c.segmentIdx].chordSourceColumn === payload.fromColumn,
+              )
+            : -1;
+          const ordinal = repositionedChordOrdinal(toLyricsOffset, chordOffsets, removedIndex);
+          nudgeCtx.setSelected({
+            line: reposition.sourceLine,
+            offset: toLyricsOffset,
+            ordinal,
+            nonce: (selected?.nonce ?? 0) + 1,
+          });
+        }
       }
     : undefined;
 
@@ -2211,7 +2245,6 @@ function LyricsLine({
 }
 
 /**
-/**
  * From a dragover/drop event, locate which chord-block segment
  * the pointer is over and the character offset (in lyric
  * coordinates) within that segment. Walks up from
@@ -2279,66 +2312,6 @@ function buildChordDragProps(
     onDragStart: (event) => {
       event.dataTransfer.setData(CHORD_DRAG_MIME, JSON.stringify(payload));
       event.dataTransfer.effectAllowed = 'copyMove';
-    },
-  };
-}
-
-/**
- * Build the `onDragOver` / `onDrop` props for a `.lyrics` span.
- * `onDragOver` gates drops to our own chord drags (no OS-file
- * drags / cross-tab text drags) and reflects the Alt-modifier
- * in the cursor; `onDrop` reads the dragged payload, maps the
- * pointer position to a character offset inside the segment's
- * text, and fires `onChordReposition` with absolute
- * coordinates.
- */
-function buildLyricsDropProps(
-  onChordReposition: (event: ChordRepositionEvent) => void,
-  destinationLine: number,
-  lyricsOffsetStart: number,
-  segmentTextLength: number,
-): {
-  onDragOver: (event: ReactDragEvent<HTMLSpanElement>) => void;
-  onDrop: (event: ReactDragEvent<HTMLSpanElement>) => void;
-} {
-  return {
-    onDragOver: (event) => {
-      if (!event.dataTransfer.types.includes(CHORD_DRAG_MIME)) return;
-      event.preventDefault();
-      event.dataTransfer.dropEffect = event.altKey ? 'copy' : 'move';
-    },
-    onDrop: (event) => {
-      const raw = event.dataTransfer.getData(CHORD_DRAG_MIME);
-      if (!raw) return;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch {
-        return;
-      }
-      // Schema gate — see `isValidChordDragPayload` doc-comment.
-      if (!isValidChordDragPayload(parsed)) return;
-      const payload = parsed;
-      event.preventDefault();
-      const target = event.currentTarget;
-      const charOffset = pointerToLyricCharOffset(
-        target,
-        event.clientX,
-        event.clientY,
-        segmentTextLength,
-      );
-      onChordReposition({
-        fromLine: payload.fromLine,
-        fromColumn: payload.fromColumn,
-        fromLength: payload.fromLength,
-        toLine: destinationLine,
-        toLyricsOffset: lyricsOffsetStart + charOffset,
-        chord: payload.chord,
-        copy: event.altKey,
-        // Guard the move's removal against the dragged chord's own
-        // token (copy removes nothing, so no guard needed).
-        expected: event.altKey ? undefined : payload.chord,
-      });
     },
   };
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -149,6 +149,7 @@ export {
   buildChordName,
   buildChordNudge,
   capoTransposeOffset,
+  caretInsideWrittenBracket,
   chordLayoutForLine,
   chordSelectionCaretOffset,
   chordSourceEditableUnderTranspose,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -159,6 +159,7 @@ export {
   nudgeChordPosition,
   partsFromRawName,
   readCapo,
+  repositionedChordOrdinal,
   setCapoInSource,
   sourceColumnToLyricsOffset,
   type CaretChordMatch,

--- a/packages/react/src/use-chord-editor.ts
+++ b/packages/react/src/use-chord-editor.ts
@@ -262,7 +262,16 @@ export function useChordEditor({
   const onChordReposition = useCallback(
     (event: ChordRepositionEvent) => {
       const result = applyChordReposition(source, event);
-      commit(result);
+      // Keep the moved / copied chord selected: land the caret just
+      // inside its new `[chord]` bracket so the caret-driven selection
+      // re-resolves onto it (parity with the nudge / insert paths, and
+      // with the standalone <ChordSheet> walker which advances its own
+      // selection on drop). `result.caretOffset` points just past the
+      // bracket; back up over `]` + the name to land right after `[`.
+      // On an optimistic-concurrency no-op the source is unchanged, so
+      // the deferred caret effect never fires and this offset is unused.
+      const target = result.caretOffset - (event.chord.length + 2) + 1;
+      commit(result, target);
     },
     [source, commit],
   );

--- a/packages/react/src/use-chord-editor.ts
+++ b/packages/react/src/use-chord-editor.ts
@@ -26,6 +26,7 @@ import {
   applyChordReposition,
   buildChordName,
   buildChordNudge,
+  caretInsideWrittenBracket,
   chordSelectionCaretOffset,
   chordSourceEditableUnderTranspose,
   findChordAtCaret,
@@ -242,8 +243,7 @@ export function useChordEditor({
       if (!nudge) return;
       const result = applyChordReposition(source, nudge.event);
       // Keep the moved chord selected: caret inside its new bracket.
-      const target = result.caretOffset - (caretChord.chordName.length + 2) + 1;
-      commit(result, target);
+      commit(result, caretInsideWrittenBracket(result, caretChord.chordName));
     },
     [caretChord, source, commit],
   );
@@ -264,14 +264,11 @@ export function useChordEditor({
       const result = applyChordReposition(source, event);
       // Keep the moved / copied chord selected: land the caret just
       // inside its new `[chord]` bracket so the caret-driven selection
-      // re-resolves onto it (parity with the nudge / insert paths, and
-      // with the standalone <ChordSheet> walker which advances its own
-      // selection on drop). `result.caretOffset` points just past the
-      // bracket; back up over `]` + the name to land right after `[`.
-      // On an optimistic-concurrency no-op the source is unchanged, so
-      // the deferred caret effect never fires and this offset is unused.
-      const target = result.caretOffset - (event.chord.length + 2) + 1;
-      commit(result, target);
+      // re-resolves onto it (parity with the nudge path, and with the
+      // standalone <ChordSheet> walker which advances its own selection
+      // on drop). On an optimistic-concurrency no-op the source is
+      // unchanged, so the deferred caret effect never fires.
+      commit(result, caretInsideWrittenBracket(result, event.chord));
     },
     [source, commit],
   );

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -13,6 +13,7 @@ import {
   buildChordName,
   buildChordNudge,
   capoTransposeOffset,
+  caretInsideWrittenBracket,
   chordLayoutForLine,
   chordSelectionCaretOffset,
   chordSourceEditableUnderTranspose,
@@ -857,6 +858,33 @@ describe('applyChordReposition — expected-token guard (parity with edit/delete
         copy: true,
       }),
     ).toThrow(/forbidden/);
+  });
+});
+
+describe('caretInsideWrittenBracket', () => {
+  test('lands just after the `[` of a repositioned chord', () => {
+    // `[Am]hi` → move Am to the end → `hi[Am]`; caretOffset points past
+    // the `]` (6). The inside-bracket caret must be just after `[` (3).
+    const result = applyChordReposition('[Am]hi', {
+      fromLine: 1,
+      fromColumn: 0,
+      fromLength: 4,
+      toLine: 1,
+      toLyricsOffset: 2,
+      chord: 'Am',
+      copy: false,
+      expected: 'Am',
+    });
+    expect(result.text).toBe('hi[Am]');
+    expect(result.caretOffset).toBe(6); // just past `]`
+    expect(caretInsideWrittenBracket(result, 'Am')).toBe(3); // just after `[`
+  });
+
+  test('lands just after the `[` of a freshly inserted chord', () => {
+    // Insert `[G]` at column 2 of `hi` → `hi[G]`; caret inside → 3.
+    const result = applyChordInsert('hi', { line: 1, column: 2, chord: 'G' });
+    expect(result.text).toBe('hi[G]');
+    expect(caretInsideWrittenBracket(result, 'G')).toBe(3);
   });
 });
 

--- a/packages/react/tests/chord-source-edit.test.ts
+++ b/packages/react/tests/chord-source-edit.test.ts
@@ -23,6 +23,7 @@ import {
   nudgeChordPosition,
   partsFromRawName,
   readCapo,
+  repositionedChordOrdinal,
   setCapoInSource,
   sourceColumnToLyricsOffset,
 } from '../src/chord-source-edit';
@@ -874,6 +875,31 @@ describe('buildChordNudge sets the expected-token guard on its move event', () =
     expect(result).not.toBeNull();
     expect(result!.event.expected).toBe('Am7');
     expect(result!.event.copy).toBe(false);
+  });
+});
+
+describe('repositionedChordOrdinal', () => {
+  // Destination line `[Am]Hello [G]World` — chords at offsets 0 and 6.
+  test('cross-line move / copy counts every chord at the offset', () => {
+    // Nothing removed from the destination line (removedIndex = -1):
+    // dropping a third chord at offset 0 lands after the existing one.
+    expect(repositionedChordOrdinal(0, [0, 6], -1)).toBe(1);
+    // Offset with no existing chord → ordinal 0.
+    expect(repositionedChordOrdinal(3, [0, 6], -1)).toBe(0);
+    // Stacked chords `[A][B][C]word` all at offset 0 → a fourth lands 3rd.
+    expect(repositionedChordOrdinal(0, [0, 0, 0], -1)).toBe(3);
+  });
+
+  test('same-line move excludes the dragged chord from the count', () => {
+    // Dragging the chord at index 0 (offset 0) to offset 6: it is removed
+    // from the destination line first, so only the chord already at 6
+    // counts → the moved chord lands after it (ordinal 1).
+    expect(repositionedChordOrdinal(6, [0, 6], 0)).toBe(1);
+    // Dragging the chord at offset 6 (index 1) back to offset 0: the
+    // chord at 0 stays, so the moved chord lands after it (ordinal 1).
+    expect(repositionedChordOrdinal(0, [0, 6], 1)).toBe(1);
+    // Moving a chord to an offset only it occupied → ordinal 0.
+    expect(repositionedChordOrdinal(0, [0], 0)).toBe(0);
   });
 });
 

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { renderChordproAst } from '../src/chordpro-jsx';
 import type { ChordSelection } from '../src/chordpro-jsx';
 import type { ChordproSong } from '../src/chordpro-ast';
+import { repositionedChordOrdinal } from '../src/chord-source-edit';
 import type { ChordRepositionEvent } from '../src/chord-source-edit';
 
 // Empty metadata helper — every metadata field has to be present
@@ -1025,6 +1026,73 @@ describe('renderChordproAst', () => {
     expect(highlighted?.closest('.chord-block')).toBe(blocks[1]);
     fireEvent.drop(targetChord, { dataTransfer: dt, clientX: 100, clientY: 5 });
     expect(repo).toHaveBeenCalledTimes(1);
+  });
+
+  // After a drop the moved chord must become the selection, so it
+  // stays focused / editable without a second click — parity with the
+  // keyboard nudge, which already advances the selection. The walker
+  // reports the moved chord's new (offset, ordinal) via
+  // `setChordSelection`; the host re-parses and re-locates it by that
+  // identity. (Selection wiring requires both `chordSelection` and
+  // `setChordSelection`; with only `onChordReposition` the chords are
+  // drag-only and nothing is reported.)
+  test('dropping a chord reports its new position as the selection', () => {
+    const repo = vi.fn();
+    const setSelected = vi.fn();
+    const ast: ChordproSong = {
+      metadata: EMPTY_META,
+      lines: [
+        {
+          kind: 'lyrics',
+          value: {
+            segments: [
+              { chord: { name: 'Am', detail: null, display: null }, text: 'Hello', spans: [] },
+              { chord: { name: 'G', detail: null, display: null }, text: 'World', spans: [] },
+            ],
+          },
+        },
+      ],
+    };
+    const { container } = render(
+      renderChordproAst(ast, {
+        onChordReposition: repo,
+        chordSelection: null,
+        setChordSelection: setSelected,
+      }),
+    );
+    const blocks = container.querySelectorAll('.chord-block');
+    const targetLyrics = blocks[1].querySelector('.lyrics') as HTMLElement;
+    const dtStore = new Map<string, string>();
+    dtStore.set(
+      'application/x-chordsketch-chord',
+      JSON.stringify({ fromLine: 1, fromColumn: 0, fromLength: 4, chord: 'Am' }),
+    );
+    const dt = {
+      types: [...dtStore.keys()],
+      getData: (k: string) => dtStore.get(k) ?? '',
+      setData: (k: string, v: string) => dtStore.set(k, v),
+      dropEffect: 'none' as DataTransfer['dropEffect'],
+      effectAllowed: 'all' as DataTransfer['effectAllowed'],
+    };
+    fireEvent.drop(targetLyrics, { dataTransfer: dt, clientX: 100, clientY: 50 });
+    expect(repo).toHaveBeenCalledTimes(1);
+    expect(setSelected).toHaveBeenCalledTimes(1);
+    // The reported selection must land exactly where the chord was
+    // repositioned to — the (line, offset) of the emitted event — so a
+    // re-parse re-locates it as the selection. Derived from the event
+    // (not a hard-coded jsdom pointer offset) so the assertion stays
+    // robust to caret-from-point quirks. Same-line move of Am (index 0
+    // among the line's chords at offsets [0, 5]); ordinal via the same
+    // helper the walker uses.
+    const repoEvent = repo.mock.calls[0][0];
+    expect(repoEvent.toLine).toBe(1);
+    expect(repoEvent.copy).toBeFalsy();
+    expect(setSelected.mock.calls[0][0]).toEqual({
+      line: repoEvent.toLine,
+      offset: repoEvent.toLyricsOffset,
+      ordinal: repositionedChordOrdinal(repoEvent.toLyricsOffset, [0, 5], 0),
+      nonce: 1,
+    });
   });
 
   // Multi-segment chord-bearing line — the marker must land in

--- a/packages/react/tests/use-chord-editor.test.tsx
+++ b/packages/react/tests/use-chord-editor.test.tsx
@@ -139,6 +139,55 @@ describe('useChordEditor', () => {
     expect(setCaretSpy.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
+  test('repositioning a chord lands the caret inside the moved bracket so it stays selected', () => {
+    mount();
+    // Move `[G]` (col 0, len 3) three lyric characters into "Almost".
+    act(() => {
+      latest.onChordReposition({
+        fromLine: 1,
+        fromColumn: 0,
+        fromLength: 3,
+        toLine: 1,
+        toLyricsOffset: 3,
+        chord: 'G',
+        copy: false,
+        expected: 'G',
+      });
+    });
+    // Source rewritten: G removed from col 0, re-inserted inside "Almost".
+    expect(currentSource).toBe('Alm[G]ost [Bbm7]heaven');
+    // The caret lands just after the moved bracket's `[` (col 4), NOT
+    // after its `]` (col 6) — the latter would sit in the lyrics and
+    // deselect the chord. This is the post-drop "keep it selected" fix.
+    expect(setCaretSpy).toHaveBeenLastCalledWith(4);
+    // And the caret-driven selection re-resolves onto the moved chord
+    // once the editor reports the restored caret.
+    caretTo(4);
+    expect(latest.inspectorProps.selected).toBe(true);
+    expect(latest.chordSelection).toMatchObject({ line: 1, offset: 3, ordinal: 0 });
+  });
+
+  test('a reposition that no-ops on the expected-token guard does not move the caret', () => {
+    mount();
+    // `expected` does not match the token at the `from` span, so
+    // applyChordReposition returns the source unchanged; the deferred
+    // caret restore must not fire (React bails on the equal setState).
+    act(() => {
+      latest.onChordReposition({
+        fromLine: 1,
+        fromColumn: 0,
+        fromLength: 3,
+        toLine: 1,
+        toLyricsOffset: 3,
+        chord: 'G',
+        copy: false,
+        expected: 'Wrong',
+      });
+    });
+    expect(currentSource).toBe(SOURCE);
+    expect(setCaretSpy).not.toHaveBeenCalled();
+  });
+
   test('under an active transpose, editing is gated: idle state + note', () => {
     mount(SOURCE, 2); // CLI transpose +2, no capo -> not source-editable
     caretTo(1); // would be `[G]` but the gate blocks resolution


### PR DESCRIPTION
## What

After dragging a chord in the `<ChordSheet>` preview and dropping it, the
moved chord is now left **selected** — no second click required to keep
editing it. This matches the keyboard-nudge behaviour, which already
advances the selection to the moved chord.

The fix lands across both selection models the walker supports:

- **Standalone `<ChordSheet>`** (walker-owned selection): `handleLineDrop`
  reports the moved chord's new `(line, offset, ordinal)` via
  `setChordSelection` right after firing `onChordReposition`, so the
  consumer's re-parse re-locates and re-selects it by identity. The
  destination offset is clamped to the line's lyric total so a drop past
  the last character resolves to the same trailing offset
  `applyChordReposition` snaps to (otherwise the selection would point at
  a phantom offset and silently fail to re-resolve).
- **Controlled mode** (`useChordEditor`, used by the playground): the
  shared `onChordReposition` now lands the editor caret just inside the
  moved `[chord]` bracket (parity with the existing nudge / insert
  paths), so the caret-driven selection re-resolves onto it. This also
  fixes the preview **keyboard nudge** in this mode, which previously
  dropped the selection because the caret was restored just *past* the
  `]` (i.e. into the lyrics).

The disambiguation-ordinal math is extracted into a pure, DOM-free
`repositionedChordOrdinal` helper in `chord-source-edit` with unit
coverage, keeping the JSX walker thin (consistent with how
`buildChordNudge` / `findChordByOffsetOrdinal` live there).

## Why

A drop that leaves nothing selected is a dead-end interaction: the user
has to hunt for and re-click the chord they just placed before they can
nudge or edit it. The nudge path already kept the chord selected, so the
two reposition gestures were inconsistent.

## Sister-site audit

Chord drag-and-drop is a React-walker-only interaction; the static Rust
renderers (text / HTML / PDF) emit no interactivity, so
`renderer-parity` does not apply here. Within the walker, the drop logic
had a second, **dead** sister site — `buildLyricsDropProps` (a
per-`.lyrics` drop builder superseded by the consolidated line-level drop
handler, with no remaining call site anywhere in the repo). It was
removed so the walker has a single drop path that cannot drift, along
with a duplicated `/**` doc-comment opener above `findDropTargetInLine`.

## Test results

- `npm test` (full `@chordsketch/react` suite): 822 passed, including:
  - `chord-source-edit.test.ts` — `repositionedChordOrdinal` (cross-line /
    copy vs same-line move exclusion, stacked chords).
  - `chordpro-jsx.test.tsx` — dropping a chord reports its new position as
    the selection.
  - `use-chord-editor.test.tsx` — a reposition lands the caret inside the
    moved bracket (keeps it selected) and an expected-token-guard no-op
    does not move the caret.
- `npm run typecheck` (tsc 5.9.3, pinned): clean.
- `npm run build` (tsup ESM + CJS + d.ts): success.

## Review summary

Root-cause fix at the library layer (not the playground), single source
of truth for the ordinal math, dead sister-site removed. No new external
dependencies.

## Deferred

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3a5oA2ZtYv72K8WeRgeJ3)_