### PR TITLE
Make a chord click an idempotent select so audio and editing stop fighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exposes a `chordAudio` config the host forwards to the preview.
   Degrades gracefully without Web Audio / under SSR and respects
   `prefers-reduced-motion`. (#2650)
+- `@chordsketch/react`: a chord click in the preview is now an idempotent
+  **select** rather than a toggle — re-clicking the already-selected
+  chord keeps it selected (and, with chord audio on, re-auditions it)
+  instead of clearing the selection. This removes the conflict where
+  "click to hear" fought "click to deselect" on one gesture; a chord
+  click can no longer clear the editing target by construction.
+  Deselection is now exclusively Escape, click-outside, the inspector ✕,
+  or moving the editor caret off the chord. (#2650)
 - Horizontal (left-nut) orientation for fretted-instrument chord
   diagrams, alongside the existing vertical layout. Enable via the
   `diagrams.orientation = "horizontal"` config key (honoured by the

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1944,10 +1944,10 @@ function LyricsLine({
   }, [isSelectedLine, focusedSegmentIdx, selected]);
 
   // Select the chord in `segmentIdx`. This is an IDEMPOTENT select, not
-  // a toggle: clicking a chord always makes it THE selected chord, and
-  // re-clicking the already-selected one re-selects it (a fresh nonce so
-  // the focus / scroll / caret-restore effects re-fire and a caret-driven
-  // host re-lands the caret on it) rather than clearing the selection.
+  // a toggle: clicking a chord makes it THE selected chord with a fresh
+  // nonce so the focus / scroll / caret-restore effects re-fire; re-
+  // clicking the already-selected chord returns early (no nonce bump, no
+  // churn) rather than clearing the selection.
   //
   // Why not a toggle: chord audio turns a chord into a "click to hear"
   // control, and a toggle would make the second audition click clear the
@@ -2295,6 +2295,12 @@ function LyricsLine({
           chordInteractiveProps = {
             tabIndex: 0,
             role: 'button',
+            // aria-pressed communicates selection state (true = active
+            // editing target). Strictly, aria-pressed implies a toggle —
+            // re-pressing un-presses — but chord clicks are now idempotent
+            // selects: re-click is a no-op; Escape / click-outside deselect.
+            // Switching to aria-selected would require a composite widget
+            // role change; the deviation is intentional and acceptable here.
             'aria-pressed': isFocusedChord,
             ...(audioEnabled
               ? {

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1922,12 +1922,14 @@ function LyricsLine({
   useEffect(() => {
     // When this line is not (or no longer) the selected line, reset
     // the handled-nonce so a FUTURE selection of this line refocuses
-    // even if its nonce repeats a previously-handled value — the
-    // per-selection nonce restarts at 1 after a full deselect
-    // (`cur` is null after an Escape / click-outside clear), so without
-    // this reset a select → deselect → reselect-the-same-chord cycle
-    // could match the stale handled value and skip the programmatic
-    // refocus.
+    // even if its nonce repeats a previously-handled value. The nonce
+    // sequence depends on the host: the standalone <ChordSheet> writes
+    // `(cur?.nonce ?? 0) + 1`, so it restarts at 1 after a full deselect
+    // (`cur` null, via Escape / click-outside); the caret-driven
+    // useChordEditor host uses a monotonic counter that never resets.
+    // This reset covers BOTH — without it a select → deselect →
+    // reselect-the-same-chord cycle could match a stale handled value
+    // and skip the programmatic refocus.
     // Do NOT reset while the segment is merely unresolved mid-reparse
     // (isSelectedLine true, focusedSegmentIdx < 0) — that transient
     // must still refocus once the new AST lands.

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1924,9 +1924,10 @@ function LyricsLine({
     // the handled-nonce so a FUTURE selection of this line refocuses
     // even if its nonce repeats a previously-handled value — the
     // per-selection nonce restarts at 1 after a full deselect
-    // (`cur` is null in `toggleSelect`), so without this reset a
-    // select → deselect → reselect-the-same-chord cycle could match
-    // the stale handled value and skip the programmatic refocus.
+    // (`cur` is null after an Escape / click-outside clear), so without
+    // this reset a select → deselect → reselect-the-same-chord cycle
+    // could match the stale handled value and skip the programmatic
+    // refocus.
     // Do NOT reset while the segment is merely unresolved mid-reparse
     // (isSelectedLine true, focusedSegmentIdx < 0) — that transient
     // must still refocus once the new AST lands.
@@ -1940,9 +1941,21 @@ function LyricsLine({
     focusedSpanRef.current?.focus();
   }, [isSelectedLine, focusedSegmentIdx, selected]);
 
-  // Toggle the selection for the chord in `segmentIdx`. Clicking
-  // the already-selected chord clears the selection.
-  const toggleSelect = (segmentIdx: number): void => {
+  // Select the chord in `segmentIdx`. This is an IDEMPOTENT select, not
+  // a toggle: clicking a chord always makes it THE selected chord, and
+  // re-clicking the already-selected one re-selects it (a fresh nonce so
+  // the focus / scroll / caret-restore effects re-fire and a caret-driven
+  // host re-lands the caret on it) rather than clearing the selection.
+  //
+  // Why not a toggle: chord audio turns a chord into a "click to hear"
+  // control, and a toggle would make the second audition click clear the
+  // editing target — the two features would fight on one gesture. An
+  // idempotent select lets click-to-hear and click-to-edit coexist.
+  // Deselection is a separate gesture: Escape (below), click-outside or
+  // the inspector ✕ (standalone <ChordSheet>), or moving the editor caret
+  // off the chord (caret-driven hosts, which already ignore a null
+  // selection write).
+  const selectChordAt = (segmentIdx: number): void => {
     if (!reposition || !nudgeCtx) return;
     const offset = segmentLayout[segmentIdx].lyricsOffsetStart;
     let ordinal = 0;
@@ -1951,21 +1964,24 @@ function LyricsLine({
       if (c.offset === offset) ordinal++;
     }
     const cur = nudgeCtx.selected;
-    const isSame =
+    // Already THE selected chord: a re-click is a selection no-op — it
+    // stays selected (no `null` write, so it cannot clear) and skips the
+    // nonce bump so the focus / scroll effects don't churn. The audio
+    // audition still fires because the caller plays BEFORE calling this.
+    if (
       cur != null &&
       cur.line === reposition.sourceLine &&
       cur.offset === offset &&
-      cur.ordinal === ordinal;
-    nudgeCtx.setSelected(
-      isSame
-        ? null
-        : {
-            line: reposition.sourceLine,
-            offset,
-            ordinal,
-            nonce: (cur?.nonce ?? 0) + 1,
-          },
-    );
+      cur.ordinal === ordinal
+    ) {
+      return;
+    }
+    nudgeCtx.setSelected({
+      line: reposition.sourceLine,
+      offset,
+      ordinal,
+      nonce: (cur?.nonce ?? 0) + 1,
+    });
   };
 
   // Move the selected chord one lyric character in `direction`.
@@ -2007,16 +2023,16 @@ function LyricsLine({
     });
   };
 
-  // Keyboard control for a chord span. Enter / Space toggles the
-  // selection of that chord; once selected, ArrowLeft / ArrowRight
-  // nudge it and Escape clears the selection.
+  // Keyboard control for a chord span. Enter / Space selects that chord
+  // (idempotent — matches the click model, not a toggle); once selected,
+  // ArrowLeft / ArrowRight nudge it and Escape clears the selection.
   const chordKeyHandler =
     (segmentIdx: number) => (event: ReactKeyboardEvent<HTMLSpanElement>): void => {
       if (!reposition || !nudgeCtx) return;
       const { key } = event;
       if (key === 'Enter' || key === ' ') {
         event.preventDefault();
-        toggleSelect(segmentIdx);
+        selectChordAt(segmentIdx);
         return;
       }
       if (segmentIdx !== focusedSegmentIdx) return;
@@ -2292,7 +2308,7 @@ function LyricsLine({
             onClick: (e: ReactMouseEvent) => {
               e.stopPropagation();
               if (audioEnabled) playChord(e.currentTarget as HTMLElement);
-              toggleSelect(i);
+              selectChordAt(i);
             },
             onKeyDown: (e: ReactKeyboardEvent) => {
               if (audioEnabled && (e.key === 'Enter' || e.key === ' ')) {

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3904,7 +3904,7 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
   test('chords are select buttons; clicking selects (solid badge + aria-pressed)', () => {
     const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
     const chord = container.querySelector('.chord') as HTMLElement;
-    // Toggle-button semantics when the feature is fully wired.
+    // Select-button semantics when the feature is fully wired.
     expect(chord.getAttribute('role')).toBe('button');
     expect(chord.getAttribute('aria-pressed')).toBe('false');
     // Nothing selected yet.

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -3901,7 +3901,7 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     };
   }
 
-  test('chords are toggle buttons; clicking selects (solid badge + aria-pressed)', () => {
+  test('chords are select buttons; clicking selects (solid badge + aria-pressed)', () => {
     const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
     const chord = container.querySelector('.chord') as HTMLElement;
     // Toggle-button semantics when the feature is fully wired.
@@ -3984,18 +3984,23 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     expect(container.querySelector('.chord--selected')).toBeNull();
   });
 
-  test('clicking the selected chord again toggles the selection off', () => {
+  test('clicking the selected chord again keeps it selected (idempotent, no toggle-off)', () => {
+    // A chord click is an idempotent SELECT, not a toggle: re-clicking the
+    // already-selected chord must NOT clear it. This is what lets "click
+    // to re-hear" (chord audio) coexist with "click to edit" — the two no
+    // longer fight on one gesture. Deselection is Escape / click-outside.
     const { container } = render(<Harness ast={twoChordAst()} onReposition={vi.fn()} />);
     const chord = container.querySelector('.chord') as HTMLElement;
     fireEvent.click(chord);
-    expect(container.querySelector('.chord--selected')).not.toBeNull();
-    // Click the (now selected) chord again.
+    const selected = container.querySelector('.chord--selected') as HTMLElement;
+    expect(selected).not.toBeNull();
+    // Click the (now selected) chord again — it stays selected.
     fireEvent.click(container.querySelector('.chord--selected') as HTMLElement);
-    expect(container.querySelector('.chord--selected')).toBeNull();
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
   });
 
   test('clicking a chord writes the selection with an advanced nonce', () => {
-    // Controlled render proving the toggle's write shape: selecting G
+    // Controlled render proving the select write shape: selecting G
     // (offset 6) from a clean state.
     const setChordSelection = vi.fn();
     const { container } = render(
@@ -4015,14 +4020,14 @@ describe('renderChordproAst click-to-focus + nudge (#2614)', () => {
     });
   });
 
-  test('without setChordSelection, chords are not toggle buttons (drag-only)', () => {
+  test('without setChordSelection, chords are not select buttons (drag-only)', () => {
     const { container } = render(
       renderChordproAst(twoChordAst(), { onChordReposition: vi.fn() }),
     );
     const chord = container.querySelector('.chord') as HTMLElement;
     // Drag still wired…
     expect(chord.getAttribute('draggable')).toBe('true');
-    // …but no click-to-select toggle semantics.
+    // …but no click-to-select semantics.
     expect(chord.getAttribute('role')).toBeNull();
     expect(container.querySelector('.chord--selected')).toBeNull();
   });
@@ -4503,12 +4508,36 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     expect(selected.getAttribute('aria-pressed')).toBe('true');
   });
 
-  test('with selection wired, Enter both plays and toggles selection', () => {
+  test('re-clicking an audio chord re-plays AND keeps it selected (the reported conflict fix)', () => {
+    // Direct regression for "press a chord, sound plays, but the
+    // selection clears." A chord click is an idempotent select, so
+    // clicking the already-selected chord auditions it again WITHOUT
+    // toggling the selection off — audio and editing no longer fight.
+    const play = vi.fn();
+    const { container } = render(<AudioSelectHarness play={play} />);
+    const chord = container.querySelector('.chord') as HTMLElement;
+    fireEvent.click(chord);
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
+    expect(play).toHaveBeenCalledTimes(1);
+    // Click the same (selected) chord again.
+    fireEvent.click(container.querySelector('.chord--selected') as HTMLElement);
+    // Still selected, and auditioned a second time.
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
+    expect(play).toHaveBeenCalledTimes(2);
+  });
+
+  test('with selection wired, Enter both plays and selects', () => {
     const play = vi.fn();
     const { container } = render(<AudioSelectHarness play={play} />);
     const chord = container.querySelector('.chord') as HTMLElement;
     fireEvent.keyDown(chord, { key: 'Enter' });
     expect(play).toHaveBeenCalledWith('Am7');
+    expect(container.querySelector('.chord--selected')).not.toBeNull();
+    // Re-pressing Enter on the selected chord re-plays and stays selected.
+    fireEvent.keyDown(container.querySelector('.chord--selected') as HTMLElement, {
+      key: 'Enter',
+    });
+    expect(play).toHaveBeenCalledTimes(2);
     expect(container.querySelector('.chord--selected')).not.toBeNull();
   });
 


### PR DESCRIPTION
## What

Fixes the chord-audio ↔ chord-selection conflict reported after #2653: clicking a chord in the preview played the sound but **cleared the selection**. The root cause is that a rendered chord was wired as a **toggle button** — clicking the already-selected chord fired a `null` selection write — so with chord audio on, a "click to re-hear" gesture doubled as a "click to deselect" gesture. The two features fought on one click and the editing target was lost on the second tap.

## Why this is a design fix, not a patch

A chord click conflated two incompatible meanings: *audition this chord* and *toggle its selection off*. The two selection hosts also handled the toggle's `null` write **asymmetrically** — caret-driven hosts (`useChordEditor.onChordSelectionChange`) already ignored `null`, while the standalone `<ChordSheet>` honoured it — so the model was already inconsistent.

The fix makes the click model a single, coherent idea: **a chord click (and Enter / Space) is an idempotent SELECT, never a toggle.**

- `toggleSelect` → `selectChordAt` in `chordpro-jsx.tsx`: re-selecting the already-selected chord is a **no-op** (it stays selected; the audio audition still fires because the walker plays *before* calling it), and it **never writes `null`**.
- Therefore a chord click can no longer clear the editing target **by construction**, in *both* selection models — closing the asymmetry too.
- Deselection is now exclusively a deliberate gesture: **Escape**, **click-outside**, the inspector **✕**, or **moving the editor caret off the chord** (caret-driven hosts). All of these paths are unchanged.

## Test results

`packages/react`: `npm test` → 850 passing (38 files), `tsc --noEmit` clean. New / updated coverage:
- **Direct regression for the report**: re-clicking an audio chord re-plays AND keeps it selected (the previous build cleared it); same for repeated Enter.
- Updated the former toggle-off assertions to the idempotent-select contract.
- The focus-refocus-after-deselect test still passes (Escape still produces the `null`/`cur=null` deselect the refocus logic relies on).

## Sister-site / parity audit

Chord audio + click-selection are React-only interaction concerns with no Rust-renderer sibling, so renderer-parity does not apply. Both selection-model surfaces (caret-driven `useChordEditor` and standalone `<ChordSheet>` internal state) are fixed by the same single change in the walker — they share `selectChordAt`. No VS Code / desktop consumer is affected.

Refs #2650

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeGEBi5EBArfUJe8q8GXA8)_