### PR TITLE
Make chord constituent-note staff use primary ink

### DIFF
--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1677,10 +1677,10 @@
 .chordsketch-staff {
   display: inline-flex;
   align-items: center;
-  /* The staff lines / clef / noteheads paint in `currentColor`; a muted
-     secondary tone keeps the staff legible without competing with the
-     crimson chord name above it. */
-  color: var(--cs-text-secondary, #67646d);
+  /* The staff lines / clef / noteheads paint in `currentColor`; the primary
+     ink keeps the notation crisp and fully legible (the muted secondary tone
+     previously used rendered it washed-out grey). */
+  color: var(--cs-text-primary, #0a0a0b);
 }
 .chordsketch-sheet__cins-staff {
   margin-top: var(--cs-sp-1, 0.25rem);


### PR DESCRIPTION
## What

Change the chord constituent-note staff (五線譜) rendered by
`<ChordStaff>` (`@chordsketch/react`) from the muted secondary tone to
the primary ink. The staff lines, treble clef, noteheads, accidentals,
and key signature all paint in `currentColor` inherited from the
`.chordsketch-staff` wrapper, which was set to
`var(--cs-text-secondary, #67646d)` — a grey that washed the notation
out. The wrapper now uses `var(--cs-text-primary, #0a0a0b)`.

## Why

The constituent-note staff is a reading aid; rendering it in a muted
grey reduced legibility against the surface. Primary ink keeps the
notation crisp and fully black.

The fix lands at the single source of the staff's colour — the wrapper
`color` that every staff glyph inherits via `currentColor` — rather than
recolouring individual glyph elements, so the whole staff stays
consistent.

## Test results

CSS-only change; no test asserted the staff colour. Audited for sister
sites per `.claude/rules/fix-propagation.md`: the constituent-note staff
is a React-only component, the text/HTML/PDF directive renderers have no
equivalent staff colouring, and there are no remaining
`#67646d`/secondary references tied to the staff.

## Review summary

- Code review: no findings (single design-token swap with correct
  fallback).
- Security review: no findings (no user input or sanitisation surface).
- Renderer parity / fix-propagation: no sister sites; design-system
  token used canonically.

## Sister-site audit

Checked the text/HTML/PDF renderers and the design-system reference for
an equivalent staff colour — none exists. The `<ChordStaff>` staff is a
React-only surface.

## Deferred

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hezQYPwAKWR5QAmQgzp8T)_