### PR TITLE
Drop the On/Off text badge from the chord-audio toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exposes a `chordAudio` config the host forwards to the preview.
   Degrades gracefully without Web Audio / under SSR and respects
   `prefers-reduced-motion`. The `<PreviewToolbar>` toggle now shows its
-  on/off state explicitly — a crimson active fill, a muted-speaker icon
-  and an On/Off badge when off, and a state-aware tooltip — so it no
-  longer looks identical whether chord audio is enabled or not.
-  (#2650, #2669)
+  on/off state explicitly — a crimson active fill, a state-aware tooltip,
+  and an icon that changes shape with state (a volume-waves glyph when on
+  vs. a struck-out muted-speaker glyph when off, so the state reads by
+  shape, not colour alone) — so it no longer looks identical whether
+  chord audio is enabled or not. (#2650, #2669, #2676)
 - `@chordsketch/react`: a chord click in the preview is now an idempotent
   **select** rather than a toggle — re-clicking the already-selected
   chord keeps it selected (and, with chord audio on, re-auditions it)

--- a/packages/playground/tests-e2e/chord-audio.spec.ts
+++ b/packages/playground/tests-e2e/chord-audio.spec.ts
@@ -38,12 +38,11 @@ test.describe('chord-audio toggle on the ChordPro preview', () => {
     await expect(toggle).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-pressed', 'false');
     // The toggle must read its state visibly, not only via aria-pressed
-    // (#2669). The visible signal is the icon shape (#2676 dropped the
-    // text badge): the off state draws the struck-out muted-speaker glyph,
-    // whose two crossing strokes are the only `<svg line>` elements either
-    // icon uses, so their presence proves the off icon rendered in the
-    // deployed bundle.
-    await expect(toggle.locator('svg line')).toHaveCount(2);
+    // (#2669). The visible signal is the icon (#2676 dropped the text
+    // badge): the off state draws the muted-speaker glyph, tagged with the
+    // geometry-independent `data-audio-icon="off"` marker, so its presence
+    // proves the off icon rendered in the deployed bundle.
+    await expect(toggle.locator('[data-audio-icon="off"]')).toHaveCount(1);
 
     // Before enabling audio mode, no chord carries the audio affordance.
     const audioChords = page.locator('.chordsketch-preview .chord--audio');
@@ -52,9 +51,10 @@ test.describe('chord-audio toggle on the ChordPro preview', () => {
     // Enable audio mode: chords become play buttons.
     await toggle.click();
     await expect(toggle).toHaveAttribute('aria-pressed', 'true');
-    // The icon flips to the volume-waves glyph (no `<line>` strokes), so the
-    // enabled state is visibly distinct in shape, not colour alone.
-    await expect(toggle.locator('svg line')).toHaveCount(0);
+    // The icon flips to the volume-waves glyph (`data-audio-icon="on"`), so
+    // the enabled state is visibly distinct in shape, not colour alone.
+    await expect(toggle.locator('[data-audio-icon="on"]')).toHaveCount(1);
+    await expect(toggle.locator('[data-audio-icon="off"]')).toHaveCount(0);
     await expect(audioChords.first()).toBeVisible();
 
     const firstChord = audioChords.first();

--- a/packages/playground/tests-e2e/chord-audio.spec.ts
+++ b/packages/playground/tests-e2e/chord-audio.spec.ts
@@ -38,8 +38,12 @@ test.describe('chord-audio toggle on the ChordPro preview', () => {
     await expect(toggle).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-pressed', 'false');
     // The toggle must read its state visibly, not only via aria-pressed
-    // (#2669) — the off state shows an "Off" badge in the deployed bundle.
-    await expect(toggle).toContainText('Off');
+    // (#2669). The visible signal is the icon shape (#2676 dropped the
+    // text badge): the off state draws the struck-out muted-speaker glyph,
+    // whose two crossing strokes are the only `<svg line>` elements either
+    // icon uses, so their presence proves the off icon rendered in the
+    // deployed bundle.
+    await expect(toggle.locator('svg line')).toHaveCount(2);
 
     // Before enabling audio mode, no chord carries the audio affordance.
     const audioChords = page.locator('.chordsketch-preview .chord--audio');
@@ -48,8 +52,9 @@ test.describe('chord-audio toggle on the ChordPro preview', () => {
     // Enable audio mode: chords become play buttons.
     await toggle.click();
     await expect(toggle).toHaveAttribute('aria-pressed', 'true');
-    // The visible badge flips to "On" so the enabled state is unmistakable.
-    await expect(toggle).toContainText('On');
+    // The icon flips to the volume-waves glyph (no `<line>` strokes), so the
+    // enabled state is visibly distinct in shape, not colour alone.
+    await expect(toggle.locator('svg line')).toHaveCount(0);
     await expect(audioChords.first()).toBeVisible();
 
     const firstChord = audioChords.first();

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -326,12 +326,6 @@ export function PreviewToolbar({
           >
             {chordAudioEnabled ? AUDIO_ON_ICON : AUDIO_OFF_ICON}
             <span>Chord audio</span>
-            <span
-              className="chordsketch-preview-toolbar__audio-state"
-              aria-hidden="true"
-            >
-              {chordAudioEnabled ? 'On' : 'Off'}
-            </span>
           </button>
         </div>
       ) : null}

--- a/packages/react/src/preview-toolbar.tsx
+++ b/packages/react/src/preview-toolbar.tsx
@@ -106,8 +106,15 @@ export interface PreviewToolbarProps
   trailing?: ReactNode;
 }
 
+// Volume-waves glyph for the on state. The `data-audio-icon` marker is a
+// stable, geometry-independent hook for the on/off visible state: tests
+// (and host CSS) target the marker rather than the glyph's internal
+// strokes, so the icon can be redrawn without breaking the state checks
+// while the marker still proves the correct *visible* icon rendered
+// (#2669, #2676).
 const AUDIO_ON_ICON = (
   <svg
+    data-audio-icon="on"
     width="16"
     height="16"
     viewBox="0 0 24 24"
@@ -130,6 +137,7 @@ const AUDIO_ON_ICON = (
 // active fill colour — see #2669.
 const AUDIO_OFF_ICON = (
   <svg
+    data-audio-icon="off"
     width="16"
     height="16"
     viewBox="0 0 24 24"

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -424,19 +424,6 @@
   border-color: var(--cs-crimson-600, #a30f37);
 }
 
-/* Explicit On/Off badge — a non-colour-dependent state signal so the
- * control is unambiguous for colour-blind users and at a glance. */
-.chordsketch-preview-toolbar__audio-state {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  padding: 0.1rem 0.35rem;
-  border: 1px solid currentColor;
-  border-radius: var(--cs-r-full, 9999px);
-}
-
 .chordsketch-sheet {
   font-family: inherit;
 }

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -191,7 +191,7 @@ describe('<PreviewToolbar>', () => {
     expect(onChordAudioToggle).toHaveBeenLastCalledWith(false);
   });
 
-  test('Audio toggle shows an explicit On/Off state label and a state-aware title', () => {
+  test('Audio toggle signals state by icon shape and a state-aware title', () => {
     const { rerender } = render(
       <PreviewToolbar
         source={SAMPLE}
@@ -202,9 +202,14 @@ describe('<PreviewToolbar>', () => {
       />,
     );
     const off = screen.getByRole('button', { name: 'Play chords on click' });
-    // The visible badge is the non-colour-dependent on/off signal (#2669).
-    expect(off.textContent).toContain('Off');
-    expect(off.textContent).not.toContain('On');
+    // The on/off state must be visible without relying on colour (#2669,
+    // #2676): the off state draws the struck-out muted-speaker glyph,
+    // whose two crossing strokes are the only `<line>` elements either
+    // icon uses, so their presence is a shape-based (not colour-based)
+    // off-state assertion. The literal "On"/"Off" text badge was dropped
+    // in #2676, so the label reads "Chord audio" in both states.
+    expect(off.querySelectorAll('svg line')).toHaveLength(2);
+    expect(off.textContent).toBe('Chord audio');
     expect(off.getAttribute('title')).toBe('Chord audio off — click to play chords');
 
     rerender(
@@ -217,7 +222,10 @@ describe('<PreviewToolbar>', () => {
       />,
     );
     const on = screen.getByRole('button', { name: 'Play chords on click' });
-    expect(on.textContent).toContain('On');
+    // The on state swaps to the volume-waves glyph, which has no `<line>`
+    // strokes — the shape flips with state.
+    expect(on.querySelectorAll('svg line')).toHaveLength(0);
+    expect(on.textContent).toBe('Chord audio');
     expect(on.getAttribute('title')).toBe(
       'Chord audio on — click to stop playing chords',
     );

--- a/packages/react/tests/preview-toolbar.test.tsx
+++ b/packages/react/tests/preview-toolbar.test.tsx
@@ -203,12 +203,13 @@ describe('<PreviewToolbar>', () => {
     );
     const off = screen.getByRole('button', { name: 'Play chords on click' });
     // The on/off state must be visible without relying on colour (#2669,
-    // #2676): the off state draws the struck-out muted-speaker glyph,
-    // whose two crossing strokes are the only `<line>` elements either
-    // icon uses, so their presence is a shape-based (not colour-based)
-    // off-state assertion. The literal "On"/"Off" text badge was dropped
-    // in #2676, so the label reads "Chord audio" in both states.
-    expect(off.querySelectorAll('svg line')).toHaveLength(2);
+    // #2676): the off state draws the muted-speaker glyph, tagged with the
+    // geometry-independent `data-audio-icon="off"` marker. Asserting on the
+    // marker proves the correct *visible* icon rendered while staying
+    // robust to the glyph being redrawn. The literal "On"/"Off" text badge
+    // was dropped in #2676, so the label reads "Chord audio" in both states.
+    expect(off.querySelector('[data-audio-icon="off"]')).not.toBeNull();
+    expect(off.querySelector('[data-audio-icon="on"]')).toBeNull();
     expect(off.textContent).toBe('Chord audio');
     expect(off.getAttribute('title')).toBe('Chord audio off — click to play chords');
 
@@ -222,9 +223,10 @@ describe('<PreviewToolbar>', () => {
       />,
     );
     const on = screen.getByRole('button', { name: 'Play chords on click' });
-    // The on state swaps to the volume-waves glyph, which has no `<line>`
-    // strokes — the shape flips with state.
-    expect(on.querySelectorAll('svg line')).toHaveLength(0);
+    // The on state swaps to the volume-waves glyph (`data-audio-icon="on"`),
+    // so the visible icon flips with state.
+    expect(on.querySelector('[data-audio-icon="on"]')).not.toBeNull();
+    expect(on.querySelector('[data-audio-icon="off"]')).toBeNull();
     expect(on.textContent).toBe('Chord audio');
     expect(on.getAttribute('title')).toBe(
       'Chord audio on — click to stop playing chords',


### PR DESCRIPTION
## What

Remove the literal **"On" / "Off" text badge** from the `<PreviewToolbar>` chord-audio toggle (added in #2673). The textual badge was visually redundant with the toggle's other state signals.

The toggle still reads its on/off state **visibly and without relying on colour alone**, via:
- the **icon shape** — a volume-waves glyph when on vs. a struck-out muted-speaker glyph when off,
- the **crimson active fill** when on,
- a **state-aware tooltip**, and
- `aria-pressed` for assistive tech.

Each icon now also carries a stable, geometry-independent **`data-audio-icon="on" / "off"`** marker on the visible `<svg>` element, so tests (and host CSS) can target the on/off state without coupling to the glyph's internal stroke geometry.

## Why

The On/Off text badge duplicated information the icon shape, active fill, and tooltip already convey. Removing it is safe for accessibility because the **icon already changes shape per state** — that shape difference (predating #2673) is the genuine non-colour-dependent visible signal #2669 required; the badge was belt-and-suspenders. `aria-pressed` continues to carry state for screen readers (the badge was `aria-hidden`, so it never reached the accessibility tree).

WCAG 1.4.1 (use of colour) stays satisfied: state is distinguishable by icon shape and tooltip, not colour alone.

## Test results

- `@chordsketch/react`: `npm test` → **889 passed (42 files)**, incl. the updated `<PreviewToolbar>` test asserting the icon-shape state marker (`data-audio-icon`) and the state-aware title flip.
- `npm run typecheck` → clean. `npm run build` → success.
- Playground `chord-audio` Playwright smoke re-pointed at the `data-audio-icon` marker (a structural anchor, per `.claude/rules/playground-smoke.md`) to prove the correct visible icon renders in the deployed bundle; the `pageerror` listener and `.chord--audio` presence/absence assertions are unchanged.

## Review summary

- **Code review** (high effort, 8 finder angles): one **Low** — the tests originally asserted state via the icon's internal `<line>` stroke count, coupling them to glyph geometry. Fixed at root by adding the `data-audio-icon` marker on the visible icon element (a stable hook that still proves the *visible* signal rendered — unlike a data attribute that merely mirrors `aria-pressed`). Delta review converged with **zero findings**.
- **Security review**: no findings — presentational change, no untrusted input, no new sinks, no new dependencies.
- **Accessibility / removed-behavior review**: confirmed safe — the icon-shape signal predates this change, `aria-pressed` covers screen readers, the removed badge was `aria-hidden`.
- **Project-rules audit**: compliant with `playground-smoke.md`, `fix-propagation.md`, `root-cause-fixes.md`, `code-style.md`, `english-only.md`, and `doc-maintenance.md` (CLAUDE.md never referenced the badge, so no stale text).

## Sister-site audit

The chord-audio toggle is defined only in `packages/react/src/preview-toolbar.tsx` (re-exported via `index.ts`, consumed by the playground); there is no duplicate toggle to keep in lockstep. Renderer-parity does not apply (toolbar control, not a ChordPro directive / AST node).

Closes #2676

---
_Generated by [Claude Code](https://claude.ai/code/session_011wWoL7Y6k6jMZEixWkba8M)_