### PR TITLE
Give disabled chord-editor chips a clear inactive style

### DIFF
--- a/design-system/ui_kits/web/editor-chord-footer.html
+++ b/design-system/ui_kits/web/editor-chord-footer.html
@@ -69,13 +69,15 @@ body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875
 .cins__chips { display: flex; flex-wrap: wrap; gap: var(--sp-1); }
 .cins__chip { flex: none; appearance: none; border: 1px solid var(--border-strong); background: var(--surface); border-radius: var(--r-full); padding: 5px 10px; font: 600 var(--fs-13)/1 var(--font-chord); color: var(--text-strong); cursor: pointer; white-space: nowrap; }
 .cins__chip[aria-pressed="true"] { background: var(--crimson-500); border-color: var(--crimson-500); color: var(--fg-on-crimson); }
+.cins__chip:hover:not(:disabled) { background: var(--surface-hover); }
+.cins__chip:disabled { background: var(--ink-50); border-color: var(--border); color: var(--text-tertiary); cursor: not-allowed; }
 .cins__input { height: 32px; border: 1px solid var(--border-strong); border-radius: var(--r-2); background: var(--surface); padding: 0 var(--sp-2); font: 500 var(--fs-14)/1 var(--font-chord); color: var(--text-primary); width: 5.5rem; }
 .cins__slash { color: var(--text-tertiary); font-weight: 700; }
 .cins__btn { height: 32px; min-width: 36px; border: 1px solid var(--border-strong); background: var(--surface); border-radius: var(--r-2); font-size: var(--fs-14); color: var(--text-strong); cursor: pointer; }
-.cins__btn:disabled { opacity: .4; cursor: default; }
+.cins__btn:disabled { opacity: .4; cursor: not-allowed; }
 .cins__spacer { flex: 1 1 var(--sp-2); }
 .cins__remove { height: 34px; padding: 0 var(--sp-3); border: 1px solid transparent; background: transparent; border-radius: var(--r-2); font: 600 var(--fs-13)/1 var(--font-jp); color: var(--crimson-600); cursor: pointer; }
-.cins__remove:disabled { opacity: .4; cursor: default; }
+.cins__remove:disabled { opacity: .4; cursor: not-allowed; }
 .cins__insert { height: 34px; padding: 0 var(--sp-4); border-radius: var(--r-2); border: 1px solid var(--crimson-500); background: var(--crimson-500); color: var(--fg-on-crimson); font: 600 var(--fs-13)/1 var(--font-jp); cursor: pointer; }
 .cins__actions { display: flex; align-items: center; gap: var(--sp-2); align-self: center; }
 

--- a/packages/playground/tests-e2e/chord-inspector.spec.ts
+++ b/packages/playground/tests-e2e/chord-inspector.spec.ts
@@ -142,6 +142,30 @@ test.describe('chord-editor footer (ChordPro playground)', () => {
     expect(errors).toEqual([]);
   });
 
+  test('an unavailable tension chip is visibly disabled (not-allowed cursor)', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    // Select the first chord (`[G]` — a bare major triad with no seventh). An
+    // altered tension (♭9) needs a seventh, so its chip is disabled in this
+    // state. This proves the `:disabled` style in styles.css actually paints
+    // in the deployed bundle: without it the chip would be indistinguishable
+    // from a live one (the pre-fix bug — the chip carried `disabled` but had
+    // no `:disabled` rule, so it looked fully pressable).
+    const footer = page.locator(FOOTER);
+    await page.locator('.pane.preview').locator(".chord[role='button']").first().click();
+    await expect(footer.locator(".chordsketch-sheet__cins[data-mode='edit']")).toBeVisible();
+
+    const flat9 = footer.locator('[aria-label="Tensions"] button', { hasText: /^♭9$/ });
+    await expect(flat9).toBeDisabled();
+    await expect(flat9).toHaveCSS('cursor', 'not-allowed');
+
+    expect(errors).toEqual([]);
+  });
+
   test('the footer is edit-only: idle shows a hint, no editing controls or Insert', async ({
     page,
   }) => {

--- a/packages/react/src/chord-inspector.tsx
+++ b/packages/react/src/chord-inspector.tsx
@@ -301,18 +301,24 @@ export function ChordInspector(props: ChordInspectorProps): JSX.Element {
           role="group"
           aria-label="Seventh"
         >
-          {SEVENTH_OPTIONS.map((opt) => (
-            <button
-              key={opt.value}
-              type="button"
-              className="chordsketch-sheet__cins-chip"
-              disabled={!isSeventhAvailable(selection.triad, opt.value)}
-              aria-pressed={recognized && selection.seventh === opt.value}
-              onClick={() => emit({ suffix: composeChordSuffix(withSeventh(selection, opt.value)) })}
-            >
-              {opt.label}
-            </button>
-          ))}
+          {SEVENTH_OPTIONS.map((opt) => {
+            const unavailable = !isSeventhAvailable(selection.triad, opt.value);
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                className="chordsketch-sheet__cins-chip"
+                disabled={unavailable}
+                // Explain why the chip is inert so the disabled style is not a
+                // dead end (a greyed control with no stated cause).
+                title={unavailable ? 'Not available for the selected triad' : undefined}
+                aria-pressed={recognized && selection.seventh === opt.value}
+                onClick={() => emit({ suffix: composeChordSuffix(withSeventh(selection, opt.value)) })}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
         </div>
       </div>
 
@@ -323,18 +329,26 @@ export function ChordInspector(props: ChordInspectorProps): JSX.Element {
           role="group"
           aria-label="Tensions"
         >
-          {TENSION_OPTIONS.map((opt) => (
-            <button
-              key={opt.value}
-              type="button"
-              className="chordsketch-sheet__cins-chip"
-              disabled={!isTensionAvailable(selection.triad, selection.seventh, opt.value)}
-              aria-pressed={recognized && selection.tensions.includes(opt.value)}
-              onClick={() => emit({ suffix: composeChordSuffix(toggleTension(selection, opt.value)) })}
-            >
-              {opt.label}
-            </button>
-          ))}
+          {TENSION_OPTIONS.map((opt) => {
+            const unavailable = !isTensionAvailable(selection.triad, selection.seventh, opt.value);
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                className="chordsketch-sheet__cins-chip"
+                disabled={unavailable}
+                // Explain why the chip is inert so the disabled style is not a
+                // dead end (a greyed control with no stated cause).
+                title={
+                  unavailable ? 'Not available for the selected chord type' : undefined
+                }
+                aria-pressed={recognized && selection.tensions.includes(opt.value)}
+                onClick={() => emit({ suffix: composeChordSuffix(toggleTension(selection, opt.value)) })}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1774,13 +1774,27 @@
   color: var(--cs-text-strong, #44424a);
   cursor: pointer;
 }
-.chordsketch-sheet__cins-chip:hover {
+.chordsketch-sheet__cins-chip:hover:not(:disabled) {
   background: var(--cs-surface-hover, #f6f4f7);
 }
 .chordsketch-sheet__cins-chip[aria-pressed='true'] {
   background: var(--cs-crimson-500, #bd1642);
   border-color: var(--cs-crimson-500, #bd1642);
   color: var(--cs-fg-on-crimson, #fff);
+}
+/* Disabled chip: a 7th / tension that the current triad+seventh cannot
+   take (isSeventhAvailable / isTensionAvailable). Must read as clearly
+   inert — muted fill + border + text, reduced opacity, and a
+   not-allowed cursor, matching the design-system button convention
+   (.btn:disabled) and the iReal grid's disabled actions. Declared after
+   the [aria-pressed='true'] rule so an unavailable chip never paints as
+   active (equal specificity → source order wins). */
+.chordsketch-sheet__cins-chip:disabled {
+  background: var(--cs-ink-50, #faf9fb);
+  border-color: var(--cs-border, #e8e6ea);
+  color: var(--cs-text-tertiary, #8a8790);
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 /* inputs */
 .chordsketch-sheet__cins-row2 {
@@ -1836,7 +1850,7 @@
 }
 .chordsketch-sheet__cins-movebtn:disabled {
   opacity: 0.35;
-  cursor: default;
+  cursor: not-allowed;
 }
 .chordsketch-sheet__cins-movelbl {
   font-size: 0.75rem;

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1783,17 +1783,20 @@
   color: var(--cs-fg-on-crimson, #fff);
 }
 /* Disabled chip: a 7th / tension that the current triad+seventh cannot
-   take (isSeventhAvailable / isTensionAvailable). Must read as clearly
-   inert — muted fill + border + text, reduced opacity, and a
-   not-allowed cursor, matching the design-system button convention
-   (.btn:disabled) and the iReal grid's disabled actions. Declared after
-   the [aria-pressed='true'] rule so an unavailable chip never paints as
-   active (equal specificity → source order wins). */
+   take (isSeventhAvailable / isTensionAvailable). Reads as clearly inert
+   via the design-system's muted-colour idiom (the same one .input/.select
+   :disabled use) — a muted fill + border and tertiary text, plus a
+   not-allowed cursor. Opacity is intentionally NOT stacked on top: the
+   text is already tertiary, and dimming it further would crush the label
+   (the `7` / `9` / `13` names a beginner needs to read) toward illegible.
+   The muted colours alone keep ~3.38:1 contrast — disabled-exempt from
+   WCAG 1.4.3 but still perceivable. Declared after the [aria-pressed='true']
+   rule so an unavailable chip never paints as active (equal specificity →
+   source order wins). */
 .chordsketch-sheet__cins-chip:disabled {
-  background: var(--cs-ink-50, #faf9fb);
+  background: var(--cs-ink-50, #fafaf7);
   border-color: var(--cs-border, #e8e6ea);
   color: var(--cs-text-tertiary, #8a8790);
-  opacity: 0.55;
   cursor: not-allowed;
 }
 /* inputs */

--- a/packages/react/tests/chord-inspector.test.tsx
+++ b/packages/react/tests/chord-inspector.test.tsx
@@ -158,6 +158,23 @@ describe('<ChordInspector>', () => {
     expect(flat9.disabled).toBe(false);
   });
 
+  test('a tension that is unavailable for the current chord is rendered disabled', () => {
+    // A bare major triad (suffix '', no seventh) cannot take an altered tension
+    // — ♭9 / ♯5 require a seventh (isTensionAvailable). The chip must carry the
+    // native `disabled` attribute so the `:disabled` style in styles.css de-
+    // emphasises it; an enabled-looking but inert chip is the bug this guards.
+    const { container } = setup({ root: 'G', suffix: '', chordName: 'G' });
+    const tension = (text: string): HTMLButtonElement =>
+      Array.from(container.querySelectorAll('[aria-label="Tensions"] button')).find(
+        (b) => b.textContent === text,
+      ) as HTMLButtonElement;
+    expect(tension('♭9').disabled).toBe(true);
+    expect(tension('♯5').disabled).toBe(true);
+    // The natural 9 add-tone is still reachable without a seventh, so it stays
+    // enabled — the disabled treatment is selective, not blanket.
+    expect(tension('9').disabled).toBe(false);
+  });
+
   test('typing in the suffix / bass inputs emits the edited value', () => {
     const { container, onChange } = setup();
     const inputs = container.querySelectorAll('.chordsketch-sheet__cins-input');

--- a/packages/react/tests/chord-inspector.test.tsx
+++ b/packages/react/tests/chord-inspector.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { ChordInspector } from '../src/chord-inspector';
 import type { ChordParts } from '../src/chord-source-edit';
 import type { ChordStaffWasmLoader, StaffNote } from '../src/use-chord-staff';
+import { readStylesheetSource } from './stylesheet-source';
 
 const AM7_STAFF: StaffNote[] = [
   { letter: 'A', accidental: 0, octave: 3, midi: 57 },
@@ -159,20 +160,45 @@ describe('<ChordInspector>', () => {
   });
 
   test('a tension that is unavailable for the current chord is rendered disabled', () => {
-    // A bare major triad (suffix '', no seventh) cannot take an altered tension
-    // — ♭9 / ♯5 require a seventh (isTensionAvailable). The chip must carry the
-    // native `disabled` attribute so the `:disabled` style in styles.css de-
-    // emphasises it; an enabled-looking but inert chip is the bug this guards.
+    // Behavioural coverage for a distinct branch from the seventh-present case
+    // above: a bare major triad (suffix '', no seventh) cannot take an altered
+    // tension — ♭9 / ♯5 require a seventh (isTensionAvailable) — so those chips
+    // carry the native `disabled` attribute, while the natural 9 add-tone stays
+    // reachable. A disabled chip also exposes a `title` explaining the reason.
+    // (The CSS that paints the disabled state is guarded separately by the
+    // stylesheet-source test below and the playground e2e — this test guards
+    // the availability → disabled-attribute wiring.)
     const { container } = setup({ root: 'G', suffix: '', chordName: 'G' });
     const tension = (text: string): HTMLButtonElement =>
       Array.from(container.querySelectorAll('[aria-label="Tensions"] button')).find(
         (b) => b.textContent === text,
       ) as HTMLButtonElement;
     expect(tension('♭9').disabled).toBe(true);
+    expect(tension('♭9').getAttribute('title')).toBe('Not available for the selected chord type');
     expect(tension('♯5').disabled).toBe(true);
     // The natural 9 add-tone is still reachable without a seventh, so it stays
-    // enabled — the disabled treatment is selective, not blanket.
+    // enabled — the disabled treatment is selective, not blanket — and carries
+    // no "unavailable" tooltip.
     expect(tension('9').disabled).toBe(false);
+    expect(tension('9').getAttribute('title')).toBeNull();
+  });
+
+  test('styles.css gives disabled chips an inert style and suppresses their hover', () => {
+    // The fast guard for the actual style fix (jsdom applies no CSS, so this
+    // asserts rule presence in source per the readStylesheetSource pattern).
+    // Without the `:disabled` rule a disabled chip would be visually
+    // indistinguishable from a pressable one; without the `:not(:disabled)`
+    // gate it would still highlight on hover. The deployed-bundle paint is
+    // additionally proven by the playground e2e.
+    const css = readStylesheetSource();
+    // A dedicated :disabled rule exists for the chip, signalling not-allowed.
+    const disabledRule = css.match(/\.chordsketch-sheet__cins-chip:disabled\s*\{([^}]*)\}/);
+    expect(disabledRule).not.toBeNull();
+    expect(disabledRule![1]).toContain('cursor: not-allowed');
+    // The chip hover is gated behind :not(:disabled) so disabled chips do not
+    // highlight.
+    expect(css).toContain('.chordsketch-sheet__cins-chip:hover:not(:disabled)');
+    expect(css).not.toMatch(/\.chordsketch-sheet__cins-chip:hover\s*\{/);
   });
 
   test('typing in the suffix / bass inputs emits the edited value', () => {


### PR DESCRIPTION
## What

Make the un-pressable buttons in the ChordPro chord-editor footer (`<ChordInspector>`) visibly, legibly disabled.

- Add `.chordsketch-sheet__cins-chip:disabled` (7th + tension chips) — the design-system muted-colour idiom (muted fill / border / tertiary text + `not-allowed` cursor). Opacity is intentionally not stacked on top of the already-muted text, so the label stays legible (~3.38:1) instead of being crushed toward invisible. Declared after the `[aria-pressed='true']` rule so an unavailable chip never paints as active (equal specificity → source order wins).
- Gate the chip `:hover` behind `:not(:disabled)` so a disabled chip no longer highlights on hover.
- Disabled chips carry a `title` explaining *why* they are unavailable, so a greyed chip is not a cause-less dead end.
- Align `.chordsketch-sheet__cins-movebtn:disabled` to `cursor: not-allowed` (was the weaker `cursor: default`) so every disabled control in the panel signals inactivity consistently.

## Why

The 7th and tension chips receive the native `disabled` attribute when the current triad + seventh cannot take that option (`isSeventhAvailable` / `isTensionAvailable`), but the stylesheet had no `:disabled` rule for them. A disabled chip rendered identically to a pressable one and still highlighted on hover, so users could not tell which chips were inactive.

Root cause: the disabled-state styling was asymmetric across the panel's buttons — the move buttons had a `:disabled` rule, the chips did not. This is a style-layer fix applied uniformly, matching the design-system `.input:disabled` muted-colour idiom and the iReal grid's existing disabled-action treatment.

## Test results

- `npm test` (packages/react): 968 passed, including (a) a unit test that a bare major triad disables altered tensions (♭9 / ♯5) and exposes the reason `title` while keeping the natural 9 enabled, and (b) a fast `readStylesheetSource` assertion that the chip `:disabled` rule exists (`cursor: not-allowed`) and the chip `:hover` is gated behind `:not(:disabled)`.
- `npm run typecheck` (packages/react): clean.
- Playground Playwright e2e (`chord-inspector.spec.ts`): an unavailable tension chip is `disabled` and computes `cursor: not-allowed`, proving the style paints in the deployed bundle (validated by `playground-smoke.yml`).

## Review summary

A four-angle pre-push review (code / security / accessibility / project-rule) was run and every finding resolved in-PR:
- Accessibility (Medium): dropped the `opacity` that crushed disabled-label contrast to ~1.8:1; use the muted-colour idiom alone (~3.38:1).
- Accessibility (Low): added the reason `title` to disabled chips.
- Code review (Low, fix-propagation): updated the design-system static kit sister site.
- Nits: added the stylesheet-source guard; fixed a drifted token fallback (`#faf9fb` → `#fafaf7`).
- Security: no findings (native `disabled` enforces non-activation; CSS only changes appearance; no untrusted-input interpolation).

## Sister-site audit

Audited every `disabled=` site in `packages/react/src/*.tsx` against `styles.css`: the iReal bar grid controls (`__bar`, `__bar-action`, `__section-action`, `__add-bar` / `__add-section`, `__popover-rowbtn`), the transpose / capo selects, and the metadata `<fieldset disabled>` inputs already carry `:disabled` rules; `<PdfExport>`'s button styling is consumer-supplied (`{...buttonProps}`). The chord-inspector chips were the only React-package site missing the treatment. The static design-system reference kit `design-system/ui_kits/web/editor-chord-footer.html` is the cross-artifact sister site for this exact footer (class prefix `cins__chip`) and was updated in the same PR. The runtime chord-inspector styles live solely in `packages/react/src/styles.css`, consumed by the playground, desktop, and VS Code surfaces via `@chordsketch/react/styles.css` — no duplicate runtime stylesheet to propagate to.

Closes #2710