### PR TITLE
Top-align the lifted chord-editor footer clusters

### DIFF
--- a/design-system/ui_kits/web/editor-chord-footer.html
+++ b/design-system/ui_kits/web/editor-chord-footer.html
@@ -54,7 +54,7 @@ body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875
 .pair .chord.is-selected { background: var(--crimson-500); color: var(--fg-on-crimson); border-radius: var(--r-2); padding: 2px 5px; margin: -2px -5px; box-shadow: var(--e-1); }
 
 /* Lifted chord-editor footer — full-width band spanning both panes. */
-.cins { flex: none; display: flex; align-items: flex-end; flex-wrap: wrap; gap: var(--sp-3) var(--sp-5); padding: var(--sp-3) var(--sp-6); min-height: 84px; background: var(--surface); border-top: 1px solid var(--border-strong); box-shadow: 0 -8px 24px rgba(10,10,11,.05); }
+.cins { flex: none; display: flex; align-items: flex-start; flex-wrap: wrap; gap: var(--sp-3) var(--sp-5); padding: var(--sp-3) var(--sp-6); min-height: 84px; background: var(--surface); border-top: 1px solid var(--border-strong); box-shadow: 0 -8px 24px rgba(10,10,11,.05); }
 .cins__id { display: flex; flex-direction: column; justify-content: center; gap: 3px; padding-right: var(--sp-4); border-right: 1px solid var(--border); min-width: 96px; align-self: stretch; }
 .cins__eyebrow { font: 700 var(--fs-10)/1 var(--font-latin); letter-spacing: .08em; text-transform: uppercase; color: var(--text-tertiary); }
 .cins__name { font: 900 var(--fs-24)/1 var(--font-chord); color: var(--crimson-500); }

--- a/packages/playground/tests-e2e/chord-inspector.spec.ts
+++ b/packages/playground/tests-e2e/chord-inspector.spec.ts
@@ -53,6 +53,40 @@ test.describe('chord-editor footer (ChordPro playground)', () => {
     expect(errors).toEqual([]);
   });
 
+  test('the lifted footer top-aligns its clusters (not bottom-aligned)', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    // The lifted footer lays its clusters out in a wrapping row. Their
+    // cross-axis alignment must be top (`flex-start`) so the labelled
+    // clusters share one baseline at the top and read top-down; the
+    // earlier `flex-end` floated every cluster to the bottom edge with
+    // empty space above. Assert the computed value so a regression back
+    // to bottom-alignment fails here. The root `.chordsketch-sheet__cins`
+    // is present in both the idle and edit states, so this holds at first
+    // paint before any chord is selected.
+    const cins = page.locator(`${FOOTER} .chordsketch-sheet__cins`);
+    await expect(cins).toBeVisible();
+    await expect(cins).toHaveCSS('align-items', 'flex-start');
+
+    // The label-less actions cluster only renders in the edit state, so
+    // select a chord first, then assert it is centred on the band (it has
+    // no label above it, so top-aligning it with the labelled clusters
+    // would pin its button above their controls).
+    await page.locator('.pane.preview').locator(".chord[role='button']").first().click();
+    await expect(
+      page.locator(`${FOOTER} .chordsketch-sheet__cins[data-mode='edit']`),
+    ).toBeVisible();
+    await expect(
+      page.locator(`${FOOTER} .chordsketch-sheet__cins-footer`),
+    ).toHaveCSS('align-self', 'center');
+
+    expect(errors).toEqual([]);
+  });
+
   test('clicking a preview chord selects it via the editor caret', async ({ page }) => {
     const errors = trackPageErrors(page);
     await page.goto('./chordpro/');

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1803,7 +1803,7 @@
 .chordsketch-chord-pro-editor__chord-footer .chordsketch-sheet__cins {
   flex-direction: row;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: var(--cs-sp-3, 0.75rem) var(--cs-sp-5, 1.25rem);
   /* Reserve a stable minimum so the footer does not jump in height
      between its idle and selected states. */

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1835,10 +1835,16 @@
 .chordsketch-chord-pro-editor__chord-footer .chordsketch-sheet__cins-input {
   width: 5.5rem;
 }
-/* Actions hug the right edge of the row. */
+/* Actions hug the right edge of the row. This cluster has no label
+   above it (unlike Root / Type / Quality / Move), so under the row's
+   top-aligned cross axis it would otherwise pin to the very top edge —
+   higher than every labelled cluster's control. Centre it on the band
+   instead, matching the design-system reference
+   (`design-system/ui_kits/web/editor-chord-footer.html` → `.cins__actions`). */
 .chordsketch-chord-pro-editor__chord-footer .chordsketch-sheet__cins-footer {
   margin-left: auto;
   gap: var(--cs-sp-2, 0.5rem);
+  align-self: center;
 }
 /* Hide the empty placeholder span the footer renders when there is no
    Remove button (idle), so it does not add a gap before Insert. */


### PR DESCRIPTION
## What

The shell-level chord-editor footer (`.chordsketch-chord-pro-editor__chord-footer`)
— the full-width chord input/edit band below the editor + preview split —
laid its clusters out in a wrapping row with `align-items: flex-end`,
bottom-aligning the chord identity block, type chips, quality/bass inputs, and
action buttons. This switches the row's cross-axis alignment to `flex-start`
so the labelled clusters share one baseline at the top and the panel reads
top-down.

Three coordinated changes:

1. **`packages/react/src/styles.css`** — flip the lifted footer's
   `.chordsketch-sheet__cins` row to `align-items: flex-start`. The identity
   head keeps `align-self: stretch`, so its right-hand divider still spans the
   full row height.
2. **`packages/react/src/styles.css`** — add `align-self: center` to the
   label-less actions cluster (`.chordsketch-sheet__cins-footer`). Unlike the
   Root / Type / Quality / Move clusters it has no label above it, so under the
   new top-aligned cross axis it would otherwise pin its Remove button to the
   row's top edge — above every labelled cluster's control. Centring matches
   the design-system reference's `.cins__actions` and closes a pre-existing
   parity gap (the React rule was missing the `align-self` the reference has).
3. **`design-system/ui_kits/web/editor-chord-footer.html`** — flip the
   canonical reference's `.cins` band to `align-items: flex-start` too, so the
   documented source of truth (declared authoritative for `@chordsketch/react`
   in `CLAUDE.md`) stays in lockstep with the shipped styles.

## Why

The bottom-aligned clusters made the chord-editor footer look misaligned: the
identity block, chip grid, and inputs floated to the bottom edge of the band
with empty space above. Top-alignment matches the design system's
left-to-right, top-down reading order.

## Test results

- Added an e2e regression assertion in
  `packages/playground/tests-e2e/chord-inspector.spec.ts` that the lifted
  footer computes `align-items: flex-start` (present in both idle and edit
  states at first paint) and that, after selecting a chord, the edit-state
  actions cluster computes `align-self: center`. Reverting either change fails
  this spec in a real browser. CSS layout is not resolved by jsdom, so the
  guard lives in the Playwright suite rather than vitest.
- No existing unit/e2e assertion targeted the previous `align-items` value
  (verified via grep over `packages/react/tests` and
  `packages/playground/tests-e2e`).

## Review summary

The fix lives in the `@chordsketch/react` library (not the playground), per
`.claude/rules/playground-is-a-sample.md`, so every consumer of the lifted
chord-editor footer (playground split view, desktop app, VS Code preview)
picks it up.

## Sister-site audit

- **In-pane dock variant** (`.chordsketch-sheet .chordsketch-sheet__cins`):
  uses `flex-direction: column`, so `align-items` does not bottom-align there —
  the `flex-end` was unique to the lifted (row) footer. Correctly left alone.
- **Design-system reference** (`editor-chord-footer.html`): reconciled in this
  PR (change 3) so the source of truth matches the shipped styles. Its existing
  `.cins__id { align-self: stretch }` and `.cins__actions { align-self: center }`
  already align with the React rules.
- **Renderer parity**: not applicable — this is editor-chrome CSS, not a
  ChordPro directive/AST rendering path, so there are no text/HTML/PDF/JSX-walker
  sister sites.

## Deferred

None.

Closes #2666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCmZZCqNtwte8DjD7jWxvC