### PR TITLE
Tighten full-size SVG chord-diagram crop and draw muted marker as a shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tightened the regular (full-size) SVG chord-diagram bounding box
+  (`chordsketch_chordpro::chord_diagram`) so it crops to the fretboard
+  instead of floating inside a large frame. The 6-string / 5-fret
+  vertical diagram shrinks from 120×160 to 73×87px: the empty bottom
+  padding (58px) is removed, the over-wide symmetric side margins are
+  replaced with a left gutter only as wide as the fret-number axis (35→18px)
+  plus a thin right gutter (5px) that just clears the rightmost dot, and
+  the fret pitch tightens 14→12px. The fret-number axis stays clear of
+  the leftmost string's finger dots while 2-digit (high-position) fret
+  numbers still fit the gutter. The horizontal layout tightens the same
+  way (140×102 → 93×89px) while keeping its wider-than-tall proportions
+  via a dedicated horizontal fret pitch. This flows through every SVG
+  consumer (CLI `--format html`, the wasm `chord_diagram_svg` exports,
+  `@chordsketch/react`'s `<ChordDiagram>`, the VS Code preview, and the
+  LSP hover). The compact inline/hover layout and the keyboard diagram
+  are unchanged; the PDF renderer's own diagram geometry is not affected.
 - Redesigned the regular (full-size) SVG chord-diagram layout
   (`chordsketch_chordpro::chord_diagram`) for a cleaner, more
   chart-like look. The fretboard grid is now compact (string spacing

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -400,11 +400,7 @@ struct DiagramMetrics {
     title_font: f32,
     /// Baseline y of the chord-name title text.
     title_baseline: f32,
-    /// Font size for the base-fret label and the muted-string `X` glyph.
-    label_font: f32,
-    /// Font size for the per-cell fret-number axis labels. Separate from
-    /// [`label_font`](Self::label_font) so the compact size can use a smaller
-    /// font that fits its narrow gutter without shrinking the muted-`X` glyph.
+    /// Font size for the per-cell fret-number axis labels.
     fret_label_font: f32,
     /// Gap (SVG px) subtracted from `left_margin` to place a vertical
     /// fret-number label's right edge anchor (`left_margin - fret_label_gap`).
@@ -461,12 +457,11 @@ impl DiagramMetrics {
             nut_margin_glyph_offset: NUT_MARGIN_GLYPH_OFFSET,
             title_font: 14.0,
             title_baseline: 14.0,
-            label_font: 10.0,
-            // Axis font matches label_font; the gap places the right edge of
-            // a right-anchored fret number at `left_margin - fret_label_gap
-            // = 18 - 6 = 12`, which clears the leftmost string's finger dot
-            // (left edge `left_margin - dot_radius = 13`) while a 2-digit
-            // label still fits inside the gutter (left edge ≈ 0).
+            // The gap places the right edge of a right-anchored fret number at
+            // `left_margin - fret_label_gap = 18 - 6 = 12`, which clears the
+            // leftmost string's finger dot (left edge `left_margin - dot_radius
+            // = 13`) while a 2-digit label still fits inside the gutter (left
+            // edge ≈ 0).
             fret_label_font: 10.0,
             fret_label_gap: 6.0,
             finger_font: 8.0,
@@ -512,10 +507,9 @@ impl DiagramMetrics {
             nut_margin_glyph_offset: 5.0,
             title_font: 11.0,
             title_baseline: 9.0,
-            label_font: 8.0,
-            // Smaller axis font + gap than label_font so the per-cell
-            // fret numbers fit the compact diagram's narrow gutter and
-            // bottom padding without enlarging the inline layout further.
+            // Small axis font + gap so the per-cell fret numbers fit the
+            // compact diagram's narrow gutter and bottom padding without
+            // enlarging the inline layout further.
             fret_label_font: 6.0,
             fret_label_gap: 2.0,
             finger_font: 7.0,
@@ -673,7 +667,6 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
         nut_margin_glyph_offset,
         title_font,
         title_baseline,
-        label_font,
         fret_label_font,
         finger_font,
         text_v_center,
@@ -811,17 +804,22 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
         }
         let x = left_margin + i as f32 * cell_w;
         if fret == -1 {
-            // Muted (X). The open-string ring below is centred on `y`, so the
-            // `X` glyph must be centred on `y` too — add `text_v_center` to the
-            // baseline (text grows upward from its baseline, so a bare `y`
-            // would float the glyph above the ring). This mirrors the
-            // horizontal renderer, which already centres its muted `X` with the
-            // same offset.
-            let y = nut_y - nut_margin_glyph_offset;
+            // Muted (X) — drawn as two crossing strokes (not a text glyph) so
+            // it is geometrically centred on the marker, exactly like the
+            // open-string ring below, independent of any font's metrics. Sized
+            // to match the open ring (half-extent = open_radius). A
+            // `muted-string` class makes the pair identifiable to CSS / tests.
+            let cy = nut_y - nut_margin_glyph_offset;
+            let r = open_radius;
             svg.push_str(&format!(
-                "<text x=\"{x}\" y=\"{}\" text-anchor=\"middle\" \
-                 font-family=\"sans-serif\" font-size=\"{label_font}\">X</text>\n",
-                y + text_v_center
+                "<line x1=\"{x1}\" y1=\"{y1}\" x2=\"{x2}\" y2=\"{y2}\" \
+                 stroke=\"black\" stroke-width=\"{line_stroke}\" class=\"muted-string\"/>\n\
+                 <line x1=\"{x1}\" y1=\"{y2}\" x2=\"{x2}\" y2=\"{y1}\" \
+                 stroke=\"black\" stroke-width=\"{line_stroke}\" class=\"muted-string\"/>\n",
+                x1 = x - r,
+                y1 = cy - r,
+                x2 = x + r,
+                y2 = cy + r,
             ));
         } else if fret == 0 {
             // Open (O)
@@ -879,7 +877,6 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
         nut_margin_glyph_offset,
         title_font,
         title_baseline,
-        label_font,
         fret_label_font,
         finger_font,
         text_v_center,
@@ -1022,14 +1019,21 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
         let row = num_strings - 1 - i;
         let y = top_margin + row as f32 * string_pitch;
         if fret == -1 {
-            // Muted (X) — to the left of the nut, one per string row.
-            // `y + text_v_center` is the same baseline-centring offset the
-            // vertical renderer uses for finger-number text.
-            let x = nut_x - nut_margin_glyph_offset;
+            // Muted (X) — two crossing strokes to the left of the nut, one
+            // per string row, centred on the row exactly like the open-string
+            // ring (see the vertical renderer for the rationale on using a
+            // shape rather than a text glyph).
+            let cx = nut_x - nut_margin_glyph_offset;
+            let r = open_radius;
             svg.push_str(&format!(
-                "<text x=\"{x}\" y=\"{}\" text-anchor=\"middle\" \
-                 font-family=\"sans-serif\" font-size=\"{label_font}\">X</text>\n",
-                y + text_v_center
+                "<line x1=\"{x1}\" y1=\"{y1}\" x2=\"{x2}\" y2=\"{y2}\" \
+                 stroke=\"black\" stroke-width=\"{line_stroke}\" class=\"muted-string\"/>\n\
+                 <line x1=\"{x1}\" y1=\"{y2}\" x2=\"{x2}\" y2=\"{y1}\" \
+                 stroke=\"black\" stroke-width=\"{line_stroke}\" class=\"muted-string\"/>\n",
+                x1 = cx - r,
+                y1 = y - r,
+                x2 = cx + r,
+                y2 = y + r,
             ));
         } else if fret == 0 {
             // Open (O) — to the left of the nut, one per string row.
@@ -1777,8 +1781,9 @@ mod tests {
         assert!(svg.contains("Am"));
         // Should have circles for fretted positions
         assert!(svg.contains("<circle"));
-        // Should have X for muted string
-        assert!(svg.contains(">X<"));
+        // Should have a muted-string marker (two crossing lines) for the
+        // muted 6th string.
+        assert!(svg.contains("class=\"muted-string\""));
     }
 
     #[test]
@@ -2814,14 +2819,15 @@ mod tests {
 
     #[test]
     fn horizontal_open_and_muted_markers_sit_left_of_nut() {
-        // Open / muted markers are placed at x = LEFT_MARGIN - 7 = 11 in
+        // Open / muted markers are centred at x = LEFT_MARGIN - 7 = 11 in
         // horizontal mode (the analogue of the vertical mode's y = nut_y - 7
         // placement above the nut).
         let svg = horizontal_am_svg();
-        // "X" mute glyph at x=11 for the muted 6th string.
+        // Muted 6th string: crossing strokes centred on x=11, so the lines
+        // span x1 = 11 - open_radius(4) = 7 to x2 = 15, tagged muted-string.
         assert!(
-            svg.contains("<text x=\"11\""),
-            "expected muted-X glyph anchored at x=11; got: {svg}"
+            svg.contains("x1=\"7\" y1=") && svg.contains("class=\"muted-string\""),
+            "expected muted-string crossing strokes centred at x=11; got: {svg}"
         );
         // Open-string circle at cx=11.
         assert!(

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -811,11 +811,17 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
         }
         let x = left_margin + i as f32 * cell_w;
         if fret == -1 {
-            // Muted (X)
+            // Muted (X). The open-string ring below is centred on `y`, so the
+            // `X` glyph must be centred on `y` too — add `text_v_center` to the
+            // baseline (text grows upward from its baseline, so a bare `y`
+            // would float the glyph above the ring). This mirrors the
+            // horizontal renderer, which already centres its muted `X` with the
+            // same offset.
             let y = nut_y - nut_margin_glyph_offset;
             svg.push_str(&format!(
-                "<text x=\"{x}\" y=\"{y}\" text-anchor=\"middle\" \
-                 font-family=\"sans-serif\" font-size=\"{label_font}\">X</text>\n"
+                "<text x=\"{x}\" y=\"{}\" text-anchor=\"middle\" \
+                 font-family=\"sans-serif\" font-size=\"{label_font}\">X</text>\n",
+                y + text_v_center
             ));
         } else if fret == 0 {
             // Open (O)

--- a/crates/chordpro/src/chord_diagram.rs
+++ b/crates/chordpro/src/chord_diagram.rs
@@ -304,22 +304,27 @@ pub enum DiagramSize {
 /// chord chart. This is the tightest spacing that does not overlap
 /// neighbouring same-fret dots; shrinking `CELL_W` below `DOT_RADIUS *
 /// 2`, or enlarging `DOT_RADIUS`, would make them overlap. The grid is
-/// intentionally compact and floated inside a generous margin (see
-/// `LEFT_MARGIN` / `TOP_MARGIN` / `DiagramMetrics::regular`'s
-/// `bottom_pad_vertical`) rather than filling the bounding box
-/// edge-to-edge.
+/// tightly cropped — the surrounding gutters (`LEFT_MARGIN` /
+/// `TOP_MARGIN` / `DiagramMetrics::right_margin`) are sized only to hold
+/// the title, the fret-number axis, and the open/muted glyphs, rather
+/// than padding the diagram out to a larger frame.
 const CELL_W: f32 = 10.0;
-/// Fret pitch in SVG user units. Larger than [`CELL_W`] so the cells stay
-/// taller than they are wide, matching a real fretboard's proportions.
-const CELL_H: f32 = 14.0;
+/// Fret pitch in SVG user units for the VERTICAL layout. Larger than
+/// [`CELL_W`] so the cells stay taller than they are wide, matching a real
+/// fretboard's proportions. The horizontal layout uses its own, slightly
+/// wider fret pitch (`DiagramMetrics::horizontal_fret_pitch`) so it reads
+/// visibly wider than tall.
+const CELL_H: f32 = 12.0;
 /// Vertical space above the nut for the title row + open/muted glyph row.
-const TOP_MARGIN: f32 = 32.0;
-/// Side gutter. With the compact grid this also recentres the fretboard
-/// inside the bounding box: `total_w = grid_w + LEFT_MARGIN * 2`, so a
-/// 6-string diagram lands at the historical 120px width with the grid
-/// centred (string axis centred under the title) instead of bleeding to
-/// the edges.
-const LEFT_MARGIN: f32 = 35.0;
+const TOP_MARGIN: f32 = 27.0;
+/// Left gutter. Holds the per-cell fret-number axis to the left of the
+/// fretboard grid, sized so a 2-digit fret number (high-position barre
+/// chords) clears both the left edge of the viewBox and the leftmost
+/// string's finger dots. The grid is no longer centred inside a symmetric
+/// margin (the historical edge-to-edge-avoidance trick); the right gutter
+/// (`DiagramMetrics::right_margin`) is much narrower since it only has to
+/// clear the rightmost dot. `total_w = grid_w + LEFT_MARGIN + right_margin`.
+const LEFT_MARGIN: f32 = 18.0;
 const DOT_RADIUS: f32 = 5.0;
 const OPEN_RADIUS: f32 = 4.0;
 /// Faint inlay-marker dot radius. Smaller and lighter than the
@@ -363,10 +368,22 @@ struct DiagramMetrics {
     cell_w: f32,
     /// Fret pitch (SVG y-axis in vertical mode).
     cell_h: f32,
+    /// Fret pitch for the HORIZONTAL layout's fret axis (SVG x-axis).
+    /// Decoupled from [`cell_h`](Self::cell_h) — the horizontal diagram
+    /// must read visibly wider than tall, which needs a longer fret axis
+    /// than the compact vertical grid uses. The vertical renderer ignores
+    /// this field.
+    horizontal_fret_pitch: f32,
     /// Space above the nut for the title + open/muted glyph row.
     top_margin: f32,
-    /// Side gutter on each edge.
+    /// Left gutter (holds the fret-number axis in vertical mode / the
+    /// open-muted glyph column in horizontal mode).
     left_margin: f32,
+    /// Right gutter. Only has to clear the rightmost finger dot, so it is
+    /// much narrower than [`left_margin`](Self::left_margin). The grid is
+    /// no longer centred in a symmetric margin: `total_w = grid_w +
+    /// left_margin + right_margin`.
+    right_margin: f32,
     /// Padding below the grid in the vertical layout.
     bottom_pad_vertical: f32,
     /// Padding below the grid in the horizontal layout.
@@ -419,34 +436,39 @@ struct DiagramMetrics {
 }
 
 impl DiagramMetrics {
-    /// Full-size metrics — the compact, centred fretboard layout used by
+    /// Full-size metrics — the tightly-cropped fretboard layout used by
     /// the end-of-song diagram grid and every non-compact SVG consumer.
     const fn regular() -> Self {
         Self {
             cell_w: CELL_W,
             cell_h: CELL_H,
+            horizontal_fret_pitch: 14.0,
             top_margin: TOP_MARGIN,
             left_margin: LEFT_MARGIN,
-            // Keeps the diagram's overall frame at the historical 120x160
-            // for a 6-string / 5-fret shape: total_h = grid_h (5*14=70) +
-            // top_margin (32) + bottom_pad_vertical (58) = 160. The compact
-            // grid floats in the upper portion of that frame rather than
-            // filling it edge-to-edge.
-            bottom_pad_vertical: 58.0,
-            bottom_pad_horizontal: 20.0,
+            right_margin: 5.0,
+            // The vertical fret-number axis sits in the left gutter and the
+            // open/muted glyphs sit above the nut, so nothing extends below
+            // the grid — the frame ends at the last fret line for a tight
+            // crop: total_h = grid_h (5*12=60) + top_margin (27) = 87 for a
+            // 6-string / 5-fret shape (was 160, mostly empty padding).
+            bottom_pad_vertical: 0.0,
+            // The horizontal fret-number axis is drawn below the grid, so
+            // the horizontal layout keeps a bottom band wide enough for it.
+            bottom_pad_horizontal: 12.0,
             dot_radius: DOT_RADIUS,
             open_radius: OPEN_RADIUS,
             position_dot_radius: POSITION_DOT_RADIUS,
             nut_margin_glyph_offset: NUT_MARGIN_GLYPH_OFFSET,
             title_font: 14.0,
-            title_baseline: 15.0,
+            title_baseline: 14.0,
             label_font: 10.0,
-            // Axis font matches label_font; the gap is widened to 7 so the
-            // right-anchored fret numbers clear the recentred grid's left
-            // edge (left_margin - fret_label_gap = 35 - 7 = 28) while still
-            // leaving room for 2-digit labels inside the gutter.
+            // Axis font matches label_font; the gap places the right edge of
+            // a right-anchored fret number at `left_margin - fret_label_gap
+            // = 18 - 6 = 12`, which clears the leftmost string's finger dot
+            // (left edge `left_margin - dot_radius = 13`) while a 2-digit
+            // label still fits inside the gutter (left edge ≈ 0).
             fret_label_font: 10.0,
-            fret_label_gap: 7.0,
+            fret_label_gap: 6.0,
             finger_font: 8.0,
             text_v_center: 3.0,
             nut_stroke: 3.0,
@@ -470,11 +492,18 @@ impl DiagramMetrics {
         Self {
             cell_w: 9.0,
             cell_h: 11.0,
+            // Compact keeps a single fret pitch for both orientations
+            // (matching its `cell_h`); its grid is small enough that the
+            // horizontal layout already reads wider than tall.
+            horizontal_fret_pitch: 11.0,
             top_margin: 22.0,
             // Left gutter widened from 9 to 11 so a 2-digit fret-number label
             // (font 6, right-anchored at left_margin - fret_label_gap) clears
             // the left edge of the viewBox.
             left_margin: 11.0,
+            // Symmetric with left_margin so the compact bounding box is
+            // unchanged (`total_w = grid_w + 11 + 11`).
+            right_margin: 11.0,
             bottom_pad_vertical: 10.0,
             bottom_pad_horizontal: 8.0,
             dot_radius: 3.2,
@@ -636,6 +665,7 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
         cell_h,
         top_margin,
         left_margin,
+        right_margin,
         bottom_pad_vertical,
         dot_radius,
         open_radius,
@@ -658,7 +688,7 @@ fn render_svg_vertical_inner(data: &DiagramData, m: &DiagramMetrics) -> String {
     let num_frets = data.frets_shown;
     let grid_w = (num_strings - 1) as f32 * cell_w;
     let grid_h = num_frets as f32 * cell_h;
-    let total_w = grid_w + left_margin * 2.0;
+    let total_w = grid_w + left_margin + right_margin;
     let total_h = grid_h + top_margin + bottom_pad_vertical;
 
     let mut svg = format!(
@@ -832,9 +862,10 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
     // literals inlined here.
     let DiagramMetrics {
         cell_w,
-        cell_h,
+        horizontal_fret_pitch,
         top_margin,
         left_margin,
+        right_margin,
         bottom_pad_horizontal,
         dot_radius,
         open_radius,
@@ -856,20 +887,18 @@ fn render_svg_horizontal_inner(data: &DiagramData, m: &DiagramMetrics) -> String
     let num_strings = data.strings;
     let num_frets = data.frets_shown;
     // Semantic aliases — the horizontal layout's fret axis is the SVG
-    // x-axis, so use `cell_h` (the vertical layout's fret pitch, the
-    // larger of the two cell values) along that axis. Likewise the
-    // string axis is the SVG y-axis, so use `cell_w` (the vertical
-    // layout's string-to-string spacing, the smaller value). Using the
-    // same metrics with swapped meanings preserves the
-    // wider-than-tall fretboard aspect ratio that the vertical
-    // renderer already encodes — the diagram looks like a real
-    // fretboard rotated 90°, not a vertical diagram with the labels
-    // shuffled.
-    let fret_pitch = cell_h;
+    // x-axis, so use the dedicated `horizontal_fret_pitch` along it.
+    // This is kept slightly larger than the vertical layout's `cell_h`
+    // so the fretboard reads visibly wider than tall (with the trimmed
+    // margins a vertical-pitch fret axis would make the diagram nearly
+    // square). The string axis is the SVG y-axis, so use `cell_w` (the
+    // string-to-string spacing). The diagram looks like a real fretboard
+    // rotated 90°, not a vertical diagram with the labels shuffled.
+    let fret_pitch = horizontal_fret_pitch;
     let string_pitch = cell_w;
     let grid_w = num_frets as f32 * fret_pitch;
     let grid_h = (num_strings - 1) as f32 * string_pitch;
-    let total_w = grid_w + left_margin * 2.0;
+    let total_w = grid_w + left_margin + right_margin;
     let total_h = grid_h + top_margin + bottom_pad_horizontal;
 
     let mut svg = format!(
@@ -2747,7 +2776,7 @@ mod tests {
         // `x1=LEFT_MARGIN x2=LEFT_MARGIN`.
         let svg = horizontal_am_svg();
         assert!(
-            svg.contains("x1=\"35\" y1=\"32\" x2=\"35\""),
+            svg.contains("x1=\"18\" y1=\"27\" x2=\"18\""),
             "expected vertical nut line anchored at LEFT_MARGIN/TOP_MARGIN; got: {svg}"
         );
         assert!(svg.contains("stroke-width=\"3\""));
@@ -2779,19 +2808,19 @@ mod tests {
 
     #[test]
     fn horizontal_open_and_muted_markers_sit_left_of_nut() {
-        // Open / muted markers are placed at x = LEFT_MARGIN - 7 = 28 in
+        // Open / muted markers are placed at x = LEFT_MARGIN - 7 = 11 in
         // horizontal mode (the analogue of the vertical mode's y = nut_y - 7
         // placement above the nut).
         let svg = horizontal_am_svg();
-        // "X" mute glyph at x=28 for the muted 6th string.
+        // "X" mute glyph at x=11 for the muted 6th string.
         assert!(
-            svg.contains("<text x=\"28\""),
-            "expected muted-X glyph anchored at x=28; got: {svg}"
+            svg.contains("<text x=\"11\""),
+            "expected muted-X glyph anchored at x=11; got: {svg}"
         );
-        // Open-string circle at cx=28.
+        // Open-string circle at cx=11.
         assert!(
-            svg.contains("<circle cx=\"28\""),
-            "expected open-string circle at cx=28; got: {svg}"
+            svg.contains("<circle cx=\"11\""),
+            "expected open-string circle at cx=11; got: {svg}"
         );
     }
 
@@ -2800,11 +2829,11 @@ mod tests {
         // Reader-view (the only horizontal layout): in ChordPro's low-to-high
         // `frets` ordering, index 5 (high E for guitar) sits on row 0 (top).
         // For Am the open 1st string (i=5, fret=0) produces an open-circle on
-        // the top row at y = TOP_MARGIN = 32.
+        // the top row at y = TOP_MARGIN = 27.
         let svg = horizontal_am_svg();
         assert!(
-            svg.contains("<circle cx=\"28\" cy=\"32\""),
-            "expected open marker for high E on top row (cy=32); got: {svg}"
+            svg.contains("<circle cx=\"11\" cy=\"27\""),
+            "expected open marker for high E on top row (cy=27); got: {svg}"
         );
     }
 
@@ -2855,11 +2884,11 @@ mod tests {
         // characteristic ± string_pitch * 0.55 offset from the centre row.
         // For 6-string guitar in horizontal mode the string axis uses
         // string_pitch = CELL_W = 10:
-        //   grid_h = (6 - 1) * 10 = 50; center_y = TOP_MARGIN + 25 = 57;
-        //   10 * 0.55 = 5.5; so cy1 = 51.5, cy2 = 62.5.
+        //   grid_h = (6 - 1) * 10 = 50; center_y = TOP_MARGIN + 25 = 52;
+        //   10 * 0.55 = 5.5; so cy1 = 46.5, cy2 = 57.5.
         assert!(
-            svg.contains("cy=\"51.5\"") && svg.contains("cy=\"62.5\""),
-            "expected 12-fret double dot at cy=51.5 / cy=62.5; got: {svg}"
+            svg.contains("cy=\"46.5\"") && svg.contains("cy=\"57.5\""),
+            "expected 12-fret double dot at cy=46.5 / cy=57.5; got: {svg}"
         );
     }
 
@@ -2947,11 +2976,11 @@ mod tests {
             "expected 1 single + 2 (double at 12); got svg: {svg}"
         );
         // For 4-string ukulele in horizontal mode: string_pitch = CELL_W = 10,
-        //   grid_h = (4 - 1) * 10 = 30; center_y = TOP_MARGIN + 15 = 47;
-        //   10 * 0.55 = 5.5; so cy1 = 41.5, cy2 = 52.5.
+        //   grid_h = (4 - 1) * 10 = 30; center_y = TOP_MARGIN + 15 = 42;
+        //   10 * 0.55 = 5.5; so cy1 = 36.5, cy2 = 47.5.
         assert!(
-            svg.contains("cy=\"41.5\"") && svg.contains("cy=\"52.5\""),
-            "expected 12-fret double dot at cy=41.5 / cy=52.5; got: {svg}",
+            svg.contains("cy=\"36.5\"") && svg.contains("cy=\"47.5\""),
+            "expected 12-fret double dot at cy=36.5 / cy=47.5; got: {svg}",
         );
     }
 
@@ -3247,14 +3276,14 @@ mod tests {
         let count = svg.matches("class=\"fret-number\"").count();
         assert_eq!(count, 5, "expected 5 fret-cell labels (1..=5); got: {svg}");
         // The first cell's label (1) is centred at x = LEFT_MARGIN + fret_pitch/2
-        // = 35 + 7 = 42, with baseline y = TOP_MARGIN + grid_h + fret_label_font
-        // = 32 + 50 + 10 = 92.
+        // = 18 + 7 = 25, with baseline y = TOP_MARGIN + grid_h + fret_label_font
+        // = 27 + 50 + 10 = 87.
         assert!(
             svg.contains(
-                "<text x=\"42\" y=\"92\" text-anchor=\"middle\" \
+                "<text x=\"25\" y=\"87\" text-anchor=\"middle\" \
                  font-family=\"sans-serif\" font-size=\"10\" class=\"fret-number\">1</text>"
             ),
-            "expected first-cell label 1 centred at x=42 y=92; got: {svg}"
+            "expected first-cell label 1 centred at x=25 y=87; got: {svg}"
         );
     }
 
@@ -3337,7 +3366,7 @@ mod tests {
         // The axis is laid out inside the existing margins / bottom padding,
         // so adding it must not change either SVG's width or height. These
         // are the regular-layout dimensions for a 6-string, 5-fret diagram
-        // (vertical 120x160, horizontal 140x102).
+        // (vertical 73x87, horizontal 93x89).
         let extract = |svg: &str, attr: &str| -> f32 {
             let needle = format!("{attr}=\"");
             let i = svg.find(&needle).unwrap() + needle.len();
@@ -3360,19 +3389,19 @@ mod tests {
         };
         let data = open_c();
         let v = render_svg_with_orientation(&data, Orientation::Vertical);
-        assert_eq!(extract(&v, "width"), 120.0);
-        assert_eq!(extract(&v, "height"), 160.0);
+        assert_eq!(extract(&v, "width"), 73.0);
+        assert_eq!(extract(&v, "height"), 87.0);
         let v_ys = label_ys(&v);
         assert!(
-            v_ys.iter().all(|&y| y <= 160.0),
+            v_ys.iter().all(|&y| y <= 87.0),
             "vertical fret-number labels overflow the frame: {v_ys:?}"
         );
         let h = render_svg_with_orientation(&data, Orientation::Horizontal);
-        assert_eq!(extract(&h, "width"), 140.0);
-        assert_eq!(extract(&h, "height"), 102.0);
+        assert_eq!(extract(&h, "width"), 93.0);
+        assert_eq!(extract(&h, "height"), 89.0);
         let h_ys = label_ys(&h);
         assert!(
-            h_ys.iter().all(|&y| y <= 102.0),
+            h_ys.iter().all(|&y| y <= 89.0),
             "horizontal fret-number labels overflow the frame: {h_ys:?}"
         );
         // Compact size: left_margin widened from 9 → 11 to fit 2-digit labels.

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -60,6 +60,7 @@
     "testEnvironment": "node",
     "testMatch": [
       "**/__tests__/**/*.test.js"
-    ]
+    ],
+    "transform": {}
   }
 }

--- a/crates/render-html/src/lib.rs
+++ b/crates/render-html/src/lib.rs
@@ -4928,10 +4928,10 @@ Verse text\n\
         let html = render("{define: C frets 0 0 0 3}");
         assert!(html.contains("<svg"));
         assert!(html.contains("chord-diagram"));
-        // 4 strings: SVG width = (4-1)*10 + 35*2 = 100
+        // 4 strings: SVG width = (4-1)*10 + 18 + 5 = 53
         assert!(
-            html.contains("width=\"100\""),
-            "Expected 4-string SVG width (100)"
+            html.contains("width=\"53\""),
+            "Expected 4-string SVG width (53)"
         );
     }
 
@@ -4939,10 +4939,10 @@ Verse text\n\
     fn test_define_banjo_diagram() {
         let html = render("{define: G frets 0 0 0 0 0}");
         assert!(html.contains("<svg"));
-        // 5 strings: SVG width = (5-1)*10 + 35*2 = 110
+        // 5 strings: SVG width = (5-1)*10 + 18 + 5 = 63
         assert!(
-            html.contains("width=\"110\""),
-            "Expected 5-string SVG width (110)"
+            html.contains("width=\"63\""),
+            "Expected 5-string SVG width (63)"
         );
     }
 
@@ -4954,10 +4954,10 @@ Verse text\n\
             .with_define("diagrams.frets=4")
             .unwrap();
         let html = render_song_with_transpose(&song, 0, &config);
-        // 4 frets: grid_h = 4*14 = 56, total_h = 56 + 32 + 58 = 146
+        // 4 frets: grid_h = 4*12 = 48, total_h = 48 + 27 + 0 = 75
         assert!(
-            html.contains("height=\"146\""),
-            "SVG height should reflect diagrams.frets=4 (expected 146)"
+            html.contains("height=\"75\""),
+            "SVG height should reflect diagrams.frets=4 (expected 75)"
         );
     }
 

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -108,7 +108,7 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -86,34 +86,34 @@ img { max-width: 100%; height: auto; }
 <header class="song-header">
 <h1>Display + Transpose Test</h1>
 </header>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="55" cy="53" r="5" fill="black"/>
-<circle cx="65" cy="53" r="5" fill="black"/>
-<circle cx="75" cy="39" r="5" fill="black"/>
-<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="38" cy="45" r="5" fill="black"/>
+<circle cx="48" cy="45" r="5" fill="black"/>
+<circle cx="58" cy="33" r="5" fill="black"/>
+<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">Hello </span></span><span class="chord-block"><span class="chord">A</span><span class="lyrics">world </span></span><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">again</span></span></div>
 </article>

--- a/crates/render-html/tests/fixtures/define-display-transposed/expected.html
+++ b/crates/render-html/tests/fixtures/define-display-transposed/expected.html
@@ -108,7 +108,8 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<line x1="14" y1="16" x2="22" y2="24" stroke="black" stroke-width="1" class="muted-string"/>
+<line x1="14" y1="24" x2="22" y2="16" stroke="black" stroke-width="1" class="muted-string"/>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -86,34 +86,34 @@ img { max-width: 100%; height: auto; }
 <header class="song-header">
 <h1>Display Test</h1>
 </header>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="55" cy="53" r="5" fill="black"/>
-<circle cx="65" cy="53" r="5" fill="black"/>
-<circle cx="75" cy="39" r="5" fill="black"/>
-<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">A minor</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="38" cy="45" r="5" fill="black"/>
+<circle cx="48" cy="45" r="5" fill="black"/>
+<circle cx="58" cy="33" r="5" fill="black"/>
+<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">Hello </span></span><span class="chord-block"><span class="chord">G</span><span class="lyrics">world </span></span><span class="chord-block"><span class="chord">A minor</span><span class="lyrics">again</span></span></div>
 </article>

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -108,7 +108,7 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/define-display/expected.html
+++ b/crates/render-html/tests/fixtures/define-display/expected.html
@@ -108,7 +108,8 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<line x1="14" y1="16" x2="22" y2="24" stroke="black" stroke-width="1" class="muted-string"/>
+<line x1="14" y1="24" x2="22" y2="16" stroke="black" stroke-width="1" class="muted-string"/>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
+++ b/crates/render-html/tests/fixtures/define-with-diagrams/expected.html
@@ -86,67 +86,67 @@ img { max-width: 100%; height: auto; }
 <header class="song-header">
 <h1>Define with Diagrams</h1>
 </header>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<circle cx="35" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="55" cy="53" r="5" fill="black"/>
-<circle cx="65" cy="53" r="5" fill="black"/>
-<circle cx="75" cy="39" r="5" fill="black"/>
-<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<circle cx="18" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="38" cy="45" r="5" fill="black"/>
+<circle cx="48" cy="45" r="5" fill="black"/>
+<circle cx="58" cy="33" r="5" fill="black"/>
+<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">Am</span><span class="lyrics">Hello </span></span><span class="chord-block"><span class="chord">G</span><span class="lyrics">world</span></span></div>
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
 <h3 id="cs-chord-diagrams-label" class="section-label">Chord Diagrams</h3>
 <div class="chord-diagrams-grid">
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<circle cx="35" cy="67" r="5" fill="black"/>
-<circle cx="45" cy="53" r="5" fill="black"/>
-<circle cx="55" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="65" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="75" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="85" cy="67" r="5" fill="black"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<circle cx="18" cy="57" r="5" fill="black"/>
+<circle cx="28" cy="45" r="5" fill="black"/>
+<circle cx="38" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="48" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="58" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="68" cy="57" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -90,63 +90,63 @@ img { max-width: 100%; height: auto; }
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
 <h3 id="cs-chord-diagrams-label" class="section-label">Chord Diagrams</h3>
 <div class="chord-diagrams-grid">
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="55" cy="53" r="5" fill="black"/>
-<circle cx="65" cy="53" r="5" fill="black"/>
-<circle cx="75" cy="39" r="5" fill="black"/>
-<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="38" cy="45" r="5" fill="black"/>
+<circle cx="48" cy="45" r="5" fill="black"/>
+<circle cx="58" cy="33" r="5" fill="black"/>
+<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<circle cx="35" cy="67" r="5" fill="black"/>
-<circle cx="45" cy="53" r="5" fill="black"/>
-<circle cx="55" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="65" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="75" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="85" cy="67" r="5" fill="black"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<circle cx="18" cy="57" r="5" fill="black"/>
+<circle cx="28" cy="45" r="5" fill="black"/>
+<circle cx="38" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="48" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="58" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="68" cy="57" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -112,7 +112,7 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/diagrams-grid/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-grid/expected.html
@@ -112,7 +112,8 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<line x1="14" y1="16" x2="22" y2="24" stroke="black" stroke-width="1" class="muted-string"/>
+<line x1="14" y1="24" x2="22" y2="16" stroke="black" stroke-width="1" class="muted-string"/>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -86,66 +86,66 @@ img { max-width: 100%; height: auto; }
 <header class="song-header">
 <h1>Horizontal Diagrams with Barre Chord</h1>
 </header>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
-<text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Bm</text>
-<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">6</text>
-<circle cx="56" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="84" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
-<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
-<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
-<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
-<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
-<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
-<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
-<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
-<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<circle cx="42" cy="82" r="5" fill="black"/>
-<circle cx="70" cy="72" r="5" fill="black"/>
-<circle cx="84" cy="62" r="5" fill="black"/>
-<circle cx="84" cy="52" r="5" fill="black"/>
-<circle cx="70" cy="42" r="5" fill="black"/>
-<circle cx="42" cy="32" r="5" fill="black"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="93" height="89" viewBox="0 0 93 89" class="chord-diagram chord-diagram-horizontal">
+<text x="53" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Bm</text>
+<text x="25" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="39" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="53" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="67" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<text x="81" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">6</text>
+<circle cx="39" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="67" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="88" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="37" x2="88" y2="37" stroke="black" stroke-width="1"/>
+<line x1="18" y1="47" x2="88" y2="47" stroke="black" stroke-width="1"/>
+<line x1="18" y1="57" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<line x1="18" y1="67" x2="88" y2="67" stroke="black" stroke-width="1"/>
+<line x1="18" y1="77" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="18" y2="77" stroke="black" stroke-width="1"/>
+<line x1="32" y1="27" x2="32" y2="77" stroke="black" stroke-width="1"/>
+<line x1="46" y1="27" x2="46" y2="77" stroke="black" stroke-width="1"/>
+<line x1="60" y1="27" x2="60" y2="77" stroke="black" stroke-width="1"/>
+<line x1="74" y1="27" x2="74" y2="77" stroke="black" stroke-width="1"/>
+<line x1="88" y1="27" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<circle cx="25" cy="77" r="5" fill="black"/>
+<circle cx="53" cy="67" r="5" fill="black"/>
+<circle cx="67" cy="57" r="5" fill="black"/>
+<circle cx="67" cy="47" r="5" fill="black"/>
+<circle cx="53" cy="37" r="5" fill="black"/>
+<circle cx="25" cy="27" r="5" fill="black"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">Bm</span><span class="lyrics">On a </span></span><span class="chord-block"><span class="chord">Am</span><span class="lyrics">horizontal layout</span></span></div>
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
 <h3 id="cs-chord-diagrams-label" class="section-label">Chord Diagrams</h3>
 <div class="chord-diagrams-grid">
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
-<text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="3"/>
-<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="98" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
-<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
-<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
-<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
-<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
-<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
-<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
-<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
-<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<text x="28" y="85" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="28" cy="72" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="56" cy="62" r="5" fill="black"/>
-<circle cx="56" cy="52" r="5" fill="black"/>
-<circle cx="42" cy="42" r="5" fill="black"/>
-<circle cx="28" cy="32" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="93" height="89" viewBox="0 0 93 89" class="chord-diagram chord-diagram-horizontal">
+<text x="53" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
+<line x1="18" y1="27" x2="18" y2="77" stroke="black" stroke-width="3"/>
+<text x="25" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="39" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="53" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="67" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="81" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="53" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="81" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="88" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="37" x2="88" y2="37" stroke="black" stroke-width="1"/>
+<line x1="18" y1="47" x2="88" y2="47" stroke="black" stroke-width="1"/>
+<line x1="18" y1="57" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<line x1="18" y1="67" x2="88" y2="67" stroke="black" stroke-width="1"/>
+<line x1="18" y1="77" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="18" y2="77" stroke="black" stroke-width="1"/>
+<line x1="32" y1="27" x2="32" y2="77" stroke="black" stroke-width="1"/>
+<line x1="46" y1="27" x2="46" y2="77" stroke="black" stroke-width="1"/>
+<line x1="60" y1="27" x2="60" y2="77" stroke="black" stroke-width="1"/>
+<line x1="74" y1="27" x2="74" y2="77" stroke="black" stroke-width="1"/>
+<line x1="88" y1="27" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<text x="11" y="80" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="11" cy="67" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="39" cy="57" r="5" fill="black"/>
+<circle cx="39" cy="47" r="5" fill="black"/>
+<circle cx="25" cy="37" r="5" fill="black"/>
+<circle cx="11" cy="27" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-barre/expected.html
@@ -140,7 +140,8 @@ img { max-width: 100%; height: auto; }
 <line x1="60" y1="27" x2="60" y2="77" stroke="black" stroke-width="1"/>
 <line x1="74" y1="27" x2="74" y2="77" stroke="black" stroke-width="1"/>
 <line x1="88" y1="27" x2="88" y2="77" stroke="black" stroke-width="1"/>
-<text x="11" y="80" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<line x1="7" y1="73" x2="15" y2="81" stroke="black" stroke-width="1" class="muted-string"/>
+<line x1="7" y1="81" x2="15" y2="73" stroke="black" stroke-width="1" class="muted-string"/>
 <circle cx="11" cy="67" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="39" cy="57" r="5" fill="black"/>
 <circle cx="39" cy="47" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal-ukulele/expected.html
@@ -86,55 +86,55 @@ img { max-width: 100%; height: auto; }
 <header class="song-header">
 <h1>Horizontal Ukulele Diagrams</h1>
 </header>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="82" viewBox="0 0 140 82" class="chord-diagram chord-diagram-horizontal">
-<text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">C</text>
-<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="3"/>
-<text x="42" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="56" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="84" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="98" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="98" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
-<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
-<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="1"/>
-<line x1="49" y1="32" x2="49" y2="62" stroke="black" stroke-width="1"/>
-<line x1="63" y1="32" x2="63" y2="62" stroke="black" stroke-width="1"/>
-<line x1="77" y1="32" x2="77" y2="62" stroke="black" stroke-width="1"/>
-<line x1="91" y1="32" x2="91" y2="62" stroke="black" stroke-width="1"/>
-<line x1="105" y1="32" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<circle cx="28" cy="62" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="28" cy="52" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="28" cy="42" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="70" cy="32" r="5" fill="black"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="93" height="69" viewBox="0 0 93 69" class="chord-diagram chord-diagram-horizontal">
+<text x="53" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">C</text>
+<line x1="18" y1="27" x2="18" y2="57" stroke="black" stroke-width="3"/>
+<text x="25" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="39" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="53" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="67" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="81" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="53" cy="42" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="81" cy="42" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="88" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="37" x2="88" y2="37" stroke="black" stroke-width="1"/>
+<line x1="18" y1="47" x2="88" y2="47" stroke="black" stroke-width="1"/>
+<line x1="18" y1="57" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="18" y2="57" stroke="black" stroke-width="1"/>
+<line x1="32" y1="27" x2="32" y2="57" stroke="black" stroke-width="1"/>
+<line x1="46" y1="27" x2="46" y2="57" stroke="black" stroke-width="1"/>
+<line x1="60" y1="27" x2="60" y2="57" stroke="black" stroke-width="1"/>
+<line x1="74" y1="27" x2="74" y2="57" stroke="black" stroke-width="1"/>
+<line x1="88" y1="27" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<circle cx="11" cy="57" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="11" cy="47" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="11" cy="37" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="53" cy="27" r="5" fill="black"/>
 </svg></figure>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="82" viewBox="0 0 140 82" class="chord-diagram chord-diagram-horizontal">
-<text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">F</text>
-<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="3"/>
-<text x="42" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="56" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="84" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="98" y="72" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="98" cy="47" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
-<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
-<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="35" y2="62" stroke="black" stroke-width="1"/>
-<line x1="49" y1="32" x2="49" y2="62" stroke="black" stroke-width="1"/>
-<line x1="63" y1="32" x2="63" y2="62" stroke="black" stroke-width="1"/>
-<line x1="77" y1="32" x2="77" y2="62" stroke="black" stroke-width="1"/>
-<line x1="91" y1="32" x2="91" y2="62" stroke="black" stroke-width="1"/>
-<line x1="105" y1="32" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<circle cx="56" cy="62" r="5" fill="black"/>
-<circle cx="28" cy="52" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="42" cy="42" r="5" fill="black"/>
-<circle cx="28" cy="32" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="93" height="69" viewBox="0 0 93 69" class="chord-diagram chord-diagram-horizontal">
+<text x="53" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">F</text>
+<line x1="18" y1="27" x2="18" y2="57" stroke="black" stroke-width="3"/>
+<text x="25" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="39" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="53" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="67" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="81" y="67" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="53" cy="42" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="81" cy="42" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="88" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="37" x2="88" y2="37" stroke="black" stroke-width="1"/>
+<line x1="18" y1="47" x2="88" y2="47" stroke="black" stroke-width="1"/>
+<line x1="18" y1="57" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="18" y2="57" stroke="black" stroke-width="1"/>
+<line x1="32" y1="27" x2="32" y2="57" stroke="black" stroke-width="1"/>
+<line x1="46" y1="27" x2="46" y2="57" stroke="black" stroke-width="1"/>
+<line x1="60" y1="27" x2="60" y2="57" stroke="black" stroke-width="1"/>
+<line x1="74" y1="27" x2="74" y2="57" stroke="black" stroke-width="1"/>
+<line x1="88" y1="27" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<circle cx="39" cy="57" r="5" fill="black"/>
+<circle cx="11" cy="47" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="25" cy="37" r="5" fill="black"/>
+<circle cx="11" cy="27" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
 <div class="line"><span class="chord-block"><span class="chord">C</span><span class="lyrics">Aloha </span></span><span class="chord-block"><span class="chord">F</span><span class="lyrics">hello</span></span></div>
 </article>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -112,7 +112,8 @@ img { max-width: 100%; height: auto; }
 <line x1="60" y1="27" x2="60" y2="77" stroke="black" stroke-width="1"/>
 <line x1="74" y1="27" x2="74" y2="77" stroke="black" stroke-width="1"/>
 <line x1="88" y1="27" x2="88" y2="77" stroke="black" stroke-width="1"/>
-<text x="11" y="80" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<line x1="7" y1="73" x2="15" y2="81" stroke="black" stroke-width="1" class="muted-string"/>
+<line x1="7" y1="81" x2="15" y2="73" stroke="black" stroke-width="1" class="muted-string"/>
 <circle cx="11" cy="67" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="39" cy="57" r="5" fill="black"/>
 <circle cx="39" cy="47" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-horizontal/expected.html
@@ -90,63 +90,63 @@ img { max-width: 100%; height: auto; }
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
 <h3 id="cs-chord-diagrams-label" class="section-label">Chord Diagrams</h3>
 <div class="chord-diagrams-grid">
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
-<text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="3"/>
-<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="98" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
-<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
-<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
-<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
-<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
-<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
-<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
-<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
-<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<text x="28" y="85" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="28" cy="72" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="56" cy="62" r="5" fill="black"/>
-<circle cx="56" cy="52" r="5" fill="black"/>
-<circle cx="42" cy="42" r="5" fill="black"/>
-<circle cx="28" cy="32" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="93" height="89" viewBox="0 0 93 89" class="chord-diagram chord-diagram-horizontal">
+<text x="53" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
+<line x1="18" y1="27" x2="18" y2="77" stroke="black" stroke-width="3"/>
+<text x="25" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="39" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="53" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="67" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="81" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="53" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="81" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="88" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="37" x2="88" y2="37" stroke="black" stroke-width="1"/>
+<line x1="18" y1="47" x2="88" y2="47" stroke="black" stroke-width="1"/>
+<line x1="18" y1="57" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<line x1="18" y1="67" x2="88" y2="67" stroke="black" stroke-width="1"/>
+<line x1="18" y1="77" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="18" y2="77" stroke="black" stroke-width="1"/>
+<line x1="32" y1="27" x2="32" y2="77" stroke="black" stroke-width="1"/>
+<line x1="46" y1="27" x2="46" y2="77" stroke="black" stroke-width="1"/>
+<line x1="60" y1="27" x2="60" y2="77" stroke="black" stroke-width="1"/>
+<line x1="74" y1="27" x2="74" y2="77" stroke="black" stroke-width="1"/>
+<line x1="88" y1="27" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<text x="11" y="80" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="11" cy="67" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="39" cy="57" r="5" fill="black"/>
+<circle cx="39" cy="47" r="5" fill="black"/>
+<circle cx="25" cy="37" r="5" fill="black"/>
+<circle cx="11" cy="27" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="140" height="102" viewBox="0 0 140 102" class="chord-diagram chord-diagram-horizontal">
-<text x="70" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="3"/>
-<text x="42" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="56" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="70" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="84" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="98" y="92" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="70" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="98" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="105" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="42" x2="105" y2="42" stroke="black" stroke-width="1"/>
-<line x1="35" y1="52" x2="105" y2="52" stroke="black" stroke-width="1"/>
-<line x1="35" y1="62" x2="105" y2="62" stroke="black" stroke-width="1"/>
-<line x1="35" y1="72" x2="105" y2="72" stroke="black" stroke-width="1"/>
-<line x1="35" y1="82" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="35" y2="82" stroke="black" stroke-width="1"/>
-<line x1="49" y1="32" x2="49" y2="82" stroke="black" stroke-width="1"/>
-<line x1="63" y1="32" x2="63" y2="82" stroke="black" stroke-width="1"/>
-<line x1="77" y1="32" x2="77" y2="82" stroke="black" stroke-width="1"/>
-<line x1="91" y1="32" x2="91" y2="82" stroke="black" stroke-width="1"/>
-<line x1="105" y1="32" x2="105" y2="82" stroke="black" stroke-width="1"/>
-<circle cx="70" cy="82" r="5" fill="black"/>
-<circle cx="56" cy="72" r="5" fill="black"/>
-<circle cx="28" cy="62" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="28" cy="52" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="28" cy="42" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="70" cy="32" r="5" fill="black"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="93" height="89" viewBox="0 0 93 89" class="chord-diagram chord-diagram-horizontal">
+<text x="53" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
+<line x1="18" y1="27" x2="18" y2="77" stroke="black" stroke-width="3"/>
+<text x="25" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="39" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="53" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="67" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="81" y="87" text-anchor="middle" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="53" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="81" cy="52" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="88" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="37" x2="88" y2="37" stroke="black" stroke-width="1"/>
+<line x1="18" y1="47" x2="88" y2="47" stroke="black" stroke-width="1"/>
+<line x1="18" y1="57" x2="88" y2="57" stroke="black" stroke-width="1"/>
+<line x1="18" y1="67" x2="88" y2="67" stroke="black" stroke-width="1"/>
+<line x1="18" y1="77" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="18" y2="77" stroke="black" stroke-width="1"/>
+<line x1="32" y1="27" x2="32" y2="77" stroke="black" stroke-width="1"/>
+<line x1="46" y1="27" x2="46" y2="77" stroke="black" stroke-width="1"/>
+<line x1="60" y1="27" x2="60" y2="77" stroke="black" stroke-width="1"/>
+<line x1="74" y1="27" x2="74" y2="77" stroke="black" stroke-width="1"/>
+<line x1="88" y1="27" x2="88" y2="77" stroke="black" stroke-width="1"/>
+<circle cx="53" cy="77" r="5" fill="black"/>
+<circle cx="39" cy="67" r="5" fill="black"/>
+<circle cx="11" cy="57" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="11" cy="47" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="11" cy="37" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="53" cy="27" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -90,63 +90,63 @@ img { max-width: 100%; height: auto; }
 <section class="chord-diagrams" aria-labelledby="cs-chord-diagrams-label">
 <h3 id="cs-chord-diagrams-label" class="section-label">Chord Diagrams</h3>
 <div class="chord-diagrams-grid">
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<text x="35" y="25" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
-<circle cx="45" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="55" cy="53" r="5" fill="black"/>
-<circle cx="65" cy="53" r="5" fill="black"/>
-<circle cx="75" cy="39" r="5" fill="black"/>
-<circle cx="85" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">Am</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="38" cy="45" r="5" fill="black"/>
+<circle cx="48" cy="45" r="5" fill="black"/>
+<circle cx="58" cy="33" r="5" fill="black"/>
+<circle cx="68" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 </svg></figure>
-<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" viewBox="0 0 120 160" class="chord-diagram">
-<text x="60" y="15" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="3"/>
-<text x="28" y="42" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
-<text x="28" y="56" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
-<text x="28" y="70" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
-<text x="28" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
-<text x="28" y="98" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
-<circle cx="60" cy="67" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<circle cx="60" cy="95" r="2.2" fill="#D4D1D6" class="position-marker"/>
-<line x1="35" y1="32" x2="35" y2="102" stroke="black" stroke-width="1"/>
-<line x1="45" y1="32" x2="45" y2="102" stroke="black" stroke-width="1"/>
-<line x1="55" y1="32" x2="55" y2="102" stroke="black" stroke-width="1"/>
-<line x1="65" y1="32" x2="65" y2="102" stroke="black" stroke-width="1"/>
-<line x1="75" y1="32" x2="75" y2="102" stroke="black" stroke-width="1"/>
-<line x1="85" y1="32" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<line x1="35" y1="32" x2="85" y2="32" stroke="black" stroke-width="1"/>
-<line x1="35" y1="46" x2="85" y2="46" stroke="black" stroke-width="1"/>
-<line x1="35" y1="60" x2="85" y2="60" stroke="black" stroke-width="1"/>
-<line x1="35" y1="74" x2="85" y2="74" stroke="black" stroke-width="1"/>
-<line x1="35" y1="88" x2="85" y2="88" stroke="black" stroke-width="1"/>
-<line x1="35" y1="102" x2="85" y2="102" stroke="black" stroke-width="1"/>
-<circle cx="35" cy="67" r="5" fill="black"/>
-<circle cx="45" cy="53" r="5" fill="black"/>
-<circle cx="55" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="65" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="75" cy="25" r="4" fill="none" stroke="black" stroke-width="1"/>
-<circle cx="85" cy="67" r="5" fill="black"/>
+<figure class="chord-diagram-container"><svg xmlns="http://www.w3.org/2000/svg" width="73" height="87" viewBox="0 0 73 87" class="chord-diagram">
+<text x="43" y="14" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold">G</text>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="3"/>
+<text x="12" y="36" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">1</text>
+<text x="12" y="48" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">2</text>
+<text x="12" y="60" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">3</text>
+<text x="12" y="72" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">4</text>
+<text x="12" y="84" text-anchor="end" font-family="sans-serif" font-size="10" class="fret-number">5</text>
+<circle cx="43" cy="57" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<circle cx="43" cy="81" r="2.2" fill="#D4D1D6" class="position-marker"/>
+<line x1="18" y1="27" x2="18" y2="87" stroke="black" stroke-width="1"/>
+<line x1="28" y1="27" x2="28" y2="87" stroke="black" stroke-width="1"/>
+<line x1="38" y1="27" x2="38" y2="87" stroke="black" stroke-width="1"/>
+<line x1="48" y1="27" x2="48" y2="87" stroke="black" stroke-width="1"/>
+<line x1="58" y1="27" x2="58" y2="87" stroke="black" stroke-width="1"/>
+<line x1="68" y1="27" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<line x1="18" y1="27" x2="68" y2="27" stroke="black" stroke-width="1"/>
+<line x1="18" y1="39" x2="68" y2="39" stroke="black" stroke-width="1"/>
+<line x1="18" y1="51" x2="68" y2="51" stroke="black" stroke-width="1"/>
+<line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
+<line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
+<line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
+<circle cx="18" cy="57" r="5" fill="black"/>
+<circle cx="28" cy="45" r="5" fill="black"/>
+<circle cx="38" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="48" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="58" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
+<circle cx="68" cy="57" r="5" fill="black"/>
 </svg></figure>
 </div>
 </section>

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -112,7 +112,7 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="20" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
+++ b/crates/render-html/tests/fixtures/diagrams-orientation-typo/expected.html
@@ -112,7 +112,8 @@ img { max-width: 100%; height: auto; }
 <line x1="18" y1="63" x2="68" y2="63" stroke="black" stroke-width="1"/>
 <line x1="18" y1="75" x2="68" y2="75" stroke="black" stroke-width="1"/>
 <line x1="18" y1="87" x2="68" y2="87" stroke="black" stroke-width="1"/>
-<text x="18" y="23" text-anchor="middle" font-family="sans-serif" font-size="10">X</text>
+<line x1="14" y1="16" x2="22" y2="24" stroke="black" stroke-width="1" class="muted-string"/>
+<line x1="14" y1="24" x2="22" y2="16" stroke="black" stroke-width="1" class="muted-string"/>
 <circle cx="28" cy="20" r="4" fill="none" stroke="black" stroke-width="1"/>
 <circle cx="38" cy="45" r="5" fill="black"/>
 <circle cx="48" cy="45" r="5" fill="black"/>

--- a/packages/playground/tests-e2e/diagrams-inline-hover.spec.ts
+++ b/packages/playground/tests-e2e/diagrams-inline-hover.spec.ts
@@ -111,17 +111,20 @@ test.describe('inline / hover compact chord diagrams (ADR-0027)', () => {
 
     // Reveal the popover (CSS :hover) and measure the inner SVG. Bug 3:
     // the SVG must render at its intrinsic full size, not collapse to the
-    // trigger's inline width. The full-size guitar diagram is 120×160;
-    // the >80 / >100 floors are deliberately generous so the test tracks
+    // trigger's inline width. The full-size guitar diagram is 73×87; the
+    // >60 / >80 floors are deliberately generous so the test tracks
     // "readable" rather than an exact pixel count — yet they still catch
-    // the regression, which collapsed the SVG to ~0.17px.
+    // the regression, which collapsed the SVG to ~0.17px. The popover must
+    // render the regular diagram, not the smaller compact inline layout, so
+    // assert it does NOT carry the `chord-diagram-compact` class.
     await trigger.hover();
     const popoverSvg = page.locator('.chord-diagram-popover svg').first();
     await expect(popoverSvg).toBeVisible();
+    await expect(popoverSvg).not.toHaveClass(/chord-diagram-compact/);
     const box = await popoverSvg.boundingBox();
     expect(box).not.toBeNull();
-    expect(box!.width).toBeGreaterThan(80);
-    expect(box!.height).toBeGreaterThan(100);
+    expect(box!.width).toBeGreaterThan(60);
+    expect(box!.height).toBeGreaterThan(80);
 
     expect(errors).toEqual([]);
   });

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -2182,7 +2182,7 @@
      explicit width the inner `<svg>` collapses to the 10px line box —
      the diagram renders at ~0px. `width: max-content` lets the
      popover size to the SVG's own intrinsic `width`/`height`
-     attributes (120×160 for the full-size diagram). */
+     attributes (73×87 for the full-size diagram). */
   width: max-content;
   margin-bottom: 4px;
   padding: 4px;
@@ -2198,7 +2198,7 @@
    `100%` resolves against the ~10px trigger box and crushes the
    diagram to ~0px. Lift the cap here (and pin `width: auto` so the svg
    uses its emitted attribute width) so the popover always paints the
-   full-size 120×160 diagram. `display: block` / `height: auto` are
+   full-size 73×87 diagram. `display: block` / `height: auto` are
    already supplied by `.chordsketch-diagram svg`. */
 .chordsketch-sheet__content .chord-diagram-popover svg {
   max-width: none;


### PR DESCRIPTION
## What

Two improvements to the regular (full-size) SVG chord diagram generated by
`chordsketch_chordpro::chord_diagram`:

1. **Tighter bounding box.** The vertical 6-string / 5-fret diagram shrinks
   from 120×160 to 73×87:
   - remove the 58px empty bottom padding (the fret-number axis lives in the
     left gutter and the open/muted glyphs sit above the nut, so nothing
     extends below the grid),
   - replace the over-wide symmetric side margins with a left gutter sized
     only for the fret-number axis (35→18px) plus a thin right gutter (5px)
     that just clears the rightmost dot (`total_w = grid_w + left_margin +
     right_margin`),
   - tighten the vertical fret pitch 14→12px and the top band 32→27px.

   The left gutter is kept wide enough that 2-digit (high-position) fret
   numbers still fit the viewBox and clear the leftmost string's finger
   dots. The horizontal layout tightens the same way (140×102 → 93×89) while
   keeping its wider-than-tall proportions via a dedicated
   `horizontal_fret_pitch` decoupled from the vertical `cell_h`.

2. **Muted marker as a shape.** The muted-string `X` was a text glyph, so
   its visual centre depended on the rendering font and never lined up
   exactly with the geometric open-string ring. It is now two crossing
   `<line>` strokes centred on the marker (half-extent = `open_radius`,
   same stroke width as the ring), tagged `class="muted-string"`. The now-unused
   `label_font` metric is removed.

## Why

The previous full-size layout floated a small fretboard inside a large frame
with ~58px of dead vertical space and 35px symmetric side margins, and the
muted `X` sat slightly higher than the open ring because text is positioned
by baseline rather than geometric centre. Both are addressed at the source.

## Test results

- `cargo test` — `chordsketch-chordpro`, `chordsketch-render-html`,
  `chordsketch-render-pdf`, `chordsketch-wasm`, `chordsketch-napi`,
  `chordsketch-lsp` all green.
- `cargo clippy` (default members) and `cargo fmt --check` clean.
- Geometry unit tests in `chord_diagram.rs` updated to the new dimensions
  (vertical 73×87, horizontal 93×89); compact (67×87 / 77×75) unchanged.
- HTML golden fixtures regenerated (`UPDATE_GOLDEN=1`).

## Review summary

Single SVG generator change flowing through CLI HTML, the wasm
`chord_diagram_svg` exports, `@chordsketch/react`'s `<ChordDiagram>`, the
VS Code preview, and the LSP hover. No new dependencies.

## Sister-site audit

- **Renderer parity (text / HTML / PDF / React JSX):** chord diagrams are
  emitted only by the single `chord_diagram.rs` SVG generator; HTML, wasm,
  NAPI, LSP, and React all consume it, so the change reaches them uniformly.
  The render-pdf crate draws diagrams with its own paper geometry (already
  uses fret pitch 12) and is intentionally left unchanged, matching the
  precedent set in #2685.
- **Vertical ↔ horizontal renderers:** both the bounding-box crop and the
  shape-based muted marker were applied to both orientations in lockstep;
  the muted-X `text_v_center` centering gap that existed only in the vertical
  path is eliminated by the shape conversion.

## Deferred

- Compact (inline/hover) and keyboard diagram geometry are unchanged
  (out of scope; the example that motivated this work is the full-size
  fretted diagram).

Closes #2698

---
_Generated by [Claude Code](https://claude.ai/code/session_01WATVoD6efBA8L4wZcyJdZL)_