### PR TITLE
Play chord audio when a chord diagram is clicked

### DIFF
--- a/packages/react/src/chord-diagram.tsx
+++ b/packages/react/src/chord-diagram.tsx
@@ -175,14 +175,20 @@ export function ChordDiagram({
     if (ringRef.current) pulseElement(ringRef.current, 'chordsketch-diagram--ringing');
   }, [chordAudio, chord]);
 
-  const wrapperClass = [
+  const baseWrapperClass = [
     'chordsketch-diagram',
     compact && 'chordsketch-diagram--compact',
-    audioOn && 'chordsketch-diagram--audio',
     className,
   ]
     .filter(Boolean)
     .join(' ');
+  // The `--audio` modifier carries the play-button affordance (cursor +
+  // hover ring); it is applied only to the branches that are ACTUALLY
+  // interactive. The error branch reuses `baseWrapperClass` so a failed
+  // diagram never paints a clickable affordance it does not honour.
+  const wrapperClass = audioOn
+    ? `${baseWrapperClass} chordsketch-diagram--audio`
+    : baseWrapperClass;
   // Surface the active orientation as a DOM attribute so consumers
   // and tests can observe it without parsing the SVG. Omitted (not
   // emitted as `data-orientation=""`) when the prop is unset so the
@@ -200,6 +206,12 @@ export function ChordDiagram({
     ? {
         role: 'button' as const,
         tabIndex: 0,
+        // `aria-label` / `data-chord` name the chord this diagram DEPICTS
+        // (the `chord` prop). For a `{define} display=` override the inline
+        // / grid call sites look the diagram up by — and pass here — the
+        // display spelling, while the audio config they inject auditions
+        // the raw name; the two are intentionally distinct (the label /
+        // hook match the visible glyph, the sound matches the real chord).
         'aria-label': `Play chord ${chord} (${instrument})`,
         'data-chord': chord,
         onClick: () => handlePlay(),
@@ -217,11 +229,25 @@ export function ChordDiagram({
       }
     : null;
 
+  // Static (audio-off) presentation for the svg branch: a labelled image,
+  // unless the consumer supplied an explicit `role` (e.g. the hover
+  // popover's `role="tooltip"`) — in which case respect it and keep the
+  // descriptive `aria-label` so an `aria-describedby` reference still
+  // resolves to a meaningful name.
+  const staticDiagramProps = {
+    role: divProps.role ?? 'img',
+    'aria-label': `${chord} chord diagram (${instrument})`,
+  };
+
   if (error !== null && errorFallback !== null) {
     const node =
       typeof errorFallback === 'function' ? errorFallback(error) : errorFallback;
+    // Static, non-interactive wrapper: `baseWrapperClass` deliberately
+    // omits `--audio` so a failed diagram does not paint a play affordance
+    // (cursor/ring) it cannot honour — its own `role="alert"` fallback
+    // node carries the error semantics.
     return (
-      <div {...divProps} {...orientationAttr} className={wrapperClass}>
+      <div {...divProps} {...orientationAttr} className={baseWrapperClass}>
         {node}
       </div>
     );
@@ -272,13 +298,11 @@ export function ChordDiagram({
       // When audio is off, expose the diagram as a labelled image to
       // assistive tech (without this, the inline SVG's accessible name is
       // the empty string and the chord identity is invisible to screen
-      // readers). When audio is on, `audioInteractiveProps` supplies
-      // `role="button"` + an action label instead — an element cannot be
-      // both an image and a button.
-      {...(audioInteractiveProps ?? {
-        role: 'img',
-        'aria-label': `${chord} chord diagram (${instrument})`,
-      })}
+      // readers) — or honour an explicit consumer `role` (see
+      // `staticDiagramProps`). When audio is on, `audioInteractiveProps`
+      // supplies `role="button"` + an action label instead — an element
+      // cannot be both an image and a button.
+      {...(audioInteractiveProps ?? staticDiagramProps)}
       // The SVG is produced by our own Rust renderer
       // (`chord_diagram::render_svg` / `render_keyboard_svg`),
       // which emits a fixed, hand-written template — nothing in

--- a/packages/react/src/chord-diagram.tsx
+++ b/packages/react/src/chord-diagram.tsx
@@ -1,5 +1,13 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import type {
+  AnimationEvent as ReactAnimationEvent,
+  HTMLAttributes,
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactNode,
+} from 'react';
+import { useCallback, useRef } from 'react';
 
+import { pulseElement } from './chord-pulse';
+import type { ChordAudioConfig } from './use-chord-audio';
 import {
   type ChordDiagramInstrument,
   type ChordDiagramOrientation,
@@ -42,6 +50,25 @@ export interface ChordDiagramProps extends Omit<HTMLAttributes<HTMLDivElement>, 
    * predate the compact export.
    */
   compact?: boolean;
+  /**
+   * Chord-audio config (#2686). When `chordAudio.enabled` is `true`, the
+   * whole diagram becomes a play button: clicking it (or pressing Enter /
+   * Space while focused) sounds the chord via `chordAudio.play(chord)`,
+   * with a brief activation pulse. When omitted / disabled, the diagram
+   * renders as a static `role="img"` figure exactly as before.
+   *
+   * Wiring audio here — at the canonical diagram component — means every
+   * consumer (the end-of-song chord-diagrams grid, the inline / hover
+   * cells in the JSX walker, and external library consumers using
+   * `<ChordDiagram>` directly) gets click-to-play uniformly, rather than
+   * each call site bolting on its own handler.
+   *
+   * Degrades gracefully: the host is responsible for only supplying an
+   * `enabled` config when Web Audio is actually available (e.g. via
+   * `useChordAudio().supported`), so on SSR / unsupported browsers the
+   * diagram stays a static figure instead of a dead button.
+   */
+  chordAudio?: ChordAudioConfig | null;
   /**
    * Optional node shown while the WASM module loads. Defaults to
    * a minimal `role="status"` placeholder.
@@ -124,6 +151,7 @@ export function ChordDiagram({
   loadingFallback,
   notFoundFallback = defaultNotFoundFallback,
   errorFallback = defaultErrorFallback,
+  chordAudio,
   wasmLoader,
   className,
   ...divProps
@@ -137,7 +165,22 @@ export function ChordDiagram({
     compact,
   );
 
-  const wrapperClass = ['chordsketch-diagram', compact && 'chordsketch-diagram--compact', className]
+  // Chord-audio (#2686). When on, the diagram is a play button. The ref
+  // points at whichever wrapper actually renders (svg / not-found /
+  // loading) so the activation pulse lands on the visible element.
+  const audioOn = Boolean(chordAudio?.enabled);
+  const ringRef = useRef<HTMLDivElement | null>(null);
+  const handlePlay = useCallback(() => {
+    chordAudio?.play(chord);
+    if (ringRef.current) pulseElement(ringRef.current, 'chordsketch-diagram--ringing');
+  }, [chordAudio, chord]);
+
+  const wrapperClass = [
+    'chordsketch-diagram',
+    compact && 'chordsketch-diagram--compact',
+    audioOn && 'chordsketch-diagram--audio',
+    className,
+  ]
     .filter(Boolean)
     .join(' ');
   // Surface the active orientation as a DOM attribute so consumers
@@ -145,6 +188,34 @@ export function ChordDiagram({
   // emitted as `data-orientation=""`) when the prop is unset so the
   // default vertical case stays attribute-free.
   const orientationAttr = orientation !== undefined ? { 'data-orientation': orientation } : {};
+
+  // Interactive button props applied to the content-bearing branches
+  // (svg / not-found / loading) when audio is on. The error branch stays
+  // a static `role="alert"` — a failed diagram is not a play target, and
+  // audio would not work either if the wasm module failed to init. The
+  // `role="button"` here replaces the static `role="img"` (an element
+  // cannot be both), with an action-naming `aria-label` so the accessible
+  // name conveys both the chord and that pressing plays it.
+  const audioInteractiveProps = audioOn
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        'aria-label': `Play chord ${chord} (${instrument})`,
+        'data-chord': chord,
+        onClick: () => handlePlay(),
+        onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handlePlay();
+          }
+        },
+        // Safety cleanup mirroring the walker's chord-name path: drop the
+        // transient ring class once its animation ends.
+        onAnimationEnd: (e: ReactAnimationEvent<HTMLDivElement>) => {
+          e.currentTarget.classList.remove('chordsketch-diagram--ringing');
+        },
+      }
+    : null;
 
   if (error !== null && errorFallback !== null) {
     const node =
@@ -160,18 +231,33 @@ export function ChordDiagram({
     if (loading) {
       const node = loadingFallback ?? defaultLoadingFallback();
       return (
-        <div {...divProps} {...orientationAttr} className={wrapperClass} aria-busy="true">
+        <div
+          {...divProps}
+          {...orientationAttr}
+          ref={audioOn ? ringRef : undefined}
+          className={wrapperClass}
+          aria-busy="true"
+          {...(audioInteractiveProps ?? {})}
+        >
           {node}
         </div>
       );
     }
-    // Not loading and no SVG — the voicing database has no entry.
+    // Not loading and no SVG — the voicing database has no entry. The
+    // diagram still plays when audio is on (the chord name fallback the
+    // inline-diagram mode shows here stays a play target).
     const node =
       typeof notFoundFallback === 'function'
         ? notFoundFallback(chord, instrument)
         : notFoundFallback;
     return (
-      <div {...divProps} {...orientationAttr} className={wrapperClass}>
+      <div
+        {...divProps}
+        {...orientationAttr}
+        ref={audioOn ? ringRef : undefined}
+        className={wrapperClass}
+        {...(audioInteractiveProps ?? {})}
+      >
         {node}
       </div>
     );
@@ -181,13 +267,18 @@ export function ChordDiagram({
     <div
       {...divProps}
       {...orientationAttr}
+      ref={audioOn ? ringRef : undefined}
       className={wrapperClass}
-      // Expose the diagram as a labelled image to assistive tech
-      // (without this, the inline SVG's accessible name is the
-      // empty string and the chord identity is invisible to
-      // screen readers).
-      role="img"
-      aria-label={`${chord} chord diagram (${instrument})`}
+      // When audio is off, expose the diagram as a labelled image to
+      // assistive tech (without this, the inline SVG's accessible name is
+      // the empty string and the chord identity is invisible to screen
+      // readers). When audio is on, `audioInteractiveProps` supplies
+      // `role="button"` + an action label instead — an element cannot be
+      // both an image and a button.
+      {...(audioInteractiveProps ?? {
+        role: 'img',
+        'aria-label': `${chord} chord diagram (${instrument})`,
+      })}
       // The SVG is produced by our own Rust renderer
       // (`chord_diagram::render_svg` / `render_keyboard_svg`),
       // which emits a fixed, hand-written template — nothing in

--- a/packages/react/src/chord-pulse.ts
+++ b/packages/react/src/chord-pulse.ts
@@ -1,0 +1,40 @@
+/**
+ * Briefly flash a `ringingClass` on an element so an audio activation
+ * (a played chord / a pressed chord diagram) gets visual feedback. The
+ * class is added imperatively — the chordpro-jsx walker is stateless per
+ * chord, and `<ChordDiagram>` reuses the same mechanism so the two paths
+ * cannot drift (.claude/rules/fix-propagation.md). The class is removed
+ * by the caller on `animationend`; a forced reflow between remove and
+ * re-add restarts the CSS animation when the same target is activated
+ * again before the previous pulse finishes.
+ *
+ * When `prefers-reduced-motion: reduce` is active the function exits
+ * early rather than adding the class — the CSS suppresses the animation
+ * (`animation: none`) and `animationend` never fires, which would leave
+ * the ring state (crimson background, white text) on the element
+ * permanently. The guard also covers SSR / non-DOM environments where
+ * `window` is undefined.
+ *
+ * @param el The element to pulse.
+ * @param ringingClass The class toggled for the duration of the pulse
+ *   (`"chord--ringing"` for chord names, `"chordsketch-diagram--ringing"`
+ *   for chord diagrams).
+ */
+export function pulseElement(el: HTMLElement, ringingClass: string): void {
+  // Skip the visual pulse when the user prefers reduced motion (or when
+  // there is no `window`/`matchMedia`, e.g. SSR). The audio still plays;
+  // only the animation feedback is suppressed. Without this guard,
+  // `animationend` never fires under `animation: none`, so the ring
+  // highlight would stick on the element indefinitely.
+  if (
+    typeof window === 'undefined' ||
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  ) {
+    return;
+  }
+  el.classList.remove(ringingClass);
+  // Reading offsetWidth forces a synchronous reflow so the re-added
+  // class starts a fresh animation rather than being coalesced away.
+  void el.offsetWidth;
+  el.classList.add(ringingClass);
+}

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -1754,19 +1754,19 @@ function ChordCell(props: {
           role: 'button' as const,
           'aria-label': `Play chord ${audioName}`,
           'data-chord': audioName,
-          onClick: (e: ReactMouseEvent) => {
+          onClick: (e: ReactMouseEvent<HTMLSpanElement>) => {
             chordAudio?.play(audioName);
-            pulseElement(e.currentTarget as HTMLElement, 'chord--ringing');
+            pulseElement(e.currentTarget, 'chord--ringing');
           },
-          onKeyDown: (e: ReactKeyboardEvent) => {
+          onKeyDown: (e: ReactKeyboardEvent<HTMLSpanElement>) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
               chordAudio?.play(audioName);
-              pulseElement(e.currentTarget as HTMLElement, 'chord--ringing');
+              pulseElement(e.currentTarget, 'chord--ringing');
             }
           },
-          onAnimationEnd: (e: ReactAnimationEvent) => {
-            (e.currentTarget as HTMLElement).classList.remove('chord--ringing');
+          onAnimationEnd: (e: ReactAnimationEvent<HTMLSpanElement>) => {
+            e.currentTarget.classList.remove('chord--ringing');
           },
         }
       : null;

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -45,6 +45,15 @@ import type {
 } from 'react';
 
 import { ChordDiagram } from './chord-diagram';
+import { pulseElement } from './chord-pulse';
+import type { ChordAudioConfig } from './use-chord-audio';
+
+// Re-export so existing consumers (chord-sheet, renderer-preview,
+// use-chord-editor, the package index) keep importing `ChordAudioConfig`
+// from `chordpro-jsx`. The type now lives in the leaf `use-chord-audio`
+// module so `<ChordDiagram>` can depend on it without forming an import
+// cycle with this walker. See use-chord-audio.ts for the definition.
+export type { ChordAudioConfig } from './use-chord-audio';
 
 // Minimal `process.env.NODE_ENV` typing for dev-only assertions
 // below — same pattern as `ireal-pro-editor.tsx` /
@@ -1570,49 +1579,14 @@ export interface ChordSelection {
 }
 
 /**
- * Chord-audio (#2650) wiring threaded to each chord-bearing lyrics line.
- * When {@link ChordAudioConfig.enabled} is `true`, activating a rendered
- * `.chord` (click / Enter / Space) sounds the chord via
- * {@link ChordAudioConfig.play}.
- *
- * Audio is additive, not a separate mode: it layers playback on top of
- * whatever interaction is already wired. With a selection consumer
- * present, clicking a chord both sounds it AND selects it for editing —
- * the editing panel stays usable while audio is on. With no selection
- * consumer (e.g. a preview-only host), the chord is a pure play button.
- */
-export interface ChordAudioConfig {
-  /** Whether chord-audio mode is active. */
-  enabled: boolean;
-  /** Sound the given raw chord name (e.g. `"Am7"`, `"C/G"`). */
-  play: (chordName: string) => void;
-}
-
-/**
  * Briefly flash a `.chord--ringing` class on a played chord element so
- * the tap gets visual feedback. The class is added imperatively (the
- * walker is stateless per chord) and removed on `animationend`; a forced
- * reflow between remove and re-add restarts the CSS animation when the
- * same chord is tapped again before the previous pulse finishes.
- *
- * When `prefers-reduced-motion: reduce` is active the function exits
- * early rather than adding the class — the CSS suppresses the animation
- * (`animation: none`) and `animationend` never fires, which would leave
- * the class (crimson background, white text) on the element permanently.
+ * the tap gets visual feedback. Delegates to the shared
+ * {@link pulseElement} mechanism (sister to the chord-diagram pulse — see
+ * .claude/rules/fix-propagation.md) so the reduced-motion guard and the
+ * animation-restart reflow live in one place.
  */
 function pulseChordElement(el: HTMLElement): void {
-  // Skip the visual pulse when the user prefers reduced motion. The audio
-  // still plays; only the animation feedback is suppressed. Without this
-  // guard, `animationend` never fires under `animation: none`, so the
-  // `.chord--ringing` highlight would stick on the element indefinitely.
-  if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
-    return;
-  }
-  el.classList.remove('chord--ringing');
-  // Reading offsetWidth forces a synchronous reflow so the re-added
-  // class starts a fresh animation rather than being coalesced away.
-  void el.offsetWidth;
-  el.classList.add('chord--ringing');
+  pulseElement(el, 'chord--ringing');
 }
 
 /**
@@ -1731,9 +1705,20 @@ function ChordCell(props: {
   instrument: ChordDiagramInstrument;
   orientation: ChordDiagramOrientation | undefined;
   defines: ReadonlyArray<readonly [string, string]> | undefined;
+  /** Chord-audio config (#2686). `null` keeps the diagram cell inert. */
+  chordAudio: ChordAudioConfig | null;
 }): JSX.Element {
-  const { mode, chord, marker, chordStyle, dragProps, instrument, orientation, defines } =
-    props;
+  const {
+    mode,
+    chord,
+    marker,
+    chordStyle,
+    dragProps,
+    instrument,
+    orientation,
+    defines,
+    chordAudio,
+  } = props;
   // The wasm voicing lookup keys on the {define} display override when
   // present, falling back to the raw chord name — the same expression
   // collectChordNames uses for the end-of-song grid. The
@@ -1746,17 +1731,55 @@ function ChordCell(props: {
     </>
   );
 
+  // Chord-audio (#2686). Play the RAW chord name — `chordName` above may
+  // be a `display` spelling override (e.g. `"A−"`) that the audio pitch
+  // lookup cannot parse, so the diagram is looked up by `chordName` but
+  // auditioned by `chord.name` (the same raw name the chord-name path
+  // plays). `null` when audio is off / the chord has no name.
+  const audioName = chord.name ?? '';
+  const audioOn = Boolean(chordAudio?.enabled) && audioName.length > 0;
+
   // Stable ID required for the aria-describedby / id pairing below.
   const tooltipId = useId();
 
   if (mode === 'hover') {
+    // In hover mode the chord NAME is the always-visible target (the
+    // diagram is a hover/focus popover), so the outer span is the play
+    // button when audio is on. A click anywhere inside — the name or the
+    // revealed popover diagram — bubbles here and sounds the chord, so the
+    // popover stays a plain `role="tooltip"` (no nested interactive). The
+    // pulse uses `event.currentTarget` (this span), not the popover.
+    const hoverAudioProps = audioOn
+      ? {
+          role: 'button' as const,
+          'aria-label': `Play chord ${audioName}`,
+          'data-chord': audioName,
+          onClick: (e: ReactMouseEvent) => {
+            chordAudio?.play(audioName);
+            pulseElement(e.currentTarget as HTMLElement, 'chord--ringing');
+          },
+          onKeyDown: (e: ReactKeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              chordAudio?.play(audioName);
+              pulseElement(e.currentTarget as HTMLElement, 'chord--ringing');
+            }
+          },
+          onAnimationEnd: (e: ReactAnimationEvent) => {
+            (e.currentTarget as HTMLElement).classList.remove('chord--ringing');
+          },
+        }
+      : null;
     return (
       <span
-        className="chord chord-has-diagram"
+        className={['chord', 'chord-has-diagram', audioOn && 'chord--audio']
+          .filter(Boolean)
+          .join(' ')}
         style={chordStyle ?? undefined}
         tabIndex={0}
         aria-describedby={tooltipId}
         {...(dragProps ?? {})}
+        {...(hoverAudioProps ?? {})}
       >
         {nameNode}
         <ChordDiagram
@@ -1775,7 +1798,13 @@ function ChordCell(props: {
     );
   }
 
-  // inline: the compact diagram stands in for the chord name.
+  // inline: the compact diagram stands in for the chord name, so the
+  // diagram itself is the play button. Hand `<ChordDiagram>` a config that
+  // auditions the RAW name (see `audioName` above) regardless of the
+  // `display`-spelled `chordName` it renders.
+  const inlineAudio: ChordAudioConfig | null = audioOn
+    ? { enabled: true, play: () => chordAudio?.play(audioName) }
+    : null;
   return (
     <span
       className="chord chord-block-inline-diagram"
@@ -1789,6 +1818,7 @@ function ChordCell(props: {
         defines={defines}
         compact
         className="chord-block-diagram"
+        chordAudio={inlineAudio}
         notFoundFallback={nameNode}
         loadingFallback={nameNode}
         errorFallback={() => nameNode}
@@ -2347,6 +2377,11 @@ function LyricsLine({
                   instrument={diagrams.instrument}
                   orientation={diagrams.orientation}
                   defines={diagrams.defines}
+                  // Chord-audio (#2686): in inline/hover diagram mode the
+                  // diagram cell — not a chord-name span — is the play
+                  // target, so the audio config is threaded into the cell
+                  // (this branch never receives `chordInteractiveProps`).
+                  chordAudio={audioEnabled ? chordAudio ?? null : null}
                 />
               ) : (
                 <span
@@ -3056,25 +3091,41 @@ interface DiagramsState {
 // `chordsketch-render-html`'s `chord_names` accumulator —
 // preserving order of first appearance so the diagram grid
 // reads top-to-bottom in source order.
-function collectChordNames(song: ChordproSong): string[] {
+/**
+ * A chord listed in the end-of-song grid. `name` is the diagram-lookup
+ * key (the `{define} display=` override when present, else the raw chord
+ * name) — what the grid shows and looks the voicing up by. `rawName` is
+ * the underlying parseable chord name used for AUDIO: a `display=`
+ * override can be an arbitrary label (e.g. `"C⁹"`) the pitch lookup
+ * cannot parse, so the two are kept distinct exactly as the inline/hover
+ * `<ChordCell>` keeps them distinct (.claude/rules/fix-propagation.md).
+ */
+interface GridChord {
+  name: string;
+  rawName: string;
+}
+
+function collectChordNames(song: ChordproSong): GridChord[] {
   const seen = new Set<string>();
-  const out: string[] = [];
-  const add = (name: string | undefined): void => {
+  const out: GridChord[] = [];
+  const add = (name: string | undefined, rawName: string | undefined): void => {
     if (!name) return;
     if (seen.has(name)) return;
     seen.add(name);
-    out.push(name);
+    out.push({ name, rawName: rawName ?? name });
   };
   for (const line of song.lines) {
     if (line.kind === 'lyrics') {
       for (const seg of line.value.segments) {
-        if (seg.chord) add(seg.chord.display ?? seg.chord.name);
+        if (seg.chord) add(seg.chord.display ?? seg.chord.name, seg.chord.name);
       }
     } else if (line.kind === 'directive') {
       const kind = line.value.kind;
       // `{define}` / `{chord}` values lead with the chord name —
       // pluck it so the grid lists explicitly-defined chords
-      // even when they don't appear in the lyrics.
+      // even when they don't appear in the lyrics. The first word IS
+      // the raw chord name (the `display=` override is a later token),
+      // so it doubles as the audio name.
       if ((kind.tag === 'define' || kind.tag === 'chordDirective') && line.value.value) {
         const firstWord = line.value.value.trim().split(/\s+/)[0];
         if (firstWord) {
@@ -3082,7 +3133,7 @@ function collectChordNames(song: ChordproSong): string[] {
           const unwrapped = firstWord.startsWith('[') && firstWord.endsWith(']')
             ? firstWord.slice(1, -1)
             : firstWord;
-          add(unwrapped);
+          add(unwrapped, unwrapped);
         }
       }
     }
@@ -4721,7 +4772,7 @@ export function renderChordproAst(
             Chord Diagrams
           </h3>
           <div className="chord-diagrams-grid">
-            {names.map((name) => (
+            {names.map(({ name, rawName }) => (
               // Each diagram is a self-contained figure — the
               // rendered SVG includes the chord name as a label
               // glyph so a separate `<figcaption>` would visually
@@ -4735,6 +4786,17 @@ export function renderChordproAst(
                   instrument={instrument}
                   defines={defines}
                   orientation={chordDiagramsOpts.orientation}
+                  // When chord-audio is on, each grid diagram is a play
+                  // button (#2686) sounding the chord it depicts. The
+                  // diagram is looked up by `name` (the display override)
+                  // but auditioned by `rawName` — a `display=` label may
+                  // not be a parseable chord — so the config plays the raw
+                  // name regardless of the `chord` prop ChordDiagram passes.
+                  chordAudio={
+                    ctx.chordAudio?.enabled
+                      ? { enabled: true, play: () => ctx.chordAudio?.play(rawName) }
+                      : ctx.chordAudio
+                  }
                 />
               </figure>
             ))}

--- a/packages/react/src/chordpro-jsx.tsx
+++ b/packages/react/src/chordpro-jsx.tsx
@@ -4795,7 +4795,7 @@ export function renderChordproAst(
                   chordAudio={
                     ctx.chordAudio?.enabled
                       ? { enabled: true, play: () => ctx.chordAudio?.play(rawName) }
-                      : ctx.chordAudio
+                      : null
                   }
                 />
               </figure>

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -2129,6 +2129,13 @@
   text-decoration: underline dotted;
   text-underline-offset: 2px;
 }
+/* When chord-audio is on (#2686) the hover trigger is also a play button,
+   so it must show the pointer affordance — not the `help` cursor. This
+   rule out-specifies the `.chord-has-diagram` cursor above (which would
+   otherwise win on source order over the `.chord--audio` rule). */
+.chordsketch-sheet__content .chord-has-diagram.chord--audio {
+  cursor: pointer;
+}
 .chordsketch-sheet__content .chord-diagram-popover {
   position: absolute;
   bottom: 100%;

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -2371,6 +2371,39 @@
   border-style: solid;
 }
 
+/* ---- Chord-diagram audio (#2686) ------------------------------ */
+/* When chord-audio is on, `<ChordDiagram>` becomes a play button (the
+   whole diagram is the click target). These rules are intentionally
+   UNSCOPED (not under `.chordsketch-sheet__content`) because a diagram
+   can be mounted standalone — the end-of-song grid, the inline / hover
+   cells, and an external `<ChordDiagram chordAudio>` all share them.
+   The activation pulse is a crimson ring + the shared `cs-chord-pulse`
+   scale animation; unlike the chord-name pulse it does NOT paint a
+   background/text colour (an SVG diagram has no text to invert). */
+.chordsketch-diagram--audio {
+  cursor: pointer;
+  border-radius: var(--cs-r-2, 4px);
+  transition:
+    box-shadow 0.12s ease,
+    transform 0.12s ease;
+}
+.chordsketch-diagram--audio:focus-visible {
+  outline: none;
+  box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
+}
+.chordsketch-diagram--audio:hover {
+  box-shadow: 0 0 0 2px var(--cs-crimson-500, #bd1642);
+}
+.chordsketch-diagram--ringing {
+  box-shadow: 0 0 0 2px var(--cs-crimson-500, #bd1642);
+  animation: cs-chord-pulse 0.45s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chordsketch-diagram--ringing {
+    animation: none;
+  }
+}
+
 /* ---------- Source editor (CodeMirror 6) ---------- */
 
 .chordsketch-source-area {

--- a/packages/react/src/use-chord-audio.ts
+++ b/packages/react/src/use-chord-audio.ts
@@ -54,6 +54,31 @@ export type ChordAudioWasmLoader = () => Promise<ChordPitchesModule>;
 const defaultLoader: ChordAudioWasmLoader = () =>
   import('@chordsketch/wasm') as unknown as Promise<ChordPitchesModule>;
 
+/**
+ * Chord-audio (#2650) wiring threaded to the chord surfaces (chord-name
+ * spans in the JSX walker, and chord diagrams via {@link ChordDiagram}).
+ * When {@link ChordAudioConfig.enabled} is `true`, activating a rendered
+ * chord (click / Enter / Space) sounds the chord via
+ * {@link ChordAudioConfig.play}.
+ *
+ * Audio is additive, not a separate mode: it layers playback on top of
+ * whatever interaction is already wired. With a selection consumer
+ * present, clicking a chord both sounds it AND selects it for editing —
+ * the editing panel stays usable while audio is on. With no selection
+ * consumer (e.g. a preview-only host), the chord is a pure play button.
+ *
+ * Defined in this leaf module (not `chordpro-jsx`) so `<ChordDiagram>`
+ * can depend on the type without importing the walker, which would form
+ * an import cycle (the walker imports `<ChordDiagram>`). Re-exported from
+ * `chordpro-jsx` so existing import paths keep resolving.
+ */
+export interface ChordAudioConfig {
+  /** Whether chord-audio mode is active. */
+  enabled: boolean;
+  /** Sound the given raw chord name (e.g. `"Am7"`, `"C/G"`). */
+  play: (chordName: string) => void;
+}
+
 /** Result of {@link useChordAudio}. */
 export interface UseChordAudioResult {
   /**

--- a/packages/react/tests/chord-diagram.test.tsx
+++ b/packages/react/tests/chord-diagram.test.tsx
@@ -273,6 +273,66 @@ describe('<ChordDiagram>', () => {
       });
     }
   });
+
+  test('chordAudio on: a still-loading diagram is already a play target', () => {
+    // Hold the loader open so the loading state is the commit state.
+    const loader: ChordDiagramWasmLoader = () =>
+      new Promise<never>(() => {
+        /* never resolves */
+      });
+    const play = vi.fn();
+    const { container } = render(
+      <ChordDiagram chord="Am" instrument="guitar" chordAudio={{ enabled: true, play }} wasmLoader={loader} />,
+    );
+    const wrapper = container.querySelector('.chordsketch-diagram--audio') as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.getAttribute('aria-busy')).toBe('true');
+    expect(wrapper.getAttribute('role')).toBe('button');
+    fireEvent.click(wrapper);
+    expect(play).toHaveBeenCalledWith('Am');
+  });
+
+  test('chordAudio on: the error branch is NOT a play affordance (no audio class / role / handler)', async () => {
+    const stub = makeStub();
+    stub.chord_diagram_svg.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const play = vi.fn();
+    const { container } = render(
+      <ChordDiagram
+        chord="Am"
+        instrument="guitar"
+        chordAudio={{ enabled: true, play }}
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe('boom');
+    });
+    const wrapper = container.querySelector('.chordsketch-diagram') as HTMLElement;
+    // The failed diagram must not paint a clickable affordance it cannot honour.
+    expect(wrapper.classList.contains('chordsketch-diagram--audio')).toBe(false);
+    expect(wrapper.getAttribute('role')).toBeNull();
+    fireEvent.click(wrapper);
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  test('audio off: an explicit consumer role survives once the SVG resolves', async () => {
+    // Regression guard for the role-respect fix: the hover popover passes
+    // role="tooltip"; the svg branch must not clobber it with role="img"
+    // when the diagram loads. The descriptive aria-label is preserved so
+    // an aria-describedby reference still resolves to a meaningful name.
+    const stub = makeStub();
+    const { container } = render(
+      <ChordDiagram chord="Am" instrument="guitar" role="tooltip" wasmLoader={makeLoader(stub)} />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.chordsketch-diagram svg')).not.toBeNull();
+    });
+    const wrapper = container.querySelector('.chordsketch-diagram') as HTMLElement;
+    expect(wrapper.getAttribute('role')).toBe('tooltip');
+    expect(wrapper.getAttribute('aria-label')).toBe('Am chord diagram (guitar)');
+  });
 });
 
 describe('useChordDiagram', () => {

--- a/packages/react/tests/chord-diagram.test.tsx
+++ b/packages/react/tests/chord-diagram.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ChordDiagram, useChordDiagram } from '../src/index';
@@ -137,6 +137,141 @@ describe('<ChordDiagram>', () => {
       });
     render(<ChordDiagram chord="Am" wasmLoader={loader} />);
     expect(screen.getByRole('status').textContent).toMatch(/loading/i);
+  });
+
+  // ---- Chord audio (#2686) ---------------------------------------
+
+  test('chordAudio on: the diagram becomes a play button that sounds its chord', async () => {
+    const stub = makeStub();
+    const play = vi.fn();
+    const { container } = render(
+      <ChordDiagram
+        chord="Am"
+        instrument="guitar"
+        chordAudio={{ enabled: true, play }}
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+    let wrapper!: HTMLElement;
+    await waitFor(() => {
+      wrapper = container.querySelector('.chordsketch-diagram--audio') as HTMLElement;
+      expect(wrapper).not.toBeNull();
+      // The SVG actually resolved, so this is the svg branch.
+      expect(wrapper.querySelector('svg')).not.toBeNull();
+    });
+    // Interactive button semantics replace the static role="img".
+    expect(wrapper.getAttribute('role')).toBe('button');
+    expect(wrapper.getAttribute('aria-label')).toBe('Play chord Am (guitar)');
+    expect(wrapper.getAttribute('data-chord')).toBe('Am');
+    expect(wrapper.tabIndex).toBe(0);
+
+    fireEvent.click(wrapper);
+    expect(play).toHaveBeenCalledWith('Am');
+
+    // Enter / Space activate from the keyboard; an unrelated key does not.
+    fireEvent.keyDown(wrapper, { key: 'Enter' });
+    fireEvent.keyDown(wrapper, { key: ' ' });
+    fireEvent.keyDown(wrapper, { key: 'x' });
+    expect(play).toHaveBeenCalledTimes(3);
+  });
+
+  test('chordAudio off / absent: the diagram stays a static role="img" figure', async () => {
+    const stub = makeStub();
+    const play = vi.fn();
+    const off = render(
+      <ChordDiagram
+        chord="Am"
+        instrument="guitar"
+        chordAudio={{ enabled: false, play }}
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+    await waitFor(() => {
+      expect(off.container.querySelector('.chordsketch-diagram svg')).not.toBeNull();
+    });
+    const offWrapper = off.container.querySelector('.chordsketch-diagram') as HTMLElement;
+    expect(offWrapper.classList.contains('chordsketch-diagram--audio')).toBe(false);
+    expect(offWrapper.getAttribute('role')).toBe('img');
+    fireEvent.click(offWrapper);
+    expect(play).not.toHaveBeenCalled();
+
+    const absent = render(
+      <ChordDiagram chord="Am" instrument="guitar" wasmLoader={makeLoader(stub)} />,
+    );
+    await waitFor(() => {
+      expect(absent.container.querySelector('.chordsketch-diagram svg')).not.toBeNull();
+    });
+    expect(
+      absent.container.querySelector('.chordsketch-diagram')?.getAttribute('role'),
+    ).toBe('img');
+  });
+
+  test('chordAudio on: a not-found chord still plays (the name fallback is the play target)', async () => {
+    const stub = makeStub();
+    const play = vi.fn();
+    const { container } = render(
+      <ChordDiagram
+        chord="ZZZ7sus4"
+        instrument="guitar"
+        chordAudio={{ enabled: true, play }}
+        wasmLoader={makeLoader(stub)}
+      />,
+    );
+    let wrapper!: HTMLElement;
+    await waitFor(() => {
+      // Not-found branch: no svg, but still an audio button.
+      wrapper = container.querySelector('.chordsketch-diagram--audio') as HTMLElement;
+      expect(wrapper).not.toBeNull();
+      expect(wrapper.querySelector('svg')).toBeNull();
+    });
+    expect(wrapper.getAttribute('role')).toBe('button');
+    fireEvent.click(wrapper);
+    expect(play).toHaveBeenCalledWith('ZZZ7sus4');
+  });
+
+  test('chordAudio on: no ringing class is left stuck under prefers-reduced-motion', async () => {
+    // Regression guard mirroring the chord-name path: `animation: none`
+    // under reduced motion stops `animationend` from firing, so the pulse
+    // class must never be added in the first place.
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+    try {
+      const stub = makeStub();
+      const play = vi.fn();
+      const { container } = render(
+        <ChordDiagram
+          chord="Am"
+          instrument="guitar"
+          chordAudio={{ enabled: true, play }}
+          wasmLoader={makeLoader(stub)}
+        />,
+      );
+      let wrapper!: HTMLElement;
+      await waitFor(() => {
+        wrapper = container.querySelector('.chordsketch-diagram--audio') as HTMLElement;
+        expect(wrapper).not.toBeNull();
+      });
+      fireEvent.click(wrapper);
+      expect(play).toHaveBeenCalledWith('Am');
+      expect(wrapper.classList.contains('chordsketch-diagram--ringing')).toBe(false);
+    } finally {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
   });
 });
 

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -4183,6 +4183,170 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
     expect(container.querySelector('.chord-diagrams')).toBeNull();
   });
 
+  // ---- Chord-diagram audio (#2686) -------------------------------
+  // The `<ChordDiagram>` instances mounted by the grid / inline / hover
+  // paths lazily load wasm; like the other diagram tests these assert
+  // only the synchronous interactive wrapper (a diagram is a play button
+  // before any SVG resolves, since the audio props apply to the
+  // loading / not-found branches too).
+
+  // A define-override song: the chord renders/looks-up under its
+  // `display` spelling but must AUDITION the raw `name`.
+  function displayOverrideSong(mode: string | null): ChordproSong {
+    return {
+      metadata: EMPTY_META,
+      lines: [
+        ...(mode === null
+          ? []
+          : [
+              {
+                kind: 'directive' as const,
+                value: {
+                  name: 'diagrams',
+                  value: mode,
+                  kind: { tag: 'diagrams' as const },
+                  selector: null,
+                },
+              },
+            ]),
+        {
+          kind: 'lyrics' as const,
+          value: {
+            segments: [
+              {
+                chord: { name: 'Am', detail: null, display: 'A−' },
+                text: 'Do',
+                spans: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+  }
+
+  test('end-of-song grid: chord-audio makes each diagram a play button', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues(null), {
+        chordDiagrams: { instrument: 'guitar' },
+        chordAudio: { enabled: true, play },
+      }),
+    );
+    const diagram = container.querySelector(
+      '.chord-diagrams .chordsketch-diagram--audio',
+    ) as HTMLElement;
+    expect(diagram).not.toBeNull();
+    expect(diagram.getAttribute('role')).toBe('button');
+    fireEvent.click(diagram);
+    expect(play).toHaveBeenCalledWith('C');
+  });
+
+  test('end-of-song grid: a display-override diagram auditions the RAW chord name', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(displayOverrideSong(null), {
+        chordDiagrams: { instrument: 'guitar' },
+        chordAudio: { enabled: true, play },
+      }),
+    );
+    const diagram = container.querySelector(
+      '.chord-diagrams .chordsketch-diagram--audio',
+    ) as HTMLElement;
+    expect(diagram).not.toBeNull();
+    fireEvent.click(diagram);
+    // Plays the parseable raw name "Am", NOT the "A−" display label.
+    expect(play).toHaveBeenCalledWith('Am');
+  });
+
+  test('grid diagrams stay inert when chord-audio is off', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues(null), {
+        chordDiagrams: { instrument: 'guitar' },
+        chordAudio: { enabled: false, play },
+      }),
+    );
+    expect(container.querySelector('.chord-diagrams .chordsketch-diagram--audio')).toBeNull();
+    const diagram = container.querySelector('.chord-diagrams .chordsketch-diagram') as HTMLElement;
+    fireEvent.click(diagram);
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  test('{diagrams: inline}: the inline diagram cell plays the chord on click', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('inline'), {
+        chordDiagrams: { instrument: 'guitar' },
+        chordAudio: { enabled: true, play },
+      }),
+    );
+    const diagram = container.querySelector(
+      '.chord-block-inline-diagram .chordsketch-diagram--audio',
+    ) as HTMLElement;
+    expect(diagram).not.toBeNull();
+    expect(diagram.getAttribute('role')).toBe('button');
+    fireEvent.click(diagram);
+    expect(play).toHaveBeenCalledWith('C');
+  });
+
+  test('{diagrams: inline}: a display-override cell auditions the RAW chord name', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(displayOverrideSong('inline'), {
+        chordDiagrams: { instrument: 'guitar' },
+        chordAudio: { enabled: true, play },
+      }),
+    );
+    const diagram = container.querySelector(
+      '.chord-block-inline-diagram .chordsketch-diagram--audio',
+    ) as HTMLElement;
+    expect(diagram).not.toBeNull();
+    fireEvent.click(diagram);
+    expect(play).toHaveBeenCalledWith('Am');
+  });
+
+  test('{diagrams: hover}: the chord-name trigger plays the chord; the popover stays a tooltip', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('hover'), {
+        chordDiagrams: { instrument: 'guitar' },
+        chordAudio: { enabled: true, play },
+      }),
+    );
+    const trigger = container.querySelector('.chord-has-diagram') as HTMLElement;
+    expect(trigger).not.toBeNull();
+    // The always-visible name span is the play button.
+    expect(trigger.classList.contains('chord--audio')).toBe(true);
+    expect(trigger.getAttribute('role')).toBe('button');
+    expect(trigger.getAttribute('data-chord')).toBe('C');
+    // The popover is NOT a nested interactive element.
+    const popover = container.querySelector('.chord-diagram-popover') as HTMLElement;
+    expect(popover.getAttribute('role')).toBe('tooltip');
+
+    fireEvent.click(trigger);
+    expect(play).toHaveBeenCalledWith('C');
+    // Enter / Space activate from the keyboard.
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    fireEvent.keyDown(trigger, { key: 'z' });
+    expect(play).toHaveBeenCalledTimes(2);
+  });
+
+  test('hover diagram cells stay inert when chord-audio is off', () => {
+    const play = vi.fn();
+    const { container } = render(
+      renderChordproAst(songWithDiagramsValues('hover'), {
+        chordDiagrams: { instrument: 'guitar' },
+        chordAudio: { enabled: false, play },
+      }),
+    );
+    const trigger = container.querySelector('.chord-has-diagram') as HTMLElement;
+    expect(trigger.classList.contains('chord--audio')).toBe(false);
+    expect(trigger.getAttribute('role')).toBeNull();
+    fireEvent.click(trigger);
+    expect(play).not.toHaveBeenCalled();
+  });
+
   // A song with a chord-bearing segment followed by a chord-LESS
   // segment on the same line, plus `{key}` / `{tempo}` directives and
   // a `{diagrams: …}` mode. Exercises the inline-diagram baseline-

--- a/packages/react/tests/chordpro-jsx.test.tsx
+++ b/packages/react/tests/chordpro-jsx.test.tsx
@@ -4326,10 +4326,11 @@ describe('renderChordproAst inline / hover diagrams (ADR-0027)', () => {
 
     fireEvent.click(trigger);
     expect(play).toHaveBeenCalledWith('C');
-    // Enter / Space activate from the keyboard.
+    // Enter / Space activate from the keyboard; an unrelated key does not.
     fireEvent.keyDown(trigger, { key: 'Enter' });
+    fireEvent.keyDown(trigger, { key: ' ' });
     fireEvent.keyDown(trigger, { key: 'z' });
-    expect(play).toHaveBeenCalledTimes(2);
+    expect(play).toHaveBeenCalledTimes(3);
   });
 
   test('hover diagram cells stay inert when chord-audio is off', () => {


### PR DESCRIPTION
## What

When chord-audio is enabled (sound on), clicking a chord **diagram** now sounds the chord — matching the existing chord-name click-to-play (#2650). Previously the diagram surfaces were inert: the end-of-song chord-diagrams grid and the inline / hover ADR-0027 cells rendered but never called the audio config, so a chord shown only as a diagram could not be auditioned.

Audio is wired at the canonical `<ChordDiagram>` component so every consumer benefits uniformly:

- `<ChordDiagram>` gains an optional `chordAudio` config. When enabled the whole diagram becomes a play button (click / Enter / Space) with an activation pulse; it degrades to the static `role="img"` figure when off / unsupported, and honours an explicit consumer `role` (e.g. the hover popover's `role="tooltip"`).
- The JSX walker threads its existing `chordAudio` config into the end-of-song grid diagrams and the inline / hover `<ChordCell>`. In hover mode the always-visible chord-name span is the play button (a click on the revealed popover bubbles to it), so the popover stays a plain `role="tooltip"` with no nested interactive control.
- Audio auditions the **raw** chord name everywhere, decoupled from the `{define} display=` override used for diagram lookup (a `display=` label can be an unparseable string). `collectChordNames` now carries the raw name for the grid, matching the decoupling the inline / hover cell already did.
- The chord-name and chord-diagram activation pulses share one `pulseElement` helper (reduced-motion guard + animation-restart reflow in one place). `ChordAudioConfig` moves to the leaf `use-chord-audio` module (re-exported from `chordpro-jsx`) so `<ChordDiagram>` can depend on the type without an import cycle.

## Why

A chord diagram is the surface a learner is most likely to tap to hear an unfamiliar chord, yet it was the one chord surface that produced no sound. This closes that gap so the diagram is a first-class audition target alongside the chord name.

## Test results

- `npm test` — 923 passing (43 files). New coverage: standalone `<ChordDiagram>` click / keyboard / not-found / loading play targets, the error branch staying inert, explicit-role survival, the reduced-motion stuck-highlight guard, and the grid / inline / hover walker surfaces incl. the raw-name-vs-display decoupling and hover-mode Space activation.
- `tsc --noEmit` — clean.
- `npm run build` (tsup ESM + CJS + DTS) — success.

## Review summary

Ran code review, security review, PR review, and a project-rules review in parallel. Findings resolved in-PR:

- **[Low]** Error branch no longer carries the `--audio` class (it painted a clickable affordance it never honoured).
- **[Low]** The svg branch respects an explicit consumer `role` instead of clobbering `role="tooltip"` with `role="img"` once the SVG resolves, while preserving the descriptive `aria-label`.
- **[Nit]** Disabled grid `chordAudio` normalised to `null` for call-site symmetry; `.chord-has-diagram.chord--audio` shows the pointer cursor; documented the intentional `data-chord` / `aria-label` (depicted display chord) vs audio (raw chord) split.

A delta review of the fix commit returned no findings. Security review found no issues (the `dangerouslySetInnerHTML` SVG boundary is unchanged; all chord-name interpolation goes through React's attribute auto-escaping).

## Sister-site audit

Audio playback is a React/browser-only affordance with no Rust-renderer sibling (same scope as #2650), so the text / HTML / PDF renderers need no change. The three diagram surfaces (grid / inline / hover) and the chord-name path all route through the shared `pulseElement` helper and the raw-name audition rule. No new playground mount path / format toggle / wasm surface, so no new Playwright smoke spec is required per `.claude/rules/playground-smoke.md`.

Closes #2686

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsEbrgj6CV57sDKsg6FGsd)_