### PR TITLE
Add chord playback to the React preview surface

### DIFF
--- a/crates/chordpro/src/chord.rs
+++ b/crates/chordpro/src/chord.rs
@@ -280,6 +280,190 @@ pub fn canonicalize_detail(detail: &ChordDetail, force_common: bool, flats: bool
 }
 
 // ---------------------------------------------------------------------------
+// Constituent pitches (MIDI note numbers)
+// ---------------------------------------------------------------------------
+
+/// MIDI note number the block voicing places the chord root on (C3).
+///
+/// Chord tones are stacked above this root; a slash bass is dropped one
+/// octave below it. Choosing C3 keeps the common pop/folk vocabulary in
+/// a comfortable mid-register for a simple oscillator synth: the lowest
+/// tone produced is the slash bass at `36..=47` (C2..B2) and the highest
+/// extension (a 13th, +21 semitones, on a root of B3 = 59) reaches 80
+/// (G#5), well within the MIDI range.
+const VOICING_ROOT_MIDI: u8 = 48;
+
+/// Computes the constituent pitches of a chord as MIDI note numbers.
+///
+/// Returns `None` when `chord_name` is not parseable as a chord (the same
+/// inputs [`parse_chord`] rejects). Otherwise returns the chord's block
+/// voicing — root, third, fifth, plus any extension / altered / added
+/// tones implied by the chord quality and extension — as ascending,
+/// de-duplicated MIDI note numbers. Slash chords prepend the bass note one
+/// octave below the root.
+///
+/// This is the musical-theory source of truth shared by every consumer
+/// that needs to *sound* a chord (the wasm / napi / ffi bindings drive the
+/// React chord-audio surface from it). It is deliberately independent of
+/// the fretted / keyboard voicing database in
+/// [`voicings`](crate::voicings): those map a chord to one *instrument's*
+/// fingering, whereas this maps a chord to its abstract constituent
+/// pitches, so it covers every parseable chord rather than only the
+/// shapes the diagram tables enumerate.
+///
+/// The register is fixed (root at C3); callers that want a different
+/// octave transpose the returned notes themselves.
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_chordpro::chord::chord_pitches;
+///
+/// // C major triad: C3, E3, G3.
+/// assert_eq!(chord_pitches("C"), Some(vec![48, 52, 55]));
+/// // A minor triad: A3, C4, E4.
+/// assert_eq!(chord_pitches("Am"), Some(vec![57, 60, 64]));
+/// // Slash chord drops the bass an octave below the root.
+/// assert_eq!(chord_pitches("C/G"), Some(vec![43, 48, 52, 55]));
+/// // Unparseable input yields None.
+/// assert_eq!(chord_pitches("xyz"), None);
+/// ```
+#[must_use]
+pub fn chord_pitches(chord_name: &str) -> Option<Vec<u8>> {
+    let detail = parse_chord(chord_name)?;
+    let root_pc = root_semitone(detail.root, detail.root_accidental);
+    let root_midi = VOICING_ROOT_MIDI + root_pc; // 48..=59
+
+    let mut pitches: Vec<u8> =
+        chord_interval_semitones(detail.quality, detail.extension.as_deref().unwrap_or(""))
+            .into_iter()
+            .map(|iv| root_midi + iv)
+            .collect();
+
+    if let Some((bass, bass_acc)) = detail.bass_note {
+        let bass_pc = root_semitone(bass, bass_acc);
+        // One octave below the root's base octave, so the bass is always
+        // the lowest sounding note (root_midi is at least 48; the bass is
+        // at most 47).
+        let bass_midi = (VOICING_ROOT_MIDI - 12) + bass_pc; // 36..=47
+        pitches.push(bass_midi);
+    }
+
+    pitches.sort_unstable();
+    pitches.dedup();
+    Some(pitches)
+}
+
+/// Maps a chord quality + extension string to the semitone intervals (from
+/// the root) of its constituent tones, including the root itself (`0`).
+///
+/// The extension grammar is the lenient one [`parse_quality_and_extension`]
+/// produces (e.g. `"7"`, `"maj7"`, `"sus4"`, `"add9"`, `"7sus4"`, `"7b5"`,
+/// `"9"`, `"13"`). Unrecognised extensions fall back to the bare triad
+/// rather than guessing — a documented, audible-but-safe degradation, not a
+/// silent wrong chord.
+fn chord_interval_semitones(quality: ChordQuality, ext: &str) -> Vec<u8> {
+    // Triad: (third, fifth) intervals above the root.
+    let (mut third, mut fifth): (u8, u8) = match quality {
+        ChordQuality::Major => (4, 7),
+        ChordQuality::Minor => (3, 7),
+        ChordQuality::Diminished => (3, 6),
+        ChordQuality::Augmented => (4, 8),
+    };
+
+    // Power chord ("C5"): root + fifth, no third.
+    if ext == "5" {
+        return vec![0, fifth];
+    }
+
+    // `sus` replaces the third with a 2nd or 4th.
+    if ext.contains("sus2") {
+        third = 2;
+    } else if ext.contains("sus4") || ext == "sus" {
+        third = 5;
+    }
+
+    // Altered fifth.
+    if ext.contains("b5") {
+        fifth = 6;
+    } else if ext.contains("#5") {
+        fifth = 8;
+    }
+
+    let mut extras: Vec<u8> = Vec::new();
+
+    if let Some(rest) = ext.strip_prefix("add") {
+        // Add-tone chord (e.g. "add9"): triad plus the added degree, no
+        // seventh.
+        if let Some(semi) = degree_to_semitone(rest) {
+            extras.push(semi);
+        }
+    } else {
+        let has13 = ext.contains("13");
+        let has11 = ext.contains("11");
+        let has9 = ext.contains('9');
+        let has_seventh = ext.contains('7') || has9 || has11 || has13;
+        // A "maj"-prefixed extension carrying a seventh-or-higher degree
+        // (maj7 / maj9 / maj13), or the "M7" / "Δ" shorthands, calls for a
+        // major seventh; bare "maj" (just `ChordQuality::Major`) does not.
+        let major_seventh =
+            (ext.starts_with("maj") && has_seventh) || ext.contains("M7") || ext.contains('Δ');
+        // A diminished chord with a seventh is fully diminished (bb7).
+        let dim_seventh = quality == ChordQuality::Diminished && ext.starts_with('7');
+
+        if dim_seventh {
+            extras.push(9);
+        } else if major_seventh {
+            extras.push(11);
+            if has9 {
+                extras.push(14);
+            }
+            if has11 {
+                extras.push(17);
+            }
+            if has13 {
+                extras.push(21);
+            }
+        } else if has_seventh {
+            extras.push(10);
+            if has9 || has11 || has13 {
+                extras.push(14);
+            }
+            if has11 || has13 {
+                extras.push(17);
+            }
+            if has13 {
+                extras.push(21);
+            }
+        }
+
+        // A sixth (e.g. "C6", "Am6") adds the major sixth — not a seventh.
+        if ext.contains('6') {
+            extras.push(9);
+        }
+    }
+
+    let mut notes = vec![0u8, third, fifth];
+    notes.append(&mut extras);
+    notes
+}
+
+/// Maps an extension degree token (the tail of an `add` chord, e.g. `"9"`)
+/// to its semitone interval above the root. Returns `None` for tokens that
+/// are not recognised added degrees.
+fn degree_to_semitone(degree: &str) -> Option<u8> {
+    match degree {
+        "2" => Some(2),
+        "4" => Some(5),
+        "6" => Some(9),
+        "9" => Some(14),
+        "11" => Some(17),
+        "13" => Some(21),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Parser
 // ---------------------------------------------------------------------------
 
@@ -1043,5 +1227,141 @@ mod tests {
         // the minor-shift is applied; pin it so a future regression in the
         // arithmetic surfaces here.
         assert_eq!(canon("Em", true, false), "Em");
+    }
+
+    // -- chord_pitches (#2650) -----------------------------------------------
+
+    #[test]
+    fn pitches_major_triad() {
+        // C major: C3, E3, G3.
+        assert_eq!(chord_pitches("C"), Some(vec![48, 52, 55]));
+        // G major rooted at G3 (pc 7 → 55): G3, B3, D4.
+        assert_eq!(chord_pitches("G"), Some(vec![55, 59, 62]));
+    }
+
+    #[test]
+    fn pitches_minor_triad() {
+        // A minor: A3, C4, E4.
+        assert_eq!(chord_pitches("Am"), Some(vec![57, 60, 64]));
+        // E minor: E3, G3, B3.
+        assert_eq!(chord_pitches("Em"), Some(vec![52, 55, 59]));
+    }
+
+    #[test]
+    fn pitches_diminished_and_augmented() {
+        // B diminished: B3, D4, F4 — root pc 11 → 59.
+        assert_eq!(chord_pitches("Bdim"), Some(vec![59, 62, 65]));
+        // C augmented: C3, E3, G#3.
+        assert_eq!(chord_pitches("Caug"), Some(vec![48, 52, 56]));
+        assert_eq!(chord_pitches("C+"), Some(vec![48, 52, 56]));
+    }
+
+    #[test]
+    fn pitches_dominant_and_minor_seventh() {
+        // G7: G3, B3, D4, F4.
+        assert_eq!(chord_pitches("G7"), Some(vec![55, 59, 62, 65]));
+        // Am7: A3, C4, E4, G4.
+        assert_eq!(chord_pitches("Am7"), Some(vec![57, 60, 64, 67]));
+    }
+
+    #[test]
+    fn pitches_major_seventh_distinct_from_dominant() {
+        // Cmaj7 has a major seventh (B3 = 59), not the dominant Bb3 (58).
+        assert_eq!(chord_pitches("Cmaj7"), Some(vec![48, 52, 55, 59]));
+        // Bare "Cmaj" is just the major triad — no seventh added.
+        assert_eq!(chord_pitches("Cmaj"), Some(vec![48, 52, 55]));
+        // Minor-major seventh ("Cmmaj7"): minor triad + major seventh.
+        assert_eq!(chord_pitches("Cmmaj7"), Some(vec![48, 51, 55, 59]));
+    }
+
+    #[test]
+    fn pitches_diminished_seventh() {
+        // Cdim7 is fully diminished: C3, Eb3, Gb3, Bbb3 (= A3, 57).
+        assert_eq!(chord_pitches("Cdim7"), Some(vec![48, 51, 54, 57]));
+    }
+
+    #[test]
+    fn pitches_half_diminished_via_m7b5() {
+        // Cm7b5: minor third, flat fifth, minor seventh.
+        assert_eq!(chord_pitches("Cm7b5"), Some(vec![48, 51, 54, 58]));
+    }
+
+    #[test]
+    fn pitches_sus_replaces_third() {
+        // Csus4: root, perfect fourth, fifth (no third).
+        assert_eq!(chord_pitches("Csus4"), Some(vec![48, 53, 55]));
+        // Csus2: root, major second, fifth.
+        assert_eq!(chord_pitches("Csus2"), Some(vec![48, 50, 55]));
+        // C7sus4: sus4 triad plus a dominant seventh.
+        assert_eq!(chord_pitches("C7sus4"), Some(vec![48, 53, 55, 58]));
+    }
+
+    #[test]
+    fn pitches_add_tone_has_no_seventh() {
+        // Cadd9 is the triad plus a 9th (D4 = 62), with NO seventh.
+        assert_eq!(chord_pitches("Cadd9"), Some(vec![48, 52, 55, 62]));
+    }
+
+    #[test]
+    fn pitches_sixth_adds_major_sixth_not_seventh() {
+        // C6: triad plus the major sixth (A3 = 57).
+        assert_eq!(chord_pitches("C6"), Some(vec![48, 52, 55, 57]));
+        // Am6: minor triad plus the major sixth (F#4 = 66).
+        assert_eq!(chord_pitches("Am6"), Some(vec![57, 60, 64, 66]));
+    }
+
+    #[test]
+    fn pitches_ninth_chord_includes_seventh_and_ninth() {
+        // G9: dominant seventh plus the ninth.
+        assert_eq!(chord_pitches("G9"), Some(vec![55, 59, 62, 65, 69]));
+    }
+
+    #[test]
+    fn pitches_power_chord_omits_third() {
+        // C5: root and fifth only.
+        assert_eq!(chord_pitches("C5"), Some(vec![48, 55]));
+    }
+
+    #[test]
+    fn pitches_slash_bass_is_lowest_note() {
+        // C/G: triad with the bass G dropped an octave below the root.
+        assert_eq!(chord_pitches("C/G"), Some(vec![43, 48, 52, 55]));
+        // Am7/G: the bass is below all chord tones and de-duplication keeps
+        // the (distinct) low G even though the chord has its own G4.
+        assert_eq!(chord_pitches("Am7/G"), Some(vec![43, 57, 60, 64, 67]));
+    }
+
+    #[test]
+    fn pitches_accidental_roots() {
+        // Bb major: Bb3 (pc 10 → 58), D4, F4.
+        assert_eq!(chord_pitches("Bb"), Some(vec![58, 62, 65]));
+        // F#m: F#3 (pc 6 → 54), A3, C#4.
+        assert_eq!(chord_pitches("F#m"), Some(vec![54, 57, 61]));
+    }
+
+    #[test]
+    fn pitches_unparseable_returns_none() {
+        assert_eq!(chord_pitches(""), None);
+        assert_eq!(chord_pitches("xyz"), None);
+        assert_eq!(chord_pitches("H"), None);
+        assert_eq!(chord_pitches("G/"), None);
+    }
+
+    #[test]
+    fn pitches_are_sorted_and_deduplicated() {
+        for name in ["C", "Am7", "Cmaj7", "G9", "C/G", "Cdim7", "F#m", "Bb13"] {
+            let pitches = chord_pitches(name).unwrap();
+            let mut sorted = pitches.clone();
+            sorted.sort_unstable();
+            assert_eq!(pitches, sorted, "{name} pitches must be ascending");
+            let mut deduped = sorted.clone();
+            deduped.dedup();
+            assert_eq!(pitches, deduped, "{name} pitches must be unique");
+            assert!(!pitches.is_empty(), "{name} must yield at least one pitch");
+            assert!(
+                pitches.iter().all(|&p| p < 128),
+                "{name} pitches must be valid MIDI notes"
+            );
+        }
     }
 }

--- a/crates/chordpro/src/chord.rs
+++ b/crates/chordpro/src/chord.rs
@@ -402,30 +402,31 @@ fn chord_interval_semitones(quality: ChordQuality, ext: &str) -> Vec<u8> {
         let has13 = ext.contains("13");
         let has11 = ext.contains("11");
         let has9 = ext.contains('9');
-        let has_seventh = ext.contains('7') || has9 || has11 || has13;
-        // A "maj"-prefixed extension carrying a seventh-or-higher degree
-        // (maj7 / maj9 / maj13), or the "M7" / "Δ" shorthands, calls for a
+        let has_six = ext.contains('6');
+        // A 9th / 11th / 13th implies a seventh — EXCEPT in a "6/9" chord
+        // (written `69`), where the 6 marks an added-tone chord carrying the
+        // 6th and 9th but no seventh.
+        let has_seventh = ext.contains('7') || ((has9 || has11 || has13) && !has_six);
+        // "maj7" / "maj9" / "maj13" (or the "M7" / "Δ" shorthands) call for a
         // major seventh; bare "maj" (just `ChordQuality::Major`) does not.
         let major_seventh =
             (ext.starts_with("maj") && has_seventh) || ext.contains("M7") || ext.contains('Δ');
-        // A diminished chord with a seventh is fully diminished (bb7).
-        let dim_seventh = quality == ChordQuality::Diminished && ext.starts_with('7');
+        // A diminished chord that carries a seventh is fully diminished (bb7).
+        let dim_seventh = quality == ChordQuality::Diminished && has_seventh;
 
-        if dim_seventh {
-            extras.push(9);
-        } else if major_seventh {
-            extras.push(11);
-            if has9 {
-                extras.push(14);
-            }
-            if has11 {
-                extras.push(17);
-            }
-            if has13 {
-                extras.push(21);
-            }
-        } else if has_seventh {
-            extras.push(10);
+        if has_seventh {
+            // Seventh quality: diminished bb7 (9), major 7th (11), or the
+            // dominant / minor 7th (10). The upper-extension ladder is shared
+            // across all three — a 13th implies the 9th and 11th below it, so
+            // maj13 and the dominant 13 are voiced consistently.
+            let seventh = if dim_seventh {
+                9
+            } else if major_seventh {
+                11
+            } else {
+                10
+            };
+            extras.push(seventh);
             if has9 || has11 || has13 {
                 extras.push(14);
             }
@@ -435,10 +436,14 @@ fn chord_interval_semitones(quality: ChordQuality, ext: &str) -> Vec<u8> {
             if has13 {
                 extras.push(21);
             }
+        } else if has9 {
+            // Reachable only for a "6/9" chord (the `has_six` guard above
+            // suppresses the implied seventh): add the 9th alongside the 6th.
+            extras.push(14);
         }
 
-        // A sixth (e.g. "C6", "Am6") adds the major sixth — not a seventh.
-        if ext.contains('6') {
+        // A sixth (e.g. "C6", "Am6", "C69") adds the major sixth.
+        if has_six {
             extras.push(9);
         }
     }
@@ -1320,6 +1325,65 @@ mod tests {
     fn pitches_power_chord_omits_third() {
         // C5: root and fifth only.
         assert_eq!(chord_pitches("C5"), Some(vec![48, 55]));
+    }
+
+    #[test]
+    fn pitches_extended_dominant_stacks_lower_tones() {
+        // G11 / C13 stack the 9th and 11th below the named degree.
+        // G11: G3 B3 D4 F4 A4 C5.
+        assert_eq!(chord_pitches("G11"), Some(vec![55, 59, 62, 65, 69, 72]));
+        // C13: C3 E3 G3 Bb3 D4 F4 A4.
+        assert_eq!(chord_pitches("C13"), Some(vec![48, 52, 55, 58, 62, 65, 69]));
+    }
+
+    #[test]
+    fn pitches_major_extended_match_dominant_stacking() {
+        // Regression guard: maj9 / maj11 / maj13 must stack the same lower
+        // extension tones the dominant equivalents do (only the seventh
+        // differs: major 7th = 11 semitones, not the dominant's 10).
+        // Cmaj9: C3 E3 G3 B3 D4.
+        assert_eq!(chord_pitches("Cmaj9"), Some(vec![48, 52, 55, 59, 62]));
+        // Cmaj11: adds the 11th (F4) AND the 9th (D4) below it.
+        assert_eq!(chord_pitches("Cmaj11"), Some(vec![48, 52, 55, 59, 62, 65]));
+        // Cmaj13: adds the 13th (A4), 11th (F4), and 9th (D4).
+        assert_eq!(
+            chord_pitches("Cmaj13"),
+            Some(vec![48, 52, 55, 59, 62, 65, 69])
+        );
+    }
+
+    #[test]
+    fn pitches_six_nine_chord_has_no_seventh() {
+        // C69 (6/9): root, third, fifth, major sixth, ninth — and NO seventh.
+        // C3 E3 G3 A3 D4.
+        assert_eq!(chord_pitches("C69"), Some(vec![48, 52, 55, 57, 62]));
+        // Minor 6/9 keeps the minor third.
+        assert_eq!(chord_pitches("Cm69"), Some(vec![48, 51, 55, 57, 62]));
+    }
+
+    #[test]
+    fn pitches_altered_fifth() {
+        // C7#5: augmented dominant seventh — raised fifth (G#3) + b7 (Bb3).
+        assert_eq!(chord_pitches("C7#5"), Some(vec![48, 52, 56, 58]));
+    }
+
+    #[test]
+    fn pitches_bare_sus_is_sus4() {
+        // "Csus" with no number defaults to a suspended fourth.
+        assert_eq!(chord_pitches("Csus"), Some(vec![48, 53, 55]));
+    }
+
+    #[test]
+    fn pitches_add_degrees() {
+        // The full degree → semitone map exercised through add chords.
+        assert_eq!(chord_pitches("Cadd2"), Some(vec![48, 50, 52, 55])); // +2
+        assert_eq!(chord_pitches("Cadd4"), Some(vec![48, 52, 53, 55])); // +5
+        assert_eq!(chord_pitches("Cadd6"), Some(vec![48, 52, 55, 57])); // +9
+        assert_eq!(chord_pitches("Cadd11"), Some(vec![48, 52, 55, 65])); // +17
+        assert_eq!(chord_pitches("Cadd13"), Some(vec![48, 52, 55, 69])); // +21
+        // An unrecognised added degree contributes no extra tone (the
+        // documented bare-triad fallback), leaving the plain triad.
+        assert_eq!(chord_pitches("Caddx"), Some(vec![48, 52, 55]));
     }
 
     #[test]

--- a/crates/chordpro/src/lib.rs
+++ b/crates/chordpro/src/lib.rs
@@ -28,7 +28,7 @@ pub mod voicings;
 
 // Re-export key types for convenience.
 pub use abc_importer::convert_abc;
-pub use chord::{Accidental, ChordDetail, ChordQuality, Note, parse_chord};
+pub use chord::{Accidental, ChordDetail, ChordQuality, Note, chord_pitches, parse_chord};
 pub use chord_diagram::{canonical_chord_name, resolve_diagrams_instrument};
 // Aliased as `format_chordpro` to avoid ambiguity with the `format!` macro at
 // call sites that use glob imports.

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -134,6 +134,7 @@ for e in errors:
 | `chord_diagram_svg_with_defines(chord, instrument, defines)` | `str \| None` | Same as `chord_diagram_svg` but consults song-level `{define}` voicings first. `defines` is a list of `(name, raw)` tuples. |
 | `chord_diagram_svg_with_orientation(chord, instrument, orientation=None)` | `str \| None` | Orientation-aware variant. `orientation`: `"vertical"` (default) or `"horizontal"` (nut on the left, Japanese tablature convention). Horizontal mode is reader-view only (high pitch on top, matches tablature stave order); see ADR-0026. Unrecognised strings fall back to vertical. |
 | `chord_diagram_svg_with_defines_orientation(chord, instrument, defines, orientation=None)` | `str \| None` | Combined surface — accepts both song-level `{define}` voicings and the orientation knob. |
+| `chord_pitches(chord)` | `list[int] \| None` | Constituent pitches of a chord as MIDI note numbers, for driving an audio synth. Returns a block voicing (root, third, fifth, plus any extension / altered / added tones, with a slash bass an octave below); `None` when the chord is not parseable. |
 
 ### Utility
 

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -138,6 +138,16 @@ namespace chordsketch {
     [Throws=ChordSketchError]
     string? chord_diagram_svg_with_defines_orientation(string chord, string instrument, sequence<ChordDefine> defines, string? orientation);
 
+    /// Constituent pitches of a chord as MIDI note numbers, for
+    /// driving an audio synth (#2650). Mirrors the wasm `chordPitches`
+    /// and NAPI `chordPitches` exports.
+    ///
+    /// Returns ascending, de-duplicated MIDI note numbers describing a
+    /// block voicing (root, third, fifth, plus any extension / altered
+    /// / added tones, with a slash bass dropped one octave below the
+    /// root), or `null` when `chord` is not parseable as a chord.
+    sequence<u8>? chord_pitches(string chord);
+
     /// Convert a ChordPro source string into an `irealb://` URL
     /// (#2067 Phase 1).
     ///

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -396,6 +396,19 @@ pub fn version() -> String {
     chordsketch_chordpro::version().to_string()
 }
 
+/// Constituent pitches of a chord as MIDI note numbers, for driving an
+/// audio synth (#2650). Mirrors the wasm `chordPitches` and NAPI
+/// `chordPitches` exports (`.claude/rules/fix-propagation.md` §Bindings).
+///
+/// Returns ascending, de-duplicated MIDI note numbers describing a block
+/// voicing (root, third, fifth, plus any extension / altered / added
+/// tones, with a slash bass dropped one octave below the root), or `None`
+/// when `chord` is not parseable as a chord.
+#[must_use]
+pub fn chord_pitches(chord: String) -> Option<Vec<u8>> {
+    chordsketch_chordpro::chord_pitches(&chord)
+}
+
 /// Look up an SVG chord diagram for the given chord name and
 /// instrument. Mirrors the WASM `chord_diagram_svg` export
 /// added in #2164 and the NAPI `chordDiagramSvg` export added
@@ -1342,5 +1355,17 @@ mod tests {
             matches!(result, Err(ChordSketchError::ConversionFailed { .. })),
             "expected ConversionFailed; got {result:?}"
         );
+    }
+
+    #[test]
+    fn test_chord_pitches_known_chord_returns_midi_notes() {
+        assert_eq!(chord_pitches("C".to_string()), Some(vec![48, 52, 55]));
+        assert_eq!(chord_pitches("Am7".to_string()), Some(vec![57, 60, 64, 67]));
+    }
+
+    #[test]
+    fn test_chord_pitches_unparseable_returns_none() {
+        assert_eq!(chord_pitches("XYZ-not-a-chord".to_string()), None);
+        assert_eq!(chord_pitches(String::new()), None);
     }
 }

--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -153,6 +153,7 @@ for (const { line, column, message } of errors) {
 | `chordDiagramSvgWithDefines(chord, instrument, defines)` | `string \| null` | Like `chordDiagramSvg` but consults song-level `{define}` voicings first. `defines` is an array of `[name, raw]` tuples (e.g. `[["Gsus4", "base-fret 1 frets 3 3 0 0 1 3"]]`). |
 | `chordDiagramSvgWithOrientation(chord, instrument, orientation?)` | `string \| null` | Orientation-aware variant. `orientation`: `"vertical"` (default) or `"horizontal"` (nut on the left, Japanese tablature convention). Horizontal mode is reader-view only (high pitch on top, matches tablature stave order); see ADR-0026. Unrecognised strings fall back to vertical. |
 | `chordDiagramSvgWithDefinesOrientation(chord, instrument, defines, orientation?)` | `string \| null` | Combined surface — accepts both song-level `{define}` voicings and the orientation knob. |
+| `chordPitches(chord)` | `Buffer \| null` | Constituent pitches of a chord as MIDI note numbers, for driving an audio synth. Returns a block voicing (root, third, fifth, plus any extension / altered / added tones, with a slash bass an octave below) as a byte `Buffer`; `null` when the chord is not parseable. |
 
 ### Utility
 

--- a/crates/napi/src/bindings.rs
+++ b/crates/napi/src/bindings.rs
@@ -491,23 +491,6 @@ pub fn chord_diagram_svg(chord: String, instrument: String) -> Result<Option<Str
 ///
 /// Returns a napi `Error` with status `InvalidArg` when
 /// `instrument` is not one of the supported values.
-/// Constituent pitches of a chord as MIDI note numbers, for driving an
-/// audio synth (#2650).
-///
-/// Returns a `Buffer` of ascending, de-duplicated MIDI note numbers
-/// describing a block voicing (root, third, fifth, plus any extension /
-/// altered / added tones, with a slash bass dropped one octave below the
-/// root), or `null` when `chord` is not parseable as a chord.
-///
-/// Thin wrapper over [`crate::chord_pitches_inner`]. Sister-site to the
-/// wasm `chordPitches` export and the FFI `chord_pitches` function
-/// (`.claude/rules/fix-propagation.md` §Bindings).
-#[must_use]
-#[napi(js_name = "chordPitches")]
-pub fn chord_pitches(chord: String) -> Option<Buffer> {
-    chord_pitches_inner(&chord).map(Buffer::from)
-}
-
 #[must_use = "callers must handle the unknown-instrument error"]
 #[napi(js_name = "chordDiagramSvgWithDefines")]
 pub fn chord_diagram_svg_with_defines(
@@ -519,6 +502,23 @@ pub fn chord_diagram_svg_with_defines(
         validate_defines_pairs(defines).map_err(|msg| Error::new(Status::InvalidArg, msg))?;
     chord_diagram_svg_inner(&chord, &instrument, &pairs)
         .map_err(|msg| Error::new(Status::InvalidArg, msg))
+}
+
+/// Constituent pitches of a chord as MIDI note numbers, for driving an
+/// audio synth (#2650).
+///
+/// Returns a `Buffer` of ascending, de-duplicated MIDI note numbers
+/// describing a block voicing (root, third, fifth, plus any extension /
+/// altered / added tones, with a slash bass dropped one octave below the
+/// root), or `null` when `chord` is not parseable as a chord.
+///
+/// Thin wrapper over the pure-Rust `chord_pitches_inner`. Sister-site to
+/// the wasm `chordPitches` export and the FFI `chord_pitches` function
+/// (`.claude/rules/fix-propagation.md` §Bindings).
+#[must_use]
+#[napi(js_name = "chordPitches")]
+pub fn chord_pitches(chord: String) -> Option<Buffer> {
+    chord_pitches_inner(&chord).map(Buffer::from)
 }
 
 /// Variant of [`chord_diagram_svg`] that takes a diagram orientation as

--- a/crates/napi/src/bindings.rs
+++ b/crates/napi/src/bindings.rs
@@ -35,7 +35,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
 use crate::{
-    chord_diagram_svg_inner, chord_diagram_svg_inner_with_orientation,
+    chord_diagram_svg_inner, chord_diagram_svg_inner_with_orientation, chord_pitches_inner,
     do_convert_chordpro_to_irealb, do_convert_irealb_to_chordpro_text, do_parse_irealb,
     do_render_bytes, do_render_ireal_pdf, do_render_ireal_png, do_render_ireal_svg,
     do_render_pdf_with_warnings, do_render_string, do_render_string_with_warnings,
@@ -491,6 +491,23 @@ pub fn chord_diagram_svg(chord: String, instrument: String) -> Result<Option<Str
 ///
 /// Returns a napi `Error` with status `InvalidArg` when
 /// `instrument` is not one of the supported values.
+/// Constituent pitches of a chord as MIDI note numbers, for driving an
+/// audio synth (#2650).
+///
+/// Returns a `Buffer` of ascending, de-duplicated MIDI note numbers
+/// describing a block voicing (root, third, fifth, plus any extension /
+/// altered / added tones, with a slash bass dropped one octave below the
+/// root), or `null` when `chord` is not parseable as a chord.
+///
+/// Thin wrapper over [`crate::chord_pitches_inner`]. Sister-site to the
+/// wasm `chordPitches` export and the FFI `chord_pitches` function
+/// (`.claude/rules/fix-propagation.md` §Bindings).
+#[must_use]
+#[napi(js_name = "chordPitches")]
+pub fn chord_pitches(chord: String) -> Option<Buffer> {
+    chord_pitches_inner(&chord).map(Buffer::from)
+}
+
 #[must_use = "callers must handle the unknown-instrument error"]
 #[napi(js_name = "chordDiagramSvgWithDefines")]
 pub fn chord_diagram_svg_with_defines(

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -233,6 +233,19 @@ pub(crate) fn chord_diagram_svg_inner(
     chord_diagram_svg_inner_with_orientation(chord, instrument, defines, None)
 }
 
+/// Pure-Rust core of [`bindings::chord_pitches`]. Returns the chord's
+/// constituent MIDI note numbers, or `None` when `chord` is not parseable.
+///
+/// Thin pass-through to [`chordsketch_chordpro::chord_pitches`]; kept here
+/// so the native test suite covers the binding's surface without the
+/// Node-API runtime. Sister-site to the wasm `chord_pitches_inner` and the
+/// FFI binding's `chord_pitches` (`.claude/rules/fix-propagation.md`
+/// §Bindings).
+#[must_use]
+pub(crate) fn chord_pitches_inner(chord: &str) -> Option<Vec<u8>> {
+    chordsketch_chordpro::chord_pitches(chord)
+}
+
 /// Orientation-aware variant of [`chord_diagram_svg_inner`].
 ///
 /// `orientation` is passed as `Option<&str>` so the JS surface can
@@ -1076,6 +1089,18 @@ mod tests {
         let svg = chord_diagram_svg_inner("C", "guitar", &[]).unwrap();
         let svg = svg.expect("guitar C must have a built-in diagram");
         assert!(svg.contains("<svg"));
+    }
+
+    #[test]
+    fn test_chord_pitches_inner_known_chord_returns_midi_notes() {
+        assert_eq!(chord_pitches_inner("C"), Some(vec![48, 52, 55]));
+        assert_eq!(chord_pitches_inner("Am7"), Some(vec![57, 60, 64, 67]));
+    }
+
+    #[test]
+    fn test_chord_pitches_inner_unparseable_returns_none() {
+        assert_eq!(chord_pitches_inner("XYZ-not-a-chord"), None);
+        assert_eq!(chord_pitches_inner(""), None);
     }
 
     #[test]

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -117,6 +117,7 @@ the
 | `chordDiagramSvgWithDefines(chord, instrument, defines)` | Same as above but consults song-level `{define}` voicings first. `defines` is an array of `[name, raw]` tuples (e.g. `[["Gsus4", "base-fret 1 frets 3 3 0 0 1 3"]]`). | `string \| null` |
 | `chordDiagramSvgWithOrientation(chord, instrument, orientation?)` | Orientation-aware variant. `orientation`: `"vertical"` (default) or `"horizontal"` (nut on the left, Japanese tablature convention). Horizontal mode is reader-view only (high pitch on top, matches tablature stave order); see ADR-0026. Unrecognised strings fall back to vertical. | `string \| null` |
 | `chordDiagramSvgWithDefinesOrientation(chord, instrument, defines, orientation?)` | Combined surface — accepts both song-level `{define}` voicings and the orientation knob. | `string \| null` |
+| `chordPitches(chord)` | Constituent pitches of a chord as MIDI note numbers, for driving an audio synth. Returns a block voicing (root, third, fifth, plus any extension / altered / added tones, with a slash bass an octave below). `undefined` when the chord is not parseable. | `Uint8Array \| undefined` |
 
 ### iReal Pro
 

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -839,7 +839,7 @@ pub fn chord_diagram_svg_with_defines_orientation_compact(
 /// added tones, with a slash bass dropped one octave below the root).
 ///
 /// Thin wrapper over [`chordsketch_chordpro::chord_pitches`] via the
-/// pure-Rust [`crate::chord_pitches_inner`]. Sister-site to the NAPI
+/// pure-Rust `chord_pitches_inner`. Sister-site to the NAPI
 /// `chordPitches` export and the FFI `chord_pitches` function
 /// (`.claude/rules/fix-propagation.md` §Bindings).
 #[wasm_bindgen(js_name = chordPitches)]

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -830,6 +830,24 @@ pub fn chord_diagram_svg_with_defines_orientation_compact(
     .map_err(|e| JsValue::from_str(&e))
 }
 
+/// Constituent pitches of a chord as MIDI note numbers, for driving an
+/// audio synth (the React `useChordAudio` chord-playback surface, #2650).
+///
+/// Returns `undefined` when `chord` is not parseable as a chord; otherwise
+/// a `Uint8Array` of ascending, de-duplicated MIDI note numbers describing
+/// a block voicing (root, third, fifth, plus any extension / altered /
+/// added tones, with a slash bass dropped one octave below the root).
+///
+/// Thin wrapper over [`chordsketch_chordpro::chord_pitches`] via the
+/// pure-Rust [`crate::chord_pitches_inner`]. Sister-site to the NAPI
+/// `chordPitches` export and the FFI `chord_pitches` function
+/// (`.claude/rules/fix-propagation.md` §Bindings).
+#[wasm_bindgen(js_name = chordPitches)]
+#[must_use]
+pub fn chord_pitches(chord: &str) -> Option<Vec<u8>> {
+    crate::chord_pitches_inner(chord)
+}
+
 /// Validate ChordPro input and return any parse errors as structured
 /// records.
 ///

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -297,6 +297,20 @@ pub(crate) fn chord_diagram_svg_inner_with_options(
     }
 }
 
+/// Pure-Rust core of [`bindings::chord_pitches`]. Returns the chord's
+/// constituent MIDI note numbers, or `None` when `chord` is not parseable.
+///
+/// A thin pass-through to [`chordsketch_chordpro::chord_pitches`] kept here
+/// (rather than calling the core directly from the binding) so the native
+/// test suite covers the binding's surface without the wasm runtime, per
+/// the crate-layout note above. Sister-site to the NAPI
+/// `chord_pitches_inner` and the FFI binding's `chord_pitches`
+/// (`.claude/rules/fix-propagation.md` §Bindings).
+#[must_use]
+pub(crate) fn chord_pitches_inner(chord: &str) -> Option<Vec<u8>> {
+    chordsketch_chordpro::chord_pitches(chord)
+}
+
 /// A single validation issue reported by [`bindings::validate`].
 ///
 /// Serialised to a plain JS `{line, column, message}` object via
@@ -1544,6 +1558,21 @@ mod tests {
     fn test_chord_diagram_svg_inner_unknown_chord_returns_none() {
         let result = chord_diagram_svg_inner("XYZ-not-a-chord", "guitar", &[]).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_chord_pitches_inner_known_chord_returns_midi_notes() {
+        // Passthrough to the core; pin a representative chord so a
+        // regression in the wiring (wrong arg, swapped return) is caught
+        // here without the wasm runtime.
+        assert_eq!(chord_pitches_inner("C"), Some(vec![48, 52, 55]));
+        assert_eq!(chord_pitches_inner("Am7"), Some(vec![57, 60, 64, 67]));
+    }
+
+    #[test]
+    fn test_chord_pitches_inner_unparseable_returns_none() {
+        assert_eq!(chord_pitches_inner("XYZ-not-a-chord"), None);
+        assert_eq!(chord_pitches_inner(""), None);
     }
 
     #[test]

--- a/packages/playground/src/chordpro/main.tsx
+++ b/packages/playground/src/chordpro/main.tsx
@@ -549,6 +549,11 @@ function PlaygroundApp(): JSX.Element {
   // behaviour; users opt into horizontal via the toolbar select.
   const [diagramsOrientation, setDiagramsOrientation] =
     useState<'vertical' | 'horizontal'>('vertical');
+  // Chord-audio mode (#2650): when on, clicking a chord in the preview
+  // plays it as a block chord via Web Audio. Off by default so the
+  // preview's first impression stays the read/edit surface; the user
+  // opts in via the toolbar toggle.
+  const [chordAudio, setChordAudio] = useState<boolean>(false);
 
   const editorRef = useRef<ChordSourceAreaHandle | null>(null);
 
@@ -859,6 +864,8 @@ function PlaygroundApp(): JSX.Element {
               showExport={false}
               chordDiagramsOrientation={diagramsOrientation}
               onChordDiagramsOrientationChange={setDiagramsOrientation}
+              chordAudioEnabled={chordAudio}
+              onChordAudioToggle={setChordAudio}
               /* `transposeMin/Max` left at the PreviewToolbar default
                  (±6) so the option list stays compact on narrow
                  preview panes. The feature ceiling of ±11 is still
@@ -871,6 +878,10 @@ function PlaygroundApp(): JSX.Element {
                 format="html"
                 chordDiagramsInstrument="guitar"
                 chordDiagramsOrientation={diagramsOrientation}
+                /* Chord-audio mode (#2650): clicking a chord plays it.
+                   Active in every view so preview-only users can audition
+                   chords too. */
+                chordAudio={chordAudio}
                 /* The active-line highlight and caret marker only make
                    sense in split view, where the editor sits beside the
                    preview. In preview-only view the editor is unmounted,

--- a/packages/playground/tests-e2e/chord-audio.spec.ts
+++ b/packages/playground/tests-e2e/chord-audio.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+// Chord-audio smoke (#2650). The toolbar's "Chord audio" toggle puts
+// the preview into audio mode, where every rendered chord becomes a
+// play button (`.chord--audio`, backed by the `useChordAudio` Web Audio
+// hook in `@chordsketch/react`). The in-package vitest suites stub Web
+// Audio and the wasm `chordPitches` export, so — per
+// `.claude/rules/playground-smoke.md` — only a real-browser smoke
+// proves the toggle wires the audio mode into the deployed bundle's
+// preview.
+//
+// The default sample ("Amazing Grace") contains chords, so the preview
+// renders chord spans without editing the source. Assertions are
+// structural (toggle state + `.chord--audio` presence + no uncaught
+// exceptions); audible output is out of scope for a headless smoke.
+
+test.describe('chord-audio toggle on the ChordPro preview', () => {
+  test('toggling Chord audio turns chords into play buttons without errors', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.goto('./chordpro/', { waitUntil: 'networkidle' });
+
+    const toolbar = page.getByRole('toolbar', {
+      name: 'Preview performance controls',
+    });
+    await expect(toolbar).toBeVisible();
+
+    const toggle = toolbar.getByRole('button', { name: 'Play chords on click' });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    // Before enabling audio mode, no chord carries the audio affordance.
+    const audioChords = page.locator('.chordsketch-preview .chord--audio');
+    await expect(audioChords).toHaveCount(0);
+
+    // Enable audio mode: chords become play buttons.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(audioChords.first()).toBeVisible();
+
+    const firstChord = audioChords.first();
+    await expect(firstChord).toHaveAttribute('role', 'button');
+    await expect(firstChord).toHaveAttribute('aria-label', /^Play chord /);
+
+    // Clicking a chord (a real user gesture, so the autoplay-gated
+    // AudioContext may run) must not raise an uncaught exception even if
+    // the wasm pitch lookup is still warming up.
+    await firstChord.click();
+
+    // Toggling back off removes the audio affordance.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(audioChords).toHaveCount(0);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/react/src/audio-context.ts
+++ b/packages/react/src/audio-context.ts
@@ -1,0 +1,54 @@
+// Page-level shared Web Audio resources.
+//
+// Browsers cap the number of concurrent `AudioContext`s, and creating
+// one per hook instance (a metronome chip plus a chord-audio surface,
+// say) would race that cap. This module owns a single lazily-created
+// `AudioContext` that every audio hook in the package reuses for the
+// page lifetime. The context is created on the first user gesture (to
+// satisfy autoplay policies) and is suspended — not closed — when idle,
+// the recommended Web Audio pattern, so it stays cheap to keep around.
+//
+// Extracted from `use-metronome.ts` (#2650) so `useMetronome` and
+// `useChordAudio` share one context instead of spawning two.
+
+type AudioContextCtor = new () => AudioContext;
+
+let sharedContext: AudioContext | null = null;
+
+/**
+ * Resolve the platform `AudioContext` constructor, tolerating the legacy
+ * `webkitAudioContext` prefix. Returns `null` under SSR or when neither is
+ * present, so callers can branch on Web Audio support.
+ */
+export function getAudioContextCtor(): AudioContextCtor | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as typeof window & {
+    webkitAudioContext?: AudioContextCtor;
+  };
+  return w.AudioContext ?? w.webkitAudioContext ?? null;
+}
+
+/**
+ * Lazily create (or reuse) the page-level shared `AudioContext`. Returns
+ * `null` when Web Audio is unavailable.
+ */
+export function getSharedAudioContext(): AudioContext | null {
+  if (sharedContext && sharedContext.state !== 'closed') return sharedContext;
+  const Ctor = getAudioContextCtor();
+  if (!Ctor) return null;
+  sharedContext = new Ctor();
+  return sharedContext;
+}
+
+/**
+ * Reset the module-level shared `AudioContext`.
+ *
+ * **Test-only** — not re-exported from the package index. Lets each test
+ * start from a clean singleton after swapping the `window.AudioContext`
+ * stub.
+ *
+ * @internal
+ */
+export function resetSharedAudioContextForTests(): void {
+  sharedContext = null;
+}

--- a/packages/react/src/audio-context.ts
+++ b/packages/react/src/audio-context.ts
@@ -52,3 +52,74 @@ export function getSharedAudioContext(): AudioContext | null {
 export function resetSharedAudioContextForTests(): void {
   sharedContext = null;
 }
+
+/** Parameters describing a single scheduled oscillator voice. */
+export interface VoiceSpec {
+  /** Oscillator waveform. */
+  type: OscillatorType;
+  /** Frequency in Hz. */
+  frequency: number;
+  /** Audio-clock time (seconds) at which the voice starts. */
+  startTime: number;
+  /**
+   * Attack time in seconds. `0` jumps straight to {@link VoiceSpec.peak}
+   * at onset (a percussive click); a positive value ramps up to the peak,
+   * avoiding the click a hard onset would make.
+   */
+  attack: number;
+  /** Seconds from {@link VoiceSpec.startTime} to the decay-to-silence end. */
+  release: number;
+  /** Peak gain for this voice. */
+  peak: number;
+  /**
+   * Extra seconds held after {@link VoiceSpec.release} before the
+   * oscillator is stopped. `0` stops exactly at the release end (the
+   * metronome's tight click); a small tail lets a sustained voice's
+   * exponential tail finish inaudibly.
+   */
+  tail: number;
+}
+
+/**
+ * Schedule a single oscillator + gain voice on `ctx` per `spec`, register
+ * it in `tracked`, and wire `onended` cleanup (remove from `tracked`,
+ * disconnect the nodes). Shared by `useMetronome` and `useChordAudio` so
+ * the envelope shape, node graph, and cleanup race-handling live in one
+ * place rather than being duplicated across both hooks.
+ *
+ * The gain envelope uses `exponentialRampToValueAtTime` toward a tiny
+ * non-zero floor (Web Audio rejects a `0` target).
+ */
+export function scheduleVoice(
+  ctx: AudioContext,
+  tracked: Set<OscillatorNode>,
+  spec: VoiceSpec,
+): void {
+  const { type, frequency, startTime, attack, release, peak, tail } = spec;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(frequency, startTime);
+  if (attack > 0) {
+    gain.gain.setValueAtTime(0.0001, startTime);
+    gain.gain.exponentialRampToValueAtTime(peak, startTime + attack);
+  } else {
+    // Percussive onset: jump to the peak immediately.
+    gain.gain.setValueAtTime(peak, startTime);
+  }
+  gain.gain.exponentialRampToValueAtTime(0.0001, startTime + release);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(startTime);
+  osc.stop(startTime + release + tail);
+  tracked.add(osc);
+  osc.onended = () => {
+    tracked.delete(osc);
+    try {
+      osc.disconnect();
+      gain.disconnect();
+    } catch {
+      // Nodes may already be disconnected if a stop() raced ahead.
+    }
+  };
+}

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -483,7 +483,7 @@ function ChordSheetAstBranch({
   // hooks) but only wired into the walker when the consumer opted in via
   // the `chordAudio` prop AND the environment supports Web Audio — so on
   // SSR / unsupported browsers chords stay inert instead of dead buttons.
-  const audio = useChordAudio(chordAudioLoader);
+  const audio = useChordAudio(chordAudioLoader, Boolean(chordAudio));
   const chordAudioConfig =
     chordAudio && audio.supported ? { enabled: true, play: audio.play } : null;
 

--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -4,6 +4,8 @@ import type { HTMLAttributes, ReactNode } from 'react';
 import { ChordInspector } from './chord-inspector';
 import { renderChordproAst, unicodeAccidentals } from './chordpro-jsx';
 import type { ChordSelection } from './chordpro-jsx';
+import { useChordAudio } from './use-chord-audio';
+import type { ChordAudioWasmLoader } from './use-chord-audio';
 import type { ChordproChord, ChordproSong } from './chordpro-ast';
 import {
   buildChordName,
@@ -153,6 +155,26 @@ export interface ChordSheetProps extends Omit<HTMLAttributes<HTMLDivElement>, 'c
   /** Setter paired with {@link chordSelection}; presence switches
    * ChordSheet into controlled-selection mode — see its docs. */
   onChordSelectionChange?: (selection: ChordSelection | null) => void;
+  /**
+   * Enable chord-audio mode (#2650). When `true`, every rendered chord
+   * becomes a play button: clicking (or Enter / Space) sounds the chord
+   * as a block chord via the Web Audio API. Audio mode takes precedence
+   * over the click-to-nudge selection / drag interactions, matching the
+   * toolbar-toggle UX where the user opts into audio explicitly.
+   *
+   * Degrades gracefully: when the environment has no Web Audio support
+   * (SSR, or a browser without `AudioContext`), the flag has no effect
+   * and chords stay inert. Only consumed by `format="html"`.
+   */
+  chordAudio?: boolean;
+  /**
+   * Test-only WASM loader override for the chord-audio hook. Production
+   * callers never supply this — the default lazy-loads
+   * `@chordsketch/wasm` for the `chordPitches` export.
+   *
+   * @internal
+   */
+  chordAudioLoader?: ChordAudioWasmLoader;
   /**
    * Configuration preset name (e.g. `"guitar"`, `"ukulele"`) or an
    * inline RRJSON configuration string.
@@ -325,6 +347,8 @@ export function ChordSheet({
   onChordDelete,
   chordSelection,
   onChordSelectionChange,
+  chordAudio,
+  chordAudioLoader,
   className,
   ...divProps
 }: ChordSheetProps): JSX.Element {
@@ -363,6 +387,8 @@ export function ChordSheet({
       onChordDelete={onChordDelete}
       controlledSelection={chordSelection}
       onChordSelectionChange={onChordSelectionChange}
+      chordAudio={chordAudio}
+      chordAudioLoader={chordAudioLoader}
       wrapperClass={wrapperClass}
       divProps={divProps}
     />
@@ -427,6 +453,8 @@ function ChordSheetAstBranch({
   onChordDelete,
   controlledSelection,
   onChordSelectionChange,
+  chordAudio,
+  chordAudioLoader,
   wrapperClass,
   divProps,
 }: BranchProps & {
@@ -441,6 +469,8 @@ function ChordSheetAstBranch({
   onChordDelete: ((target: ChordDeleteTarget) => void) | undefined;
   controlledSelection: ChordSelection | null | undefined;
   onChordSelectionChange: ((selection: ChordSelection | null) => void) | undefined;
+  chordAudio: boolean | undefined;
+  chordAudioLoader: ChordAudioWasmLoader | undefined;
 }): JSX.Element {
   const { ast, loading, error, transposedKey, transposedKeyDirectives } = useChordproAst(
     source,
@@ -448,6 +478,14 @@ function ChordSheetAstBranch({
     wasmLoader,
   );
   const errorNode = error !== null && errorFallback !== null ? errorFallback(error) : null;
+
+  // Chord-audio mode (#2650). The hook is always instantiated (rules of
+  // hooks) but only wired into the walker when the consumer opted in via
+  // the `chordAudio` prop AND the environment supports Web Audio — so on
+  // SSR / unsupported browsers chords stay inert instead of dead buttons.
+  const audio = useChordAudio(chordAudioLoader);
+  const chordAudioConfig =
+    chordAudio && audio.supported ? { enabled: true, play: audio.play } : null;
 
   // Click-to-focus + nudge selection state (#2614). Owned here so it
   // survives the re-render a nudge triggers (the nudge mutates source,
@@ -602,6 +640,7 @@ function ChordSheetAstBranch({
           onChordReposition: repositionCb,
           chordSelection: repositionCb ? chordSelection : null,
           setChordSelection: repositionCb ? selectChord : undefined,
+          chordAudio: chordAudioConfig,
         })}
       </div>
       {!controlled && resolvedChord && editCb ? (

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -35,6 +35,7 @@ import {
   useState,
 } from 'react';
 import type {
+  AnimationEvent as ReactAnimationEvent,
   CSSProperties,
   DragEvent as ReactDragEvent,
   JSX,
@@ -1594,6 +1595,39 @@ export interface ChordSelection {
 }
 
 /**
+ * Chord-audio (#2650) wiring threaded to each chord-bearing lyrics line.
+ * When {@link ChordAudioConfig.enabled} is `true`, every rendered
+ * `.chord` becomes a play button: clicking / Enter / Space sounds the
+ * chord via {@link ChordAudioConfig.play}.
+ *
+ * Audio mode takes precedence over the click-to-nudge selection
+ * interaction (a chord cannot be both a "select to edit" target and a
+ * "tap to hear" target at once), matching the toolbar-toggle UX where
+ * the user opts into audio mode explicitly.
+ */
+export interface ChordAudioConfig {
+  /** Whether chord-audio mode is active. */
+  enabled: boolean;
+  /** Sound the given raw chord name (e.g. `"Am7"`, `"C/G"`). */
+  play: (chordName: string) => void;
+}
+
+/**
+ * Briefly flash a `.chord--ringing` class on a played chord element so
+ * the tap gets visual feedback. The class is added imperatively (the
+ * walker is stateless per chord) and removed on `animationend`; a forced
+ * reflow between remove and re-add restarts the CSS animation when the
+ * same chord is tapped again before the previous pulse finishes.
+ */
+function pulseChordElement(el: HTMLElement): void {
+  el.classList.remove('chord--ringing');
+  // Reading offsetWidth forces a synchronous reflow so the re-added
+  // class starts a fresh animation rather than being coalesced away.
+  void el.offsetWidth;
+  el.classList.add('chord--ringing');
+}
+
+/**
  * Drag-and-drop + click-to-nudge context threaded to each
  * chord-bearing lyrics line. Carries the per-line source number,
  * the reposition callback the consumer wires, and the shared
@@ -1632,6 +1666,8 @@ function renderLyricsLine(
   /** Inline / hover diagram config (ADR-0027); `null` keeps the
    * plain chord-name rendering. */
   diagrams: LyricsDiagramConfig | null = null,
+  /** Chord-audio config (#2650); `null` keeps chords inert. */
+  chordAudio: ChordAudioConfig | null = null,
 ): JSX.Element {
   return (
     <LyricsLine
@@ -1643,6 +1679,7 @@ function renderLyricsLine(
       reposition={reposition}
       className="line"
       diagrams={diagrams}
+      chordAudio={chordAudio}
     />
   );
 }
@@ -1663,6 +1700,8 @@ interface LyricsLineProps {
   /** Inline / hover diagram config (ADR-0027). `null` / `'section'`
    * keeps the plain chord-name rendering. */
   diagrams?: LyricsDiagramConfig | null;
+  /** Chord-audio config (#2650). `null` keeps chords inert. */
+  chordAudio?: ChordAudioConfig | null;
 }
 
 /**
@@ -1805,6 +1844,7 @@ function LyricsLine({
   className,
   'data-source-line': dataSourceLine,
   diagrams,
+  chordAudio,
 }: LyricsLineProps): JSX.Element {
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
   // Pre-walk segments to record per-chord source columns and
@@ -2098,8 +2138,11 @@ function LyricsLine({
             ? renderMarker(caret.withinRatio)
             : null;
         const segLayout = segmentLayout[i];
+        // In chord-audio mode the chord is a play button, not a drag
+        // handle — suppress drag wiring so a tap-to-hear gesture is not
+        // also a drag-to-reposition gesture (#2650).
         const chordDragProps =
-          reposition && segment.chord
+          reposition && segment.chord && !(chordAudio?.enabled)
             ? buildChordDragProps(
                 segment.chord,
                 segLayout.chordSourceColumn,
@@ -2137,8 +2180,38 @@ function LyricsLine({
         const isRealChord = segment.chord != null;
         const isFocusedChord =
           reposition != null && isRealChord && i === focusedSegmentIdx;
-        const chordInteractiveProps =
-          reposition && nudgeCtx && isRealChord
+        // Chord-audio mode (#2650) turns each chord into a play button.
+        // It takes precedence over the click-to-nudge selection so a
+        // chord is never both "tap to edit" and "tap to hear" at once —
+        // the user opts into audio mode via the toolbar toggle.
+        const audioEnabled = Boolean(chordAudio?.enabled) && isRealChord;
+        const playChord = (e: ReactMouseEvent | ReactKeyboardEvent) => {
+          chordAudio?.play(segment.chord?.name ?? '');
+          pulseChordElement(e.currentTarget as HTMLElement);
+        };
+        const chordInteractiveProps = audioEnabled
+          ? {
+              tabIndex: 0,
+              role: 'button' as const,
+              'aria-label': `Play chord ${segment.chord?.name ?? ''}`,
+              'data-chord': segment.chord?.name ?? '',
+              onClick: (e: ReactMouseEvent) => {
+                e.stopPropagation();
+                playChord(e);
+              },
+              onKeyDown: (e: ReactKeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  playChord(e);
+                }
+              },
+              onAnimationEnd: (e: ReactAnimationEvent) => {
+                (e.currentTarget as HTMLElement).classList.remove(
+                  'chord--ringing',
+                );
+              },
+            }
+          : reposition && nudgeCtx && isRealChord
             ? {
                 tabIndex: 0,
                 role: 'button' as const,
@@ -2180,7 +2253,13 @@ function LyricsLine({
                 />
               ) : (
                 <span
-                  className={isFocusedChord ? 'chord chord--selected' : 'chord'}
+                  className={
+                    audioEnabled
+                      ? 'chord chord--audio'
+                      : isFocusedChord
+                        ? 'chord chord--selected'
+                        : 'chord'
+                  }
                   style={chordStyle ?? undefined}
                   ref={isFocusedChord ? focusedSpanRef : undefined}
                   {...(chordDragProps ?? {})}
@@ -2887,6 +2966,14 @@ export interface RenderChordproAstOptions {
   chordSelection?: ChordSelection | null;
   /** Setter paired with {@link chordSelection}; see its docs. */
   setChordSelection?: (next: ChordSelection | null) => void;
+  /**
+   * Chord-audio config (#2650). When `enabled`, each rendered `.chord`
+   * becomes a play button that sounds the chord via `play`. Audio mode
+   * takes precedence over the click-to-nudge selection. `<ChordSheet>`
+   * wires this from its own `useChordAudio` hook when `chordAudio` is
+   * set; direct `renderChordproAst` callers supply their own.
+   */
+  chordAudio?: ChordAudioConfig | null;
 }
 
 /**
@@ -3793,6 +3880,9 @@ interface WalkContext {
    */
   chordSelection?: ChordSelection | null;
   setChordSelection?: (next: ChordSelection | null) => void;
+  /** Chord-audio config (#2650), forwarded from
+   * `RenderChordproAstOptions`. `null` keeps chords inert. */
+  chordAudio?: ChordAudioConfig | null;
   /**
    * Diagram state (visibility / mode / instrument / position) resolved
    * once over the whole song. The per-line chord-block renderer reads
@@ -4409,6 +4499,7 @@ function renderLine(ctx: WalkContext, line: ChordproLine, key: number): void {
                 defines: ctx.diagramDefines,
               }
             : null,
+          ctx.chordAudio,
         ),
         sourceLine,
         null,
@@ -4485,6 +4576,7 @@ export function renderChordproAst(
     onChordReposition: options.onChordReposition,
     chordSelection: options.chordSelection,
     setChordSelection: options.setChordSelection,
+    chordAudio: options.chordAudio ?? null,
     diagramsState: options.chordDiagrams ? resolveDiagramsState(song) : null,
     diagramDefines: options.chordDiagrams ? collectDefines(song) : undefined,
     chordDiagramsInstrument: options.chordDiagrams?.instrument,

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1618,8 +1618,20 @@ export interface ChordAudioConfig {
  * walker is stateless per chord) and removed on `animationend`; a forced
  * reflow between remove and re-add restarts the CSS animation when the
  * same chord is tapped again before the previous pulse finishes.
+ *
+ * When `prefers-reduced-motion: reduce` is active the function exits
+ * early rather than adding the class — the CSS suppresses the animation
+ * (`animation: none`) and `animationend` never fires, which would leave
+ * the class (crimson background, white text) on the element permanently.
  */
 function pulseChordElement(el: HTMLElement): void {
+  // Skip the visual pulse when the user prefers reduced motion. The audio
+  // still plays; only the animation feedback is suppressed. Without this
+  // guard, `animationend` never fires under `animation: none`, so the
+  // `.chord--ringing` highlight would stick on the element indefinitely.
+  if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+    return;
+  }
   el.classList.remove('chord--ringing');
   // Reading offsetWidth forces a synchronous reflow so the re-added
   // class starts a fresh animation rather than being coalesced away.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -55,12 +55,24 @@ export {
   METRONOME_MAX_BPM,
   type UseMetronomeResult,
 } from './use-metronome';
+// Chord-audio playback (#2650). `useChordAudio` turns a chord name into
+// sound via the core `chordPitches` export; `<ChordSheet chordAudio>`
+// and `<PreviewToolbar onChordAudioToggle>` wire the toolbar-toggle UX.
+export {
+  useChordAudio,
+  type UseChordAudioResult,
+  type ChordAudioWasmLoader,
+} from './use-chord-audio';
 
 // AST → JSX walker (#2475 / ADR-0017). Powers `<ChordSheet>`'s
 // `format="html"` branch — exposed at the package boundary so
 // custom consumers can drive their own React tree off the same
 // AST without the `<ChordSheet>` shell.
-export { renderChordproAst, type ChordSelection } from './chordpro-jsx';
+export {
+  renderChordproAst,
+  type ChordSelection,
+  type ChordAudioConfig,
+} from './chordpro-jsx';
 export {
   useChordproAst,
   type ChordproAstResult,

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -68,6 +68,24 @@ export interface PreviewToolbarProps
    * otherwise. Pass an explicit value to override the auto-default.
    */
   showChordDiagrams?: boolean;
+  /**
+   * Current chord-audio mode state (#2650). Enables the Audio group
+   * when paired with `onChordAudioToggle`. Omit (or pass without the
+   * handler) to hide the group entirely — hosts that don't want a chord
+   * playback control pay no extra DOM.
+   */
+  chordAudioEnabled?: boolean;
+  /**
+   * Fires with the next desired state when the user clicks the Audio
+   * toggle. The host owns the boolean and forwards it to
+   * `<ChordSheet chordAudio={…}>`.
+   */
+  onChordAudioToggle?: (next: boolean) => void;
+  /**
+   * Force-show / force-hide the Audio group. Defaults to `true` when
+   * `onChordAudioToggle` is provided, `false` otherwise.
+   */
+  showChordAudio?: boolean;
   /** Filename for the PDF download. Defaults to `chordsketch-output.pdf`. */
   exportFilename?: string;
   /**
@@ -87,6 +105,25 @@ export interface PreviewToolbarProps
    */
   trailing?: ReactNode;
 }
+
+const AUDIO_ICON = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+    <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+    <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+  </svg>
+);
 
 const EXPORT_ICON = (
   <svg
@@ -146,6 +183,9 @@ export function PreviewToolbar({
   chordDiagramsOrientation,
   onChordDiagramsOrientationChange,
   showChordDiagrams,
+  chordAudioEnabled,
+  onChordAudioToggle,
+  showChordAudio,
   trailing,
   className,
   ...divProps
@@ -154,6 +194,8 @@ export function PreviewToolbar({
   const diagramsEnabled =
     (showChordDiagrams ?? onChordDiagramsOrientationChange !== undefined) &&
     onChordDiagramsOrientationChange !== undefined;
+  const audioEnabled =
+    (showChordAudio ?? onChordAudioToggle !== undefined) && onChordAudioToggle !== undefined;
   const effectiveOrientation: ChordDiagramOrientation =
     chordDiagramsOrientation ?? 'vertical';
   const wrapperClass = [
@@ -226,6 +268,31 @@ export function PreviewToolbar({
             <option value="vertical">Vertical (nut top)</option>
             <option value="horizontal">Horizontal (nut left)</option>
           </select>
+        </div>
+      ) : null}
+      {audioEnabled ? (
+        <div
+          className="chordsketch-preview-toolbar__group tool-group chordsketch-preview-toolbar__group--audio"
+          role="group"
+          aria-label="Chord audio"
+        >
+          <span
+            className="chordsketch-preview-toolbar__label label"
+            aria-hidden="true"
+          >
+            Audio
+          </span>
+          <button
+            type="button"
+            className="chordsketch-preview-toolbar__audio-toggle btn btn-secondary btn-sm"
+            aria-pressed={Boolean(chordAudioEnabled)}
+            aria-label="Play chords on click"
+            title="Play chords on click"
+            onClick={() => onChordAudioToggle!(!chordAudioEnabled)}
+          >
+            {AUDIO_ICON}
+            <span>Chord audio</span>
+          </button>
         </div>
       ) : null}
       {showExport ? (

--- a/packages/react/src/renderer-preview.tsx
+++ b/packages/react/src/renderer-preview.tsx
@@ -2,6 +2,7 @@ import type { HTMLAttributes, ReactNode } from 'react';
 
 import { ChordSheet } from './chord-sheet';
 import type { ChordSelection } from './chordpro-jsx';
+import type { ChordAudioWasmLoader } from './use-chord-audio';
 import { PdfExport } from './pdf-export';
 import type {
   ChordDeleteTarget,
@@ -95,6 +96,20 @@ export interface RendererPreviewProps extends Omit<HTMLAttributes<HTMLDivElement
   /** Setter paired with {@link chordSelection}; see its docs. */
   onChordSelectionChange?: (selection: ChordSelection | null) => void;
   /**
+   * Enable chord-audio mode (#2650). Forwarded to {@link ChordSheet};
+   * see `ChordSheetProps.chordAudio`. When `true`, each chord becomes a
+   * play button (Web Audio block chord). Only consumed by
+   * `format="html"`; degrades to inert chords without Web Audio support.
+   */
+  chordAudio?: boolean;
+  /**
+   * Test-only WASM loader override for the chord-audio hook. Forwarded
+   * to {@link ChordSheet}; production callers never supply this.
+   *
+   * @internal
+   */
+  chordAudioLoader?: ChordAudioWasmLoader;
+  /**
    * Optional content rendered while the wasm runtime is initialising.
    *
    * Only honoured by the inline `html` / `text` branches — the
@@ -162,6 +177,8 @@ export function RendererPreview({
   onChordDelete,
   chordSelection,
   onChordSelectionChange,
+  chordAudio,
+  chordAudioLoader,
   loadingFallback,
   errorFallback,
   wasmLoader,
@@ -204,6 +221,8 @@ export function RendererPreview({
       onChordDelete={onChordDelete}
       chordSelection={chordSelection}
       onChordSelectionChange={onChordSelectionChange}
+      chordAudio={chordAudio}
+      chordAudioLoader={chordAudioLoader}
       loadingFallback={loadingFallback}
       errorFallback={errorFallback}
       wasmLoader={wasmLoader}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1505,6 +1505,46 @@
   box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
 }
 
+/* ---- Chord audio (#2650) -------------------------------------- */
+/* In chord-audio mode each chord is a play button. Hover/focus give a
+   speaker affordance; activating one briefly pulses the `.chord--ringing`
+   class (added imperatively by the walker, removed on animationend). */
+.chordsketch-sheet__content .chord--audio {
+  cursor: pointer;
+  border-radius: var(--cs-r-2, 4px);
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+.chordsketch-sheet__content .chord--audio:hover {
+  background: var(--cs-crimson-50, #fdf2f5);
+}
+.chordsketch-sheet__content .chord--audio:focus-visible {
+  outline: none;
+  box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
+}
+.chordsketch-sheet__content .chord--ringing {
+  background: var(--cs-crimson-500, #bd1642);
+  color: var(--cs-fg-on-crimson, #fff);
+  animation: cs-chord-pulse 0.45s ease;
+}
+@keyframes cs-chord-pulse {
+  0% {
+    transform: scale(1);
+  }
+  30% {
+    transform: scale(1.16);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chordsketch-sheet__content .chord--ringing {
+    animation: none;
+  }
+}
+
 /* ---- Chord-editor footer (#2622, #2644) ----------------------- */
 /* The design-system-styled chord editor panel. The component rules are
    ancestor-agnostic so the SAME markup renders in two contexts:

--- a/packages/react/src/use-chord-audio.ts
+++ b/packages/react/src/use-chord-audio.ts
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { getAudioContextCtor, getSharedAudioContext } from './audio-context';
+
+// ---- Voicing / envelope tuning ---------------------------------
+// A block chord is several oscillators started at once. The total
+// peak gain is divided across the voices so a six-note chord does not
+// clip; a short attack avoids the click a hard onset would make, and a
+// long exponential release lets the chord ring and decay naturally.
+const ATTACK_S = 0.008;
+const RELEASE_S = 1.4;
+const PEAK_GAIN = 0.22;
+
+/**
+ * Minimal structural view of the `@chordsketch/wasm` surface this hook
+ * touches. Kept structural (not an import of the wasm glue types) so the
+ * React package does not drag the wasm module into its type graph — the
+ * module is dynamically imported at runtime. Mirrors the
+ * `chordPitches` export added in #2650.
+ */
+interface ChordPitchesModule {
+  default: () => Promise<unknown>;
+  /**
+   * MIDI note numbers for a block voicing of `chord`, or `undefined`
+   * when the string is not parseable as a chord. Sister to
+   * `chordsketch_chordpro::chord_pitches`.
+   */
+  chordPitches: (chord: string) => Uint8Array | null | undefined;
+}
+
+/**
+ * WASM loader injected by tests. Production callers take the default,
+ * which lazy-loads `@chordsketch/wasm`.
+ *
+ * @internal
+ */
+export type ChordAudioWasmLoader = () => Promise<ChordPitchesModule>;
+
+// Two-step cast through `unknown` — the wasm module's generated types,
+// resolved against the JS bundle host bundlers see, do not formally
+// include `chordPitches`'s typed signature even though the export is
+// present at runtime. The `ChordPitchesModule` shape models the runtime
+// contract; the runtime test against a stubbed loader is what guards it.
+const defaultLoader: ChordAudioWasmLoader = () =>
+  import('@chordsketch/wasm') as unknown as Promise<ChordPitchesModule>;
+
+/** MIDI note number → frequency in Hz (A4 = MIDI 69 = 440 Hz). */
+function midiToFreq(midi: number): number {
+  return 440 * 2 ** ((midi - 69) / 12);
+}
+
+/** Result of {@link useChordAudio}. */
+export interface UseChordAudioResult {
+  /**
+   * Whether the Web Audio API is available in the current environment.
+   * `false` under SSR or in a browser without `AudioContext`; callers
+   * should fall back to a non-interactive presentation rather than
+   * rendering a dead control.
+   */
+  readonly supported: boolean;
+  /**
+   * Play the named chord (e.g. `"Am7"`, `"C/G"`) as a block chord. A
+   * no-op when Web Audio is unavailable, the wasm module has not
+   * finished loading, or the name is not a parseable chord. Playing a
+   * new chord cuts any chord still ringing so rapid taps retrigger
+   * cleanly.
+   */
+  play: (chordName: string) => void;
+  /** Silence any currently-ringing chord. Safe to call when silent. */
+  stop: () => void;
+}
+
+/**
+ * Audition a single chord through the Web Audio API.
+ *
+ * The chord's constituent pitches are computed by
+ * `@chordsketch/wasm`'s `chordPitches` export (sister to
+ * `chordsketch_chordpro::chord_pitches`) — the musical-theory source of
+ * truth lives in the core library, not here (see
+ * `.claude/rules/playground-is-a-sample.md`). This hook only turns those
+ * MIDI note numbers into sound, sharing the page-level `AudioContext`
+ * with {@link useMetronome} via `audio-context.ts`.
+ *
+ * The wasm module is preloaded on mount so {@link UseChordAudioResult.play}
+ * can run synchronously inside the click / keydown gesture that browser
+ * autoplay policies require.
+ *
+ * @example
+ * ```tsx
+ * const audio = useChordAudio();
+ * return (
+ *   <button onClick={() => audio.play('Am7')} disabled={!audio.supported}>
+ *     Play Am7
+ *   </button>
+ * );
+ * ```
+ */
+export function useChordAudio(
+  loader: ChordAudioWasmLoader = defaultLoader,
+): UseChordAudioResult {
+  const supported = useMemo(() => getAudioContextCtor() !== null, []);
+
+  const moduleRef = useRef<ChordPitchesModule | null>(null);
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+
+  // Per-name pitch cache: `chordPitches` is deterministic, so a chord
+  // tapped repeatedly is computed once.
+  const pitchCacheRef = useRef<Map<string, number[]>>(new Map());
+
+  // Oscillators currently scheduled / sounding, tracked so `stop` (and
+  // unmount) can silence them and a retrigger does not stack voices.
+  const voicesRef = useRef<Set<OscillatorNode>>(new Set());
+
+  // Preload the wasm module so `play` can resolve pitches synchronously
+  // inside the user gesture. If the load fails, `moduleRef` stays null
+  // and `play` is a no-op rather than throwing.
+  useEffect(() => {
+    if (!supported) return undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const mod = await loaderRef.current();
+        await mod.default();
+        if (!cancelled) moduleRef.current = mod;
+      } catch {
+        // Leave moduleRef null; play() degrades to a no-op.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [supported]);
+
+  const stop = useCallback(() => {
+    for (const osc of voicesRef.current) {
+      try {
+        osc.stop();
+      } catch {
+        // Already stopped / ended.
+      }
+    }
+    voicesRef.current.clear();
+  }, []);
+
+  const play = useCallback(
+    (chordName: string) => {
+      const mod = moduleRef.current;
+      const ctx = getSharedAudioContext();
+      if (!ctx || !mod) return;
+      // A context left 'suspended' by the autoplay policy stays silent
+      // until resumed; this play() call is the authorising user gesture.
+      if (ctx.state === 'suspended') {
+        void ctx.resume();
+      }
+
+      let pitches = pitchCacheRef.current.get(chordName);
+      if (!pitches) {
+        const raw = mod.chordPitches(chordName);
+        pitches = raw ? Array.from(raw) : [];
+        pitchCacheRef.current.set(chordName, pitches);
+      }
+      if (pitches.length === 0) return;
+
+      // Cut any chord still ringing so a fresh tap retriggers cleanly.
+      stop();
+
+      const now = ctx.currentTime;
+      const perVoice = PEAK_GAIN / pitches.length;
+      const tracked = voicesRef.current;
+      for (const midi of pitches) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(midiToFreq(midi), now);
+        // Soft attack then exponential decay toward (but not to) zero —
+        // Web Audio's exponentialRampToValueAtTime rejects a 0 target.
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.exponentialRampToValueAtTime(perVoice, now + ATTACK_S);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + RELEASE_S);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(now);
+        osc.stop(now + RELEASE_S + 0.05);
+        tracked.add(osc);
+        osc.onended = () => {
+          tracked.delete(osc);
+          try {
+            osc.disconnect();
+            gain.disconnect();
+          } catch {
+            // Nodes may already be disconnected if `stop` raced ahead.
+          }
+        };
+      }
+    },
+    [stop],
+  );
+
+  // Silence on unmount; the shared context is intentionally NOT closed
+  // (other live hooks reuse it for the page lifetime).
+  useEffect(() => () => stop(), [stop]);
+
+  return { supported, play, stop };
+}

--- a/packages/react/src/use-chord-audio.ts
+++ b/packages/react/src/use-chord-audio.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { getAudioContextCtor, getSharedAudioContext } from './audio-context';
+import {
+  getAudioContextCtor,
+  getSharedAudioContext,
+  scheduleVoice,
+} from './audio-context';
 
 // ---- Voicing / envelope tuning ---------------------------------
 // A block chord is several oscillators started at once. The total
@@ -81,9 +85,11 @@ export interface UseChordAudioResult {
  * MIDI note numbers into sound, sharing the page-level `AudioContext`
  * with {@link useMetronome} via `audio-context.ts`.
  *
- * The wasm module is preloaded on mount so {@link UseChordAudioResult.play}
- * can run synchronously inside the click / keydown gesture that browser
- * autoplay policies require.
+ * The wasm module is preloaded so {@link UseChordAudioResult.play} can run
+ * synchronously inside the click / keydown gesture that browser autoplay
+ * policies require. Pass `enabled = false` to defer that import until the
+ * consumer actually turns chord audio on (the hook is still called
+ * unconditionally, per the rules of hooks).
  *
  * @example
  * ```tsx
@@ -97,6 +103,7 @@ export interface UseChordAudioResult {
  */
 export function useChordAudio(
   loader: ChordAudioWasmLoader = defaultLoader,
+  enabled = true,
 ): UseChordAudioResult {
   const supported = useMemo(() => getAudioContextCtor() !== null, []);
 
@@ -113,10 +120,12 @@ export function useChordAudio(
   const voicesRef = useRef<Set<OscillatorNode>>(new Set());
 
   // Preload the wasm module so `play` can resolve pitches synchronously
-  // inside the user gesture. If the load fails, `moduleRef` stays null
-  // and `play` is a no-op rather than throwing.
+  // inside the user gesture. Gated on `enabled` so a `<ChordSheet>` that
+  // never turns chord audio on does not pay the import; the load fires
+  // the first time a consumer enables the feature. If the load fails,
+  // `moduleRef` stays null and `play` is a no-op rather than throwing.
   useEffect(() => {
-    if (!supported) return undefined;
+    if (!supported || !enabled) return undefined;
     let cancelled = false;
     void (async () => {
       try {
@@ -130,7 +139,7 @@ export function useChordAudio(
     return () => {
       cancelled = true;
     };
-  }, [supported]);
+  }, [supported, enabled]);
 
   const stop = useCallback(() => {
     for (const osc of voicesRef.current) {
@@ -166,32 +175,21 @@ export function useChordAudio(
       stop();
 
       const now = ctx.currentTime;
+      // Divide the peak across the voices so a six-note chord does not
+      // clip; a soft attack avoids a click and the long release lets the
+      // chord ring. The shared `scheduleVoice` owns the node graph +
+      // cleanup (sister to the metronome's tick scheduling).
       const perVoice = PEAK_GAIN / pitches.length;
-      const tracked = voicesRef.current;
       for (const midi of pitches) {
-        const osc = ctx.createOscillator();
-        const gain = ctx.createGain();
-        osc.type = 'triangle';
-        osc.frequency.setValueAtTime(midiToFreq(midi), now);
-        // Soft attack then exponential decay toward (but not to) zero —
-        // Web Audio's exponentialRampToValueAtTime rejects a 0 target.
-        gain.gain.setValueAtTime(0.0001, now);
-        gain.gain.exponentialRampToValueAtTime(perVoice, now + ATTACK_S);
-        gain.gain.exponentialRampToValueAtTime(0.0001, now + RELEASE_S);
-        osc.connect(gain);
-        gain.connect(ctx.destination);
-        osc.start(now);
-        osc.stop(now + RELEASE_S + 0.05);
-        tracked.add(osc);
-        osc.onended = () => {
-          tracked.delete(osc);
-          try {
-            osc.disconnect();
-            gain.disconnect();
-          } catch {
-            // Nodes may already be disconnected if `stop` raced ahead.
-          }
-        };
+        scheduleVoice(ctx, voicesRef.current, {
+          type: 'triangle',
+          frequency: midiToFreq(midi),
+          startTime: now,
+          attack: ATTACK_S,
+          release: RELEASE_S,
+          peak: perVoice,
+          tail: 0.05,
+        });
       }
     },
     [stop],

--- a/packages/react/src/use-metronome.ts
+++ b/packages/react/src/use-metronome.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import {
+  getAudioContextCtor,
+  getSharedAudioContext,
+  resetSharedAudioContextForTests,
+} from './audio-context';
+
 /**
  * Lowest / highest BPM the metronome will tick at. Values outside
  * this range are clamped rather than rejected so a typo'd
@@ -66,62 +72,33 @@ export interface UseMetronomeResult {
   isRunning: () => boolean;
 }
 
-type AudioContextCtor = new () => AudioContext;
-
 /** Per-instance handle the module-level coordinator can stop. */
 interface MetronomeController {
   stop: () => void;
 }
 
-// ---- Page-level shared audio resources -------------------------
-// A page should use a single AudioContext: browsers cap concurrent
-// contexts, and a song with several `{tempo}` chips would otherwise
-// spawn one context per chip. A module-level coordinator also
-// guarantees that starting one metronome stops any other so two
-// chips never tick over each other. The context is created lazily
-// on the first user gesture and lives for the page lifetime (the
-// recommended Web Audio pattern — it is suspended, not closed, when
-// idle, so it is cheap to keep around).
+// ---- Page-level single-active coordination ---------------------
+// The shared `AudioContext` itself lives in `audio-context.ts` so it
+// is reused across every audio hook in the package. A module-level
+// coordinator here additionally guarantees that starting one
+// metronome stops any other, so two `{tempo}` chips never tick over
+// each other.
 
-let sharedContext: AudioContext | null = null;
 let activeController: MetronomeController | null = null;
-
-/**
- * Resolve the platform `AudioContext` constructor, tolerating the
- * legacy `webkitAudioContext` prefix. Returns `null` under SSR or
- * when neither is present so callers can branch on support.
- */
-function getAudioContextCtor(): AudioContextCtor | null {
-  if (typeof window === 'undefined') return null;
-  const w = window as typeof window & {
-    webkitAudioContext?: AudioContextCtor;
-  };
-  return w.AudioContext ?? w.webkitAudioContext ?? null;
-}
-
-/**
- * Lazily create (or reuse) the shared `AudioContext`. Returns `null`
- * when Web Audio is unavailable.
- */
-function getSharedContext(): AudioContext | null {
-  if (sharedContext && sharedContext.state !== 'closed') return sharedContext;
-  const Ctor = getAudioContextCtor();
-  if (!Ctor) return null;
-  sharedContext = new Ctor();
-  return sharedContext;
-}
 
 /**
  * Reset the module-level shared audio state.
  *
  * **Test-only** — not re-exported from the package index. Lets each
  * test start from a clean singleton after swapping the
- * `window.AudioContext` stub.
+ * `window.AudioContext` stub. Resets both the shared `AudioContext`
+ * (owned by `audio-context.ts`) and the metronome's single-active
+ * coordinator.
  *
  * @internal
  */
 export function resetMetronomeSharedStateForTests(): void {
-  sharedContext = null;
+  resetSharedAudioContextForTests();
   activeController = null;
 }
 
@@ -217,7 +194,7 @@ export function useMetronome(): UseMetronomeResult {
 
   const start = useCallback(
     (bpm: number) => {
-      const ctx = getSharedContext();
+      const ctx = getSharedAudioContext();
       if (!ctx) return;
       // A context left 'suspended' by the autoplay policy stays
       // silent until resumed; the `start` call is the authorising

--- a/packages/react/src/use-metronome.ts
+++ b/packages/react/src/use-metronome.ts
@@ -4,6 +4,7 @@ import {
   getAudioContextCtor,
   getSharedAudioContext,
   resetSharedAudioContextForTests,
+  scheduleVoice,
 } from './audio-context';
 
 /**
@@ -143,30 +144,20 @@ export function useMetronome(): UseMetronomeResult {
   const supported = useMemo(() => getAudioContextCtor() !== null, []);
 
   const scheduleTick = useCallback((ctx: AudioContext, time: number) => {
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'square';
-    osc.frequency.setValueAtTime(TICK_FREQUENCY_HZ, time);
-    // Percussive envelope: jump to peak at the tick onset, then
-    // decay exponentially toward (but never to) zero — Web Audio's
-    // `exponentialRampToValueAtTime` rejects a 0 target.
-    gain.gain.setValueAtTime(TICK_PEAK_GAIN, time);
-    gain.gain.exponentialRampToValueAtTime(0.0001, time + TICK_DURATION_S);
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start(time);
-    osc.stop(time + TICK_DURATION_S);
-    const tracked = oscillatorsRef.current;
-    tracked.add(osc);
-    osc.onended = () => {
-      tracked.delete(osc);
-      try {
-        osc.disconnect();
-        gain.disconnect();
-      } catch {
-        // Nodes may already be disconnected if `stop` raced ahead.
-      }
-    };
+    // Percussive square-wave blip: `attack: 0` jumps to the peak at the
+    // tick onset, then decays over `TICK_DURATION_S`; `tail: 0` stops the
+    // oscillator exactly at the decay end so the click stays tight. The
+    // shared `scheduleVoice` tracks the node in `oscillatorsRef` and wires
+    // the same `onended` cleanup `useChordAudio` relies on.
+    scheduleVoice(ctx, oscillatorsRef.current, {
+      type: 'square',
+      frequency: TICK_FREQUENCY_HZ,
+      startTime: time,
+      attack: 0,
+      release: TICK_DURATION_S,
+      peak: TICK_PEAK_GAIN,
+      tail: 0,
+    });
   }, []);
 
   const stop = useCallback(() => {

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, test, vi } from 'vitest';
 import { ChordSheet } from '../src/index';
 import type { ChordWasmLoader } from '../src/use-chord-render';
 import type { ChordproWasmLoader } from '../src/use-chordpro-ast';
+import { resetSharedAudioContextForTests } from '../src/audio-context';
+import type { ChordAudioWasmLoader } from '../src/use-chord-audio';
 
 // Stub renderer surface — covers BOTH the AST → JSX path
 // (parseChordproWithWarnings* used by `format="html"`
@@ -970,5 +972,94 @@ describe('<ChordSheet>', () => {
     // scrolling song content (so it sits below the song, not over it).
     expect(wrapper?.contains(inspector ?? null)).toBe(true);
     expect(content?.contains(inspector ?? null)).toBe(false);
+  });
+
+  // ---- Chord audio (#2650) ---------------------------------------
+
+  // Minimal Web Audio stand-in; the hook only needs the constructor to
+  // exist for `supported` and a no-op graph for `play`.
+  class FakeAudioContext {
+    state = 'running';
+    currentTime = 0;
+    destination = {};
+    resume = vi.fn(() => Promise.resolve());
+    createOscillator = vi.fn(() => ({
+      type: '',
+      onended: null,
+      frequency: { setValueAtTime: vi.fn() },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    }));
+    createGain = vi.fn(() => ({
+      gain: { setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+  }
+
+  const chordAudioLoader: ChordAudioWasmLoader = () =>
+    Promise.resolve({
+      default: () => Promise.resolve(),
+      chordPitches: (chord: string) =>
+        chord === 'Am' ? new Uint8Array([57, 60, 64]) : undefined,
+    });
+
+  test('chordAudio prop turns chords into play buttons when Web Audio is supported', async () => {
+    const original = (globalThis as { AudioContext?: unknown }).AudioContext;
+    (window as unknown as { AudioContext: unknown }).AudioContext = FakeAudioContext;
+    resetSharedAudioContextForTests();
+    try {
+      const { container } = render(
+        <ChordSheet
+          source="[Am]hi"
+          chordAudio
+          chordAudioLoader={chordAudioLoader}
+          astWasmLoader={makeAstLoader(chordNamedStub('Am'))}
+        />,
+      );
+      await waitFor(() =>
+        expect(container.querySelector('.chord--audio')).not.toBeNull(),
+      );
+      const chord = container.querySelector('.chord--audio') as HTMLElement;
+      expect(chord.getAttribute('role')).toBe('button');
+      expect(chord.getAttribute('aria-label')).toBe('Play chord Am');
+      // Clicking must not throw even before the wasm module resolves.
+      fireEvent.click(chord);
+    } finally {
+      if (original === undefined) {
+        delete (window as unknown as { AudioContext?: unknown }).AudioContext;
+      } else {
+        (window as unknown as { AudioContext: unknown }).AudioContext = original;
+      }
+      resetSharedAudioContextForTests();
+    }
+  });
+
+  test('chordAudio degrades to inert chords without Web Audio support', async () => {
+    const original = (globalThis as { AudioContext?: unknown }).AudioContext;
+    delete (window as unknown as { AudioContext?: unknown }).AudioContext;
+    resetSharedAudioContextForTests();
+    try {
+      const { container } = render(
+        <ChordSheet
+          source="[Am]hi"
+          chordAudio
+          chordAudioLoader={chordAudioLoader}
+          astWasmLoader={makeAstLoader(chordNamedStub('Am'))}
+        />,
+      );
+      await waitFor(() =>
+        expect(container.querySelector('.chord')).not.toBeNull(),
+      );
+      // No Web Audio ⇒ audio mode is suppressed; chords stay plain.
+      expect(container.querySelector('.chord--audio')).toBeNull();
+    } finally {
+      if (original !== undefined) {
+        (window as unknown as { AudioContext: unknown }).AudioContext = original;
+      }
+      resetSharedAudioContextForTests();
+    }
   });
 });

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -4252,5 +4252,65 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     // Sanity: the grid that justifies the modifier really is present.
     expect(section.container.querySelector('.chord-diagrams')).not.toBeNull();
   });
+
+  // ---- Chord audio (#2650) ---------------------------------------
+
+  const chordLineSong = (): ChordproSong => ({
+    metadata: EMPTY_META,
+    lines: [
+      {
+        kind: 'lyrics',
+        value: {
+          segments: [
+            {
+              chord: { name: 'Am7', detail: null, display: null },
+              text: 'hello',
+              spans: [],
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  test('chord-audio mode makes the chord a play button that calls play with the raw name', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(chordLineSong(), {
+        chordAudio: { enabled: true, play },
+      }),
+    );
+    const chord = container.querySelector('.chord--audio') as HTMLElement;
+    expect(chord).not.toBeNull();
+    expect(chord.getAttribute('role')).toBe('button');
+    expect(chord.getAttribute('aria-label')).toBe('Play chord Am7');
+    expect(chord.getAttribute('data-chord')).toBe('Am7');
+    expect(chord.tabIndex).toBe(0);
+
+    fireEvent.click(chord);
+    expect(play).toHaveBeenCalledWith('Am7');
+
+    // Enter / Space activate from the keyboard; an unrelated key does not.
+    fireEvent.keyDown(chord, { key: 'Enter' });
+    fireEvent.keyDown(chord, { key: ' ' });
+    fireEvent.keyDown(chord, { key: 'a' });
+    expect(play).toHaveBeenCalledTimes(3);
+  });
+
+  test('chords stay inert when chord-audio is disabled or absent', () => {
+    const play = vi.fn();
+    const disabled = render(
+      renderChordproAst(chordLineSong(), {
+        chordAudio: { enabled: false, play },
+      }),
+    );
+    expect(disabled.container.querySelector('.chord--audio')).toBeNull();
+    const chord = disabled.container.querySelector('.chord') as HTMLElement;
+    fireEvent.click(chord);
+    expect(play).not.toHaveBeenCalled();
+
+    const absent = render(renderChordproAst(chordLineSong()));
+    expect(absent.container.querySelector('.chord--audio')).toBeNull();
+  });
 });
 

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -4312,5 +4312,50 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     const absent = render(renderChordproAst(chordLineSong()));
     expect(absent.container.querySelector('.chord--audio')).toBeNull();
   });
+
+  test('chord--ringing class is NOT added under prefers-reduced-motion (prevents stuck highlight)', () => {
+    // Regression test for the bug where `animation: none` from the
+    // reduced-motion media query prevents `animationend` from firing,
+    // which would leave .chord--ringing (crimson background) on the
+    // element permanently after any click.
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+
+    try {
+      const play = vi.fn();
+      const { container } = render(
+        renderChordproAst(chordLineSong(), {
+          chordAudio: { enabled: true, play },
+        }),
+      );
+      const chord = container.querySelector('.chord--audio') as HTMLElement;
+      expect(chord).not.toBeNull();
+
+      fireEvent.click(chord);
+
+      // play() was invoked (audio still plays) but the ringing class was
+      // NOT added — pulseChordElement exits early under reduced motion so
+      // the stuck-highlight bug cannot occur.
+      expect(play).toHaveBeenCalledWith('Am7');
+      expect(chord.classList.contains('chord--ringing')).toBe(false);
+    } finally {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
 });
 

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -143,6 +143,54 @@ describe('<PreviewToolbar>', () => {
     expect(screen.getByRole('group', { name: 'Transpose' })).toBeTruthy();
   });
 
+  test('Audio group is hidden by default and shown when onChordAudioToggle is provided', () => {
+    const { rerender } = render(
+      <PreviewToolbar source={SAMPLE} transpose={0} onTransposeChange={vi.fn()} />,
+    );
+    expect(screen.queryByRole('group', { name: 'Chord audio' })).toBeNull();
+
+    rerender(
+      <PreviewToolbar
+        source={SAMPLE}
+        transpose={0}
+        onTransposeChange={vi.fn()}
+        onChordAudioToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('group', { name: 'Chord audio' })).toBeTruthy();
+  });
+
+  test('Audio toggle reflects state and reports the next value on click', () => {
+    const onChordAudioToggle = vi.fn();
+    const { rerender } = render(
+      <PreviewToolbar
+        source={SAMPLE}
+        transpose={0}
+        onTransposeChange={vi.fn()}
+        chordAudioEnabled={false}
+        onChordAudioToggle={onChordAudioToggle}
+      />,
+    );
+    const toggle = screen.getByRole('button', { name: 'Play chords on click' });
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(toggle);
+    expect(onChordAudioToggle).toHaveBeenCalledWith(true);
+
+    rerender(
+      <PreviewToolbar
+        source={SAMPLE}
+        transpose={0}
+        onTransposeChange={vi.fn()}
+        chordAudioEnabled
+        onChordAudioToggle={onChordAudioToggle}
+      />,
+    );
+    const pressed = screen.getByRole('button', { name: 'Play chords on click' });
+    expect(pressed.getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(pressed);
+    expect(onChordAudioToggle).toHaveBeenLastCalledWith(false);
+  });
+
   test('per-group opt-out: showTranspose/showExport=false', () => {
     render(
       <PreviewToolbar

--- a/packages/react/tests/use-chord-audio.test.ts
+++ b/packages/react/tests/use-chord-audio.test.ts
@@ -1,0 +1,176 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { resetSharedAudioContextForTests } from '../src/audio-context';
+import {
+  type ChordAudioWasmLoader,
+  useChordAudio,
+} from '../src/use-chord-audio';
+
+// ---- Web Audio API stand-ins -----------------------------------
+// jsdom ships no Web Audio API, so the hook is exercised against a
+// minimal fake that records the graph operations `play` performs.
+
+class FakeOscillator {
+  type = '';
+  onended: (() => void) | null = null;
+  frequency = { setValueAtTime: vi.fn() };
+  connect = vi.fn();
+  disconnect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+class FakeGain {
+  gain = {
+    setValueAtTime: vi.fn(),
+    exponentialRampToValueAtTime: vi.fn(),
+  };
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = [];
+  state: 'suspended' | 'running' | 'closed' = 'running';
+  currentTime = 0;
+  destination = {};
+  oscillators: FakeOscillator[] = [];
+  resume = vi.fn(() => {
+    this.state = 'running';
+    return Promise.resolve();
+  });
+  createOscillator = vi.fn(() => {
+    const osc = new FakeOscillator();
+    this.oscillators.push(osc);
+    return osc;
+  });
+  createGain = vi.fn(() => new FakeGain());
+  constructor() {
+    FakeAudioContext.instances.push(this);
+  }
+}
+
+// A C major triad / Am7 chord lookup, mirroring `chord_pitches`.
+const fakePitches = vi.fn((chord: string): Uint8Array | undefined => {
+  switch (chord) {
+    case 'C':
+      return new Uint8Array([48, 52, 55]);
+    case 'Am7':
+      return new Uint8Array([57, 60, 64, 67]);
+    case 'xyz':
+      return undefined;
+    default:
+      return undefined;
+  }
+});
+
+const defaultFn = vi.fn(() => Promise.resolve());
+const makeLoader = (): ChordAudioWasmLoader => () =>
+  Promise.resolve({ default: defaultFn, chordPitches: fakePitches });
+
+const originalAudioContext = (globalThis as { AudioContext?: unknown }).AudioContext;
+
+beforeEach(() => {
+  FakeAudioContext.instances = [];
+  resetSharedAudioContextForTests();
+  fakePitches.mockClear();
+  defaultFn.mockClear();
+  (window as unknown as { AudioContext: unknown }).AudioContext = FakeAudioContext;
+});
+
+afterEach(() => {
+  resetSharedAudioContextForTests();
+  if (originalAudioContext === undefined) {
+    delete (window as unknown as { AudioContext?: unknown }).AudioContext;
+  } else {
+    (window as unknown as { AudioContext: unknown }).AudioContext = originalAudioContext;
+  }
+});
+
+/** Render the hook and wait for its on-mount wasm preload to resolve. */
+async function renderLoaded(loader = makeLoader()) {
+  const rendered = renderHook(() => useChordAudio(loader));
+  await waitFor(() => expect(defaultFn).toHaveBeenCalled());
+  // One extra microtask flush so `moduleRef` is assigned after the
+  // second await inside the preload effect.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return rendered;
+}
+
+describe('useChordAudio', () => {
+  test('reports support when AudioContext is present', () => {
+    const { result } = renderHook(() => useChordAudio(makeLoader()));
+    expect(result.current.supported).toBe(true);
+  });
+
+  test('reports no support and play is a no-op without AudioContext', () => {
+    delete (window as unknown as { AudioContext?: unknown }).AudioContext;
+    const { result } = renderHook(() => useChordAudio(makeLoader()));
+    expect(result.current.supported).toBe(false);
+    // Must not throw even though no module / context exists.
+    act(() => result.current.play('C'));
+    expect(FakeAudioContext.instances).toHaveLength(0);
+  });
+
+  test('play schedules one oscillator per pitch with correct frequencies', async () => {
+    const { result } = await renderLoaded();
+    act(() => result.current.play('C'));
+
+    const ctx = FakeAudioContext.instances[0]!;
+    expect(ctx.oscillators).toHaveLength(3);
+    for (const osc of ctx.oscillators) {
+      expect(osc.type).toBe('triangle');
+      expect(osc.start).toHaveBeenCalled();
+      expect(osc.stop).toHaveBeenCalled();
+    }
+    // C3 = MIDI 48 ⇒ ~130.81 Hz; the highest tone G3 = MIDI 55.
+    const freqs = ctx.oscillators.map(
+      (o) => (o.frequency.setValueAtTime.mock.calls[0]?.[0] as number) ?? 0,
+    );
+    expect(freqs[0]).toBeCloseTo(130.81, 1);
+    expect(freqs[2]).toBeCloseTo(196.0, 1);
+  });
+
+  test('play on an unparseable chord schedules nothing', async () => {
+    const { result } = await renderLoaded();
+    act(() => result.current.play('xyz'));
+    // The shared context may have been created, but no voice sounds.
+    const ctx = FakeAudioContext.instances[0];
+    expect(ctx?.oscillators ?? []).toHaveLength(0);
+  });
+
+  test('repeated plays of the same chord look it up once (cache)', async () => {
+    const { result } = await renderLoaded();
+    act(() => result.current.play('Am7'));
+    act(() => result.current.play('Am7'));
+    expect(fakePitches).toHaveBeenCalledTimes(1);
+  });
+
+  test('a new play cuts the previously ringing chord', async () => {
+    const { result } = await renderLoaded();
+    act(() => result.current.play('C'));
+    const ctx = FakeAudioContext.instances[0]!;
+    const firstVoices = [...ctx.oscillators];
+    act(() => result.current.play('Am7'));
+    // The first chord's oscillators were stopped before the new chord.
+    for (const osc of firstVoices) {
+      expect(osc.stop).toHaveBeenCalled();
+    }
+    // 3 (C) + 4 (Am7) oscillators created in total.
+    expect(ctx.oscillators).toHaveLength(7);
+  });
+
+  test('stop silences all ringing voices', async () => {
+    const { result } = await renderLoaded();
+    act(() => result.current.play('Am7'));
+    const ctx = FakeAudioContext.instances[0]!;
+    const voices = [...ctx.oscillators];
+    act(() => result.current.stop());
+    for (const osc of voices) {
+      expect(osc.stop).toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a per-chord audition feature to the React ChordPro preview. In "chord audio" mode, clicking (or Enter/Space on) a rendered chord plays its constituent pitches as a block chord via the Web Audio API.

- **Core (`chordsketch-chordpro`)**: new public `chord_pitches(chord_name) -> Option<Vec<u8>>` returning the MIDI note numbers of a chord's block voicing (root, third, fifth, plus extension / altered / added tones, with a slash bass dropped one octave below the root), reusing the existing `parse_chord` infrastructure. It is independent of the instrument-specific voicing database, so it covers every parseable chord.
- **Bindings**: exposed across all three bindings — wasm `chordPitches` (`Uint8Array | undefined`), napi `chordPitches` (`Buffer | null`), ffi `chord_pitches` (`sequence<u8>?`) — each with a pure-Rust core, native unit tests, and a README API entry.
- **`@chordsketch/react`**: new `useChordAudio` hook synthesising the core's MIDI notes; the page-level `AudioContext` is extracted into `audio-context.ts` so `useMetronome` and `useChordAudio` share a single context. The AST→JSX walker turns chords into play buttons in audio mode (`role="button"`, `aria-label`, keyboard activation, a pulse animation, `data-chord`), taking precedence over click-to-nudge selection and suppressing drag wiring. `<ChordSheet chordAudio>` / `<RendererPreview chordAudio>` wire it; `<PreviewToolbar onChordAudioToggle>` adds the toggle. Degrades to inert chords without Web Audio support / under SSR.
- **Playground + smoke**: toolbar toggle wired into the ChordPro playground; a Playwright smoke exercises the toggle + chord activation.

## Why

The chord name → constituent pitches mapping is musical-theory logic that belongs in the core library, not the React layer (`playground-is-a-sample.md`). Exposing it through every binding keeps the bindings symmetric (`fix-propagation.md` §Bindings). The React layer only turns those notes into sound.

## Test results

- `cargo test` for `chordsketch-chordpro` (16 new `chord_pitches` unit tests + doctest), `chordsketch-wasm`, `chordsketch-napi`, `chordsketch-ffi` — green.
- `cargo clippy -- -D warnings` and `cargo fmt --check` on the changed crates — clean.
- `@chordsketch/react` vitest: 830 passing, including new `use-chord-audio`, walker chord-audio, `<ChordSheet>` chord-audio (incl. graceful degradation), and `<PreviewToolbar>` toggle tests.
- New Playwright smoke `tests-e2e/chord-audio.spec.ts`.

## Review summary

- **Renderer parity**: chord audio is a React-JSX-surface interactive feature with no Rust-renderer sibling (text/HTML/PDF produce static output); not a parity gap, consistent with the existing click-to-nudge / metronome React-only interactions.
- **Sister-site audit (bindings)**: `chord_pitches` added to all three bindings (wasm/napi/ffi) with matching pure-Rust cores + tests; README API tables updated for each.
- **Single AudioContext**: extracted `audio-context.ts`; `useMetronome` refactored to consume it (its existing 13 tests stay green).

Closes #2650

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4BXRqHgqbuT32C5TnDLAj)_