### PR TITLE
Drop editor focus when clearing the chord selection from the preview

### DIFF
--- a/packages/react/src/chord-source-area.tsx
+++ b/packages/react/src/chord-source-area.tsx
@@ -32,6 +32,13 @@ import { chordProLanguage, chordProTagTable } from './chordpro-language';
 export interface ChordSourceAreaHandle {
   /** Move keyboard focus into the editor. */
   focus(): void;
+  /**
+   * Remove keyboard focus from the editor (so its caret stops
+   * blinking). Used when a host wants to fully dismiss the editor —
+   * e.g. clicking a non-chord part of the preview to clear the chord
+   * selection should leave no lingering caret behind.
+   */
+  blur(): void;
   /** Read the current document contents. */
   getValue(): string;
   /**
@@ -447,6 +454,12 @@ export const ChordSourceArea = forwardRef<ChordSourceAreaHandle, ChordSourceArea
       () => ({
         focus() {
           viewRef.current?.focus();
+        },
+        blur() {
+          // Blur the actual contenteditable surface CodeMirror renders;
+          // `view.dom` is the outer wrapper, `view.contentDOM` is the
+          // focusable element that carries the caret.
+          viewRef.current?.contentDOM.blur();
         },
         getValue() {
           return viewRef.current?.state.doc.toString() ?? '';

--- a/packages/react/src/use-chord-editor.ts
+++ b/packages/react/src/use-chord-editor.ts
@@ -370,6 +370,13 @@ export function useChordEditor({
           target = base + lineText.length;
         }
         editorRef.current?.setCaret(target);
+        // Then drop editor focus entirely so no caret lingers blinking
+        // after the deselect — the user dismissed the chord, they did
+        // not ask to keep editing at the off-chord position. setCaret
+        // must run first: it clears the caret-derived selection (the
+        // `.chord--selected` badge); blur only removes the visible
+        // caret and does not move the selection.
+        editorRef.current?.blur();
         return;
       }
       const offset = chordSelectionCaretOffset(source, selection);

--- a/packages/react/tests/use-chord-editor.test.tsx
+++ b/packages/react/tests/use-chord-editor.test.tsx
@@ -18,6 +18,7 @@ const SOURCE = '[G]Almost [Bbm7]heaven';
 let latest: UseChordEditor;
 let currentSource: string;
 let setCaretSpy: ReturnType<typeof vi.fn>;
+let blurSpy: ReturnType<typeof vi.fn>;
 
 function Harness({
   initial,
@@ -35,8 +36,10 @@ function Harness({
   const ref = useRef<ChordSourceAreaHandle | null>(null);
   if (ref.current === null) {
     setCaretSpy = vi.fn();
+    blurSpy = vi.fn();
     ref.current = {
       focus: vi.fn(),
+      blur: blurSpy,
       getValue: () => source,
       setValue: vi.fn(),
       insertAtCursor: vi.fn(),
@@ -120,6 +123,8 @@ describe('useChordEditor', () => {
     // Caret lands just past `[G]`'s `]` (col 3, in the lyrics), so the
     // caret-derived selection clears once the editor reports it back.
     expect(setCaretSpy).toHaveBeenLastCalledWith(3);
+    // ...and editor focus is dropped so no caret lingers blinking.
+    expect(blurSpy).toHaveBeenCalledTimes(1);
     caretTo(3);
     expect(latest.inspectorProps.selected).toBe(false);
     expect(latest.chordSelection).toBeNull();
@@ -163,6 +168,8 @@ describe('useChordEditor', () => {
       latest.onChordSelectionChange(null);
     });
     expect(setCaretSpy.mock.calls.length).toBe(callsBefore);
+    // Nothing was selected, so focus must be left untouched.
+    expect(blurSpy).not.toHaveBeenCalled();
   });
 
   test('deleting the selected chord removes its token', () => {


### PR DESCRIPTION
## What

Follow-up to #2654 (PR #2655). When the user clears the chord selection by clicking a non-chord part of the ChordPro preview, the editor now loses focus entirely instead of leaving a caret blinking at the off-chord position.

- `ChordSourceAreaHandle` gains a `blur()` method that blurs CodeMirror's `contentDOM` (the focusable element that carries the caret).
- `useChordEditor.onChordSelectionChange(null)` calls `blur()` after `setCaret`. Order matters: `setCaret` moves the caret off the chord, which clears the caret-derived selection (the `.chord--selected` badge); `blur` only removes the visible caret and does not move the selection. A deselect when nothing is selected stays a no-op (neither `setCaret` nor `blur` runs).

## Why

After #2655, clicking a non-chord part of the preview cleared the selection but the editor kept focus, so a caret lingered blinking in the editor — visually distracting and contrary to the "dismiss the selection" intent. Dropping focus completes the dismissal.

## Test results

`packages/react`: `npm test` → 876 passing (41 files), `npm run typecheck` clean, `npm run build` succeeds. Updated `use-chord-editor` tests assert `blur()` fires on a real deselect and does **not** fire on the no-chord-under-caret no-op path.

## Sister-site audit

The deselect-with-an-editor flow exists only in controlled-selection mode (`useChordEditor`, consumed by `<ChordProEditor>` and the playground). Standalone `<ChordSheet>` (uncontrolled) clears its own `internalSelection` with no editor handle to blur, so there is no sibling to update. No renderer-parity surface (text / HTML / PDF are static, non-interactive). No new mount site / format toggle / wasm-surface change, so per `.claude/rules/playground-smoke.md` no new Playwright spec is required.

Closes #2661

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGiuZFguoonWgGKcFNxjEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGiuZFguoonWgGKcFNxjEQ)_