### PR TITLE
Give the chord-audio toggle a visible on/off state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single shared voice manager — `useChordEditor` owns the instance and
   exposes a `chordAudio` config the host forwards to the preview.
   Degrades gracefully without Web Audio / under SSR and respects
-  `prefers-reduced-motion`. (#2650)
+  `prefers-reduced-motion`. The `<PreviewToolbar>` toggle now shows its
+  on/off state explicitly — a crimson active fill, a muted-speaker icon
+  and an On/Off badge when off, and a state-aware tooltip — so it no
+  longer looks identical whether chord audio is enabled or not.
+  (#2650, #2669)
 - `@chordsketch/react`: a chord click in the preview is now an idempotent
   **select** rather than a toggle — re-clicking the already-selected
   chord keeps it selected (and, with chord audio on, re-auditions it)

--- a/packages/playground/tests-e2e/chord-audio.spec.ts
+++ b/packages/playground/tests-e2e/chord-audio.spec.ts
@@ -37,6 +37,9 @@ test.describe('chord-audio toggle on the ChordPro preview', () => {
     const toggle = toolbar.getByRole('button', { name: 'Play chords on click' });
     await expect(toggle).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    // The toggle must read its state visibly, not only via aria-pressed
+    // (#2669) — the off state shows an "Off" badge in the deployed bundle.
+    await expect(toggle).toContainText('Off');
 
     // Before enabling audio mode, no chord carries the audio affordance.
     const audioChords = page.locator('.chordsketch-preview .chord--audio');
@@ -45,6 +48,8 @@ test.describe('chord-audio toggle on the ChordPro preview', () => {
     // Enable audio mode: chords become play buttons.
     await toggle.click();
     await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    // The visible badge flips to "On" so the enabled state is unmistakable.
+    await expect(toggle).toContainText('On');
     await expect(audioChords.first()).toBeVisible();
 
     const firstChord = audioChords.first();

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -106,7 +106,7 @@ export interface PreviewToolbarProps
   trailing?: ReactNode;
 }
 
-const AUDIO_ICON = (
+const AUDIO_ON_ICON = (
   <svg
     width="16"
     height="16"
@@ -122,6 +122,28 @@ const AUDIO_ICON = (
     <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
     <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
     <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+  </svg>
+);
+
+// Muted-speaker glyph (a struck-out volume mark) so the off state is
+// distinguishable from the on state by shape alone, not just by the
+// active fill colour — see #2669.
+const AUDIO_OFF_ICON = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+    <line x1="23" y1="9" x2="17" y2="15" />
+    <line x1="17" y1="9" x2="23" y2="15" />
   </svg>
 );
 
@@ -287,11 +309,21 @@ export function PreviewToolbar({
             className="chordsketch-preview-toolbar__audio-toggle btn btn-secondary btn-sm"
             aria-pressed={Boolean(chordAudioEnabled)}
             aria-label="Play chords on click"
-            title="Play chords on click"
+            title={
+              chordAudioEnabled
+                ? 'Chord audio on — click to stop playing chords'
+                : 'Chord audio off — click to play chords'
+            }
             onClick={() => onChordAudioToggle!(!chordAudioEnabled)}
           >
-            {AUDIO_ICON}
+            {chordAudioEnabled ? AUDIO_ON_ICON : AUDIO_OFF_ICON}
             <span>Chord audio</span>
+            <span
+              className="chordsketch-preview-toolbar__audio-state"
+              aria-hidden="true"
+            >
+              {chordAudioEnabled ? 'On' : 'Off'}
+            </span>
           </button>
         </div>
       ) : null}

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -306,7 +306,15 @@ export function PreviewToolbar({
           </span>
           <button
             type="button"
-            className="chordsketch-preview-toolbar__audio-toggle btn btn-secondary btn-sm"
+            /* No `btn btn-secondary` here, unlike the Export button: this
+               is a stateful toggle, and `@chordsketch/react-ui`'s generic
+               `.btn-secondary:hover` background fights the `aria-pressed`
+               active fill when both stylesheets are loaded (the playground
+               loads react-ui after react). The dedicated
+               `.chordsketch-preview-toolbar__audio-toggle` rule owns the
+               full styling so the on/off state is correct with or without
+               react-ui present (#2669). */
+            className="chordsketch-preview-toolbar__audio-toggle"
             aria-pressed={Boolean(chordAudioEnabled)}
             aria-label="Play chords on click"
             title={

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -368,18 +368,31 @@
 }
 
 /* Chord-audio toggle (#2669). The button is a stateful on/off control,
- * so it must look visibly different in each state — the bare
- * `btn btn-secondary` it previously inherited rendered identically
- * whether audio mode was on or off, leaving the only state signal in the
- * invisible `aria-pressed` attribute. The off state is a neutral outline
+ * so it must look visibly different in each state — before this rule the
+ * button only carried the generic `btn btn-secondary` classes and
+ * rendered identically whether audio mode was on or off, leaving the
+ * only state signal in the invisible `aria-pressed` attribute.
+ *
+ * This rule is fully self-contained (it does NOT rely on
+ * `@chordsketch/react-ui`'s `.btn` classes, which are an optional peer
+ * stylesheet not loaded by every consumer, and whose
+ * `.btn-secondary:hover` background actively conflicts with the active
+ * fill below when it is loaded). The off state is a neutral outline
  * button; the on (`aria-pressed='true'`) state fills with the
- * design-system crimson, matching the `<ChordInspector>` chip pattern. */
+ * design-system crimson, matching the `<ChordInspector>` chip pattern.
+ * The sizing / font tokens mirror `.btn-sm` (28px) so the toggle lines
+ * up with the Export button and the Diagrams select beside it. */
 .chordsketch-preview-toolbar__audio-toggle {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
-  padding: 0.25rem 0.625rem;
-  font: inherit;
+  box-sizing: border-box;
+  height: 28px;
+  padding: 0 0.625rem;
+  font-family: var(--cs-font-jp);
+  font-weight: 500;
+  font-size: 0.8125rem;
+  line-height: 1;
   cursor: pointer;
   background: var(--cs-surface, #fff);
   border: 1px solid var(--cs-border-strong, #d4d1d6);

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -367,6 +367,63 @@
   outline-offset: 2px;
 }
 
+/* Chord-audio toggle (#2669). The button is a stateful on/off control,
+ * so it must look visibly different in each state — the bare
+ * `btn btn-secondary` it previously inherited rendered identically
+ * whether audio mode was on or off, leaving the only state signal in the
+ * invisible `aria-pressed` attribute. The off state is a neutral outline
+ * button; the on (`aria-pressed='true'`) state fills with the
+ * design-system crimson, matching the `<ChordInspector>` chip pattern. */
+.chordsketch-preview-toolbar__audio-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  font: inherit;
+  cursor: pointer;
+  background: var(--cs-surface, #fff);
+  border: 1px solid var(--cs-border-strong, #d4d1d6);
+  border-radius: 4px;
+  color: var(--cs-text-secondary, #67646d);
+  transition: background-color var(--cs-dur-1) var(--cs-ease-out),
+    border-color var(--cs-dur-1) var(--cs-ease-out),
+    color var(--cs-dur-1) var(--cs-ease-out);
+}
+
+.chordsketch-preview-toolbar__audio-toggle:hover {
+  border-color: var(--cs-text-secondary, #67646d);
+}
+
+.chordsketch-preview-toolbar__audio-toggle:focus-visible {
+  outline: none;
+  border-color: var(--cs-crimson-500, #bd1642);
+  box-shadow: var(--cs-focus-ring, 0 0 0 3px rgba(189, 22, 66, 0.35));
+}
+
+.chordsketch-preview-toolbar__audio-toggle[aria-pressed='true'] {
+  background: var(--cs-crimson-500, #bd1642);
+  border-color: var(--cs-crimson-500, #bd1642);
+  color: var(--cs-fg-on-crimson, #fff);
+}
+
+.chordsketch-preview-toolbar__audio-toggle[aria-pressed='true']:hover {
+  background: var(--cs-crimson-600, #a30f37);
+  border-color: var(--cs-crimson-600, #a30f37);
+}
+
+/* Explicit On/Off badge — a non-colour-dependent state signal so the
+ * control is unambiguous for colour-blind users and at a glance. */
+.chordsketch-preview-toolbar__audio-state {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.35rem;
+  border: 1px solid currentColor;
+  border-radius: var(--cs-r-full, 9999px);
+}
+
 .chordsketch-sheet {
   font-family: inherit;
 }

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -191,6 +191,38 @@ describe('<PreviewToolbar>', () => {
     expect(onChordAudioToggle).toHaveBeenLastCalledWith(false);
   });
 
+  test('Audio toggle shows an explicit On/Off state label and a state-aware title', () => {
+    const { rerender } = render(
+      <PreviewToolbar
+        source={SAMPLE}
+        transpose={0}
+        onTransposeChange={vi.fn()}
+        chordAudioEnabled={false}
+        onChordAudioToggle={vi.fn()}
+      />,
+    );
+    const off = screen.getByRole('button', { name: 'Play chords on click' });
+    // The visible badge is the non-colour-dependent on/off signal (#2669).
+    expect(off.textContent).toContain('Off');
+    expect(off.textContent).not.toContain('On');
+    expect(off.getAttribute('title')).toBe('Chord audio off — click to play chords');
+
+    rerender(
+      <PreviewToolbar
+        source={SAMPLE}
+        transpose={0}
+        onTransposeChange={vi.fn()}
+        chordAudioEnabled
+        onChordAudioToggle={vi.fn()}
+      />,
+    );
+    const on = screen.getByRole('button', { name: 'Play chords on click' });
+    expect(on.textContent).toContain('On');
+    expect(on.getAttribute('title')).toBe(
+      'Chord audio on — click to stop playing chords',
+    );
+  });
+
   test('per-group opt-out: showTranspose/showExport=false', () => {
     render(
       <PreviewToolbar


### PR DESCRIPTION
## What

The "Chord audio" toggle in `<PreviewToolbar>` (the Audio group used by
the playground preview, and available to the VS Code / desktop hosts)
now reads its on/off state visibly:

- An **active fill** in the on state — design-system crimson with white
  label, matching the `<ChordInspector>` `aria-pressed` chip pattern; a
  neutral outline button in the off state.
- A **muted-speaker icon** when off vs. the volume icon when on, so the
  state is distinguishable by shape, not colour alone.
- An explicit **On/Off badge** and a **state-aware tooltip**, so the
  control is unambiguous for colour-blind users and at a glance.

The toggle is also **decoupled from `@chordsketch/react-ui`'s generic
`.btn` classes** and given complete self-contained styling in
`@chordsketch/react/styles.css`.

## Why

Before this change the button carried only the generic
`btn btn-secondary btn-sm` classes and had **no CSS rule of its own**, so
it rendered identically whether chord audio was on or off — the only
state signal lived in the invisible `aria-pressed` attribute. Sighted
users could not tell whether audio mode was enabled.

The decoupling fixes a second, deeper defect surfaced during self-review:
react-ui's `.btn-secondary:hover:not(:disabled)` (specificity `0,3,0`)
ties the `[aria-pressed='true']:hover` rule but loads *after*
`@chordsketch/react/styles.css` in the playground, so hovering the **on**
toggle painted an `ink-100` grey background under the white label —
unreadable and indistinguishable from off, defeating the fix in the
deployed bundle. react-ui is also an optional peer stylesheet (VS Code /
desktop never load it), so the toggle must own its styling outright. The
dedicated rule now renders correctly with or without react-ui present and
mirrors `.btn-sm` sizing so it still lines up with the Export button.

## Test results

- `@chordsketch/react`: `npm test` → 879 passed (41 files), incl. a new
  `<PreviewToolbar>` test asserting the visible On/Off label and the
  state-aware title flip.
- `npm run typecheck` → clean (exit 0). `npm run build` → success.
- Playground `chord-audio` Playwright smoke extended to assert the
  visible "On"/"Off" badge in the deployed bundle (not just
  `aria-pressed`), per `.claude/rules/playground-smoke.md`.

## Review summary

- **Code review** (high effort): surfaced one Medium — the react-ui
  `.btn-secondary:hover` cascade conflict overriding the active state on
  hover in the playground — fixed at root by decoupling from the generic
  button classes rather than out-specifying the cascade.
- **Security review**: no findings. Presentational change only; the sole
  dynamic value is a `boolean`, no untrusted input, no
  `dangerouslySetInnerHTML`, no new attack surface.
- **Sister-site audit**: the toggle UI exists only in
  `preview-toolbar.tsx`; no equivalent control in other surfaces, so no
  fix-propagation obligation. Renderer-parity does not apply (this is a
  toolbar control, not a ChordPro directive / AST node).

## Sister-site audit

Checked for duplicate toggle implementations across `packages/` — the
`chordsketch-preview-toolbar__audio-toggle` control is defined only in
`packages/react/src/preview-toolbar.tsx`; all other `chordAudio`
references are consumers (e.g. `<ChordSheet>` rendering audio chords),
not copies of the toggle. No equivalent fix needed elsewhere.

Closes #2669
</body>


---
_Generated by [Claude Code](https://claude.ai/code/session_011wWoL7Y6k6jMZEixWkba8M)_