### PR TITLE
Show chord constituent notes on a staff in the chord editor

### DIFF
--- a/crates/chordpro/src/chord.rs
+++ b/crates/chordpro/src/chord.rs
@@ -338,7 +338,7 @@ pub fn chord_pitches(chord_name: &str) -> Option<Vec<u8>> {
         chord_intervals(detail.quality, detail.extension.as_deref().unwrap_or(""))
             .all
             .into_iter()
-            .map(|iv| root_midi + iv)
+            .map(|iv| root_midi + iv.semitone)
             .collect();
 
     if let Some((bass, bass_acc)) = detail.bass_note {
@@ -470,19 +470,42 @@ pub fn key_tonic_triad(key: &str) -> Option<Vec<u8>> {
     Some(vec![root_midi, root_midi + third, root_midi + 7])
 }
 
+/// A chord tone tagged with its diatonic scale degree and its semitone
+/// offset above the root.
+///
+/// The `degree` fixes the staff LETTER the tone is conventionally spelled
+/// on — independent of any accidental — while `semitone` fixes its pitch
+/// class. Both are needed to spell a tone correctly for staff notation
+/// (e.g. a diminished seventh is degree 7 at 9 semitones, which spells as a
+/// double-flat seventh `B𝄫` over a C root, not as a major sixth `A`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ScaleTone {
+    /// Diatonic degree above the root: 1 = root, 3 = third (or the 2/4 of a
+    /// `sus`), 5 = fifth, 6 = sixth, 7 = seventh, 9/11/13 = the compound
+    /// tensions. Determines the note letter `(root_letter + (degree - 1))`.
+    degree: u8,
+    /// Semitones above the root (root `0` included).
+    semitone: u8,
+}
+
+/// Convenience constructor for a [`ScaleTone`].
+const fn tone(degree: u8, semitone: u8) -> ScaleTone {
+    ScaleTone { degree, semitone }
+}
+
 /// The constituent intervals of a chord, split into the full tone set and
 /// the subset that defines the chord's identity.
 struct ChordIntervals {
-    /// Every interval (in semitones above the root, root `0` included) the
-    /// chord nominally contains — the full stack a piano voicing would play.
-    all: Vec<u8>,
+    /// Every tone the chord nominally contains (root included) — the full
+    /// stack a piano voicing would play.
+    all: Vec<ScaleTone>,
     /// The subset of `all` that a reduced fretboard voicing MUST sound for
     /// the result to be unambiguously this chord: root, third (or `sus`
     /// replacement), the seventh (when present), the single highest named
     /// tension, and any altered / characteristic fifth. The perfect fifth and
     /// the inner (implied) tensions are droppable, mirroring how guitarists
     /// reduce extended chords to fit six strings.
-    essential: Vec<u8>,
+    essential: Vec<ScaleTone>,
 }
 
 /// Maps a chord quality + extension string to the semitone intervals (from
@@ -508,16 +531,20 @@ fn chord_intervals(quality: ChordQuality, ext: &str) -> ChordIntervals {
     // Power chord ("C5"): root + fifth, no third. Both tones are essential.
     if ext == "5" {
         return ChordIntervals {
-            all: vec![0, fifth],
-            essential: vec![0, fifth],
+            all: vec![tone(1, 0), tone(5, fifth)],
+            essential: vec![tone(1, 0), tone(5, fifth)],
         };
     }
 
-    // `sus` replaces the third with a 2nd or 4th.
+    // `sus` replaces the third with a 2nd or 4th. The replacement keeps its
+    // own diatonic degree (2 or 4) so it spells on the correct staff letter.
+    let mut third_degree = 3u8;
     if ext.contains("sus2") {
         third = 2;
+        third_degree = 2;
     } else if ext.contains("sus4") || ext == "sus" {
         third = 5;
+        third_degree = 4;
     }
 
     // Altered fifth. `b5` / `#5` are explicit; the `alt` dominant raises the
@@ -537,15 +564,20 @@ fn chord_intervals(quality: ChordQuality, ext: &str) -> ChordIntervals {
         fifth = 8;
     }
 
-    let mut all_extras: Vec<u8> = Vec::new();
-    let mut ess_extras: Vec<u8> = Vec::new();
+    let mut all_extras: Vec<ScaleTone> = Vec::new();
+    let mut ess_extras: Vec<ScaleTone> = Vec::new();
 
     if let Some(rest) = ext.strip_prefix("add") {
         // Add-tone chord (e.g. "add9"): triad plus the added degree, no
         // seventh. The added tone is the chord's identity, so it is essential.
         if let Some(semi) = degree_to_semitone(rest) {
-            all_extras.push(semi);
-            ess_extras.push(semi);
+            // `degree_to_semitone` matches only the bare degree tokens
+            // "2"/"4"/"6"/"9"/"11"/"13", so `rest` is exactly that degree.
+            let degree: u8 = rest
+                .parse()
+                .expect("degree_to_semitone only matches numeric degree tokens");
+            all_extras.push(tone(degree, semi));
+            ess_extras.push(tone(degree, semi));
         }
     } else {
         let has_six = ext.contains('6');
@@ -582,8 +614,8 @@ fn chord_intervals(quality: ChordQuality, ext: &str) -> ChordIntervals {
             } else {
                 10
             };
-            all_extras.push(seventh);
-            ess_extras.push(seventh);
+            all_extras.push(tone(7, seventh));
+            ess_extras.push(tone(7, seventh));
 
             // Ninth: flat / sharp / natural. `alt` implies a sharp ninth.
             let ninth = if ext.contains("b9") {
@@ -615,46 +647,46 @@ fn chord_intervals(quality: ChordQuality, ext: &str) -> ChordIntervals {
             };
 
             if let Some(n) = ninth {
-                all_extras.push(n);
+                all_extras.push(tone(9, n));
             }
             if let Some(e) = eleventh {
-                all_extras.push(e);
+                all_extras.push(tone(11, e));
             }
             if let Some(t) = thirteenth {
-                all_extras.push(t);
+                all_extras.push(tone(13, t));
             }
 
             // The single highest named tension is the chord's headline colour
             // and must survive a reduced voicing; the tensions below it are
             // droppable.
             if let Some(t) = thirteenth {
-                ess_extras.push(t);
+                ess_extras.push(tone(13, t));
             } else if let Some(e) = eleventh {
-                ess_extras.push(e);
+                ess_extras.push(tone(11, e));
             } else if let Some(n) = ninth {
-                ess_extras.push(n);
+                ess_extras.push(tone(9, n));
             }
         } else if has9 {
             // Reachable only for a "6/9" chord (the `has_six` guard above
             // suppresses the implied seventh): add the 9th alongside the 6th.
-            all_extras.push(14);
-            ess_extras.push(14);
+            all_extras.push(tone(9, 14));
+            ess_extras.push(tone(9, 14));
         }
 
         // A sixth (e.g. "C6", "Am6", "C69") adds the major sixth, which is the
         // chord's defining colour.
         if has_six {
-            all_extras.push(9);
-            ess_extras.push(9);
+            all_extras.push(tone(6, 9));
+            ess_extras.push(tone(6, 9));
         }
     }
 
-    let mut all = vec![0u8, third, fifth];
+    let mut all = vec![tone(1, 0), tone(third_degree, third), tone(5, fifth)];
     all.extend_from_slice(&all_extras);
 
-    let mut essential = vec![0u8, third];
+    let mut essential = vec![tone(1, 0), tone(third_degree, third)];
     if fifth_essential {
-        essential.push(fifth);
+        essential.push(tone(5, fifth));
     }
     essential.extend_from_slice(&ess_extras);
 
@@ -711,8 +743,8 @@ pub fn chord_tones(chord_name: &str) -> Option<ChordTones> {
         None => root_pc,
     };
 
-    let to_pcs = |ivs: &[u8]| {
-        let mut v: Vec<u8> = ivs.iter().map(|&s| (root_pc + s) % 12).collect();
+    let to_pcs = |ivs: &[ScaleTone]| {
+        let mut v: Vec<u8> = ivs.iter().map(|t| (root_pc + t.semitone) % 12).collect();
         // A slash bass that is not already a chord tone still has to be voiced
         // and is part of the chord's identity.
         v.push(bass_pc);
@@ -727,6 +759,163 @@ pub fn chord_tones(chord_name: &str) -> Option<ChordTones> {
         pitch_classes: to_pcs(&intervals.all),
         essential: to_pcs(&intervals.essential),
     })
+}
+
+// ---------------------------------------------------------------------------
+// Staff notation placement
+// ---------------------------------------------------------------------------
+
+/// MIDI note number the staff layout places the chord root on (C4, middle C).
+///
+/// Unlike [`chord_pitches`] — which fixes the root at C3 for a comfortable
+/// synth register — staff display centres the root around middle C so a
+/// typical chord's tones sit on or near the treble staff (bottom line E4,
+/// top line F5) with few ledger lines.
+const STAFF_ROOT_MIDI: i32 = 60;
+
+/// The seven natural-note pitch classes, indexed by diatonic letter
+/// (`0` = C, `1` = D, … `6` = B).
+const LETTER_PITCH_CLASSES: [i32; 7] = [0, 2, 4, 5, 7, 9, 11];
+
+/// The seven note letters, indexed as in [`LETTER_PITCH_CLASSES`].
+const LETTER_NAMES: [char; 7] = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+
+/// Diatonic letter index of a [`Note`] (`C` = 0, `D` = 1, … `B` = 6).
+const fn letter_index(note: Note) -> i32 {
+    match note {
+        Note::C => 0,
+        Note::D => 1,
+        Note::E => 2,
+        Note::F => 3,
+        Note::G => 4,
+        Note::A => 5,
+        Note::B => 6,
+    }
+}
+
+/// A chord tone placed for staff notation: its diatonic spelling (note
+/// letter + accidental) and octave, ready for a renderer to position on a
+/// five-line staff.
+///
+/// The tone is spelled from the chord's own structure — its diatonic degree
+/// fixes the letter — so each note lands on the staff line/space a musician
+/// expects (e.g. `Ebm7` → E♭ G♭ B♭ D♭, not the enharmonic D♯ F♯ A♯ C♯).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StaffNote {
+    /// The note letter the tone is spelled on, `'A'..='G'`.
+    pub letter: char,
+    /// The accidental applied to `letter`, as a signed semitone offset:
+    /// `-2` double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+    pub accidental: i8,
+    /// Scientific-pitch-notation octave (middle C = C4, so `octave == 4`).
+    pub octave: i8,
+    /// Absolute MIDI note number, consistent with `letter` + `accidental` +
+    /// `octave`. Lets a consumer cross-check the spelling or drive audio.
+    pub midi: u8,
+}
+
+/// Picks the octave (in diatonic letter-step terms) for a letter so its
+/// natural pitch sits as close as possible to `target_midi`. Rounding to the
+/// nearest octave keeps the resulting accidental small (≈ -2..=2) and places
+/// enharmonic spellings such as `Cb` / `B#` in the correct register.
+fn root_octave_for(letter_idx: i32, target_midi: i32) -> i32 {
+    let natural_pc = LETTER_PITCH_CLASSES[letter_idx as usize];
+    // natural_midi = (octave + 1) * 12 + natural_pc; solve for octave and
+    // round so the chosen octave minimises |target_midi - natural_midi|.
+    let raw = f64::from(target_midi - natural_pc) / 12.0 - 1.0;
+    raw.round() as i32
+}
+
+/// Places a diatonic staff step (`letter_index + 7 * octave`) at the exact
+/// pitch `target_midi`, deriving the accidental as the signed difference
+/// between the target and the letter's natural pitch at that octave. The
+/// returned [`StaffNote`]'s `midi` therefore always equals `target_midi`.
+fn place_step(step: i32, target_midi: i32) -> StaffNote {
+    let letter_idx = step.rem_euclid(7) as usize;
+    let octave = step.div_euclid(7);
+    let natural_midi = (octave + 1) * 12 + LETTER_PITCH_CLASSES[letter_idx];
+    StaffNote {
+        letter: LETTER_NAMES[letter_idx],
+        accidental: (target_midi - natural_midi) as i8,
+        octave: octave as i8,
+        // The chord-tone range is provably 47..=92 (slash bass at C2 through a
+        // 13th over a B root), well inside the MIDI byte; clamp defensively so
+        // a future interval change can never wrap the cast.
+        midi: target_midi.clamp(0, 127) as u8,
+    }
+}
+
+/// Diatonic staff placement of a chord's constituent tones, spelled from the
+/// chord's own structure so each tone lands on its conventional staff
+/// line/space.
+///
+/// Returns the tones ascending by pitch (a slash bass, dropped an octave
+/// below the root, sorts first). Returns `None` when `chord_name` is not a
+/// parseable chord — the same inputs [`parse_chord`] rejects.
+///
+/// This is the spelling companion to [`chord_pitches`] (MIDI for audio) and
+/// [`chord_tones`] (octave-independent pitch classes for voicing synthesis):
+/// where those discard letter spelling, this keeps it, which is exactly what
+/// a staff renderer needs to choose the right line for each note. The root is
+/// centred at middle C (see `STAFF_ROOT_MIDI`).
+///
+/// # Examples
+///
+/// ```
+/// use chordsketch_chordpro::chord_staff_notes;
+///
+/// let notes = chord_staff_notes("Cmaj9").unwrap();
+/// let spelled: Vec<(char, i8)> = notes.iter().map(|n| (n.letter, n.accidental)).collect();
+/// // C E G B D — all naturals, each on its own staff letter.
+/// assert_eq!(spelled, vec![('C', 0), ('E', 0), ('G', 0), ('B', 0), ('D', 0)]);
+///
+/// // Flat-side chords spell with flats, not the enharmonic sharps.
+/// let ebm7 = chord_staff_notes("Ebm7").unwrap();
+/// let letters: Vec<char> = ebm7.iter().map(|n| n.letter).collect();
+/// assert_eq!(letters, vec!['E', 'G', 'B', 'D']);
+/// assert!(ebm7.iter().all(|n| n.accidental == -1));
+///
+/// assert!(chord_staff_notes("not-a-chord").is_none());
+/// ```
+#[must_use]
+pub fn chord_staff_notes(chord_name: &str) -> Option<Vec<StaffNote>> {
+    let detail = parse_chord(chord_name)?;
+    let root_pc = i32::from(root_semitone(detail.root, detail.root_accidental));
+    let root_letter = letter_index(detail.root);
+    let root_midi = STAFF_ROOT_MIDI + root_pc;
+
+    // Diatonic position of the root, counted in letter-steps. Choosing the
+    // octave by `root_octave_for` keeps the root's accidental small and pins
+    // its MIDI to `root_midi` regardless of how the root is spelled.
+    let root_step = root_letter + 7 * root_octave_for(root_letter, root_midi);
+
+    let intervals = chord_intervals(detail.quality, detail.extension.as_deref().unwrap_or(""));
+
+    let mut notes: Vec<StaffNote> = intervals
+        .all
+        .iter()
+        .map(|t| {
+            // Stack each tone its diatonic degree above the root letter and
+            // place it at the exact pitch `root_midi + semitone`.
+            let step = root_step + i32::from(t.degree - 1);
+            place_step(step, root_midi + i32::from(t.semitone))
+        })
+        .collect();
+
+    // A slash bass that is not already a chord tone is part of the chord's
+    // identity; drop it an octave below the root so it is the lowest note,
+    // matching `chord_pitches`.
+    if let Some((bass, bass_acc)) = detail.bass_note {
+        let bass_pc = i32::from(root_semitone(bass, bass_acc));
+        let bass_letter = letter_index(bass);
+        let bass_midi = (STAFF_ROOT_MIDI - 12) + bass_pc;
+        let bass_step = bass_letter + 7 * root_octave_for(bass_letter, bass_midi);
+        notes.push(place_step(bass_step, bass_midi));
+    }
+
+    notes.sort_by_key(|n| (n.midi, n.letter, n.accidental));
+    notes.dedup();
+    Some(notes)
 }
 
 /// Maps an extension degree token (the tail of an `add` chord, e.g. `"9"`)
@@ -963,6 +1152,153 @@ mod tests {
     /// Shorthand: parse and unwrap.
     fn pd(input: &str) -> ChordDetail {
         parse_chord(input).unwrap_or_else(|| panic!("expected Some for chord '{input}'"))
+    }
+
+    // -- Staff notation placement -------------------------------------------
+
+    /// `(letter, accidental, octave)` triples for the spelled chord tones.
+    fn staff_spelling(chord: &str) -> Vec<(char, i8, i8)> {
+        chord_staff_notes(chord)
+            .unwrap_or_else(|| panic!("expected Some for chord '{chord}'"))
+            .into_iter()
+            .map(|n| (n.letter, n.accidental, n.octave))
+            .collect()
+    }
+
+    #[test]
+    fn staff_notes_reject_unparseable() {
+        assert!(chord_staff_notes("not-a-chord").is_none());
+        assert!(chord_staff_notes("").is_none());
+    }
+
+    #[test]
+    fn staff_notes_major_triad_all_naturals() {
+        // C major: C E G, each on its own staff letter, no accidentals, root
+        // at middle C (C4).
+        assert_eq!(
+            staff_spelling("C"),
+            vec![('C', 0, 4), ('E', 0, 4), ('G', 0, 4)]
+        );
+    }
+
+    #[test]
+    fn staff_notes_extended_chord_keeps_diatonic_letters() {
+        // Cmaj9 stacks C E G B D — five distinct staff letters, the 9th an
+        // octave up on D5.
+        assert_eq!(
+            staff_spelling("Cmaj9"),
+            vec![
+                ('C', 0, 4),
+                ('E', 0, 4),
+                ('G', 0, 4),
+                ('B', 0, 4),
+                ('D', 0, 5),
+            ]
+        );
+    }
+
+    #[test]
+    fn staff_notes_flat_chord_spells_with_flats() {
+        // Ebm7 must spell E♭ G♭ B♭ D♭, NOT the enharmonic D♯ F♯ A♯ C♯ — the
+        // letters land on E/G/B/D staff lines with flats.
+        assert_eq!(
+            staff_spelling("Ebm7"),
+            vec![('E', -1, 4), ('G', -1, 4), ('B', -1, 4), ('D', -1, 5),]
+        );
+    }
+
+    #[test]
+    fn staff_notes_diminished_seventh_double_flat() {
+        // Cdim7 = C E♭ G♭ B𝄫: the diminished seventh spells as a double-flat
+        // seventh (degree 7), not as the enharmonic natural sixth (A).
+        assert_eq!(
+            staff_spelling("Cdim7"),
+            vec![('C', 0, 4), ('E', -1, 4), ('G', -1, 4), ('B', -2, 4),]
+        );
+    }
+
+    #[test]
+    fn staff_notes_sus_chords_use_second_and_fourth_letters() {
+        // Csus2 → C D G (2nd on the D letter); Csus4 → C F G (4th on F).
+        assert_eq!(
+            staff_spelling("Csus2"),
+            vec![('C', 0, 4), ('D', 0, 4), ('G', 0, 4)]
+        );
+        assert_eq!(
+            staff_spelling("Csus4"),
+            vec![('C', 0, 4), ('F', 0, 4), ('G', 0, 4)]
+        );
+    }
+
+    #[test]
+    fn staff_notes_slash_bass_sorts_below_root() {
+        // C/G drops the bass G an octave below the root so it is the lowest
+        // note (G3), then C E G of the triad above.
+        let notes = chord_staff_notes("C/G").unwrap();
+        assert_eq!(notes.first().map(|n| (n.letter, n.octave)), Some(('G', 3)));
+        // Ascending by MIDI.
+        assert!(notes.windows(2).all(|w| w[0].midi <= w[1].midi));
+        assert_eq!(notes.first().unwrap().midi, 55); // G3
+    }
+
+    #[test]
+    fn staff_notes_midi_matches_spelling() {
+        // The reported MIDI must equal the pitch implied by letter + accidental
+        // + octave for every tone, across a spread of chord types.
+        for chord in ["C", "Am7", "F#7b9", "Bbmaj13", "G/B", "Cdim7", "Dsus4"] {
+            for n in chord_staff_notes(chord).unwrap() {
+                let natural_pc =
+                    LETTER_PITCH_CLASSES[LETTER_NAMES.iter().position(|&c| c == n.letter).unwrap()];
+                let expected =
+                    (i32::from(n.octave) + 1) * 12 + natural_pc + i32::from(n.accidental);
+                assert_eq!(
+                    i32::from(n.midi),
+                    expected,
+                    "midi/spelling mismatch for {chord}: {n:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn staff_notes_enharmonic_roots_land_in_register() {
+        // B# spells on the B letter (sharp) and Cb on the C letter (flat),
+        // each still pitched near middle C rather than an octave off.
+        let bsharp = chord_staff_notes("B#").unwrap();
+        assert_eq!(bsharp[0].letter, 'B');
+        assert_eq!(bsharp[0].accidental, 1);
+        assert_eq!(bsharp[0].midi, 60); // B#3 == C4 pitch
+
+        let cflat = chord_staff_notes("Cb").unwrap();
+        assert_eq!(cflat[0].letter, 'C');
+        assert_eq!(cflat[0].accidental, -1);
+        assert_eq!(cflat[0].midi, 71); // Cb5 == B4 pitch
+    }
+
+    #[test]
+    fn staff_notes_cover_every_root_and_quality() {
+        // Smoke: every root × a spread of qualities yields a non-empty, in-range
+        // placement with small accidentals — no panic, no wild spelling.
+        for root in ["C", "D", "E", "F", "G", "A", "B", "Bb", "F#", "C#", "Ab"] {
+            for suffix in [
+                "", "m", "7", "maj7", "m7b5", "dim7", "aug", "sus4", "13", "6",
+            ] {
+                let chord = format!("{root}{suffix}");
+                let notes = chord_staff_notes(&chord)
+                    .unwrap_or_else(|| panic!("expected Some for {chord}"));
+                assert!(!notes.is_empty(), "no notes for {chord}");
+                for n in notes {
+                    assert!(
+                        (-2..=2).contains(&n.accidental),
+                        "wild accidental for {chord}: {n:?}"
+                    );
+                    assert!(
+                        (36..=96).contains(&n.midi),
+                        "out-of-register {chord}: {n:?}"
+                    );
+                }
+            }
+        }
     }
 
     // -- Basic major chords --------------------------------------------------

--- a/crates/chordpro/src/chord.rs
+++ b/crates/chordpro/src/chord.rs
@@ -805,7 +805,12 @@ pub struct StaffNote {
     /// The note letter the tone is spelled on, `'A'..='G'`.
     pub letter: char,
     /// The accidental applied to `letter`, as a signed semitone offset:
-    /// `-2` double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+    /// `-1` flat, `0` natural, `1` sharp, `±2` double, and — only for an
+    /// enharmonically-extreme root such as `Cb` / `B#` whose own letter
+    /// already carries an accidental opposite to the chord's tones (e.g.
+    /// `Cbdim7`, whose strict seventh is a triple-flat B) — `±3`. A renderer
+    /// must handle the full `-3..=3` range, not assume double accidentals are
+    /// the maximum.
     pub accidental: i8,
     /// Scientific-pitch-notation octave (middle C = C4, so `octave == 4`).
     pub octave: i8,
@@ -816,8 +821,9 @@ pub struct StaffNote {
 
 /// Picks the octave (in diatonic letter-step terms) for a letter so its
 /// natural pitch sits as close as possible to `target_midi`. Rounding to the
-/// nearest octave keeps the resulting accidental small (≈ -2..=2) and places
-/// enharmonic spellings such as `Cb` / `B#` in the correct register.
+/// nearest octave keeps the resulting accidental small (`-3..=3`, almost always
+/// `-2..=2`) and places enharmonic spellings such as `Cb` / `B#` in the
+/// correct register.
 fn root_octave_for(letter_idx: i32, target_midi: i32) -> i32 {
     let natural_pc = LETTER_PITCH_CLASSES[letter_idx as usize];
     // natural_midi = (octave + 1) * 12 + natural_pc; solve for octave and
@@ -1273,6 +1279,28 @@ mod tests {
         assert_eq!(cflat[0].letter, 'C');
         assert_eq!(cflat[0].accidental, -1);
         assert_eq!(cflat[0].midi, 71); // Cb5 == B4 pitch
+    }
+
+    #[test]
+    fn staff_notes_enharmonic_extreme_root_reaches_triple_accidental() {
+        // A diminished seventh over an already-flat-spelled root (Cb) forces a
+        // strictly-correct triple-flat seventh on the B letter. This documents
+        // the `-3..=3` edge of the `StaffNote.accidental` contract — a renderer
+        // must handle it, not assume double accidentals are the maximum.
+        let notes = chord_staff_notes("Cbdim7").unwrap();
+        let seventh = notes
+            .iter()
+            .find(|n| n.letter == 'B')
+            .expect("Cbdim7 has a B-letter seventh");
+        assert_eq!(seventh.accidental, -3);
+        // The pitch is still exact: B triple-flat over Cb is enharmonically A.
+        let natural_pc = LETTER_PITCH_CLASSES[LETTER_NAMES
+            .iter()
+            .position(|&c| c == seventh.letter)
+            .unwrap()];
+        let expected =
+            (i32::from(seventh.octave) + 1) * 12 + natural_pc + i32::from(seventh.accidental);
+        assert_eq!(i32::from(seventh.midi), expected);
     }
 
     #[test]

--- a/crates/chordpro/src/lib.rs
+++ b/crates/chordpro/src/lib.rs
@@ -31,8 +31,8 @@ pub mod voicings;
 // Re-export key types for convenience.
 pub use abc_importer::convert_abc;
 pub use chord::{
-    Accidental, ChordDetail, ChordQuality, ChordTones, Note, chord_pitches, chord_tones,
-    key_scale_pitches, key_tonic_triad, parse_chord,
+    Accidental, ChordDetail, ChordQuality, ChordTones, Note, StaffNote, chord_pitches,
+    chord_staff_notes, chord_tones, key_scale_pitches, key_tonic_triad, parse_chord,
 };
 pub use chord_diagram::{canonical_chord_name, resolve_diagrams_instrument};
 pub use key::{ChurchMode, Key, KeyMode, parse_key};

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -148,6 +148,17 @@ namespace chordsketch {
     /// root), or `null` when `chord` is not parseable as a chord.
     sequence<u8>? chord_pitches(string chord);
 
+    /// Constituent tones of a chord spelled for staff notation (#2695).
+    /// Mirrors the wasm `chordStaffNotes` and NAPI `chordStaffNotes`
+    /// exports.
+    ///
+    /// Returns the tones ascending by pitch (a slash bass sorts first),
+    /// or `null` when `chord` is not parseable as a chord. Each tone is
+    /// spelled diatonically from the chord's structure (e.g. `Ebm7` →
+    /// E♭ G♭ B♭ D♭, not D♯ F♯ A♯ C♯), so a renderer can place it on its
+    /// conventional staff line.
+    sequence<StaffNote>? chord_staff_notes(string chord);
+
     /// Ascending one-octave scale of a musical key as MIDI note
     /// numbers, for auditioning the key by ear — the movable-do "do re
     /// mi fa sol la ti do" (#2658). Mirrors the wasm `keyScalePitches`
@@ -326,6 +337,21 @@ dictionary ValidationError {
     u32 column;
     /// Human-readable description of the issue.
     string message;
+};
+
+/// One staff-placed chord tone returned by `chord_staff_notes()`.
+///
+/// Mirrors the wasm `StaffNote` interface and the NAPI `StaffNote` object.
+dictionary StaffNote {
+    /// Note letter the tone is spelled on, `"A"`–`"G"`.
+    string letter;
+    /// Signed accidental as a semitone offset on `letter`: `-2`
+    /// double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+    i8 accidental;
+    /// Scientific-pitch-notation octave (middle C = C4).
+    i8 octave;
+    /// Absolute MIDI note number, consistent with the spelling.
+    u8 midi;
 };
 
 [Error]

--- a/crates/ffi/src/chordsketch.udl
+++ b/crates/ffi/src/chordsketch.udl
@@ -345,8 +345,10 @@ dictionary ValidationError {
 dictionary StaffNote {
     /// Note letter the tone is spelled on, `"A"`–`"G"`.
     string letter;
-    /// Signed accidental as a semitone offset on `letter`: `-2`
-    /// double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+    /// Signed accidental as a semitone offset on `letter`: `-1` flat,
+    /// `0` natural, `1` sharp, `±2` double, and `±3` for an
+    /// enharmonically-extreme root (e.g. `Cbdim7`). Consumers must handle
+    /// the full `-3..=3` range.
     i8 accidental;
     /// Scientific-pitch-notation octave (middle C = C4).
     i8 octave;

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -409,6 +409,48 @@ pub fn chord_pitches(chord: String) -> Option<Vec<u8>> {
     chordsketch_chordpro::chord_pitches(&chord)
 }
 
+/// One staff-placed chord tone returned by [`chord_staff_notes`].
+///
+/// Mirrors the wasm `StaffNote` interface and the NAPI `StaffNote` object,
+/// and the `StaffNote` dictionary in `chordsketch.udl`. The `letter` field
+/// carries a single `A`–`G` character as a string (the UDL has no `char`
+/// type).
+#[derive(Clone, Debug)]
+pub struct StaffNote {
+    /// Note letter the tone is spelled on, `"A"`–`"G"`.
+    pub letter: String,
+    /// Signed accidental semitone offset: `-2` double-flat … `2` double-sharp.
+    pub accidental: i8,
+    /// Scientific-pitch-notation octave (middle C = C4).
+    pub octave: i8,
+    /// Absolute MIDI note number, consistent with the spelling.
+    pub midi: u8,
+}
+
+/// Constituent tones of a chord spelled for staff notation — note letter,
+/// signed accidental, octave, and MIDI — for drawing the chord on a
+/// five-line staff (#2695). Mirrors the wasm `chordStaffNotes` and NAPI
+/// `chordStaffNotes` exports (`.claude/rules/fix-propagation.md` §Bindings).
+///
+/// Returns the tones ascending by pitch (a slash bass sorts first), or
+/// `None` when `chord` is not parseable as a chord. Each tone is spelled
+/// diatonically from the chord's structure (e.g. `Ebm7` → E♭ G♭ B♭ D♭, not
+/// D♯ F♯ A♯ C♯).
+#[must_use]
+pub fn chord_staff_notes(chord: String) -> Option<Vec<StaffNote>> {
+    chordsketch_chordpro::chord_staff_notes(&chord).map(|notes| {
+        notes
+            .into_iter()
+            .map(|n| StaffNote {
+                letter: n.letter.to_string(),
+                accidental: n.accidental,
+                octave: n.octave,
+                midi: n.midi,
+            })
+            .collect()
+    })
+}
+
 /// Ascending one-octave scale of a musical key as MIDI note numbers, for
 /// auditioning the key by ear — the movable-do "do re mi fa sol la ti do"
 /// (#2658). Mirrors the wasm `keyScalePitches` and NAPI `keyScalePitches`
@@ -1396,6 +1438,22 @@ mod tests {
     fn test_chord_pitches_unparseable_returns_none() {
         assert_eq!(chord_pitches("XYZ-not-a-chord".to_string()), None);
         assert_eq!(chord_pitches(String::new()), None);
+    }
+
+    #[test]
+    fn test_chord_staff_notes_spelling_and_none() {
+        let notes = chord_staff_notes("Cmaj9".to_string()).expect("Cmaj9 is a chord");
+        let spelled: Vec<(&str, i8)> = notes
+            .iter()
+            .map(|n| (n.letter.as_str(), n.accidental))
+            .collect();
+        assert_eq!(
+            spelled,
+            vec![("C", 0), ("E", 0), ("G", 0), ("B", 0), ("D", 0)]
+        );
+        let ebm7 = chord_staff_notes("Ebm7".to_string()).expect("Ebm7 is a chord");
+        assert!(ebm7.iter().all(|n| n.accidental == -1));
+        assert!(chord_staff_notes("XYZ-not-a-chord".to_string()).is_none());
     }
 
     #[test]

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -419,7 +419,9 @@ pub fn chord_pitches(chord: String) -> Option<Vec<u8>> {
 pub struct StaffNote {
     /// Note letter the tone is spelled on, `"A"`–`"G"`.
     pub letter: String,
-    /// Signed accidental semitone offset: `-2` double-flat … `2` double-sharp.
+    /// Signed accidental semitone offset: `-1` flat … `2` double-sharp, and
+    /// `±3` for an enharmonically-extreme root (e.g. `Cbdim7`); consumers must
+    /// handle the full `-3..=3` range.
     pub accidental: i8,
     /// Scientific-pitch-notation octave (middle C = C4).
     pub octave: i8,

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -249,6 +249,34 @@ export function chordDiagramSvgWithDefines(
 export function chordPitches(chord: string): Buffer | null;
 
 /**
+ * One staff-placed chord tone returned by `chordStaffNotes`. Mirrors the
+ * WASM `StaffNote` interface and the FFI `StaffNote` dictionary.
+ */
+export interface StaffNote {
+  /** Note letter the tone is spelled on, `"A"`–`"G"`. */
+  letter: string;
+  /**
+   * Signed accidental as a semitone offset on `letter`: `-2` double-flat,
+   * `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+   */
+  accidental: number;
+  /** Scientific-pitch-notation octave (middle C = C4). */
+  octave: number;
+  /** Absolute MIDI note number, consistent with the spelling. */
+  midi: number;
+}
+
+/**
+ * Constituent tones of a chord spelled for staff notation (#2695). Mirrors
+ * the WASM `chordStaffNotes` and FFI `chord_staff_notes` exports.
+ *
+ * Returns the tones ascending by pitch (a slash bass sorts first), or `null`
+ * when `chord` is not parseable as a chord. Each tone is spelled diatonically
+ * from the chord's structure (e.g. `Ebm7` → E♭ G♭ B♭ D♭, not D♯ F♯ A♯ C♯).
+ */
+export function chordStaffNotes(chord: string): Array<StaffNote> | null;
+
+/**
  * Ascending one-octave scale of a musical key as MIDI note numbers, for
  * auditioning the key by ear — the movable-do "do re mi fa sol la ti do"
  * (#2658). Mirrors the WASM `keyScalePitches` and FFI `key_scale_pitches`

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -256,8 +256,10 @@ export interface StaffNote {
   /** Note letter the tone is spelled on, `"A"`–`"G"`. */
   letter: string;
   /**
-   * Signed accidental as a semitone offset on `letter`: `-2` double-flat,
-   * `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+   * Signed accidental as a semitone offset on `letter`: `-1` flat, `0`
+   * natural, `1` sharp, `±2` double. For enharmonically-extreme roots
+   * (e.g. `Cbdim7`'s triple-flat seventh) the value reaches `±3` — renderers
+   * must handle the full `-3..=3` range, not assume `±2` is the maximum.
    */
   accidental: number;
   /** Scientific-pitch-notation octave (middle C = C4). */

--- a/crates/napi/src/bindings.rs
+++ b/crates/napi/src/bindings.rs
@@ -528,12 +528,14 @@ pub fn chord_pitches(chord: String) -> Option<Buffer> {
 ///
 /// `accidental` / `octave` are `i32` (not the core's `i8`) because napi-rs
 /// marshals only the wider integer types as plain JS `number`s; the value
-/// ranges (accidental ≈ -2..=2, octave ≈ 2..=6) are unchanged.
+/// ranges (accidental ≈ -3..=3, octave ≈ 2..=6) are unchanged.
 #[napi(object)]
 pub struct StaffNote {
     /// Note letter the tone is spelled on, `"A"`–`"G"`.
     pub letter: String,
-    /// Signed accidental semitone offset: `-2` double-flat … `2` double-sharp.
+    /// Signed accidental semitone offset: `-1` flat … `2` double-sharp, and
+    /// `±3` for an enharmonically-extreme root (e.g. `Cbdim7`); consumers must
+    /// handle the full `-3..=3` range.
     pub accidental: i32,
     /// Scientific-pitch-notation octave (middle C = C4).
     pub octave: i32,

--- a/crates/napi/src/bindings.rs
+++ b/crates/napi/src/bindings.rs
@@ -36,12 +36,12 @@ use napi_derive::napi;
 
 use crate::{
     chord_diagram_svg_inner, chord_diagram_svg_inner_with_orientation, chord_pitches_inner,
-    do_convert_chordpro_to_irealb, do_convert_irealb_to_chordpro_text, do_parse_irealb,
-    do_render_bytes, do_render_ireal_pdf, do_render_ireal_png, do_render_ireal_svg,
-    do_render_pdf_with_warnings, do_render_string, do_render_string_with_warnings,
-    do_serialize_irealb, key_scale_pitches_inner, key_tonic_triad_inner,
-    render_html_css_with_options_inner, resolve_options_inner, validate_defines_pairs,
-    validate_inner,
+    chord_staff_notes_inner, do_convert_chordpro_to_irealb, do_convert_irealb_to_chordpro_text,
+    do_parse_irealb, do_render_bytes, do_render_ireal_pdf, do_render_ireal_png,
+    do_render_ireal_svg, do_render_pdf_with_warnings, do_render_string,
+    do_render_string_with_warnings, do_serialize_irealb, key_scale_pitches_inner,
+    key_tonic_triad_inner, render_html_css_with_options_inner, resolve_options_inner,
+    validate_defines_pairs, validate_inner,
 };
 
 /// Render options matching the WASM package API.
@@ -520,6 +520,53 @@ pub fn chord_diagram_svg_with_defines(
 #[napi(js_name = "chordPitches")]
 pub fn chord_pitches(chord: String) -> Option<Buffer> {
     chord_pitches_inner(&chord).map(Buffer::from)
+}
+
+/// One staff-placed chord tone. Mirrors the `StaffNote` interface in
+/// `crates/napi/index.d.ts`; the `#[napi(object)]` attribute marshals this
+/// into a plain JS `{letter, accidental, octave, midi}` record.
+///
+/// `accidental` / `octave` are `i32` (not the core's `i8`) because napi-rs
+/// marshals only the wider integer types as plain JS `number`s; the value
+/// ranges (accidental ≈ -2..=2, octave ≈ 2..=6) are unchanged.
+#[napi(object)]
+pub struct StaffNote {
+    /// Note letter the tone is spelled on, `"A"`–`"G"`.
+    pub letter: String,
+    /// Signed accidental semitone offset: `-2` double-flat … `2` double-sharp.
+    pub accidental: i32,
+    /// Scientific-pitch-notation octave (middle C = C4).
+    pub octave: i32,
+    /// Absolute MIDI note number, consistent with the spelling.
+    pub midi: u8,
+}
+
+/// Constituent tones of a chord spelled for staff notation — note letter,
+/// signed accidental, octave, and MIDI — for drawing the chord on a
+/// five-line staff (#2695).
+///
+/// Returns the tones ascending by pitch (a slash bass sorts first), or
+/// `null` when `chord` is not parseable as a chord. Each tone is spelled
+/// diatonically from the chord's structure (e.g. `Ebm7` → E♭ G♭ B♭ D♭, not
+/// D♯ F♯ A♯ C♯).
+///
+/// Thin wrapper over the pure-Rust `chord_staff_notes_inner`. Sister-site to
+/// the wasm `chordStaffNotes` export and the FFI `chord_staff_notes` function
+/// (`.claude/rules/fix-propagation.md` §Bindings).
+#[must_use]
+#[napi(js_name = "chordStaffNotes")]
+pub fn chord_staff_notes(chord: String) -> Option<Vec<StaffNote>> {
+    chord_staff_notes_inner(&chord).map(|notes| {
+        notes
+            .into_iter()
+            .map(|n| StaffNote {
+                letter: n.letter.to_string(),
+                accidental: i32::from(n.accidental),
+                octave: i32::from(n.octave),
+                midi: n.midi,
+            })
+            .collect()
+    })
 }
 
 /// Ascending one-octave scale of a musical key as MIDI note numbers, for

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -246,6 +246,20 @@ pub(crate) fn chord_pitches_inner(chord: &str) -> Option<Vec<u8>> {
     chordsketch_chordpro::chord_pitches(chord)
 }
 
+/// Pure-Rust core of [`bindings::chord_staff_notes`]. Returns the chord's
+/// constituent tones spelled for staff notation, or `None` when `chord` is
+/// not parseable.
+///
+/// Thin pass-through to [`chordsketch_chordpro::chord_staff_notes`]; kept here
+/// so the native test suite covers the binding's surface without the Node-API
+/// runtime. Sister-site to the wasm `chord_staff_notes_inner` and the FFI
+/// binding's `chord_staff_notes` (`.claude/rules/fix-propagation.md`
+/// §Bindings).
+#[must_use]
+pub(crate) fn chord_staff_notes_inner(chord: &str) -> Option<Vec<chordsketch_chordpro::StaffNote>> {
+    chordsketch_chordpro::chord_staff_notes(chord)
+}
+
 /// Pure-Rust core of [`bindings::key_scale_pitches`]. Returns the ascending
 /// one-octave scale of `key` as MIDI note numbers, or `None` when `key` is
 /// not parseable as a chord.
@@ -1123,6 +1137,19 @@ mod tests {
     fn test_chord_pitches_inner_unparseable_returns_none() {
         assert_eq!(chord_pitches_inner("XYZ-not-a-chord"), None);
         assert_eq!(chord_pitches_inner(""), None);
+    }
+
+    #[test]
+    fn test_chord_staff_notes_inner_spelling_and_none() {
+        let notes = chord_staff_notes_inner("Cmaj9").expect("Cmaj9 is a chord");
+        let spelled: Vec<(char, i8)> = notes.iter().map(|n| (n.letter, n.accidental)).collect();
+        assert_eq!(
+            spelled,
+            vec![('C', 0), ('E', 0), ('G', 0), ('B', 0), ('D', 0)]
+        );
+        let ebm7 = chord_staff_notes_inner("Ebm7").expect("Ebm7 is a chord");
+        assert!(ebm7.iter().all(|n| n.accidental == -1));
+        assert!(chord_staff_notes_inner("XYZ-not-a-chord").is_none());
     }
 
     #[test]

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -1024,8 +1024,10 @@ export interface StaffNote {
   /** Note letter the tone is spelled on, `"A"`–`"G"`. */
   letter: string;
   /**
-   * Signed accidental as a semitone offset on {@link letter}: `-2`
-   * double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+   * Signed accidental as a semitone offset on {@link letter}: `-1` flat,
+   * `0` natural, `1` sharp, `±2` double. For enharmonically-extreme roots
+   * (e.g. `Cbdim7`'s triple-flat seventh) the value reaches `±3` — renderers
+   * must handle the full `-3..=3` range, not assume `±2` is the maximum.
    */
   accidental: number;
   /** Scientific-pitch-notation octave (middle C = C4). */

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -867,6 +867,11 @@ pub fn chord_pitches(chord: &str) -> Option<Vec<u8>> {
 ///
 /// Returns a `JsValue` error string only if serialisation fails — a
 /// defensive path callers can treat as infallible in normal use.
+// No `#[must_use]`: like the sibling `validate` / `listDirectives` JsValue
+// exports, the return is a `Result` (already `#[must_use]`), so a bare
+// attribute would be redundant (clippy::double_must_use). The NAPI / FFI
+// `chord_staff_notes` return a plain `Option` value and DO mark `#[must_use]`,
+// matching their own `chord_pitches` siblings.
 #[wasm_bindgen(js_name = chordStaffNotes, skip_typescript)]
 pub fn chord_staff_notes(chord: &str) -> Result<JsValue, JsValue> {
     to_js_value(&crate::chord_staff_notes_inner(chord))

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -848,6 +848,30 @@ pub fn chord_pitches(chord: &str) -> Option<Vec<u8>> {
     crate::chord_pitches_inner(chord)
 }
 
+/// Constituent tones of a chord spelled for staff notation — note letter,
+/// signed accidental, octave, and MIDI — for drawing the chord on a
+/// five-line staff (the React `<ChordStaff>` surface, #2695).
+///
+/// Returns `undefined` when `chord` is not parseable as a chord; otherwise a
+/// JS array of `{letter, accidental, octave, midi}` objects, ascending by
+/// pitch (a slash bass sorts first). Each tone is spelled diatonically from
+/// the chord's structure so it lands on its conventional staff line (e.g.
+/// `Ebm7` → E♭ G♭ B♭ D♭, not D♯ F♯ A♯ C♯).
+///
+/// Thin wrapper over [`chordsketch_chordpro::chord_staff_notes`] via the
+/// pure-Rust `chord_staff_notes_inner`. Sister-site to the NAPI
+/// `chordStaffNotes` export and the FFI `chord_staff_notes` function
+/// (`.claude/rules/fix-propagation.md` §Bindings).
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string only if serialisation fails — a
+/// defensive path callers can treat as infallible in normal use.
+#[wasm_bindgen(js_name = chordStaffNotes, skip_typescript)]
+pub fn chord_staff_notes(chord: &str) -> Result<JsValue, JsValue> {
+    to_js_value(&crate::chord_staff_notes_inner(chord))
+}
+
 /// Ascending one-octave scale of a musical key as MIDI note numbers, for
 /// auditioning the key by ear — the movable-do "do re mi fa sol la ti do"
 /// (the React `useKeyAudio` key-audition surface).
@@ -984,6 +1008,36 @@ export function chordDiagramSvgWithDefinesOrientationCompact(
   defines: Array<[string, string]>,
   orientation?: ChordDiagramOrientation | null,
 ): string | null;
+
+/**
+ * One staff-placed chord tone returned by {@link chordStaffNotes}.
+ *
+ * Matches the NAPI (`@chordsketch/node`) `StaffNote` interface and the UDL
+ * `StaffNote` dictionary exposed by the FFI bindings.
+ */
+export interface StaffNote {
+  /** Note letter the tone is spelled on, `"A"`–`"G"`. */
+  letter: string;
+  /**
+   * Signed accidental as a semitone offset on {@link letter}: `-2`
+   * double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+   */
+  accidental: number;
+  /** Scientific-pitch-notation octave (middle C = C4). */
+  octave: number;
+  /** Absolute MIDI note number, consistent with the spelling. */
+  midi: number;
+}
+
+/**
+ * Constituent tones of a chord spelled for staff notation, ascending by
+ * pitch (a slash bass sorts first).
+ *
+ * Returns `undefined` when `chord` is not parseable as a chord. Each tone is
+ * spelled diatonically from the chord's structure (e.g. `Ebm7` → E♭ G♭ B♭ D♭,
+ * not D♯ F♯ A♯ C♯) so a renderer can place it on its conventional staff line.
+ */
+export function chordStaffNotes(chord: string): StaffNote[] | undefined;
 "#;
 
 /// Return the ChordPro directive catalog as a JS array of `DirectiveInfo`

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -343,7 +343,8 @@ pub(crate) fn key_tonic_triad_inner(key: &str) -> Option<Vec<u8>> {
 pub(crate) struct StaffNotePayload {
     /// Note letter the tone is spelled on, `"A"`–`"G"`.
     pub(crate) letter: String,
-    /// Signed accidental semitone offset (`-2`..=`2`).
+    /// Signed accidental semitone offset (`-3..=3`; almost always `-2..=2`,
+    /// but reaches `±3` for enharmonically-extreme roots such as `Cbdim7`).
     pub(crate) accidental: i8,
     /// Scientific-pitch-notation octave (middle C = C4).
     pub(crate) octave: i8,

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -336,6 +336,42 @@ pub(crate) fn key_tonic_triad_inner(key: &str) -> Option<Vec<u8>> {
     chordsketch_chordpro::key_tonic_triad(key)
 }
 
+/// One staff-placed chord tone, serialised to a plain JS
+/// `{letter, accidental, octave, midi}` object via `serde_wasm_bindgen`.
+/// Mirrors the NAPI `StaffNote` object and the FFI `StaffNote` dictionary.
+#[derive(Serialize)]
+pub(crate) struct StaffNotePayload {
+    /// Note letter the tone is spelled on, `"A"`–`"G"`.
+    pub(crate) letter: String,
+    /// Signed accidental semitone offset (`-2`..=`2`).
+    pub(crate) accidental: i8,
+    /// Scientific-pitch-notation octave (middle C = C4).
+    pub(crate) octave: i8,
+    /// Absolute MIDI note number, consistent with the spelling.
+    pub(crate) midi: u8,
+}
+
+/// Pure-Rust core of [`bindings::chord_staff_notes`]. Returns the chord's
+/// constituent tones spelled for staff notation, or `None` when `chord` is
+/// not parseable.
+///
+/// Sister-site to the NAPI `chord_staff_notes_inner` and the FFI binding's
+/// `chord_staff_notes` (`.claude/rules/fix-propagation.md` §Bindings).
+#[must_use]
+pub(crate) fn chord_staff_notes_inner(chord: &str) -> Option<Vec<StaffNotePayload>> {
+    chordsketch_chordpro::chord_staff_notes(chord).map(|notes| {
+        notes
+            .into_iter()
+            .map(|n| StaffNotePayload {
+                letter: n.letter.to_string(),
+                accidental: n.accidental,
+                octave: n.octave,
+                midi: n.midi,
+            })
+            .collect()
+    })
+}
+
 /// A single validation issue reported by [`bindings::validate`].
 ///
 /// Serialised to a plain JS `{line, column, message}` object via
@@ -1737,6 +1773,23 @@ mod tests {
     fn test_chord_pitches_inner_unparseable_returns_none() {
         assert_eq!(chord_pitches_inner("XYZ-not-a-chord"), None);
         assert_eq!(chord_pitches_inner(""), None);
+    }
+
+    #[test]
+    fn test_chord_staff_notes_inner_spelling_and_none() {
+        let notes = chord_staff_notes_inner("Cmaj9").expect("Cmaj9 is a chord");
+        let spelled: Vec<(&str, i8)> = notes
+            .iter()
+            .map(|n| (n.letter.as_str(), n.accidental))
+            .collect();
+        assert_eq!(
+            spelled,
+            vec![("C", 0), ("E", 0), ("G", 0), ("B", 0), ("D", 0)]
+        );
+        // Flat-side chord spells with flats, not enharmonic sharps.
+        let ebm7 = chord_staff_notes_inner("Ebm7").expect("Ebm7 is a chord");
+        assert!(ebm7.iter().all(|n| n.accidental == -1));
+        assert!(chord_staff_notes_inner("XYZ-not-a-chord").is_none());
     }
 
     #[test]

--- a/packages/react/src/chord-inspector.tsx
+++ b/packages/react/src/chord-inspector.tsx
@@ -24,10 +24,12 @@
 
 import type { JSX, KeyboardEvent as ReactKeyboardEvent } from 'react';
 
+import { ChordStaff } from './chord-staff';
 import {
   CHORD_TYPE_PRESETS,
   type ChordParts,
 } from './chord-source-edit';
+import type { ChordStaffWasmLoader } from './use-chord-staff';
 
 /** Root letters offered in the segmented control, C-major order. */
 const ROOT_NOTES = ['C', 'D', 'E', 'F', 'G', 'A', 'B'] as const;
@@ -98,6 +100,12 @@ export interface ChordInspectorProps {
    * Only rendered in the idle state (when {@link selected} is false); a
    * `note` passed alongside `selected: true` is not shown. */
   note?: string;
+  /** Test-only WASM loader override forwarded to the `<ChordStaff>` shown
+   * beneath the chord name. Production callers never supply this — the staff
+   * lazy-loads `@chordsketch/wasm` itself.
+   *
+   * @internal */
+  staffLoader?: ChordStaffWasmLoader;
 }
 
 /**
@@ -168,9 +176,20 @@ export function ChordInspector(props: ChordInspectorProps): JSX.Element {
       onKeyDown={onKeyDown}
     >
       <div className="chordsketch-sheet__cins-head">
-        <div>
+        <div className="chordsketch-sheet__cins-title">
           <div className="chordsketch-sheet__cins-eyebrow">Editing chord</div>
           <div className="chordsketch-sheet__cins-name">{titleName || '—'}</div>
+          {/* Constituent notes of the chord on a five-line staff, beneath
+              the name. Empty `chordName` (a rootless / unparseable token)
+              still renders the placeholder rather than a broken staff. */}
+          {chordName ? (
+            <ChordStaff
+              chord={chordName}
+              displayName={titleName || undefined}
+              wasmLoader={props.staffLoader}
+              className="chordsketch-sheet__cins-staff"
+            />
+          ) : null}
         </div>
         {props.onClose ? (
           <button

--- a/packages/react/src/chord-staff.tsx
+++ b/packages/react/src/chord-staff.tsx
@@ -1,0 +1,342 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import {
+  type ChordStaffWasmLoader,
+  type StaffNote,
+  useChordStaff,
+} from './use-chord-staff';
+
+// ---- Staff geometry ---------------------------------------------
+//
+// A five-line treble staff drawn in its own SVG user-space. Vertical
+// position is driven by each tone's DIATONIC step (letter + octave), not its
+// pitch class, so enharmonic spellings land on the right line (the core
+// already spelled them — see `chordsketch_chordpro::chord_staff_notes`).
+//
+// "Staff step" counts diatonic letters from C0: `octave * 7 + letterIndex`,
+// with C = 0 … B = 6. On a treble staff the bottom line (E4) is step 30 and
+// the top line (F5) is step 38, so the five lines sit on the even steps
+// 30/32/34/36/38 and each unit step is half a line gap.
+
+const LETTER_ORDER = 'CDEFGAB';
+const LINE_GAP = 9;
+const HALF_GAP = LINE_GAP / 2;
+/** Staff step of the bottom treble line (E4). */
+const BOTTOM_LINE_STEP = 30;
+/** Staff step of the top treble line (F5). */
+const TOP_LINE_STEP = 38;
+const NOTE_RX = 5.2;
+const NOTE_RY = 3.9;
+const LEDGER_HALF_WIDTH = 7.5;
+const NOTE_SPACING = 15;
+const NOTE_START_X = 27;
+const PAD = 6;
+/** Scale mapping the simplified clef path's staff (lines at y 4..16, gap 3)
+ * onto this staff (gap {@link LINE_GAP}). */
+const CLEF_SCALE = LINE_GAP / 3;
+const CLEF_X = 7;
+
+/** Diatonic staff step of a spelled note (`octave * 7 + letterIndex`). */
+export function staffStep(note: StaffNote): number {
+  const idx = LETTER_ORDER.indexOf(note.letter.toUpperCase());
+  // An unrecognised letter would corrupt the layout; treat it as C so the
+  // note still renders rather than landing at NaN.
+  return note.octave * 7 + (idx === -1 ? 0 : idx);
+}
+
+/** Unicode accidental glyph for a signed semitone offset. Double accidentals
+ * use a doubled single glyph (`♭♭` / `♯♯`) so they render in any font, unlike
+ * the dedicated U+1D12A/B double glyphs. */
+export function accidentalGlyph(accidental: number): string {
+  switch (accidental) {
+    case -2:
+      return '♭♭';
+    case -1:
+      return '♭';
+    case 0:
+      return '';
+    case 1:
+      return '♯';
+    case 2:
+      return '♯♯';
+    default:
+      return '';
+  }
+}
+
+/** Even staff steps (line positions) a notehead at `step` needs ledger lines
+ * drawn at: below the staff (steps < bottom line) or above it (> top line). */
+export function ledgerSteps(step: number): number[] {
+  const out: number[] = [];
+  if (step < BOTTOM_LINE_STEP) {
+    for (let e = BOTTOM_LINE_STEP - 2; e >= step; e -= 2) out.push(e);
+  } else if (step > TOP_LINE_STEP) {
+    for (let e = TOP_LINE_STEP + 2; e <= step; e += 2) out.push(e);
+  }
+  return out;
+}
+
+/** A laid-out notehead column. */
+interface StaffColumn {
+  x: number;
+  /** Notehead centre y (relative space, before normalisation). */
+  cy: number;
+  accidental: string;
+  ledgers: number[];
+  midi: number;
+}
+
+/** The full geometry needed to paint the staff, in normalised (all-positive,
+ * padded) SVG user-space. Exported for unit tests. */
+export interface StaffModel {
+  width: number;
+  height: number;
+  /** y of each of the five staff lines, top (F5) → bottom (E4). */
+  lineYs: number[];
+  staffLeft: number;
+  staffRight: number;
+  clefTransform: string;
+  columns: Array<{
+    x: number;
+    cy: number;
+    accidental: string;
+    ledgerYs: number[];
+    midi: number;
+  }>;
+}
+
+/** Relative y (smaller = higher pitch) of a staff step, anchored so the
+ * bottom line (E4) is 0. */
+function relY(step: number): number {
+  return -(step - BOTTOM_LINE_STEP) * HALF_GAP;
+}
+
+/**
+ * Lay the spelled tones out on a treble staff. Notes are arpeggiated
+ * left-to-right (ascending pitch) so adjacent seconds never collide — a clean,
+ * unambiguous "these are the notes" reading suited to the editor helper, not a
+ * vertically-stacked engraving.
+ */
+export function buildStaffModel(notes: readonly StaffNote[]): StaffModel {
+  const columns: StaffColumn[] = notes.map((note, i) => ({
+    x: NOTE_START_X + i * NOTE_SPACING,
+    cy: relY(staffStep(note)),
+    accidental: accidentalGlyph(note.accidental),
+    ledgers: ledgerSteps(staffStep(note)).map(relY),
+    midi: note.midi,
+  }));
+
+  // Relative y extents: the five staff lines, every notehead (± its radius),
+  // every ledger line, and the clef's vertical overhang. Seed the bounds with
+  // the staff + clef so an empty / sparse chord still frames the staff.
+  const staffTopRel = relY(TOP_LINE_STEP);
+  const staffBottomRel = relY(BOTTOM_LINE_STEP);
+  // The simplified clef path spans y≈2.5..21 in its own space; mapped onto
+  // this staff (its line y=4 → staffTopRel) it overhangs both ends.
+  const clefTopRel = staffTopRel + (2.5 - 4) * CLEF_SCALE;
+  const clefBottomRel = staffTopRel + (21 - 4) * CLEF_SCALE;
+  let minRel = Math.min(staffTopRel, clefTopRel);
+  let maxRel = Math.max(staffBottomRel, clefBottomRel);
+  for (const col of columns) {
+    minRel = Math.min(minRel, col.cy - NOTE_RY, ...col.ledgers);
+    maxRel = Math.max(maxRel, col.cy + NOTE_RY, ...col.ledgers);
+  }
+
+  const offsetY = PAD - minRel;
+  const height = maxRel - minRel + 2 * PAD;
+  const lastX = columns.length > 0 ? columns[columns.length - 1]!.x : NOTE_START_X;
+  const width = lastX + NOTE_RX + PAD + 4;
+  const staffLeft = 3;
+  const staffRight = width - 2;
+
+  // Five lines from top (F5) to bottom (E4) on the even steps.
+  const lineYs: number[] = [];
+  for (let step = TOP_LINE_STEP; step >= BOTTOM_LINE_STEP; step -= 2) {
+    lineYs.push(relY(step) + offsetY);
+  }
+
+  // Clef: map its path-space onto this staff and shift by the normalisation
+  // offset. (point x,y) → (CLEF_X + (x-4.5)*s, (staffTopRel+offsetY) + (y-4)*s).
+  const clefTy = staffTopRel + offsetY - 4 * CLEF_SCALE;
+  const clefTx = CLEF_X - 4.5 * CLEF_SCALE;
+  const clefTransform = `translate(${clefTx.toFixed(2)} ${clefTy.toFixed(2)}) scale(${CLEF_SCALE.toFixed(3)})`;
+
+  return {
+    width,
+    height,
+    lineYs,
+    staffLeft,
+    staffRight,
+    clefTransform,
+    columns: columns.map((col) => ({
+      x: col.x,
+      cy: col.cy + offsetY,
+      accidental: col.accidental,
+      ledgerYs: col.ledgers.map((y) => y + offsetY),
+      midi: col.midi,
+    })),
+  };
+}
+
+// The simplified treble-clef outline, shared with `music-glyphs.tsx`'s
+// `KeySignatureGlyph` (its own coordinate space: staff lines at y 4..16). It
+// is a caricature of the SMuFL gClef that reads as "treble clef" at icon size
+// without a Bravura font load.
+const CLEF_PATH =
+  'M9 19 C 9 21, 5.5 21, 5.5 18.5 C 5.5 16, 9 16, 9 14 ' +
+  'C 9 11, 4.5 9, 4.5 7 C 4.5 4, 8.5 2.5, 9.5 5 ' +
+  'C 10.5 8, 6 9.5, 6 13 C 6 16, 10 16, 10 13.5';
+
+/** Props accepted by {@link ChordStaff}. */
+export interface ChordStaffProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  /** Chord name whose constituent notes to draw (e.g. `"Cmaj9"`, `"Ebm7"`). */
+  chord: string;
+  /**
+   * The chord name with Unicode accidentals (e.g. `"E♭m7"`), used only in the
+   * accessible label so it matches how the chord is displayed elsewhere.
+   * Falls back to {@link chord}.
+   */
+  displayName?: string;
+  /**
+   * Node shown while the WASM module loads. Defaults to a minimal
+   * `role="status"` placeholder so the staff area does not jump.
+   */
+  loadingFallback?: ReactNode;
+  /**
+   * Test-only WASM loader override. Production callers never supply this — the
+   * default lazy-loads `@chordsketch/wasm`.
+   *
+   * @internal
+   */
+  wasmLoader?: ChordStaffWasmLoader;
+}
+
+function defaultLoadingFallback(): ReactNode {
+  return (
+    <div role="status" aria-live="polite" className="chordsketch-staff__loading">
+      Loading staff…
+    </div>
+  );
+}
+
+/**
+ * Render a chord's constituent notes on a five-line treble staff (五線譜).
+ *
+ * The note placement and spelling come from `@chordsketch/wasm`'s
+ * `chordStaffNotes` (sister to `chordsketch_chordpro::chord_staff_notes`), so
+ * every consumer draws the same musically-correct staff. The SVG itself is
+ * assembled here in React — it is geometry, not user content — so there is no
+ * `dangerouslySetInnerHTML`.
+ *
+ * Degrades gracefully: a `role="status"` placeholder while the module loads,
+ * and nothing (an empty, labelled figure) when the chord is not parseable or
+ * Web Assembly is unavailable under SSR.
+ *
+ * ```tsx
+ * <ChordStaff chord="Cmaj9" />
+ * ```
+ */
+export function ChordStaff({
+  chord,
+  displayName,
+  loadingFallback,
+  wasmLoader,
+  className,
+  ...divProps
+}: ChordStaffProps): JSX.Element {
+  const { notes, loading } = useChordStaff(chord, wasmLoader);
+  const wrapperClass = ['chordsketch-staff', className].filter(Boolean).join(' ');
+  const label = `Notes of ${displayName ?? chord} on a staff`;
+
+  if (notes === null) {
+    if (loading) {
+      return (
+        <div {...divProps} className={wrapperClass} aria-busy="true">
+          {loadingFallback ?? defaultLoadingFallback()}
+        </div>
+      );
+    }
+    // Not loading and no notes — the chord is not parseable (or SSR without
+    // WASM). Render an empty, labelled figure rather than nothing so the
+    // layout stays stable and the absence is announced.
+    return (
+      <div {...divProps} className={wrapperClass} role="img" aria-label={`${label} (unavailable)`} />
+    );
+  }
+
+  const model = buildStaffModel(notes);
+
+  return (
+    <div {...divProps} className={wrapperClass}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox={`0 0 ${model.width.toFixed(2)} ${model.height.toFixed(2)}`}
+        width={model.width}
+        height={model.height}
+        className="chordsketch-staff__svg"
+        role="img"
+        aria-label={label}
+      >
+        {/* Five staff lines */}
+        {model.lineYs.map((y, i) => (
+          <line
+            key={`staff-line-${i}`}
+            x1={model.staffLeft}
+            x2={model.staffRight}
+            y1={y}
+            y2={y}
+            stroke="currentColor"
+            strokeWidth={0.7}
+          />
+        ))}
+        {/* Treble clef */}
+        <path
+          d={CLEF_PATH}
+          transform={model.clefTransform}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1}
+          strokeLinecap="round"
+        />
+        {/* Noteheads, ledger lines, accidentals */}
+        {model.columns.map((col, i) => (
+          <g key={`note-${i}`} className="chordsketch-staff__note">
+            {col.ledgerYs.map((y, j) => (
+              <line
+                key={`ledger-${i}-${j}`}
+                x1={col.x - LEDGER_HALF_WIDTH}
+                x2={col.x + LEDGER_HALF_WIDTH}
+                y1={y}
+                y2={y}
+                stroke="currentColor"
+                strokeWidth={0.7}
+              />
+            ))}
+            {col.accidental ? (
+              <text
+                x={col.x - NOTE_RX - 4}
+                y={col.cy}
+                className="chordsketch-staff__accidental"
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill="currentColor"
+              >
+                {col.accidental}
+              </text>
+            ) : null}
+            <ellipse
+              cx={col.x}
+              cy={col.cy}
+              rx={NOTE_RX}
+              ry={NOTE_RY}
+              // A filled (quarter-note) head reads clearly at small size; the
+              // slight rotation echoes engraved noteheads.
+              transform={`rotate(-20 ${col.x} ${col.cy})`}
+              fill="currentColor"
+            />
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/packages/react/src/chord-staff.tsx
+++ b/packages/react/src/chord-staff.tsx
@@ -44,24 +44,17 @@ export function staffStep(note: StaffNote): number {
   return note.octave * 7 + (idx === -1 ? 0 : idx);
 }
 
-/** Unicode accidental glyph for a signed semitone offset. Double accidentals
- * use a doubled single glyph (`♭♭` / `♯♯`) so they render in any font, unlike
- * the dedicated U+1D12A/B double glyphs. */
+/** Unicode accidental glyph for a signed semitone offset. Multi-semitone
+ * accidentals repeat the single glyph (`♭♭` / `♯♯` / `♭♭♭`) so they render in
+ * any font, unlike the dedicated U+1D12A/B double glyphs — and so the full
+ * `StaffNote.accidental` range is covered: the core can emit ±3 for an
+ * enharmonically-extreme root (e.g. `Cbdim7`'s triple-flat seventh), which a
+ * fixed `-2..=2` switch would have dropped to no glyph at all. Capped at four
+ * repeats as a defensive bound against a pathological value. */
 export function accidentalGlyph(accidental: number): string {
-  switch (accidental) {
-    case -2:
-      return '♭♭';
-    case -1:
-      return '♭';
-    case 0:
-      return '';
-    case 1:
-      return '♯';
-    case 2:
-      return '♯♯';
-    default:
-      return '';
-  }
+  const n = Math.trunc(accidental);
+  if (n === 0) return '';
+  return (n < 0 ? '♭' : '♯').repeat(Math.min(Math.abs(n), 4));
 }
 
 /** Even staff steps (line positions) a notehead at `step` needs ledger lines

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,6 +10,13 @@ export {
   type ChordDiagramOrientation,
   type ChordDiagramResult,
 } from './use-chord-diagram';
+export { ChordStaff, type ChordStaffProps } from './chord-staff';
+export {
+  useChordStaff,
+  type ChordStaffResult,
+  type ChordStaffWasmLoader,
+  type StaffNote,
+} from './use-chord-staff';
 export { ChordTextarea, type ChordTextareaProps } from './chord-textarea';
 export { ChordSheet, type ChordSheetProps } from './chord-sheet';
 export {

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1667,6 +1667,39 @@
   line-height: 1.1;
   color: var(--cs-crimson-500, #bd1642);
 }
+.chordsketch-sheet__cins-title {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cs-sp-1, 0.25rem);
+}
+
+/* Constituent-notes staff beneath the chord name (#2695). */
+.chordsketch-staff {
+  display: inline-flex;
+  align-items: center;
+  /* The staff lines / clef / noteheads paint in `currentColor`; a muted
+     secondary tone keeps the staff legible without competing with the
+     crimson chord name above it. */
+  color: var(--cs-text-secondary, #67646d);
+}
+.chordsketch-sheet__cins-staff {
+  margin-top: var(--cs-sp-1, 0.25rem);
+}
+.chordsketch-staff__svg {
+  display: block;
+  height: auto;
+  /* Cap the rendered height so a wide chord (many tones / ledger lines)
+     stays proportionate inside the footer header. */
+  max-height: 88px;
+}
+.chordsketch-staff__accidental {
+  font-size: 9px;
+  font-family: var(--cs-font-ui, system-ui, sans-serif);
+}
+.chordsketch-staff__loading {
+  font-size: 0.6875rem;
+  color: var(--cs-text-tertiary, #8a8790);
+}
 .chordsketch-sheet__cins-close {
   width: 28px;
   height: 28px;

--- a/packages/react/src/use-chord-staff.ts
+++ b/packages/react/src/use-chord-staff.ts
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Narrow WASM surface this hook touches. Kept structural so the React
+// package does not drag the WASM glue into its type graph — the module is
+// dynamically imported at runtime. Mirrors the `chordStaffNotes` export added
+// in #2695 (sister to `chordsketch_chordpro::chord_staff_notes`).
+interface StaffNotesModule {
+  default: () => Promise<unknown>;
+  /**
+   * Constituent tones of `chord` spelled for staff notation, ascending by
+   * pitch (a slash bass sorts first), or `null` / `undefined` when the
+   * string is not parseable as a chord.
+   */
+  chordStaffNotes: (chord: string) => StaffNote[] | null | undefined;
+}
+
+/**
+ * One staff-placed chord tone — the React mirror of the wasm `StaffNote`
+ * object (`chordsketch_chordpro::StaffNote`). Spelled diatonically from the
+ * chord's structure so it lands on its conventional staff line (e.g. `Ebm7`
+ * → E♭ G♭ B♭ D♭, not the enharmonic D♯ F♯ A♯ C♯).
+ */
+export interface StaffNote {
+  /** Note letter the tone is spelled on, `"A"`–`"G"`. */
+  readonly letter: string;
+  /**
+   * Signed accidental as a semitone offset on {@link letter}: `-2`
+   * double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+   */
+  readonly accidental: number;
+  /** Scientific-pitch-notation octave (middle C = C4). */
+  readonly octave: number;
+  /** Absolute MIDI note number, consistent with the spelling. */
+  readonly midi: number;
+}
+
+/**
+ * WASM loader injected by tests. Production callers take the default, which
+ * lazy-loads `@chordsketch/wasm`.
+ *
+ * @internal
+ */
+export type ChordStaffWasmLoader = () => Promise<StaffNotesModule>;
+
+// Two-step cast through `unknown` — the wasm module's generated types,
+// resolved against the JS bundle host bundlers see, do not formally include
+// `chordStaffNotes`'s typed signature even though the export is present at
+// runtime. The `StaffNotesModule` shape models the runtime contract; the
+// runtime test against a stubbed loader is what guards it.
+const defaultLoader: ChordStaffWasmLoader = () =>
+  import('@chordsketch/wasm') as unknown as Promise<StaffNotesModule>;
+
+/** State exposed by {@link useChordStaff}. */
+export interface ChordStaffResult {
+  /**
+   * The chord's spelled constituent tones, or `null` while the WASM module
+   * loads or when `chord` is not parseable. A parseable chord with no tones
+   * is not possible — `null` always means "loading or not a chord".
+   */
+  notes: StaffNote[] | null;
+  /** `true` while the WASM module loads or a lookup is in flight. */
+  loading: boolean;
+  /** Set only when WASM init itself fails. An unparseable chord is NOT an
+   * error — it surfaces via `notes === null` once `loading` is `false`. */
+  error: Error | null;
+}
+
+/**
+ * Resolve a chord's spelled staff tones via `@chordsketch/wasm`'s
+ * `chordStaffNotes`. The WASM module is loaded lazily and cached per hook
+ * instance; the result re-resolves whenever `chord` changes.
+ *
+ * The musical-theory source of truth (which tones a chord contains and how
+ * they are spelled) lives in the core library, not here — this hook only
+ * fetches the precomputed placement (see
+ * `.claude/rules/playground-is-a-sample.md`).
+ *
+ * ```ts
+ * const { notes, loading } = useChordStaff('Cmaj9');
+ * ```
+ */
+export function useChordStaff(
+  chord: string,
+  loader: ChordStaffWasmLoader = defaultLoader,
+): ChordStaffResult {
+  const [notes, setNotes] = useState<StaffNote[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const moduleRef = useRef<StaffNotesModule | null>(null);
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async (): Promise<void> => {
+      setLoading(true);
+      try {
+        if (moduleRef.current === null) {
+          const mod = await loaderRef.current();
+          await mod.default();
+          if (cancelled) return;
+          moduleRef.current = mod;
+        }
+        const result = moduleRef.current.chordStaffNotes(chord);
+        if (cancelled) return;
+        setNotes(result ?? null);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+        setNotes(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chord]);
+
+  return { notes, loading, error };
+}

--- a/packages/react/src/use-chord-staff.ts
+++ b/packages/react/src/use-chord-staff.ts
@@ -24,8 +24,10 @@ export interface StaffNote {
   /** Note letter the tone is spelled on, `"A"`–`"G"`. */
   readonly letter: string;
   /**
-   * Signed accidental as a semitone offset on {@link letter}: `-2`
-   * double-flat, `-1` flat, `0` natural, `1` sharp, `2` double-sharp.
+   * Signed accidental as a semitone offset on {@link letter}: `-1` flat,
+   * `0` natural, `1` sharp, `±2` double. For enharmonically-extreme roots
+   * (e.g. `Cbdim7`'s triple-flat seventh) the value reaches `±3` — renderers
+   * must handle the full `-3..=3` range, not assume `±2` is the maximum.
    */
   readonly accidental: number;
   /** Scientific-pitch-notation octave (middle C = C4). */

--- a/packages/react/tests/chord-inspector.test.tsx
+++ b/packages/react/tests/chord-inspector.test.tsx
@@ -1,8 +1,26 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { ChordInspector } from '../src/chord-inspector';
 import type { ChordParts } from '../src/chord-source-edit';
+import type { ChordStaffWasmLoader, StaffNote } from '../src/use-chord-staff';
+
+const AM7_STAFF: StaffNote[] = [
+  { letter: 'A', accidental: 0, octave: 3, midi: 57 },
+  { letter: 'C', accidental: 0, octave: 4, midi: 60 },
+  { letter: 'E', accidental: 0, octave: 4, midi: 64 },
+  { letter: 'G', accidental: 0, octave: 4, midi: 67 },
+];
+
+// Deterministic staff loader so the inspector's `<ChordStaff>` never reaches
+// for the real (unbuilt) `@chordsketch/wasm` during these unit tests.
+const stubStaffLoader: ChordStaffWasmLoader = vi.fn(
+  async () =>
+    ({
+      default: vi.fn(async () => undefined),
+      chordStaffNotes: (chord: string) => (chord === 'Am7' ? AM7_STAFF : null),
+    }) as unknown as Awaited<ReturnType<ChordStaffWasmLoader>>,
+);
 
 function setup(overrides: Partial<Parameters<typeof ChordInspector>[0]> = {}) {
   const onChange = vi.fn();
@@ -21,6 +39,7 @@ function setup(overrides: Partial<Parameters<typeof ChordInspector>[0]> = {}) {
     onNudge,
     onRemove,
     onClose,
+    staffLoader: stubStaffLoader,
     ...overrides,
   };
   const utils = render(<ChordInspector {...props} />);
@@ -40,6 +59,22 @@ describe('<ChordInspector>', () => {
       '.chordsketch-sheet__cins-chip[aria-pressed="true"]',
     );
     expect(pressedChip?.textContent).toBe('m7');
+  });
+
+  test('renders the constituent-notes staff beneath the chord name', async () => {
+    const { container } = setup();
+    await waitFor(() => {
+      const svg = container.querySelector('.chordsketch-sheet__cins-staff .chordsketch-staff__svg');
+      expect(svg).not.toBeNull();
+      // One notehead per tone of Am7.
+      expect(svg!.querySelectorAll('ellipse')).toHaveLength(AM7_STAFF.length);
+    });
+    expect(stubStaffLoader).toHaveBeenCalled();
+  });
+
+  test('omits the staff in the idle state', () => {
+    const { container } = setup({ selected: false });
+    expect(container.querySelector('.chordsketch-staff')).toBeNull();
   });
 
   test('changing the root emits the full parts with the new root', () => {

--- a/packages/react/tests/chord-staff.test.tsx
+++ b/packages/react/tests/chord-staff.test.tsx
@@ -46,12 +46,16 @@ describe('staff geometry helpers', () => {
     expect(staffStep({ letter: 'C', accidental: 0, octave: 4, midi: 60 })).toBe(28);
   });
 
-  test('accidentalGlyph maps signed offsets to Unicode', () => {
+  test('accidentalGlyph maps signed offsets to Unicode across the full range', () => {
     expect(accidentalGlyph(-2)).toBe('♭♭');
     expect(accidentalGlyph(-1)).toBe('♭');
     expect(accidentalGlyph(0)).toBe('');
     expect(accidentalGlyph(1)).toBe('♯');
     expect(accidentalGlyph(2)).toBe('♯♯');
+    // The core can emit ±3 for an enharmonically-extreme root (e.g. Cbdim7);
+    // the glyph must render it rather than silently dropping to no accidental.
+    expect(accidentalGlyph(-3)).toBe('♭♭♭');
+    expect(accidentalGlyph(3)).toBe('♯♯♯');
   });
 
   test('ledgerSteps adds lines for notes outside the staff only', () => {

--- a/packages/react/tests/chord-staff.test.tsx
+++ b/packages/react/tests/chord-staff.test.tsx
@@ -1,0 +1,147 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  ChordStaff,
+  accidentalGlyph,
+  buildStaffModel,
+  ledgerSteps,
+  staffStep,
+} from '../src/chord-staff';
+import type { ChordStaffWasmLoader, StaffNote } from '../src/use-chord-staff';
+
+// -- Fixtures ------------------------------------------------------
+
+const CMAJ9: StaffNote[] = [
+  { letter: 'C', accidental: 0, octave: 4, midi: 60 },
+  { letter: 'E', accidental: 0, octave: 4, midi: 64 },
+  { letter: 'G', accidental: 0, octave: 4, midi: 67 },
+  { letter: 'B', accidental: 0, octave: 4, midi: 71 },
+  { letter: 'D', accidental: 0, octave: 5, midi: 74 },
+];
+const EBM7: StaffNote[] = [
+  { letter: 'E', accidental: -1, octave: 4, midi: 63 },
+  { letter: 'G', accidental: -1, octave: 4, midi: 66 },
+  { letter: 'B', accidental: -1, octave: 4, midi: 70 },
+  { letter: 'D', accidental: -1, octave: 5, midi: 73 },
+];
+
+function makeLoader(table: Record<string, StaffNote[]>): ChordStaffWasmLoader {
+  return vi.fn(
+    async () =>
+      ({
+        default: vi.fn(async () => undefined),
+        chordStaffNotes: (chord: string) => table[chord] ?? null,
+      }) as unknown as Awaited<ReturnType<ChordStaffWasmLoader>>,
+  );
+}
+
+// -- Pure geometry helpers ----------------------------------------
+
+describe('staff geometry helpers', () => {
+  test('staffStep counts diatonic letters from C0', () => {
+    // E4 (bottom treble line) = 30; F5 (top line) = 38; middle C4 = 28.
+    expect(staffStep({ letter: 'E', accidental: 0, octave: 4, midi: 64 })).toBe(30);
+    expect(staffStep({ letter: 'F', accidental: 0, octave: 5, midi: 77 })).toBe(38);
+    expect(staffStep({ letter: 'C', accidental: 0, octave: 4, midi: 60 })).toBe(28);
+  });
+
+  test('accidentalGlyph maps signed offsets to Unicode', () => {
+    expect(accidentalGlyph(-2)).toBe('♭♭');
+    expect(accidentalGlyph(-1)).toBe('♭');
+    expect(accidentalGlyph(0)).toBe('');
+    expect(accidentalGlyph(1)).toBe('♯');
+    expect(accidentalGlyph(2)).toBe('♯♯');
+  });
+
+  test('ledgerSteps adds lines for notes outside the staff only', () => {
+    // Within the staff (E4..F5): no ledgers.
+    expect(ledgerSteps(30)).toEqual([]);
+    expect(ledgerSteps(34)).toEqual([]);
+    // Middle C (28) needs one ledger line below.
+    expect(ledgerSteps(28)).toEqual([28]);
+    // A note a space below middle C still hangs off the C4 ledger only.
+    expect(ledgerSteps(27)).toEqual([28]);
+    // Two ledgers below for A3 (26).
+    expect(ledgerSteps(26)).toEqual([28, 26]);
+    // Above the top line: A5 (40) gets one ledger.
+    expect(ledgerSteps(40)).toEqual([40]);
+    // The space directly above the top line needs none.
+    expect(ledgerSteps(39)).toEqual([]);
+  });
+
+  test('buildStaffModel lays notes left-to-right with five ascending lines', () => {
+    const model = buildStaffModel(CMAJ9);
+    expect(model.columns).toHaveLength(5);
+    // Five staff lines, ordered top (smallest y) to bottom.
+    expect(model.lineYs).toHaveLength(5);
+    for (let i = 1; i < model.lineYs.length; i++) {
+      expect(model.lineYs[i]!).toBeGreaterThan(model.lineYs[i - 1]!);
+    }
+    // Columns ascend in x; higher-pitched notes sit higher (smaller y).
+    for (let i = 1; i < model.columns.length; i++) {
+      expect(model.columns[i]!.x).toBeGreaterThan(model.columns[i - 1]!.x);
+      expect(model.columns[i]!.cy).toBeLessThan(model.columns[i - 1]!.cy);
+    }
+    // Middle C (first column) hangs below the staff → one ledger line.
+    expect(model.columns[0]!.ledgerYs).toHaveLength(1);
+    // All-natural chord → no accidental glyphs.
+    expect(model.columns.every((c) => c.accidental === '')).toBe(true);
+  });
+
+  test('buildStaffModel emits flat glyphs for a flat-spelled chord', () => {
+    const model = buildStaffModel(EBM7);
+    expect(model.columns.every((c) => c.accidental === '♭')).toBe(true);
+  });
+});
+
+// -- Component -----------------------------------------------------
+
+describe('<ChordStaff>', () => {
+  test('renders a labelled five-line staff with one notehead per tone', async () => {
+    const { container } = render(
+      <ChordStaff chord="Cmaj9" wasmLoader={makeLoader({ Cmaj9: CMAJ9 })} />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.chordsketch-staff__svg')).not.toBeNull();
+    });
+    const svg = container.querySelector('.chordsketch-staff__svg')!;
+    expect(svg.getAttribute('aria-label')).toContain('Cmaj9');
+    // Five staff lines + ledger line(s); five noteheads.
+    expect(svg.querySelectorAll('ellipse')).toHaveLength(5);
+    expect(svg.querySelectorAll('.chordsketch-staff__note')).toHaveLength(5);
+    // A treble clef path is drawn.
+    expect(svg.querySelector('path')).not.toBeNull();
+  });
+
+  test('passes the display name into the accessible label', async () => {
+    const { container } = render(
+      <ChordStaff
+        chord="Ebm7"
+        displayName="E♭m7"
+        wasmLoader={makeLoader({ Ebm7: EBM7 })}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('.chordsketch-staff__svg')).not.toBeNull();
+    });
+    expect(
+      container.querySelector('.chordsketch-staff__svg')!.getAttribute('aria-label'),
+    ).toContain('E♭m7');
+    // Flat accidental glyphs accompany the noteheads.
+    const accidentals = container.querySelectorAll('.chordsketch-staff__accidental');
+    expect(accidentals).toHaveLength(4);
+    expect(accidentals[0]!.textContent).toBe('♭');
+  });
+
+  test('renders an "unavailable" figure when the chord is not parseable', async () => {
+    const { container } = render(
+      <ChordStaff chord="not-a-chord" wasmLoader={makeLoader({})} />,
+    );
+    await waitFor(() => {
+      const fig = container.querySelector('[role="img"]');
+      expect(fig?.getAttribute('aria-label')).toContain('unavailable');
+    });
+    expect(container.querySelector('.chordsketch-staff__svg')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a five-line treble staff (五線譜) beneath the **"Editing chord &lt;name&gt;"** header of the ChordPro chord-editor footer, showing the selected chord's constituent notes (e.g. `Cmaj9` → C E G B D).

- **Core (`chordsketch-chordpro`)**: new `chord_staff_notes` + `StaffNote`. Each tone is spelled **diatonically from the chord's own structure** — note letter, signed accidental, scientific-pitch octave, and MIDI — so it lands on its conventional staff line rather than an enharmonic equivalent. The internal `ChordIntervals` tones are now tagged with their diatonic degree (`ScaleTone`) so spelling shares one source of truth with `chord_pitches` / `chord_tones`.
- **Bindings**: exposed across all three surfaces in the same PR — wasm `chordStaffNotes`, NAPI `chordStaffNotes` (+ `StaffNote` object + `index.d.ts`), FFI `chord_staff_notes` (+ `StaffNote` UDL dictionary).
- **React (`@chordsketch/react`)**: `useChordStaff` hook (lazy-loads the wasm export) + `<ChordStaff>` component that assembles the staff SVG in React (staff lines, treble clef, noteheads, ledger lines, accidental glyphs). Mounted in `<ChordInspector>` beneath the chord name; degrades to a labelled placeholder while loading and under SSR / no-wasm.

## Why

The chord editor named the chord but never showed what notes it contains. Pitch-class data (`chord_pitches` / `chord_tones`) is not enough for a staff: placing a tone on the right line needs note-letter spelling, and the spelling must come from the chord structure (the musical-theory source of truth belongs in the core library, not the React layer — `.claude/rules/playground-is-a-sample.md`). Examples the spelling gets right:

- `Ebm7` → E♭ G♭ B♭ D♭ (not the enharmonic D♯ F♯ A♯ C♯).
- `Cdim7` → C E♭ G♭ B𝄫 (double-flat seventh, not the enharmonic natural sixth A).
- `Csus2` / `Csus4` place the 2nd / 4th on the D / F letters.

## Test results

- `cargo test` — chordpro (1346) + wasm + napi + ffi binding suites all green, including new spelling/double-flat/sus/slash/enharmonic-root/midi-consistency/every-root-smoke unit tests and per-binding parity tests.
- `cargo fmt --check` + `cargo clippy` (touched crates) — clean.
- `@chordsketch/react`: `vitest run` — 44 files / 933 tests pass (new `chord-staff` geometry + component tests and `chord-inspector` staff-integration tests); `tsc --noEmit` clean.

## Sister-site audit

- **Bindings** (`.claude/rules/fix-propagation.md` §Bindings): `chord_staff_notes` lands in wasm + NAPI + FFI together, each with an inner helper and a parity unit test; the NAPI `index.d.ts` and the FFI UDL dictionary are updated to match the wasm `typescript_custom_section`.
- **Renderers** (text / HTML / PDF / JSX walker): not applicable — this adds an editor-only visualization, not a ChordPro directive or AST node rendered by those surfaces, so no renderer match-arm parity is involved.
- `ChordIntervals` is private to `chord.rs`; its only callers (`chord_pitches`, `chord_tones`, `chord_staff_notes`) were all migrated to the degree-tagged `ScaleTone`.

## Deferred

- Playground Playwright smoke: the staff is a transitive child of the already-smoke-tested `<ChordSheet>` / `<ChordProEditor>` mount paths and the playground does not call `chordStaffNotes` directly, so no new mount site / format-toggle entry is introduced (`.claude/rules/playground-smoke.md`). No new e2e spec added.

Closes #2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017qEjMhMhh4bcMdSHiBbziF)_