### PR TITLE
Relabel chord inspector move control to "Move chord"

### DIFF
--- a/design-system/ui_kits/web/editor-chord-footer.html
+++ b/design-system/ui_kits/web/editor-chord-footer.html
@@ -163,10 +163,10 @@ body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875
       </div>
     </div>
     <div class="cins__group">
-      <span class="cins__label">Move one step</span>
+      <span class="cins__label">Move chord</span>
       <div class="cins__rowc">
         <button class="cins__btn" aria-label="Move chord left">◀</button>
-        <span class="cins__movelbl">Move chord</span>
+        <span class="cins__movelbl">one step</span>
         <button class="cins__btn" aria-label="Move chord right">▶</button>
       </div>
     </div>

--- a/design-system/ui_kits/web/editor-chord-footer.html
+++ b/design-system/ui_kits/web/editor-chord-footer.html
@@ -62,6 +62,7 @@ body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875
 .cins__group { display: flex; flex-direction: column; gap: var(--sp-2); }
 .cins__label { font: 600 var(--fs-12)/1 var(--font-latin); color: var(--text-strong); }
 .cins__rowc { display: flex; align-items: center; gap: var(--sp-2); }
+.cins__movelbl { font: 600 var(--fs-12)/1 var(--font-latin); color: var(--text-secondary); white-space: nowrap; }
 .cins__seg { display: inline-flex; gap: 2px; padding: 2px; background: var(--ink-100); border: 1px solid var(--border); border-radius: var(--r-2); }
 .cins__seg button { appearance: none; border: 0; background: transparent; border-radius: var(--r-1); padding: 5px 8px; min-width: 28px; font: 600 var(--fs-13)/1 var(--font-chord); color: var(--text-secondary); cursor: pointer; }
 .cins__seg button[aria-pressed="true"] { background: var(--surface); color: var(--crimson-600); box-shadow: var(--e-1); }
@@ -165,6 +166,7 @@ body { font-family: var(--font-jp); font-size: var(--fs-16); line-height: 1.6875
       <span class="cins__label">Move one step</span>
       <div class="cins__rowc">
         <button class="cins__btn" aria-label="Move chord left">◀</button>
+        <span class="cins__movelbl">Move chord</span>
         <button class="cins__btn" aria-label="Move chord right">▶</button>
       </div>
     </div>

--- a/packages/react/src/chord-inspector.tsx
+++ b/packages/react/src/chord-inspector.tsx
@@ -368,7 +368,7 @@ export function ChordInspector(props: ChordInspectorProps): JSX.Element {
       <div className="chordsketch-sheet__cins-divider" />
 
       <div className="chordsketch-sheet__cins-group">
-        <span className="chordsketch-sheet__cins-label">Move one step</span>
+        <span className="chordsketch-sheet__cins-label">Move chord</span>
         <div className="chordsketch-sheet__cins-move">
           <button
             type="button"
@@ -379,7 +379,7 @@ export function ChordInspector(props: ChordInspectorProps): JSX.Element {
           >
             ◀
           </button>
-          <span className="chordsketch-sheet__cins-movelbl">Move chord</span>
+          <span className="chordsketch-sheet__cins-movelbl">one step</span>
           <button
             type="button"
             className="chordsketch-sheet__cins-movebtn"

--- a/packages/react/src/chord-inspector.tsx
+++ b/packages/react/src/chord-inspector.tsx
@@ -379,7 +379,7 @@ export function ChordInspector(props: ChordInspectorProps): JSX.Element {
           >
             ◀
           </button>
-          <span className="chordsketch-sheet__cins-movelbl">lyric position</span>
+          <span className="chordsketch-sheet__cins-movelbl">Move chord</span>
           <button
             type="button"
             className="chordsketch-sheet__cins-movebtn"

--- a/packages/react/tests/chord-inspector.test.tsx
+++ b/packages/react/tests/chord-inspector.test.tsx
@@ -188,15 +188,24 @@ describe('<ChordInspector>', () => {
     expect(onNudge).toHaveBeenCalledWith(1);
   });
 
-  test('move control inline label names the chord, matching the buttons', () => {
+  test('move control labels name the chord and its step granularity', () => {
     const { container } = setup();
-    // The inline label between the ◀ / ▶ buttons describes what moves —
-    // the chord, not the lyric — so it agrees with the buttons'
-    // "Move chord left" / "Move chord right" accessible names.
-    const label = container.querySelector(
+    // The group header names what moves — the chord, not the lyric — so it
+    // agrees with the buttons' "Move chord left" / "Move chord right"
+    // accessible names. The inline label between the ◀ / ▶ buttons names the
+    // step granularity, not the object, so the two labels don't both repeat
+    // "Move chord".
+    const moveGroup = (
+      container.querySelector('.chordsketch-sheet__cins-move') as HTMLElement
+    ).parentElement as HTMLElement;
+    const header = moveGroup.querySelector(
+      '.chordsketch-sheet__cins-label',
+    ) as HTMLElement;
+    const inline = moveGroup.querySelector(
       '.chordsketch-sheet__cins-movelbl',
     ) as HTMLElement;
-    expect(label.textContent).toBe('Move chord');
+    expect(header.textContent).toBe('Move chord');
+    expect(inline.textContent).toBe('one step');
   });
 
   test('Escape closes; the close button closes; Remove fires onRemove', () => {

--- a/packages/react/tests/chord-inspector.test.tsx
+++ b/packages/react/tests/chord-inspector.test.tsx
@@ -188,6 +188,17 @@ describe('<ChordInspector>', () => {
     expect(onNudge).toHaveBeenCalledWith(1);
   });
 
+  test('move control inline label names the chord, matching the buttons', () => {
+    const { container } = setup();
+    // The inline label between the ◀ / ▶ buttons describes what moves —
+    // the chord, not the lyric — so it agrees with the buttons'
+    // "Move chord left" / "Move chord right" accessible names.
+    const label = container.querySelector(
+      '.chordsketch-sheet__cins-movelbl',
+    ) as HTMLElement;
+    expect(label.textContent).toBe('Move chord');
+  });
+
   test('Escape closes; the close button closes; Remove fires onRemove', () => {
     const { container, onClose, onRemove } = setup();
     fireEvent.keyDown(container.querySelector('.chordsketch-sheet__cins') as HTMLElement, {


### PR DESCRIPTION
## What

Relabel the inline text in `<ChordInspector>`'s "Move one step" control from
`lyric position` to `Move chord` (`packages/react/src/chord-inspector.tsx`),
mirror the label into the canonical design-system reference
(`design-system/ui_kits/web/editor-chord-footer.html`), and add a component
test that locks the copy.

## Why

The control moves the **selected chord** one position along the lyric line —
not the lyric. The inline label `lyric position` read as if it operated on the
lyric, and it contradicted the buttons' own accessible names
(`Move chord left` / `Move chord right`). `Move chord` makes the visible copy
agree with the accessible names.

The design-system reference for this control had **no** inline label, so the
React surface had silently diverged by adding one. Adding the matching label to
the reference brings the two surfaces back into parity.

## Test results

- `packages/react`: `vitest run` — 967 passed (44 files), including the new
  `move control inline label names the chord, matching the buttons` test.
- `packages/react`: `tsc --noEmit` — clean.

## Review summary

Auto-review pending.

## Sister-site audit

- Visible `lyric position` copy existed only in
  `packages/react/src/chord-inspector.tsx`; desktop / VS Code mount the same
  `@chordsketch/react` component and inherit the label (no second copy).
- The canonical design reference
  `design-system/ui_kits/web/editor-chord-footer.html` is the design sister
  site and is updated in lockstep.
- The `Move chord left` / `Move chord right` `aria-label`s and the iReal
  popover's `Move chord up` / `Move chord down` controls already use the
  `Move chord` family; this change makes the ChordPro inspector consistent
  with them.
- No renderer surface (text / HTML / PDF / JSX walker) is involved — this is
  editor chrome, not ChordPro output.

## Deferred

None.

Closes #2712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8vpYF8simw77zM7RQ2Vvz)_