### PR TITLE
Suppress redundant focus ring on the keyboard-nudged selected chord

### DIFF
--- a/packages/playground/tests-e2e/chord-inspector.spec.ts
+++ b/packages/playground/tests-e2e/chord-inspector.spec.ts
@@ -189,7 +189,15 @@ test.describe('chord-editor footer (ChordPro playground)', () => {
     const boxShadow = await preview
       .locator('.chord--selected')
       .evaluate((el) => getComputedStyle(el).boxShadow);
+    // Negative: the crimson ring colour must be gone.
     expect(boxShadow).not.toContain('189, 22, 66');
+    // Positive: the badge's elevation shadow (`--cs-e-1` =
+    // rgba(10, 10, 11, 0.04)) must be what remains. Asserting the
+    // expected shadow IS present (not merely that the ring is absent)
+    // keeps the test meaningful even if the focus-ring token's colour
+    // ever changes — the regression is the ring REPLACING the elevation
+    // shadow, so checking for the elevation shadow catches it directly.
+    expect(boxShadow).toContain('10, 10, 11');
 
     expect(errors).toEqual([]);
   });

--- a/packages/playground/tests-e2e/chord-inspector.spec.ts
+++ b/packages/playground/tests-e2e/chord-inspector.spec.ts
@@ -163,6 +163,35 @@ test.describe('chord-editor footer (ChordPro playground)', () => {
     expect(errors).toEqual([]);
   });
 
+  test('keyboard-nudging the selected chord shows no focus-ring outline', async ({
+    page,
+  }) => {
+    const errors = trackPageErrors(page);
+    await page.goto('./chordpro/');
+    await expect(page.locator('.cm-editor')).toBeVisible();
+
+    const preview = page.locator('.pane.preview');
+    await preview.locator(".chord[role='button']").first().click();
+    await expect(preview.locator('.chord--selected')).toBeVisible();
+
+    // Nudge with the keyboard: this moves the chord AND makes
+    // `:focus-visible` match (the last input modality is now a key), and
+    // the walker re-focuses the advanced selection. The crimson badge is
+    // the selection / focus indicator; a focus ring stacked on top would
+    // read as an unwanted outline flickering on every Arrow press. The
+    // computed box-shadow must therefore stay the badge's elevation
+    // shadow, NOT the crimson focus ring (rgb(189, 22, 70) = #bd1642).
+    await page.keyboard.press('ArrowRight');
+    await expect(preview.locator('.chord--selected')).toBeVisible();
+
+    const boxShadow = await preview
+      .locator('.chord--selected')
+      .evaluate((el) => getComputedStyle(el).boxShadow);
+    expect(boxShadow).not.toContain('189, 22, 70');
+
+    expect(errors).toEqual([]);
+  });
+
   test('selecting a chord does not reflow its neighbours (#2638)', async ({ page }) => {
     const errors = trackPageErrors(page);
     await page.goto('./chordpro/');

--- a/packages/playground/tests-e2e/chord-inspector.spec.ts
+++ b/packages/playground/tests-e2e/chord-inspector.spec.ts
@@ -180,14 +180,16 @@ test.describe('chord-editor footer (ChordPro playground)', () => {
     // the selection / focus indicator; a focus ring stacked on top would
     // read as an unwanted outline flickering on every Arrow press. The
     // computed box-shadow must therefore stay the badge's elevation
-    // shadow, NOT the crimson focus ring (rgb(189, 22, 70) = #bd1642).
+    // shadow, NOT the crimson focus ring. `--cs-focus-ring` resolves to
+    // `var(--cs-crimson-500)` = #BD1642 = rgb(189, 22, 66), so that
+    // colour appearing in the box-shadow proves the ring leaked.
     await page.keyboard.press('ArrowRight');
     await expect(preview.locator('.chord--selected')).toBeVisible();
 
     const boxShadow = await preview
       .locator('.chord--selected')
       .evaluate((el) => getComputedStyle(el).boxShadow);
-    expect(boxShadow).not.toContain('189, 22, 70');
+    expect(boxShadow).not.toContain('189, 22, 66');
 
     expect(errors).toEqual([]);
   });

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1557,9 +1557,18 @@
   margin: -2px -5px;
   box-shadow: var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
 }
+/* The selected chord is ALWAYS the programmatically-focused element
+   (the walker focuses it on every select / nudge), so `:focus-visible`
+   matches throughout a keyboard nudge. The crimson badge above already
+   marks it unambiguously as the focused editing target, so a second
+   focus ring stacked on top is redundant — and it flickers on every
+   ArrowLeft / ArrowRight press as focus is re-driven, which reads as an
+   unwanted outline. Suppress the ring and keep the badge's elevation
+   shadow; the badge IS the visible-focus indicator here, so this does
+   not drop the WCAG 2.4.7 focus cue. */
 .chordsketch-sheet__content .chord--selected:focus-visible {
   outline: none;
-  box-shadow: var(--cs-focus-ring, 0 0 0 2px #fff, 0 0 0 4px #bd1642);
+  box-shadow: var(--cs-e-1, 0 1px 2px rgba(10, 10, 11, 0.04));
 }
 
 /* ---- Chord audio (#2650) -------------------------------------- */


### PR DESCRIPTION
## What

Stop the crimson focus ring from painting on top of the selected-chord badge
in the ChordPro preview while the chord is nudged left/right with the keyboard.
`.chord--selected:focus-visible` now keeps the badge's elevation shadow instead
of the `--cs-focus-ring` double ring.

## Why

The selected chord is always the programmatically-focused element: the JSX
walker (`packages/react/src/chordpro-jsx.tsx`) focuses it on every select and
re-focuses the advanced selection on every nudge. During keyboard nudging the
last input modality is a key press, so `:focus-visible` matched throughout the
nudge and the focus ring flickered on every ArrowLeft / ArrowRight press,
reading as an unwanted outline.

The crimson `.chord--selected` badge (filled chip, inverted text) is itself the
visible-focus / editing-target indicator, so a second ring stacked on top is
redundant. Keeping the badge as the sole indicator preserves the WCAG 2.4.7
focus cue without the flicker.

This is the root-cause fix at the styling boundary that produced the artefact,
not a band-aid: the ring rule was the source, and it is the rule that changed.

## Test results

- `cd packages/react && npm test` — 966 passed (44 files). The CSS-only change
  does not regress any unit test.
- Added a Playwright regression in
  `packages/playground/tests-e2e/chord-inspector.spec.ts`: selects a preview
  chord, presses ArrowRight to nudge it (which also makes `:focus-visible`
  match), and asserts the selected chord's computed `box-shadow` no longer
  contains the crimson ring colour `rgb(189, 22, 66)` (`#BD1642`, the colour
  `--cs-focus-ring` resolves to via `--cs-crimson-500`) and DOES contain the
  badge's elevation shadow (`rgba(10, 10, 11, 0.04)`, `--cs-e-1`). The positive
  assertion keeps the test meaningful even if the ring token colour changes.
  The spec fails against the pre-fix CSS and passes after.

## Review summary

Reviewed in parallel via code review, security review, and a project-rules
audit. Findings:

- **Code review (High, fixed):** the regression test originally asserted
  `rgb(189, 22, 70)`, but `#BD1642` is `rgb(189, 22, 66)` (hex `0x42` = 66), so
  the assertion passed unconditionally and never caught the bug. Corrected to
  `189, 22, 66` and hardened with a positive elevation-shadow assertion.
- **Security review:** no findings — CSS + test only, no sanitizer/URI surface.
- **Project-rules audit:** clean against fix-propagation, renderer-parity,
  playground-smoke, root-cause-fixes, golden-tests, code-style, and
  evidence-based-claims.

## Sister-site audit

Searched for `.chord--selected` and `--cs-focus-ring` across the repo: the only
chord-selection CSS rule is in `packages/react/src/styles.css`. The playground,
desktop app, design-system, react-ui, and VS Code extension all consume the
single canonical `@chordsketch/react/styles.css` and define no chord-selection
CSS of their own, so they inherit the fix. The static Rust renderers have no
click-to-nudge selection (React-only per ADR-0017). No sister site to update.

Closes #2715

🤖 Generated with [Claude Code](https://claude.com/claude-code)