### PR TITLE
Remove chord-audio hover tint that hid the ringing chord

### DIFF
--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1568,14 +1568,13 @@
    ring, and the activation pulse (`.chord--ringing`, added imperatively
    by the walker and removed on animationend).
 
-   There is deliberately NO hover background tint. A hover tint paints a
-   light background, but `.chord--ringing` paints WHITE text on the
-   chord while it sounds, and a hover selector outscopes the ringing
-   rule on specificity — so a light hover background under white ring
-   text rendered the chord unreadable (it looked like it vanished). The
-   earlier `:not(.chord--selected)` scoping only covered the persistent
-   selected badge and missed this transient white-text state, so the
-   tint is removed at the root rather than re-scoped. */
+   Do NOT add a hover background tint here. `.chord--ringing` paints
+   WHITE text on the chord while it sounds, and a `:hover` selector
+   wins over the `.chord--ringing` rule on specificity — so a light
+   hover background would render under white ring text and make the
+   just-played chord unreadable (it looks like it vanished). Scoping
+   the tint with `:not(.chord--selected)` does not help: that guards
+   only the persistent selected badge, not the transient ring state. */
 .chordsketch-sheet__content .chord--audio {
   cursor: pointer;
   border-radius: var(--cs-r-2, 4px);

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1563,24 +1563,25 @@
 }
 
 /* ---- Chord audio (#2650) -------------------------------------- */
-/* In chord-audio mode each chord is a play button. Hover/focus give a
-   speaker affordance; activating one briefly pulses the `.chord--ringing`
-   class (added imperatively by the walker, removed on animationend). */
+/* In chord-audio mode each chord is a play button. The clickable
+   affordance is carried by `cursor: pointer`, the `:focus-visible`
+   ring, and the activation pulse (`.chord--ringing`, added imperatively
+   by the walker and removed on animationend).
+
+   There is deliberately NO hover background tint. A hover tint paints a
+   light background, but `.chord--ringing` paints WHITE text on the
+   chord while it sounds, and a hover selector outscopes the ringing
+   rule on specificity — so a light hover background under white ring
+   text rendered the chord unreadable (it looked like it vanished). The
+   earlier `:not(.chord--selected)` scoping only covered the persistent
+   selected badge and missed this transient white-text state, so the
+   tint is removed at the root rather than re-scoped. */
 .chordsketch-sheet__content .chord--audio {
   cursor: pointer;
   border-radius: var(--cs-r-2, 4px);
   transition:
     background 0.12s ease,
     color 0.12s ease;
-}
-/* Audio + selection are additive (#2650 follow-up): a chord can carry
-   both classes. The selected badge (filled crimson + white text) must
-   keep winning over the audio hover tint, otherwise hovering a selected
-   chord would paint white text on the light-pink hover background and
-   become unreadable — so scope the hover tint to the non-selected
-   chord. */
-.chordsketch-sheet__content .chord--audio:not(.chord--selected):hover {
-  background: var(--cs-crimson-50, #fdf2f5);
 }
 .chordsketch-sheet__content .chord--audio:focus-visible {
   outline: none;

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -1,9 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
-
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
+
+import { readStylesheetSource } from './stylesheet-source';
 
 import { ChordSheet } from '../src/index';
 import type { ChordWasmLoader } from '../src/use-chord-render';
@@ -1292,26 +1290,28 @@ describe('<ChordSheet>', () => {
   });
 
   test('audio chords carry no hover background tint that could clash with the ringing white text', () => {
-    // Regression: in audio-only (preview) mode, clicking a chord adds
-    // `.chord--ringing` (crimson background + WHITE text) for the
-    // activation pulse. A `.chord--audio…:hover` rule that paints a light
-    // background outscopes the ringing rule on specificity, so hovering
-    // during/after the ring painted a light background under white text —
-    // the chord looked like it vanished. The fix removes the hover
-    // background tint at the root rather than re-scoping it; jsdom does
-    // not apply CSS, so the guard reads the stylesheet source directly
-    // (same approach as metronome-button.test.tsx).
-    const here = dirname(fileURLToPath(import.meta.url));
-    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8').replace(
-      /\/\*[\s\S]*?\*\//g,
-      '',
-    );
-    // Every `.chord--audio … :hover { … }` block (if any survive) must
-    // not set a `background`, the property that produced the unreadable
-    // white-on-light-tint state.
-    const hoverRules = css.match(/\.chord--audio[^{]*:hover[^{]*\{[^}]*\}/g) ?? [];
-    for (const rule of hoverRules) {
-      expect(rule).not.toMatch(/background/);
+    // Regression for the bug fixed alongside this test: see the
+    // "Chord audio" comment in src/styles.css for the full rationale.
+    // In short, a hover rule that paints a light background under a
+    // `.chord--audio` element outranks `.chord--ringing` (white text)
+    // on specificity, so a just-played chord became white-on-light and
+    // looked like it vanished. The fix removes the hover background tint
+    // at the root rather than re-scoping it.
+    const css = readStylesheetSource();
+    // Inspect every rule block (`selector { body }`) and fail any whose
+    // selector targets a `.chord--audio` element on `:hover` while its
+    // body sets a `background`. Splitting on `}` (rather than matching
+    // a `:hover`-immediately-before-`{` shape) catches grouped selector
+    // lists and whitespace variants, so the guard is not bypassed by a
+    // reintroduction in a slightly different form.
+    for (const block of css.split('}')) {
+      const braceAt = block.indexOf('{');
+      if (braceAt === -1) continue;
+      const selector = block.slice(0, braceAt);
+      const body = block.slice(braceAt + 1);
+      if (selector.includes('.chord--audio') && selector.includes(':hover')) {
+        expect(body).not.toMatch(/background/);
+      }
     }
   });
 });

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -1298,19 +1298,19 @@ describe('<ChordSheet>', () => {
     // looked like it vanished. The fix removes the hover background tint
     // at the root rather than re-scoping it.
     const css = readStylesheetSource();
-    // Inspect every rule block (`selector { body }`) and fail any whose
-    // selector targets a `.chord--audio` element on `:hover` while its
-    // body sets a `background`. Splitting on `}` (rather than matching
-    // a `:hover`-immediately-before-`{` shape) catches grouped selector
-    // lists and whitespace variants, so the guard is not bypassed by a
-    // reintroduction in a slightly different form.
-    for (const block of css.split('}')) {
-      const braceAt = block.indexOf('{');
-      if (braceAt === -1) continue;
-      const selector = block.slice(0, braceAt);
-      const body = block.slice(braceAt + 1);
-      if (selector.includes('.chord--audio') && selector.includes(':hover')) {
-        expect(body).not.toMatch(/background/);
+    // Split on `}` so each fragment spans a single rule (selector +
+    // body) — robust to grouped selector lists, whitespace variants,
+    // AND `@media` nesting (the wrapper's `@media (…) {` opener lands in
+    // the same fragment as the inner rule). Fail any fragment that
+    // mentions `.chord--audio`, `:hover`, and `background` together:
+    // that is the unreadable-on-ring combination, in whatever form it
+    // is reintroduced. The base `.chord--audio` rule sets `background`
+    // (in its `transition`) but has no `:hover`, so it is not flagged.
+    for (const fragment of css.split('}')) {
+      const targetsAudioHover =
+        fragment.includes('.chord--audio') && fragment.includes(':hover');
+      if (targetsAudioHover) {
+        expect(fragment).not.toMatch(/background/);
       }
     }
   });

--- a/packages/react/tests/chord-sheet.test.tsx
+++ b/packages/react/tests/chord-sheet.test.tsx
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
@@ -1285,5 +1289,29 @@ describe('<ChordSheet>', () => {
     expect(onChordReposition).toHaveBeenCalledTimes(1);
     expect(play).toHaveBeenCalledTimes(2);
     expect(play).toHaveBeenLastCalledWith('Am');
+  });
+
+  test('audio chords carry no hover background tint that could clash with the ringing white text', () => {
+    // Regression: in audio-only (preview) mode, clicking a chord adds
+    // `.chord--ringing` (crimson background + WHITE text) for the
+    // activation pulse. A `.chord--audio…:hover` rule that paints a light
+    // background outscopes the ringing rule on specificity, so hovering
+    // during/after the ring painted a light background under white text —
+    // the chord looked like it vanished. The fix removes the hover
+    // background tint at the root rather than re-scoping it; jsdom does
+    // not apply CSS, so the guard reads the stylesheet source directly
+    // (same approach as metronome-button.test.tsx).
+    const here = dirname(fileURLToPath(import.meta.url));
+    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8').replace(
+      /\/\*[\s\S]*?\*\//g,
+      '',
+    );
+    // Every `.chord--audio … :hover { … }` block (if any survive) must
+    // not set a `background`, the property that produced the unreadable
+    // white-on-light-tint state.
+    const hoverRules = css.match(/\.chord--audio[^{]*:hover[^{]*\{[^}]*\}/g) ?? [];
+    for (const rule of hoverRules) {
+      expect(rule).not.toMatch(/background/);
+    }
   });
 });

--- a/packages/react/tests/metronome-button.test.tsx
+++ b/packages/react/tests/metronome-button.test.tsx
@@ -1,13 +1,10 @@
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { MetronomeButton } from '../src/metronome-button';
 import { resetMetronomeSharedStateForTests } from '../src/use-metronome';
 import { FakeAudioContext } from './fake-audio-context';
+import { readStylesheetSource } from './stylesheet-source';
 
 // Web Audio fake: the shared stand-in (`./fake-audio-context`). The
 // button test only needs the graph calls not to throw; timing accuracy
@@ -145,14 +142,10 @@ describe('<MetronomeButton>', () => {
   // layout property jsdom does not compute, so the DOM-level tests
   // above cannot catch a regression here.
   test('`.meta-inline` pins box-sizing so span and button chips share a height (#2624)', () => {
-    const here = dirname(fileURLToPath(import.meta.url));
-    // Strip CSS comments first — the explanatory comment inside the
-    // rule mentions `{key}` / `{tempo}` / `{time}`, whose braces would
-    // otherwise terminate the `[^}]` rule-block match prematurely.
-    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8').replace(
-      /\/\*[\s\S]*?\*\//g,
-      '',
-    );
+    // Comments are stripped (helper default) so an explanatory
+    // comment's `{key}` / `{tempo}` / `{time}` braces do not terminate
+    // the `[^}]` rule-block match prematurely.
+    const css = readStylesheetSource();
     // The base `.meta-inline` rule (not a `--variant` modifier) must
     // carry `box-sizing: border-box`. Match the rule block and assert
     // the declaration lives inside it.
@@ -171,11 +164,7 @@ describe('<MetronomeButton>', () => {
   // so assert it against the stylesheet source like the box-sizing
   // test above.
   test('extinguishes the beat-dot LED while playing', () => {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8').replace(
-      /\/\*[\s\S]*?\*\//g,
-      '',
-    );
+    const css = readStylesheetSource();
     // The playing-state rule that targets the beat dot must turn its
     // animation off and set it fully transparent (extinguished).
     const rule = css.match(

--- a/packages/react/tests/music-glyphs.test.tsx
+++ b/packages/react/tests/music-glyphs.test.tsx
@@ -1,7 +1,3 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
-
 import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 
@@ -15,6 +11,7 @@ import {
   relativeMajor,
   tempoMarkingFor,
 } from '../src/music-glyphs';
+import { readStylesheetSource } from './stylesheet-source';
 
 describe('keySignatureFor', () => {
   // Key signature lookups against the Wikipedia "Key signature"
@@ -347,8 +344,10 @@ describe('<MetronomeGlyph>', () => {
   // and one that drops the delay would move the flash back to the
   // extremes — neither would fail the DOM-level tests above.
   test('beat blink and swing share --cs-metronome-period in styles.css', () => {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const css = readFileSync(resolve(here, '../src/styles.css'), 'utf8');
+    // Verbatim source (comments kept): the assertions below match
+    // keyframe / animation declarations that cannot collide with
+    // comment braces.
+    const css = readStylesheetSource({ stripComments: false });
     expect(css).toContain('@keyframes cs-metronome-beat');
     expect(css).toMatch(
       /\.music-glyph--metronome__beat\s*\{\s*animation:\s*cs-metronome-beat var\(--cs-metronome-period/,

--- a/packages/react/tests/stylesheet-source.ts
+++ b/packages/react/tests/stylesheet-source.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const stylesheetPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../src/styles.css',
+);
+
+/**
+ * Read `src/styles.css` as a string for rule-presence assertions.
+ *
+ * jsdom does not apply CSS, so tests that need to assert a stylesheet
+ * rule exists (or, in regression guards, does NOT exist) read the
+ * source directly rather than computing styles on a rendered node.
+ *
+ * Comments are stripped by default: an explanatory comment's braces
+ * (e.g. `{key}` / `{tempo}`) would otherwise terminate a `[^}]`
+ * rule-block match prematurely. Pass `{ stripComments: false }` when a
+ * test matches against keyframe / declaration text that cannot collide
+ * with comment braces and wants the verbatim source.
+ */
+export function readStylesheetSource(
+  options: { stripComments?: boolean } = {},
+): string {
+  const css = readFileSync(stylesheetPath, 'utf8');
+  return options.stripComments === false
+    ? css
+    : css.replace(/\/\*[\s\S]*?\*\//g, '');
+}


### PR DESCRIPTION
## What

Remove the `.chord--audio:not(.chord--selected):hover` background tint from `packages/react/src/styles.css`, and add a stylesheet-source regression guard.

## Why

In chord-audio mode on a preview-only `<ChordSheet>`, clicking a chord plays it and briefly pulses `.chord--ringing`, which paints a crimson background and **white** text. The audio hover rule painted a light-pink background (`--cs-crimson-50`, `#fdf2f5`). A `:hover` selector (4 class-equivalents of specificity) outscopes the `.chord--ringing` rule (2), so hovering during/after the ring left white text on a light background — the chord name became unreadable and looked like it had vanished.

The earlier `:not(.chord--selected)` scoping only guarded the persistent selected badge; it never accounted for the transient white-text ring state, so it was an incomplete fix for the very readability problem its own comment described. The root cause is a hover background rule that can desync from an imperative white-text state, so the tint is removed at the root rather than re-scoped. The click/play affordance remains discoverable via `cursor: pointer`, the `:focus-visible` ring, and the activation pulse — none of which can desync background from text colour.

## Test results

- `npm test` (packages/react): 909 passed (43 files), including the new regression test.
- `npm run typecheck` (local TypeScript 5.9.3): exit 0.
- `npm run build` (tsup ESM + CJS + d.ts): success.
- Verified the new guard fails when the hover tint is reintroduced and passes once removed.

The regression guard reads `styles.css` directly because jsdom does not apply CSS, mirroring the existing approach in `metronome-button.test.tsx`. It asserts no surviving `.chord--audio…:hover` rule sets a `background`.

## Review summary

- Renderer parity: chord-audio is a React-only interaction layer on the JSX walker output; there is no Rust-renderer sibling for the play-button hover state, so no text/HTML/PDF parity change is required.
- `--cs-crimson-50` remains in use elsewhere (`.chordsketch-sheet__cins-chip`), so the token is not orphaned.

## Sister-site audit

The defect class is "a hover background rule outscopes an imperative white-text state on a `.chord`." Searched all `.chord…:hover` rules in `styles.css`: the audio tint was the only chord-level hover background; `.chord--selected` sets no hover background. No equivalent defect remains.

Closes #2683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012qWZocGdQ5UA991G8m5fPW)_