### PR TITLE
Double the pause before the tonic-chord strum in the key audition

### DIFF
--- a/packages/react/src/use-key-audio.ts
+++ b/packages/react/src/use-key-audio.ts
@@ -20,7 +20,9 @@ const NOTE_RELEASE_S = 0.34; // each scale note decays past the next onset
 const NOTE_PEAK_GAIN = 0.2;
 const NOTE_TAIL_S = 0.05;
 // Pause between the last scale note's onset and the triad strum.
-const SCALE_TO_CHORD_GAP_S = 0.12;
+// Doubled from 0.12 to give a clearer breath before the "jara-n"
+// lands (#2660).
+const SCALE_TO_CHORD_GAP_S = 0.24;
 // Per-note delay across the triad so it reads as a strum, not a stab.
 const STRUM_OFFSET_S = 0.035;
 const CHORD_ATTACK_S = 0.008;


### PR DESCRIPTION
## What

Double the silent gap between the end of the movable-do scale and the tonic-triad strum in the React `{key}` chip audition (#2658): `SCALE_TO_CHORD_GAP_S` `0.12`s → `0.24`s.

## Why

A longer breath before the "jara-n" makes the scale-then-chord audition read more clearly as two phases.

## Test results

- `packages/react`: `npx vitest run tests/use-key-audio.test.ts` → 9 passing. The existing timing assertion (triad onsets after the whole scale) still holds — the larger gap only widens the margin.

## Sister-site audit

Single React-only timing constant in `use-key-audio.ts`; no Rust/binding/renderer sibling. No DOM-contract or public-API change.

## Deferred

None.

Closes #2660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSX1ZccyCDrNrBcaEWREmx)_