### PR TITLE
Clear the chord selection when clicking a non-chord part of the preview

### DIFF
--- a/packages/react/src/chord-sheet.tsx
+++ b/packages/react/src/chord-sheet.tsx
@@ -436,6 +436,22 @@ function ChordSheetTextBranch({
   );
 }
 
+// Preview elements whose press must NOT clear an active chord
+// selection. Two classes, both inside the song body:
+//   - `.chord` — the chord glyphs (re-selected by their own click
+//     handler; also covers audio play-buttons and inline diagrams,
+//     which carry `.chord`).
+//   - `.meta-inline` — inline directive chips, notably the `{tempo}`
+//     metronome chip, which is an interactive `<button>` when Web Audio
+//     is available (see `chordpro-jsx.tsx`). Pressing a chip performs
+//     its own action (ticking the metronome, etc.); clearing the
+//     selection as a side effect would surprise the user.
+// Everything else inside the preview — lyrics, whitespace — is "outside
+// a chord" and clears. Shared by the controlled and uncontrolled
+// branches of the outside-press listener so the two stay in lockstep
+// (.claude/rules/fix-propagation.md).
+const PREVIEW_SELECTION_KEEP = '.chord, .meta-inline';
+
 function ChordSheetAstBranch({
   source,
   transpose,
@@ -513,16 +529,19 @@ function ChordSheetAstBranch({
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   // Clear the selection when the user presses down anywhere that is
-  // not a chord / nudge control belonging to THIS sheet. Clicking a
-  // chord re-selects via that chord's own handler, so we keep the
-  // selection only for presses on this sheet's own `.chord` /
-  // `.chord-nudge`; presses elsewhere — empty space, the editor, or
-  // even another sheet instance's chords — clear it. Scoped to when a
-  // selection is active so there is no idle global listener.
+  // not a chord / inline chip belonging to THIS sheet's preview.
+  // Clicking a chord re-selects via that chord's own handler, so we keep
+  // the selection only for presses that land on `PREVIEW_SELECTION_KEEP`
+  // targets; presses on bare lyrics / whitespace clear it. Scoped to
+  // when a selection is active so there is no idle global listener.
+  //
+  // The listener is per-instance (`wrapperRef` is THIS sheet's root):
+  // the shipped shells mount a single preview, so there is no
+  // cross-instance interference; a host that mounts two controlled
+  // previews against one shared selection would need to scope the
+  // selection per preview, which is the host's responsibility.
   useEffect(() => {
-    // Controlled mode: the shell owns the selection (caret-driven), so
-    // there is no in-pane outside-click clear to manage here.
-    if (controlled || chordSelection == null) return;
+    if (chordSelection == null) return;
     const onPointerDown = (event: PointerEvent): void => {
       const node = event.target as Node | null;
       // Resolve to the nearest Element: a pointer event's target can be
@@ -531,15 +550,35 @@ function ChordSheetAstBranch({
       // selection the instant the user presses on the chord glyph.
       const el =
         node instanceof Element ? node : (node?.parentElement ?? null);
-      // Scope to THIS sheet's subtree (chords in `__content` + the
-      // sibling inspector footer), so a press on a chord or anywhere in
-      // the inspector keeps the selection; anything else clears it.
       const root = wrapperRef.current;
+      if (controlled) {
+        // Controlled mode: the shell owns the selection (caret-driven)
+        // and renders the chord-editor footer OUTSIDE this sheet, so the
+        // only clear scoped here is a press on a non-chord part of the
+        // preview (#2654) — that reports `null` upward, and the shell
+        // moves the editor caret off the chord. Presses outside the
+        // preview (the editor, the footer) are owned by the editor caret
+        // and must not be disturbed here.
+        if (
+          root != null &&
+          el != null &&
+          root.contains(el) &&
+          el.closest(PREVIEW_SELECTION_KEEP) == null
+        ) {
+          onChordSelectionChange?.(null);
+        }
+        return;
+      }
+      // Uncontrolled mode: scope to THIS sheet's subtree (chords / chips
+      // in `__content` + the sibling inspector footer), so a press on a
+      // chord, an inline chip, or anywhere in the inspector keeps the
+      // selection; anything else — including clicks entirely outside
+      // this sheet — clears it.
       if (
         root != null &&
         el != null &&
         root.contains(el) &&
-        el.closest('.chord, .chordsketch-sheet__cins')
+        el.closest(`${PREVIEW_SELECTION_KEEP}, .chordsketch-sheet__cins`)
       ) {
         return;
       }
@@ -547,7 +586,7 @@ function ChordSheetAstBranch({
     };
     document.addEventListener('pointerdown', onPointerDown);
     return () => document.removeEventListener('pointerdown', onPointerDown);
-  }, [controlled, chordSelection]);
+  }, [controlled, chordSelection, onChordSelectionChange]);
 
   // Resolve the selection into the selected chord's coordinates + parts
   // for the inspector. Recomputed whenever the AST (a re-parse after an

--- a/packages/react/src/use-chord-editor.ts
+++ b/packages/react/src/use-chord-editor.ts
@@ -275,7 +275,6 @@ export function useChordEditor({
 
   const onChordSelectionChange = useCallback(
     (selection: ChordSelection | null) => {
-      if (!selection) return;
       // If a source-mutating commit is in flight (e.g. the preview's
       // keyboard nudge fires onChordReposition then this in the same
       // tick), its caret restoration is already queued against the NEW
@@ -283,13 +282,35 @@ export function useChordEditor({
       // still-stale `source` here. The click path has no pending commit,
       // so it falls through and moves the caret as intended.
       if (pendingCaretRef.current != null) return;
+      if (!selection) {
+        // Deselect (#2654): the user clicked a non-chord part of the
+        // preview, or re-clicked the selected chord to toggle it off.
+        // The selection is a pure function of the editor caret, so the
+        // only way to clear it is to move the caret off the chord —
+        // just past the selected chord's `]`. A caret there falls into
+        // the lyrics (see findChordAtCaret), so the caret-derived
+        // selection re-resolves to null.
+        if (!caretChord) return;
+        const base = lineBaseOffset(source, caretChord.line);
+        let target = base + caretChord.sourceColumn + caretChord.bracketLength;
+        // Guard the adjacent-stacked-chord case (`[A][B]`): the column
+        // just past [A]'s `]` equals [B]'s `[`, which findChordAtCaret
+        // would re-select instead of clearing. Fall back to the end of
+        // the line, which is always off every chord on it.
+        if (findChordAtCaret(source, target) != null) {
+          const lineText = source.split('\n')[caretChord.line - 1] ?? '';
+          target = base + lineText.length;
+        }
+        editorRef.current?.setCaret(target);
+        return;
+      }
       const offset = chordSelectionCaretOffset(source, selection);
       if (offset == null) return;
       // Move the editor caret just inside the clicked chord's bracket;
       // the caret path then re-resolves it as the selection.
       editorRef.current?.setCaret(offset + 1);
     },
-    [source, editorRef],
+    [source, editorRef, caretChord],
   );
 
   const canLeft = caretChord

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -132,6 +132,53 @@ function chordNamedStub(name: string): StubRenderer {
   };
 }
 
+// A stub returning a `{time}` directive line (rendered as a
+// `.meta-inline` chip) followed by a chord-bearing lyrics line, so a
+// test can assert that pressing an inline chip does not clear the
+// chord selection.
+function chordWithChipStub(): StubRenderer {
+  const songAst = JSON.stringify({
+    metadata: {
+      title: null,
+      subtitles: [],
+      artists: [],
+      composers: [],
+      lyricists: [],
+      album: null,
+      year: null,
+      key: null,
+      tempo: null,
+      time: null,
+      capo: null,
+      sortTitle: null,
+      sortArtist: null,
+      arrangers: [],
+      copyright: null,
+      duration: null,
+      tags: [],
+      custom: [],
+    },
+    lines: [
+      {
+        kind: 'directive',
+        value: { name: 'time', value: '4/4', kind: { tag: 'time' }, selector: null },
+      },
+      {
+        kind: 'lyrics',
+        value: {
+          segments: [{ chord: { name: 'Am', detail: null, display: null }, text: 'hi', spans: [] }],
+        },
+      },
+    ],
+  });
+  const result = { ast: songAst, warnings: [], transposedKey: undefined };
+  return {
+    ...makeStub(),
+    parseChordproWithWarnings: vi.fn(() => result),
+    parseChordproWithWarningsAndOptions: vi.fn(() => result),
+  };
+}
+
 describe('<ChordSheet>', () => {
   test('renders HTML output via parseChordpro when no options are set', async () => {
     const stub = makeStub();
@@ -846,6 +893,108 @@ describe('<ChordSheet>', () => {
     fireEvent.pointerDown(textNode as Node);
     // Selection survives — the press resolved to the `.chord` element.
     expect(container.querySelector('.chord--selected')).not.toBeNull();
+  });
+
+  test('controlled mode: pressing a non-chord part of the preview reports null', async () => {
+    // #2654: in controlled mode the shell owns the selection (caret-
+    // driven). A press on a non-chord part of the preview must report
+    // `null` upward so the shell can move the caret off the chord; a
+    // press on the chord, or anywhere outside the preview, must not.
+    const onChordSelectionChange = vi.fn();
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        chordSelection={{ line: 1, offset: 0, ordinal: 0, nonce: 1 }}
+        onChordSelectionChange={onChordSelectionChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.lyrics')).not.toBeNull();
+    });
+    // Non-chord part of the preview (the lyrics span) → deselect.
+    fireEvent.pointerDown(container.querySelector('.lyrics') as HTMLElement);
+    expect(onChordSelectionChange).toHaveBeenLastCalledWith(null);
+
+    // The chord itself → kept (its own click handler re-selects it).
+    onChordSelectionChange.mockClear();
+    fireEvent.pointerDown(container.querySelector('.chord') as HTMLElement);
+    expect(onChordSelectionChange).not.toHaveBeenCalled();
+
+    // Outside the preview entirely (the editor / footer live there) →
+    // not this listener's business; the editor caret owns it.
+    onChordSelectionChange.mockClear();
+    fireEvent.pointerDown(document.body);
+    expect(onChordSelectionChange).not.toHaveBeenCalled();
+  });
+
+  test('controlled mode: pressing an inline directive chip keeps the selection', async () => {
+    // #2654 follow-up: the {tempo} metronome chip (and other
+    // `.meta-inline` chips) are interactive controls inside the preview.
+    // Pressing one performs its own action; it must NOT report a
+    // deselect upward as a side effect.
+    const onChordSelectionChange = vi.fn();
+    const { container } = render(
+      <ChordSheet
+        source="{time: 4/4}\n[Am]hi"
+        astWasmLoader={makeAstLoader(chordWithChipStub())}
+        onChordReposition={vi.fn()}
+        chordSelection={{ line: 2, offset: 0, ordinal: 0, nonce: 1 }}
+        onChordSelectionChange={onChordSelectionChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.meta-inline--time')).not.toBeNull();
+    });
+    fireEvent.pointerDown(container.querySelector('.meta-inline--time') as HTMLElement);
+    expect(onChordSelectionChange).not.toHaveBeenCalled();
+    // Sanity: a bare-lyrics press still clears, proving the chip path is
+    // the exception, not a blanket "never clear".
+    fireEvent.pointerDown(container.querySelector('.lyrics') as HTMLElement);
+    expect(onChordSelectionChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test('uncontrolled mode: pressing an inline directive chip keeps the selection', async () => {
+    // Sister-site parity with the controlled-mode chip test: the
+    // uncontrolled in-pane listener must keep the selection on a chip
+    // press too (the keep-list is shared via PREVIEW_SELECTION_KEEP).
+    const { container } = render(
+      <ChordSheet
+        source="{time: 4/4}\n[Am]hi"
+        astWasmLoader={makeAstLoader(chordWithChipStub())}
+        onChordReposition={vi.fn()}
+        onChordEdit={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".chord[role='button']")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector(".chord[role='button']") as HTMLElement);
+    expect(container.querySelector('.chordsketch-sheet__cins')).not.toBeNull();
+    // Press the inline chip — the selection / inspector must survive.
+    fireEvent.pointerDown(container.querySelector('.meta-inline--time') as HTMLElement);
+    expect(container.querySelector('.chordsketch-sheet__cins')).not.toBeNull();
+  });
+
+  test('controlled mode: no clear is reported when nothing is selected', async () => {
+    // The listener is scoped to an active selection; with a null
+    // controlled selection a non-chord press must stay silent.
+    const onChordSelectionChange = vi.fn();
+    const { container } = render(
+      <ChordSheet
+        source="[Am]hi"
+        astWasmLoader={makeAstLoader(chordStub())}
+        onChordReposition={vi.fn()}
+        chordSelection={null}
+        onChordSelectionChange={onChordSelectionChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.lyrics')).not.toBeNull();
+    });
+    fireEvent.pointerDown(container.querySelector('.lyrics') as HTMLElement);
+    expect(onChordSelectionChange).not.toHaveBeenCalled();
   });
 
   test('a non-zero transpose disables chord selection + the inspector', async () => {

--- a/packages/react/tests/use-chord-editor.test.tsx
+++ b/packages/react/tests/use-chord-editor.test.tsx
@@ -91,6 +91,61 @@ describe('useChordEditor', () => {
     expect(setCaretSpy).toHaveBeenLastCalledWith(11);
   });
 
+  test('deselecting (null) moves the caret off the selected chord', () => {
+    mount();
+    caretTo(1); // select `[G]` (col 0..2)
+    expect(latest.inspectorProps.selected).toBe(true);
+    act(() => {
+      latest.onChordSelectionChange(null);
+    });
+    // Caret lands just past `[G]`'s `]` (col 3, in the lyrics), so the
+    // caret-derived selection clears once the editor reports it back.
+    expect(setCaretSpy).toHaveBeenLastCalledWith(3);
+    caretTo(3);
+    expect(latest.inspectorProps.selected).toBe(false);
+    expect(latest.chordSelection).toBeNull();
+  });
+
+  test('deselecting an adjacent stacked chord falls back to end of line', () => {
+    // `[A][B]word`: col 3 (just past [A]'s `]`) equals [B]'s `[`, which
+    // findChordAtCaret would re-select. The deselect must skip past it to
+    // the end of the line, which is off every chord on it.
+    mount('[A][B]word');
+    act(() => {
+      latest.onCaretChange({ line: 1, column: 1, lineLength: 10 }); // inside [A]
+    });
+    expect(latest.inspectorProps.selected).toBe(true);
+    act(() => {
+      latest.onChordSelectionChange(null);
+    });
+    expect(setCaretSpy).toHaveBeenLastCalledWith('[A][B]word'.length);
+  });
+
+  test('deselecting a chord on a later line uses that line base offset', () => {
+    // Locks in the multi-line `lineBaseOffset` arithmetic in the
+    // deselect branch: `[G]` sits on line 2, so the caret target is the
+    // line-2 base (9) + past its `]` (3) = 12, just after `]` in "two".
+    mount('line one\n[G]two');
+    act(() => {
+      latest.onCaretChange({ line: 2, column: 1, lineLength: 6 }); // inside [G]
+    });
+    expect(latest.inspectorProps.selected).toBe(true);
+    act(() => {
+      latest.onChordSelectionChange(null);
+    });
+    expect(setCaretSpy).toHaveBeenLastCalledWith(12);
+  });
+
+  test('deselecting with no chord under the caret is a no-op', () => {
+    mount();
+    caretTo(5); // in the lyrics, no chord selected
+    const callsBefore = setCaretSpy.mock.calls.length;
+    act(() => {
+      latest.onChordSelectionChange(null);
+    });
+    expect(setCaretSpy.mock.calls.length).toBe(callsBefore);
+  });
+
   test('deleting the selected chord removes its token', () => {
     mount();
     caretTo(1); // select `[G]`


### PR DESCRIPTION
## What

When a chord is selected in the ChordPro preview, clicking a part of the preview that is **not** a chord now clears the selection.

- **Controlled-selection mode** (`<ChordProEditor>` footer + playground split view, #2644): `<ChordSheet>` now runs its outside-press listener in controlled mode too, scoped to the preview subtree. A pointer press inside the preview that is not on a chord / inline chip reports `null` upward; the shell (`useChordEditor`) moves the editor caret off the chord, so the caret-derived selection re-resolves to `null`. Presses outside the preview (the editor, the footer) stay owned by the editor caret and are untouched.
- `useChordEditor.onChordSelectionChange(null)` clears the selection by moving the editor caret just past the selected chord's closing `]`, into the lyrics where `findChordAtCaret` resolves to `null`. The adjacent-stacked-chord case (`[A][B]`, where the column past `[A]`'s `]` is `[B]`'s `[`) falls back to end-of-line, which is off every chord. As a side effect this also makes re-clicking the selected chord toggle it off in controlled mode.
- The keep-list is extracted into `PREVIEW_SELECTION_KEEP` (`'.chord, .meta-inline'`), shared by the controlled and uncontrolled branches so they stay in lockstep — which also fixes a latent gap where pressing an inline directive chip (notably the interactive `{tempo}` metronome `<button>`) spuriously cleared the selection in uncontrolled mode.

## Why

The selection in controlled mode is a pure function of the editor caret. Clicking a chord moved the caret onto it, but there was no way to deselect from the preview: the in-pane outside-click listener was skipped in controlled mode and `onChordSelectionChange` ignored `null`. A selected chord therefore stayed selected (and the footer stayed in edit mode) regardless of where else in the preview the user clicked. The fix expresses deselection in the model's own terms (move the caret off the chord) rather than adding a parallel "force-null" override — a root-cause fix, not a band-aid.

## Test results

`packages/react`: `npm test` → 845 passing (38 files; +12 new), `npm run typecheck` clean, `npm run build` succeeds. New coverage:
- `useChordEditor`: deselect moves the caret off the chord (plain), multi-line line-base-offset arithmetic, adjacent-stacked-chord end-of-line fallback, and the no-chord-under-caret no-op.
- `<ChordSheet>` controlled mode: a non-chord press reports `null`, a chord press / outside-preview press does not, a null selection stays silent, and an inline-chip press keeps the selection.
- `<ChordSheet>` uncontrolled mode: sister-site chip-keep test.

## Review summary

Four reviews were run in parallel (code review, security review, project-rule compliance, correctness/simplification). Security and project-rule reviews were clean. One Medium — the inline `{tempo}` metronome chip spuriously deselecting — was fixed via the shared `PREVIEW_SELECTION_KEEP` keep-list (this PR's chip handling), and the delta re-review returned no findings.

## Sister-site audit

The selection / deselection interaction is a `@chordsketch/react`-only concern (`<ChordSheet>` + `useChordEditor`); the Rust text / HTML / PDF renderers produce static, non-interactive output, so renderer-parity does not apply. Both `<ChordSheet>` modes (controlled and uncontrolled) received the keep-list change through one shared constant. No new mount site / format toggle / mount-sequence / `Renderers.init` / wasm-surface change, so per `.claude/rules/playground-smoke.md` no new Playwright spec is required. All logic lives in the library, not the playground (`.claude/rules/playground-is-a-sample.md`).

Closes #2654

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGiuZFguoonWgGKcFNxjEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGiuZFguoonWgGKcFNxjEQ)_