### PR TITLE
Redesign full-size SVG chord-diagram layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Redesigned the regular (full-size) SVG chord-diagram layout
+  (`chordsketch_chordpro::chord_diagram`) for a cleaner, more
+  chart-like look. The fretboard grid is now compact (string spacing
+  16→10px, fret pitch 20→14px) and centred inside the same bounding
+  box with generous margins instead of bleeding to the edges, so the
+  finger dots (radius unchanged at 5px) read as bold, prominent
+  markers — the standard appearance of a printed chord chart. Open/
+  muted glyphs sit closer to the nut (offset 10→7px). The 6-string /
+  5-fret frame is preserved at 120×160px with the grid centred under
+  the title; the horizontal layout follows the same proportions
+  (height 130→102px). This flows through every SVG consumer (CLI
+  `--format html`, the wasm `chord_diagram_svg` exports,
+  `@chordsketch/react`'s `<ChordDiagram>`, the VS Code preview, and
+  the LSP hover). The compact inline/hover layout and the keyboard
+  diagram are unchanged; the PDF renderer's own diagram geometry is
+  not affected.
 - The `@chordsketch/react` Web Audio surface now sounds with more
   musical timbres. `useChordAudio` and `useKeyAudio` voice every pitch
   with a synthesized **piano** timbre (a piano-like `PeriodicWave`

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -296,17 +296,27 @@ pub enum DiagramSize {
 // SVG rendering constants
 // ---------------------------------------------------------------------------
 
-/// Cell width in SVG user units (pixels at 1:1 zoom).
+/// String-to-string spacing in SVG user units (pixels at 1:1 zoom).
 ///
-/// Intentionally larger than the PDF renderer's 10.0 pt because SVG
-/// diagrams target on-screen display where more generous spacing
-/// improves readability. The PDF renderer uses smaller values (10x12 pt)
-/// suited for printed page layout.
-const CELL_W: f32 = 16.0;
-/// Cell height in SVG user units. See [`CELL_W`] for rationale.
-const CELL_H: f32 = 20.0;
-const TOP_MARGIN: f32 = 30.0;
-const LEFT_MARGIN: f32 = 20.0;
+/// Deliberately tighter than the finger-dot diameter (`DOT_RADIUS * 2 =
+/// 10`) so a fretted dot reads as a bold, prominent marker that nearly
+/// spans the gap between adjacent strings — the standard look of a
+/// printed chord chart. The grid is intentionally compact and floated
+/// inside a generous margin (see `LEFT_MARGIN` / `TOP_MARGIN` /
+/// `DiagramMetrics::regular`'s `bottom_pad_vertical`) rather than
+/// filling the bounding box edge-to-edge.
+const CELL_W: f32 = 10.0;
+/// Fret pitch in SVG user units. Larger than [`CELL_W`] so the cells stay
+/// taller than they are wide, matching a real fretboard's proportions.
+const CELL_H: f32 = 14.0;
+/// Vertical space above the nut for the title row + open/muted glyph row.
+const TOP_MARGIN: f32 = 32.0;
+/// Side gutter. With the compact grid this also recentres the fretboard
+/// inside the bounding box: `total_w = grid_w + LEFT_MARGIN * 2`, so a
+/// 6-string diagram lands at the historical 120px width with the grid
+/// centred (string axis centred under the title) instead of bleeding to
+/// the edges.
+const LEFT_MARGIN: f32 = 35.0;
 const DOT_RADIUS: f32 = 5.0;
 const OPEN_RADIUS: f32 = 4.0;
 /// Faint inlay-marker dot radius. Smaller and lighter than the
@@ -315,11 +325,12 @@ const OPEN_RADIUS: f32 = 4.0;
 const POSITION_DOT_RADIUS: f32 = 2.2;
 /// Distance from the nut at which open / muted single-string glyphs
 /// sit. In the vertical renderer this is the vertical offset
-/// `nut_y - 10.0` (above the nut); in the horizontal renderer it is
-/// the analogous horizontal offset `nut_x - 10.0` (left of the nut).
-/// Pinned at 10 SVG-pixels so glyphs clear the nut line + stroke
-/// width without colliding with the chord title text above.
-const NUT_MARGIN_GLYPH_OFFSET: f32 = 10.0;
+/// `nut_y - 7.0` (above the nut); in the horizontal renderer it is
+/// the analogous horizontal offset `nut_x - 7.0` (left of the nut).
+/// Pinned at 7 SVG-pixels so glyphs sit close to the nut (a tight,
+/// chart-like look) while still clearing the nut line + stroke width
+/// without colliding with the chord title text above.
+const NUT_MARGIN_GLYPH_OFFSET: f32 = 7.0;
 /// Fraction of `CELL_W` / `CELL_H` by which the 12-fret octave inlay's
 /// two dots offset from their cell centre. Slightly past the half-cell
 /// (0.50) so the gap reads as "two dots" rather than "one dot wider
@@ -411,7 +422,12 @@ impl DiagramMetrics {
             cell_h: CELL_H,
             top_margin: TOP_MARGIN,
             left_margin: LEFT_MARGIN,
-            bottom_pad_vertical: 30.0,
+            // Keeps the diagram's overall frame at the historical 120x160
+            // for a 6-string / 5-fret shape: total_h = grid_h (5*14=70) +
+            // top_margin (32) + bottom_pad_vertical (58) = 160. The compact
+            // grid floats in the upper portion of that frame rather than
+            // filling it edge-to-edge.
+            bottom_pad_vertical: 58.0,
             bottom_pad_horizontal: 20.0,
             dot_radius: DOT_RADIUS,
             open_radius: OPEN_RADIUS,
@@ -420,10 +436,12 @@ impl DiagramMetrics {
             title_font: 14.0,
             title_baseline: 15.0,
             label_font: 10.0,
-            // Regular keeps the historical axis font/gap (= label_font, 4.0) so
-            // its output stays byte-for-byte identical.
+            // Axis font matches label_font; the gap is widened to 7 so the
+            // right-anchored fret numbers clear the recentred grid's left
+            // edge (left_margin - fret_label_gap = 35 - 7 = 28) while still
+            // leaving room for 2-digit labels inside the gutter.
             fret_label_font: 10.0,
-            fret_label_gap: 4.0,
+            fret_label_gap: 7.0,
             finger_font: 8.0,
             text_v_center: 3.0,
             nut_stroke: 3.0,
@@ -2723,7 +2741,7 @@ mod tests {
         // `x1=LEFT_MARGIN x2=LEFT_MARGIN`.
         let svg = horizontal_am_svg();
         assert!(
-            svg.contains("x1=\"20\" y1=\"30\" x2=\"20\""),
+            svg.contains("x1=\"35\" y1=\"32\" x2=\"35\""),
             "expected vertical nut line anchored at LEFT_MARGIN/TOP_MARGIN; got: {svg}"
         );
         assert!(svg.contains("stroke-width=\"3\""));
@@ -2755,19 +2773,19 @@ mod tests {
 
     #[test]
     fn horizontal_open_and_muted_markers_sit_left_of_nut() {
-        // Open / muted markers are placed at x = LEFT_MARGIN - 10 = 10 in
-        // horizontal mode (the analogue of the vertical mode's y = nut_y - 10
+        // Open / muted markers are placed at x = LEFT_MARGIN - 7 = 28 in
+        // horizontal mode (the analogue of the vertical mode's y = nut_y - 7
         // placement above the nut).
         let svg = horizontal_am_svg();
-        // "X" mute glyph at x=10 for the muted 6th string.
+        // "X" mute glyph at x=28 for the muted 6th string.
         assert!(
-            svg.contains("<text x=\"10\""),
-            "expected muted-X glyph anchored at x=10; got: {svg}"
+            svg.contains("<text x=\"28\""),
+            "expected muted-X glyph anchored at x=28; got: {svg}"
         );
-        // Open-string circle at cx=10.
+        // Open-string circle at cx=28.
         assert!(
-            svg.contains("<circle cx=\"10\""),
-            "expected open-string circle at cx=10; got: {svg}"
+            svg.contains("<circle cx=\"28\""),
+            "expected open-string circle at cx=28; got: {svg}"
         );
     }
 
@@ -2776,11 +2794,11 @@ mod tests {
         // Reader-view (the only horizontal layout): in ChordPro's low-to-high
         // `frets` ordering, index 5 (high E for guitar) sits on row 0 (top).
         // For Am the open 1st string (i=5, fret=0) produces an open-circle on
-        // the top row at y = TOP_MARGIN = 30.
+        // the top row at y = TOP_MARGIN = 32.
         let svg = horizontal_am_svg();
         assert!(
-            svg.contains("<circle cx=\"10\" cy=\"30\""),
-            "expected open marker for high E on top row (cy=30); got: {svg}"
+            svg.contains("<circle cx=\"28\" cy=\"32\""),
+            "expected open marker for high E on top row (cy=32); got: {svg}"
         );
     }
 
@@ -2830,12 +2848,12 @@ mod tests {
         // and differ only in y. Look for two dots with the same cx and the
         // characteristic ± string_pitch * 0.55 offset from the centre row.
         // For 6-string guitar in horizontal mode the string axis uses
-        // string_pitch = CELL_W = 16:
-        //   grid_h = (6 - 1) * 16 = 80; center_y = TOP_MARGIN + 40 = 70;
-        //   16 * 0.55 = 8.8; so cy1 = 61.2, cy2 = 78.8.
+        // string_pitch = CELL_W = 10:
+        //   grid_h = (6 - 1) * 10 = 50; center_y = TOP_MARGIN + 25 = 57;
+        //   10 * 0.55 = 5.5; so cy1 = 51.5, cy2 = 62.5.
         assert!(
-            svg.contains("cy=\"61.2\"") && svg.contains("cy=\"78.8\""),
-            "expected 12-fret double dot at cy=61.2 / cy=78.8; got: {svg}"
+            svg.contains("cy=\"51.5\"") && svg.contains("cy=\"62.5\""),
+            "expected 12-fret double dot at cy=51.5 / cy=62.5; got: {svg}"
         );
     }
 
@@ -2922,12 +2940,12 @@ mod tests {
             count, 3,
             "expected 1 single + 2 (double at 12); got svg: {svg}"
         );
-        // For 4-string ukulele in horizontal mode: string_pitch = CELL_W = 16,
-        //   grid_h = (4 - 1) * 16 = 48; center_y = TOP_MARGIN + 24 = 54;
-        //   16 * 0.55 = 8.8; so cy1 = 45.2, cy2 = 62.8.
+        // For 4-string ukulele in horizontal mode: string_pitch = CELL_W = 10,
+        //   grid_h = (4 - 1) * 10 = 30; center_y = TOP_MARGIN + 15 = 47;
+        //   10 * 0.55 = 5.5; so cy1 = 41.5, cy2 = 52.5.
         assert!(
-            svg.contains("cy=\"45.2\"") && svg.contains("cy=\"62.8\""),
-            "expected 12-fret double dot at cy=45.2 / cy=62.8; got: {svg}",
+            svg.contains("cy=\"41.5\"") && svg.contains("cy=\"52.5\""),
+            "expected 12-fret double dot at cy=41.5 / cy=52.5; got: {svg}",
         );
     }
 
@@ -3223,13 +3241,14 @@ mod tests {
         let count = svg.matches("class=\"fret-number\"").count();
         assert_eq!(count, 5, "expected 5 fret-cell labels (1..=5); got: {svg}");
         // The first cell's label (1) is centred at x = LEFT_MARGIN + fret_pitch/2
-        // = 20 + 10 = 30.
+        // = 35 + 7 = 42, with baseline y = TOP_MARGIN + grid_h + fret_label_font
+        // = 32 + 50 + 10 = 92.
         assert!(
             svg.contains(
-                "<text x=\"30\" y=\"120\" text-anchor=\"middle\" \
+                "<text x=\"42\" y=\"92\" text-anchor=\"middle\" \
                  font-family=\"sans-serif\" font-size=\"10\" class=\"fret-number\">1</text>"
             ),
-            "expected first-cell label 1 centred at x=30 y=120; got: {svg}"
+            "expected first-cell label 1 centred at x=42 y=92; got: {svg}"
         );
     }
 
@@ -3343,10 +3362,10 @@ mod tests {
         );
         let h = render_svg_with_orientation(&data, Orientation::Horizontal);
         assert_eq!(extract(&h, "width"), 140.0);
-        assert_eq!(extract(&h, "height"), 130.0);
+        assert_eq!(extract(&h, "height"), 102.0);
         let h_ys = label_ys(&h);
         assert!(
-            h_ys.iter().all(|&y| y <= 130.0),
+            h_ys.iter().all(|&y| y <= 102.0),
             "horizontal fret-number labels overflow the frame: {h_ys:?}"
         );
         // Compact size: left_margin widened from 9 → 11 to fit 2-digit labels.

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -298,13 +298,16 @@ pub enum DiagramSize {
 
 /// String-to-string spacing in SVG user units (pixels at 1:1 zoom).
 ///
-/// Deliberately tighter than the finger-dot diameter (`DOT_RADIUS * 2 =
-/// 10`) so a fretted dot reads as a bold, prominent marker that nearly
-/// spans the gap between adjacent strings — the standard look of a
-/// printed chord chart. The grid is intentionally compact and floated
-/// inside a generous margin (see `LEFT_MARGIN` / `TOP_MARGIN` /
-/// `DiagramMetrics::regular`'s `bottom_pad_vertical`) rather than
-/// filling the bounding box edge-to-edge.
+/// Equal to the finger-dot diameter (`DOT_RADIUS * 2 = 10`): a fretted
+/// dot therefore reads as a bold, prominent marker whose edges are
+/// tangent to the adjacent strings — the standard look of a printed
+/// chord chart. This is the tightest spacing that does not overlap
+/// neighbouring same-fret dots; shrinking `CELL_W` below `DOT_RADIUS *
+/// 2`, or enlarging `DOT_RADIUS`, would make them overlap. The grid is
+/// intentionally compact and floated inside a generous margin (see
+/// `LEFT_MARGIN` / `TOP_MARGIN` / `DiagramMetrics::regular`'s
+/// `bottom_pad_vertical`) rather than filling the bounding box
+/// edge-to-edge.
 const CELL_W: f32 = 10.0;
 /// Fret pitch in SVG user units. Larger than [`CELL_W`] so the cells stay
 /// taller than they are wide, matching a real fretboard's proportions.
@@ -350,9 +353,10 @@ const OCTAVE_DOUBLE_DOT_OFFSET: f32 = 0.55;
 /// renderer functions — a geometry fix lands once and applies to both
 /// sizes (cf. `.claude/rules/fix-propagation.md`).
 ///
-/// `regular()` reproduces the historical hard-coded values verbatim; the
+/// `regular()` and `compact()` are the two constructors; the
 /// `render_svg_default_byte_identical_across_chord_shapes` test pins that
-/// the regular output is byte-for-byte unchanged by this indirection.
+/// the `render_svg` wrapper stays in lockstep with the explicit
+/// `Vertical` entry point across every chord shape.
 #[derive(Debug, Clone, Copy)]
 struct DiagramMetrics {
     /// String-to-string spacing (SVG x-axis in vertical mode).
@@ -415,7 +419,8 @@ struct DiagramMetrics {
 }
 
 impl DiagramMetrics {
-    /// Full-size metrics — byte-for-byte the historical layout.
+    /// Full-size metrics — the compact, centred fretboard layout used by
+    /// the end-of-song diagram grid and every non-compact SVG consumer.
     const fn regular() -> Self {
         Self {
             cell_w: CELL_W,
@@ -623,9 +628,9 @@ pub fn render_svg_with_options(
 
 fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
     // Bind every metric to a local so the SVG format strings can
-    // inline-capture them by name (`{cell_w}` etc.). With
-    // `DiagramMetrics::regular()` these reproduce the historical literals
-    // exactly — guarded by `render_svg_default_byte_identical_across_chord_shapes`.
+    // inline-capture them by name (`{cell_w}` etc.). The values come from
+    // whichever `DiagramMetrics` constructor the caller chose (regular /
+    // compact), so geometry lives in one place rather than in literals here.
     let DiagramMetrics {
         cell_w,
         cell_h,
@@ -823,7 +828,8 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
 /// double-dot, base-fret label, finger numbers) must change in the other.
 fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
     // See `render_svg_vertical_inner` for why every metric is bound to a
-    // local. `regular()` reproduces the historical literals byte-for-byte.
+    // local — the values come from the caller's `DiagramMetrics`, not from
+    // literals inlined here.
     let DiagramMetrics {
         cell_w,
         cell_h,
@@ -3330,7 +3336,8 @@ mod tests {
     fn fret_number_axis_does_not_grow_the_bounding_box() {
         // The axis is laid out inside the existing margins / bottom padding,
         // so adding it must not change either SVG's width or height. These
-        // are the historical dimensions for a 6-string, 5-fret diagram.
+        // are the regular-layout dimensions for a 6-string, 5-fret diagram
+        // (vertical 120x160, horizontal 140x102).
         let extract = |svg: &str, attr: &str| -> f32 {
             let needle = format!("{attr}=\"");
             let i = svg.find(&needle).unwrap() + needle.len();

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -4928,10 +4928,10 @@ Verse text\n\
         let html = render("{define: C frets 0 0 0 3}");
         assert!(html.contains("<svg"));
         assert!(html.contains("chord-diagram"));
-        // 4 strings: SVG width = (4-1)*16 + 20*2 = 88
+        // 4 strings: SVG width = (4-1)*10 + 35*2 = 100
         assert!(
-            html.contains("width=\"88\""),
-            "Expected 4-string SVG width (88)"
+            html.contains("width=\"100\""),
+            "Expected 4-string SVG width (100)"
         );
     }
 
@@ -4939,10 +4939,10 @@ Verse text\n\
     fn test_define_banjo_diagram() {
         let html = render("{define: G frets 0 0 0 0 0}");
         assert!(html.contains("<svg"));
-        // 5 strings: SVG width = (5-1)*16 + 20*2 = 104
+        // 5 strings: SVG width = (5-1)*10 + 35*2 = 110
         assert!(
-            html.contains("width=\"104\""),
-            "Expected 5-string SVG width (104)"
+            html.contains("width=\"110\""),
+            "Expected 5-string SVG width (110)"
         );
     }
 
@@ -4954,10 +4954,10 @@ Verse text\n\
             .with_define("diagrams.frets=4")
             .unwrap();
         let html = render_song_with_transpose(&song, 0, &config);
-        // 4 frets: grid_h = 4*20 = 80, total_h = 80 + 30 + 30 = 140
+        // 4 frets: grid_h = 4*14 = 56, total_h = 56 + 32 + 58 = 146
         assert!(
-            html.contains("height=\"140\""),
-            "SVG height should reflect diagrams.frets=4 (expected 140)"
+            html.contains("height=\"146\""),
+            "SVG height should reflect diagrams.frets=4 (expected 146)"
         );
     }
 

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -88,32 +88,32 @@ img { max-width: 100%; height: auto; }
 </header>
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<text x="20" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="36" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="52" cy="60" r="5" fill="black"/>
-<circle cx="68" cy="60" r="5" fill="black"/>
-<circle cx="84" cy="40" r="5" fill="black"/>
-<circle cx="100" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="55" cy="53" r="5" fill="black"/>
+<circle cx="65" cy="53" r="5" fill="black"/>
+<circle cx="75" cy="39" r="5" fill="black"/>
+<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">Hello </span></span><span class="chord-block"><span class="chord">A</span><span class="lyrics">world </span></span><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">again</span></span></div>
 </article>

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -88,32 +88,32 @@ img { max-width: 100%; height: auto; }
 </header>
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<text x="20" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="36" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="52" cy="60" r="5" fill="black"/>
-<circle cx="68" cy="60" r="5" fill="black"/>
-<circle cx="84" cy="40" r="5" fill="black"/>
-<circle cx="100" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="55" cy="53" r="5" fill="black"/>
+<circle cx="65" cy="53" r="5" fill="black"/>
+<circle cx="75" cy="39" r="5" fill="black"/>
+<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">Hello </span></span><span class="chord-block"><span class="chord">G</span><span class="lyrics">world </span></span><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">again</span></span></div>
 </article>

--- a/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
+++ b/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
@@ -88,32 +88,32 @@ img { max-width: 100%; height: auto; }
 </header>
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<circle cx="20" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="36" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="52" cy="60" r="5" fill="black"/>
-<circle cx="68" cy="60" r="5" fill="black"/>
-<circle cx="84" cy="40" r="5" fill="black"/>
-<circle cx="100" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<circle cx="35" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="55" cy="53" r="5" fill="black"/>
+<circle cx="65" cy="53" r="5" fill="black"/>
+<circle cx="75" cy="39" r="5" fill="black"/>
+<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">Am</span><span class="lyrics">Hello </span></span><span class="chord-block"><span class="chord">G</span><span class="lyrics">world</span></span></div>
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
@@ -121,32 +121,32 @@ img { max-width: 100%; height: auto; }
 <div class="chord-diagrams-grid">
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<circle cx="20" cy="80" r="5" fill="black"/>
-<circle cx="36" cy="60" r="5" fill="black"/>
-<circle cx="52" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="84" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="100" cy="80" r="5" fill="black"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<circle cx="35" cy="67" r="5" fill="black"/>
+<circle cx="45" cy="53" r="5" fill="black"/>
+<circle cx="55" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="65" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="75" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="85" cy="67" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -92,61 +92,61 @@ img { max-width: 100%; height: auto; }
 <div class="chord-diagrams-grid">
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<text x="20" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="36" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="52" cy="60" r="5" fill="black"/>
-<circle cx="68" cy="60" r="5" fill="black"/>
-<circle cx="84" cy="40" r="5" fill="black"/>
-<circle cx="100" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="55" cy="53" r="5" fill="black"/>
+<circle cx="65" cy="53" r="5" fill="black"/>
+<circle cx="75" cy="39" r="5" fill="black"/>
+<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<circle cx="20" cy="80" r="5" fill="black"/>
-<circle cx="36" cy="60" r="5" fill="black"/>
-<circle cx="52" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="84" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="100" cy="80" r="5" fill="black"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<circle cx="35" cy="67" r="5" fill="black"/>
+<circle cx="45" cy="53" r="5" fill="black"/>
+<circle cx="55" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="65" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="75" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="85" cy="67" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -86,66 +86,66 @@ img { max-width: 100%; height: auto; }
 <header class="song-header">
 <h1>Horizontal Diagrams with Barre Chord</h1>
 </header>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Bm</text>
-<text x="30" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="50" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="90" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<text x="110" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">6</text>
-<circle cx="50" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="90" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="46" x2="120" y2="46" stroke="black" stroke-width="1"/>
-<line x1="20" y1="62" x2="120" y2="62" stroke="black" stroke-width="1"/>
-<line x1="20" y1="78" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<line x1="20" y1="94" x2="120" y2="94" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="1"/>
-<line x1="40" y1="30" x2="40" y2="110" stroke="black" stroke-width="1"/>
-<line x1="60" y1="30" x2="60" y2="110" stroke="black" stroke-width="1"/>
-<line x1="80" y1="30" x2="80" y2="110" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="120" y1="30" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<circle cx="30" cy="110" r="5" fill="black"/>
-<circle cx="70" cy="94" r="5" fill="black"/>
-<circle cx="90" cy="78" r="5" fill="black"/>
-<circle cx="90" cy="62" r="5" fill="black"/>
-<circle cx="70" cy="46" r="5" fill="black"/>
-<circle cx="30" cy="30" r="5" fill="black"/>
+<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">6</text>
+<circle cx="56" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="84" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
+<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
+<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
+<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
+<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
+<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
+<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
+<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
+<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<circle cx="42" cy="82" r="5" fill="black"/>
+<circle cx="70" cy="72" r="5" fill="black"/>
+<circle cx="84" cy="62" r="5" fill="black"/>
+<circle cx="84" cy="52" r="5" fill="black"/>
+<circle cx="70" cy="42" r="5" fill="black"/>
+<circle cx="42" cy="32" r="5" fill="black"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">Bm</span><span class="lyrics">On a </span></span><span class="chord-block"><span class="chord">Am</span><span class="lyrics">horizontal layout</span></span></div>
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
 <h3 id="cs-chord-diagrams-label" class="section-label">Chord Diagrams</h3>
 <div class="chord-diagrams-grid">
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="3"/>
-<text x="30" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="50" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="90" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="110" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="110" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="46" x2="120" y2="46" stroke="black" stroke-width="1"/>
-<line x1="20" y1="62" x2="120" y2="62" stroke="black" stroke-width="1"/>
-<line x1="20" y1="78" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<line x1="20" y1="94" x2="120" y2="94" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="1"/>
-<line x1="40" y1="30" x2="40" y2="110" stroke="black" stroke-width="1"/>
-<line x1="60" y1="30" x2="60" y2="110" stroke="black" stroke-width="1"/>
-<line x1="80" y1="30" x2="80" y2="110" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="120" y1="30" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<text x="10" y="113" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="10" cy="94" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="50" cy="78" r="5" fill="black"/>
-<circle cx="50" cy="62" r="5" fill="black"/>
-<circle cx="30" cy="46" r="5" fill="black"/>
-<circle cx="10" cy="30" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="3"/>
+<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="70" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="98" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
+<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
+<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
+<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
+<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
+<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
+<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
+<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
+<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<text x="28" y="85" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="28" cy="72" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="56" cy="62" r="5" fill="black"/>
+<circle cx="56" cy="52" r="5" fill="black"/>
+<circle cx="42" cy="42" r="5" fill="black"/>
+<circle cx="28" cy="32" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
@@ -86,55 +86,55 @@ img { max-width: 100%; height: auto; }
 <header class="song-header">
 <h1>Horizontal Ukulele Diagrams</h1>
 </header>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="98" viewBox="0 0 140 98" class="chord-diagram chord-diagram-horizontal">
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="82" viewBox="0 0 140 82" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">C</text>
-<line x1="20" y1="30" x2="20" y2="78" stroke="black" stroke-width="3"/>
-<text x="30" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="90" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="110" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="110" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="46" x2="120" y2="46" stroke="black" stroke-width="1"/>
-<line x1="20" y1="62" x2="120" y2="62" stroke="black" stroke-width="1"/>
-<line x1="20" y1="78" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="20" y2="78" stroke="black" stroke-width="1"/>
-<line x1="40" y1="30" x2="40" y2="78" stroke="black" stroke-width="1"/>
-<line x1="60" y1="30" x2="60" y2="78" stroke="black" stroke-width="1"/>
-<line x1="80" y1="30" x2="80" y2="78" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="78" stroke="black" stroke-width="1"/>
-<line x1="120" y1="30" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<circle cx="10" cy="78" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="10" cy="62" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="10" cy="46" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="70" cy="30" r="5" fill="black"/>
+<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="3"/>
+<text x="42" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="56" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="70" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="84" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="98" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="70" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="98" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
+<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
+<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="1"/>
+<line x1="49" y1="32" x2="49" y2="62" stroke="black" stroke-width="1"/>
+<line x1="63" y1="32" x2="63" y2="62" stroke="black" stroke-width="1"/>
+<line x1="77" y1="32" x2="77" y2="62" stroke="black" stroke-width="1"/>
+<line x1="91" y1="32" x2="91" y2="62" stroke="black" stroke-width="1"/>
+<line x1="105" y1="32" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<circle cx="28" cy="62" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="28" cy="52" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="28" cy="42" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="70" cy="32" r="5" fill="black"/>
 </svg></figure>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="98" viewBox="0 0 140 98" class="chord-diagram chord-diagram-horizontal">
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="82" viewBox="0 0 140 82" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">F</text>
-<line x1="20" y1="30" x2="20" y2="78" stroke="black" stroke-width="3"/>
-<text x="30" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="90" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="110" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="110" cy="54" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="46" x2="120" y2="46" stroke="black" stroke-width="1"/>
-<line x1="20" y1="62" x2="120" y2="62" stroke="black" stroke-width="1"/>
-<line x1="20" y1="78" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="20" y2="78" stroke="black" stroke-width="1"/>
-<line x1="40" y1="30" x2="40" y2="78" stroke="black" stroke-width="1"/>
-<line x1="60" y1="30" x2="60" y2="78" stroke="black" stroke-width="1"/>
-<line x1="80" y1="30" x2="80" y2="78" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="78" stroke="black" stroke-width="1"/>
-<line x1="120" y1="30" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<circle cx="50" cy="78" r="5" fill="black"/>
-<circle cx="10" cy="62" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="30" cy="46" r="5" fill="black"/>
-<circle cx="10" cy="30" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="3"/>
+<text x="42" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="56" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="70" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="84" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="98" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="70" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="98" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
+<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
+<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="1"/>
+<line x1="49" y1="32" x2="49" y2="62" stroke="black" stroke-width="1"/>
+<line x1="63" y1="32" x2="63" y2="62" stroke="black" stroke-width="1"/>
+<line x1="77" y1="32" x2="77" y2="62" stroke="black" stroke-width="1"/>
+<line x1="91" y1="32" x2="91" y2="62" stroke="black" stroke-width="1"/>
+<line x1="105" y1="32" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<circle cx="56" cy="62" r="5" fill="black"/>
+<circle cx="28" cy="52" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="42" cy="42" r="5" fill="black"/>
+<circle cx="28" cy="32" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">C</span><span class="lyrics">Aloha </span></span><span class="chord-block"><span class="chord">F</span><span class="lyrics">hello</span></span></div>
 </article>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -90,63 +90,63 @@ img { max-width: 100%; height: auto; }
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
 <h3 id="cs-chord-diagrams-label" class="section-label">Chord Diagrams</h3>
 <div class="chord-diagrams-grid">
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="3"/>
-<text x="30" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="50" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="90" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="110" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="110" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="46" x2="120" y2="46" stroke="black" stroke-width="1"/>
-<line x1="20" y1="62" x2="120" y2="62" stroke="black" stroke-width="1"/>
-<line x1="20" y1="78" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<line x1="20" y1="94" x2="120" y2="94" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="1"/>
-<line x1="40" y1="30" x2="40" y2="110" stroke="black" stroke-width="1"/>
-<line x1="60" y1="30" x2="60" y2="110" stroke="black" stroke-width="1"/>
-<line x1="80" y1="30" x2="80" y2="110" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="120" y1="30" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<text x="10" y="113" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="10" cy="94" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="50" cy="78" r="5" fill="black"/>
-<circle cx="50" cy="62" r="5" fill="black"/>
-<circle cx="30" cy="46" r="5" fill="black"/>
-<circle cx="10" cy="30" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="3"/>
+<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="70" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="98" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
+<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
+<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
+<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
+<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
+<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
+<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
+<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
+<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<text x="28" y="85" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="28" cy="72" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="56" cy="62" r="5" fill="black"/>
+<circle cx="56" cy="52" r="5" fill="black"/>
+<circle cx="42" cy="42" r="5" fill="black"/>
+<circle cx="28" cy="32" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="130" viewBox="0 0 140 130" class="chord-diagram chord-diagram-horizontal">
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
 <text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="3"/>
-<text x="30" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="50" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="90" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="110" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="110" cy="70" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="120" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="46" x2="120" y2="46" stroke="black" stroke-width="1"/>
-<line x1="20" y1="62" x2="120" y2="62" stroke="black" stroke-width="1"/>
-<line x1="20" y1="78" x2="120" y2="78" stroke="black" stroke-width="1"/>
-<line x1="20" y1="94" x2="120" y2="94" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="20" y2="110" stroke="black" stroke-width="1"/>
-<line x1="40" y1="30" x2="40" y2="110" stroke="black" stroke-width="1"/>
-<line x1="60" y1="30" x2="60" y2="110" stroke="black" stroke-width="1"/>
-<line x1="80" y1="30" x2="80" y2="110" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="120" y1="30" x2="120" y2="110" stroke="black" stroke-width="1"/>
-<circle cx="70" cy="110" r="5" fill="black"/>
-<circle cx="50" cy="94" r="5" fill="black"/>
-<circle cx="10" cy="78" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="10" cy="62" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="10" cy="46" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="70" cy="30" r="5" fill="black"/>
+<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="3"/>
+<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="70" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="98" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
+<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
+<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
+<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
+<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
+<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
+<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
+<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
+<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
+<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
+<circle cx="70" cy="82" r="5" fill="black"/>
+<circle cx="56" cy="72" r="5" fill="black"/>
+<circle cx="28" cy="62" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="28" cy="52" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="28" cy="42" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="70" cy="32" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -92,61 +92,61 @@ img { max-width: 100%; height: auto; }
 <div class="chord-diagrams-grid">
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<text x="20" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="36" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="52" cy="60" r="5" fill="black"/>
-<circle cx="68" cy="60" r="5" fill="black"/>
-<circle cx="84" cy="40" r="5" fill="black"/>
-<circle cx="100" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="55" cy="53" r="5" fill="black"/>
+<circle cx="65" cy="53" r="5" fill="black"/>
+<circle cx="75" cy="39" r="5" fill="black"/>
+<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
 <text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="3"/>
-<text x="16" y="43" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="16" y="63" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="16" y="83" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="16" y="103" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="16" y="123" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="80" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="120" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="20" y1="30" x2="20" y2="130" stroke="black" stroke-width="1"/>
-<line x1="36" y1="30" x2="36" y2="130" stroke="black" stroke-width="1"/>
-<line x1="52" y1="30" x2="52" y2="130" stroke="black" stroke-width="1"/>
-<line x1="68" y1="30" x2="68" y2="130" stroke="black" stroke-width="1"/>
-<line x1="84" y1="30" x2="84" y2="130" stroke="black" stroke-width="1"/>
-<line x1="100" y1="30" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<line x1="20" y1="30" x2="100" y2="30" stroke="black" stroke-width="1"/>
-<line x1="20" y1="50" x2="100" y2="50" stroke="black" stroke-width="1"/>
-<line x1="20" y1="70" x2="100" y2="70" stroke="black" stroke-width="1"/>
-<line x1="20" y1="90" x2="100" y2="90" stroke="black" stroke-width="1"/>
-<line x1="20" y1="110" x2="100" y2="110" stroke="black" stroke-width="1"/>
-<line x1="20" y1="130" x2="100" y2="130" stroke="black" stroke-width="1"/>
-<circle cx="20" cy="80" r="5" fill="black"/>
-<circle cx="36" cy="60" r="5" fill="black"/>
-<circle cx="52" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="84" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="100" cy="80" r="5" fill="black"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
+<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
+<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
+<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
+<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
+<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
+<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
+<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
+<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
+<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
+<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
+<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
+<circle cx="35" cy="67" r="5" fill="black"/>
+<circle cx="45" cy="53" r="5" fill="black"/>
+<circle cx="55" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="65" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="75" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="85" cy="67" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>


### PR DESCRIPTION
## What

Redesigns the regular (full-size) SVG chord-diagram layout in the single
generator `crates/chordpro/src/chord_diagram.rs`:

- String spacing `CELL_W` 16 → **10**, fret pitch `CELL_H` 20 → **14** — a
  compact fretboard grid.
- `LEFT_MARGIN` 20 → **35** and `bottom_pad_vertical` 30 → **58** so the grid
  is recentred inside the **unchanged** 120×160 frame (6-string / 5-fret) with
  generous margins, instead of bleeding to the edges. The grid centre now sits
  under the title.
- Open/muted glyph offset `NUT_MARGIN_GLYPH_OFFSET` 10 → **7** (glyphs sit
  closer to the nut).
- `fret_label_gap` 4 → **7** so the right-anchored fret numbers clear the
  recentred grid's left edge.
- Marker radii are **unchanged** (finger dot 5, open ring 4, inlay 2.2), so
  relative to the shrunk grid the finger dots now read as bold, prominent
  markers — the standard look of a printed chord chart.

The horizontal layout inherits the same proportions (frame height 130 → 102).

## Why

The previous layout filled the bounding box edge-to-edge with thin spacing,
which read as cramped. The redesign matches a reference "after" diagram
provided by the maintainer: a compact, centred grid with bold dots and
breathing room. Scope was confirmed as **geometry only** (text stays
`<text>`, not outlined paths) applied across the **whole SVG diagram
generator**.

Because the change lives in the one SVG generator, it flows through every
consumer automatically: CLI `--format html`, the wasm `chord_diagram_svg`
exports, `@chordsketch/react`'s `<ChordDiagram>` (which injects the wasm SVG
via `dangerouslySetInnerHTML`), the VS Code preview, and the LSP hover.

## Test results

- `crates/chordpro` (incl. `chord_diagram` unit tests), `render-html`,
  `lsp`, `wasm`, `napi`, `cli`, `render-pdf` suites all pass.
- Updated the 7 horizontal hardcoded-coordinate assertions and the 3
  render-html dimension tests with recomputed values.
- Regenerated the 8 render-html golden fixtures via `UPDATE_GOLDEN=1`.
- `cargo fmt --check` and `cargo clippy` clean on the touched crates.

## Sister-site audit

- **render-pdf**: has its own diagram geometry and does not consume
  `chord_diagram::render_svg`; out of scope by design.
- **render-text**: uses `render_ascii` (no pixel geometry); unaffected.
- **React JSX walker / `<ChordDiagram>`**: injects the wasm-generated SVG
  string; no parallel JS geometry to update.
- **Compact (inline/hover) layout** and the **keyboard diagram**: intentionally
  unchanged.

## Deferred

- Outlining text glyphs to `<path>` (font-independent rendering, present in the
  reference) is out of scope: `chordsketch-chordpro` is zero-dependency, so it
  would require embedding glyph-outline data — a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017p42g7KSewgnAmwAiSeGBk

---
_Generated by [Claude Code](https://claude.ai/code/session_017p42g7KSewgnAmwAiSeGBk)_